### PR TITLE
Simplify DataFrame-based tests and restore auto registration

### DIFF
--- a/sidemantic/__init__.py
+++ b/sidemantic/__init__.py
@@ -10,7 +10,6 @@ from sidemantic.core.pre_aggregation import PreAggregation, RefreshKey, RefreshR
 from sidemantic.core.preagg_recommender import PreAggRecommendation, PreAggregationRecommender, QueryPattern
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.segment import Segment
-
 # Backwards compatibility alias
 Measure = Metric
 

--- a/tests/dates/test_time_comparison.py
+++ b/tests/dates/test_time_comparison.py
@@ -1,6 +1,7 @@
 """Test that time_comparison metrics defined in model.metrics are auto-registered at graph level."""
 
 import duckdb
+import math
 
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.metric import Metric
@@ -59,10 +60,10 @@ def test_model_level_time_comparison_metric():
     # 2024-03: 120 - 150 = -30
     # 2024-04: 180 - 120 = 60
 
-    assert results[0][2] is None  # Jan (no prior)
-    assert results[1][2] == 50  # Feb
-    assert results[2][2] == -30  # Mar
-    assert results[3][2] == 60  # Apr
+    assert math.isnan(results.loc[0, "revenue_mom_change"])  # Jan (no prior)
+    assert results.loc[1, "revenue_mom_change"] == 50  # Feb
+    assert results.loc[2, "revenue_mom_change"] == -30  # Mar
+    assert results.loc[3, "revenue_mom_change"] == 60  # Apr
 
 
 def test_model_level_conversion_metric():
@@ -119,4 +120,4 @@ def test_model_level_conversion_metric():
     # User 2: signup on 01-05, purchase on 01-20 (15 days) - NOT CONVERTED (>7 days)
     # User 3: signup on 01-10, no purchase - NOT CONVERTED
     # Conversion rate: 1/3 = 0.333...
-    assert abs(results[0][0] - 0.333) < 0.01
+    assert abs(results.loc[0, "signup_conversion"] - 0.333) < 0.01

--- a/tests/joins/test_multi_hop.py
+++ b/tests/joins/test_multi_hop.py
@@ -106,7 +106,7 @@ result = sl.query(
 )
 
 print("Results (region_name, revenue):")
-for row in result.fetchdf():
+for row in result.fetchdf().itertuples(index=False, name=None):
     print(f"  {row}")
 print()
 

--- a/tests/metrics/test_cross_model.py
+++ b/tests/metrics/test_cross_model.py
@@ -97,7 +97,7 @@ result = sl.query(
 )
 
 print("Results:")
-for row in result.fetchdf():
+for row in result.fetchdf().itertuples(index=False, name=None):
     print(f"  {row}")
 print()
 
@@ -133,7 +133,7 @@ result = sl.query(
 )
 
 print("Results (region, revenue, customers, revenue_per_customer):")
-for row in result.fetchdf():
+for row in result.fetchdf().itertuples(index=False, name=None):
     print(f"  {row}")
 print()
 

--- a/tests/test_critical_fixes.py
+++ b/tests/test_critical_fixes.py
@@ -4,6 +4,7 @@ import duckdb
 import pytest
 
 from sidemantic import Dimension, Metric, Model, Relationship, SemanticLayer
+from tests.utils import df_rows
 
 
 def test_query_level_metric_filters_use_having():
@@ -41,6 +42,8 @@ def test_query_level_metric_filters_use_having():
 
 def test_dimension_filters_use_where():
     """Test that filters on dimensions still use WHERE clause."""
+    layer = SemanticLayer()
+
     orders = Model(
         name="orders",
         table="orders_table",
@@ -54,7 +57,6 @@ def test_dimension_filters_use_where():
         ],
     )
 
-    layer = SemanticLayer()
     layer.add_model(orders)
 
     # Filter on dimension should use WHERE
@@ -71,6 +73,8 @@ def test_dimension_filters_use_where():
 
 def test_mixed_filters_separate_where_and_having():
     """Test that mixed metric and dimension filters use both WHERE and HAVING."""
+    layer = SemanticLayer()
+
     orders = Model(
         name="orders",
         table="orders_table",
@@ -84,7 +88,6 @@ def test_mixed_filters_separate_where_and_having():
         ],
     )
 
-    layer = SemanticLayer()
     layer.add_model(orders)
 
     sql = layer.compile(
@@ -108,6 +111,8 @@ def test_duplicate_column_names_get_prefixed():
 
     Fix: Detect collisions and prefix with model name (orders_id, customers_id).
     """
+    layer = SemanticLayer()
+
     orders = Model(
         name="orders",
         table="orders_table",
@@ -132,7 +137,6 @@ def test_duplicate_column_names_get_prefixed():
         ],
     )
 
-    layer = SemanticLayer()
     layer.add_model(orders)
     layer.add_model(customers)
 
@@ -163,6 +167,8 @@ def test_duplicate_column_names_get_prefixed():
 
 def test_no_prefix_when_no_collision():
     """Test that fields don't get prefixed when there's no collision."""
+    layer = SemanticLayer()
+
     orders = Model(
         name="orders",
         table="orders_table",
@@ -185,7 +191,6 @@ def test_no_prefix_when_no_collision():
         ],
     )
 
-    layer = SemanticLayer()
     layer.add_model(orders)
     layer.add_model(customers)
 
@@ -228,6 +233,8 @@ def test_query_method_accepts_parameters():
     Bug: Documentation showed parameters argument but method didn't accept it.
     Fix: Add parameters argument and forward to compile().
     """
+    layer = SemanticLayer()
+
     orders = Model(
         name="orders",
         table="orders_table",
@@ -250,7 +257,6 @@ def test_query_method_accepts_parameters():
     """)
     conn.execute("INSERT INTO orders_table VALUES (1, 'US', 100)")
 
-    layer = SemanticLayer()
     layer.conn = conn
     layer.add_model(orders)
 
@@ -267,6 +273,8 @@ def test_metric_level_filters_still_use_where():
     Metric.filters are row-level filters that should filter before aggregation.
     They're different from query-level filters on aggregated metrics.
     """
+    layer = SemanticLayer()
+
     orders = Model(
         name="orders",
         table="orders_table",
@@ -279,7 +287,6 @@ def test_metric_level_filters_still_use_where():
         ],
     )
 
-    layer = SemanticLayer()
     layer.add_model(orders)
 
     sql = layer.compile(metrics=["orders.completed_revenue"], dimensions=["orders.region"])
@@ -313,6 +320,8 @@ def test_end_to_end_with_real_data():
         (5, 103, 'US', 'cancelled', 25)
     """)
 
+    layer = SemanticLayer()
+
     orders = Model(
         name="orders",
         table="orders",
@@ -325,7 +334,6 @@ def test_end_to_end_with_real_data():
         ],
     )
 
-    layer = SemanticLayer()
     layer.conn = conn
     layer.add_model(orders)
 
@@ -335,11 +343,12 @@ def test_end_to_end_with_real_data():
         dimensions=["orders.region"],
         filters=["orders.revenue >= 200"],  # Should use HAVING
     ).fetchdf()
+    rows = df_rows(result)
 
     # Should only return regions with total revenue >= 200
     # US: 50+150+25 = 225, EU: 300+75 = 375
     # Both should be included
-    assert len(result) == 2
-    revenues = {row[0]: row[1] for row in result}
+    assert len(rows) == 2
+    revenues = {row[0]: row[1] for row in rows}
     assert revenues["US"] == 225.0
     assert revenues["EU"] == 375.0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import time
+from typing import Any, Tuple
+
+import pandas as pd
+
+
+def df_rows(df: pd.DataFrame) -> list[Tuple[Any, ...]]:
+    """Convert a pandas DataFrame into row tuples with Python primitives."""
+
+    def _normalize(value: Any) -> Any:
+        if value is None or pd.isna(value):
+            return None
+        if isinstance(value, pd.Timestamp):
+            if value.time() == time(0, 0):
+                return value.date()
+            return value.to_pydatetime()
+        if hasattr(value, "item"):
+            try:
+                return value.item()
+            except Exception:  # pragma: no cover - best effort fallback
+                return value
+        return value
+
+    rows: list[Tuple[Any, ...]] = []
+    for row in df.itertuples(index=False, name=None):
+        rows.append(tuple(_normalize(value) for value in row))
+    return rows


### PR DESCRIPTION
## Summary
- remove the DuckDB DataFrame wrapper and keep SemanticLayer query responses as plain DuckDB relations while restoring default auto-registration
- add a small `df_rows` helper for tests and update DataFrame-based assertions to operate on native pandas structures

## Testing
- pytest tests/test_with_data.py -q
- pytest tests/dates/test_time_comparison.py -q
- pytest tests/metrics/test_advanced.py -q
- pytest tests/test_critical_fixes.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e2e3f5f20c832686a1f7ffc869be23