### PR TITLE
Simplify tests to use DuckDB results directly

### DIFF
--- a/sidemantic/__init__.py
+++ b/sidemantic/__init__.py
@@ -10,7 +10,6 @@ from sidemantic.core.pre_aggregation import PreAggregation, RefreshKey, RefreshR
 from sidemantic.core.preagg_recommender import PreAggRecommendation, PreAggregationRecommender, QueryPattern
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.segment import Segment
-
 # Backwards compatibility alias
 Measure = Metric
 

--- a/tests/joins/test_multi_hop.py
+++ b/tests/joins/test_multi_hop.py
@@ -3,6 +3,7 @@
 import duckdb
 
 from sidemantic import Dimension, Metric, Model, Relationship, SemanticLayer
+from tests.utils import fetch_rows
 
 conn = duckdb.connect(":memory:")
 
@@ -106,7 +107,7 @@ result = sl.query(
 )
 
 print("Results (region_name, revenue):")
-for row in result.fetchdf():
+for row in fetch_rows(result):
     print(f"  {row}")
 print()
 

--- a/tests/joins/test_multi_hop_joins.py
+++ b/tests/joins/test_multi_hop_joins.py
@@ -8,6 +8,7 @@ import duckdb
 import pytest
 
 from sidemantic import Dimension, Metric, Model, Relationship, SemanticLayer
+from tests.utils import fetch_dicts
 
 
 @pytest.fixture
@@ -187,11 +188,11 @@ def test_query_execution(three_table_chain):
 
     # Execute multi-hop query
     result = layer.query(metrics=["orders.revenue"], dimensions=["regions.region_name"])
-    df = result.fetchdf()
+    records = fetch_dicts(result)
 
     # Should have 2 regions with correct revenue
-    assert len(df) == 2
-    revenues = {row["region_name"]: row["revenue"] for _, row in df.iterrows()}
+    assert len(records) == 2
+    revenues = {row["region_name"]: row["revenue"] for row in records}
     # North America: orders 1,3,4 (Alice:150+100, Charlie:300) = 550
     # Europe: order 2 (Bob:200) = 200
     assert revenues["North America"] == 550.0

--- a/tests/metrics/test_advanced.py
+++ b/tests/metrics/test_advanced.py
@@ -7,6 +7,7 @@ from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.sql.generator_v2 import SQLGenerator
+from tests.utils import df_rows
 
 
 def test_month_to_date_metric():
@@ -39,9 +40,10 @@ def test_month_to_date_metric():
     print(sql)
 
     conn = duckdb.connect(":memory:")
-    results = conn.execute(sql).fetchdf()
+    result = conn.execute(sql)
+    rows = df_rows(result)
 
-    print("Results:", results)
+    print("Results:", rows)
 
     # Check MTD resets at start of February
     # Results are (date, amount, mtd_revenue)
@@ -50,11 +52,11 @@ def test_month_to_date_metric():
     # Jan 15: amount=200, MTD=450 (100+150+200)
     # Feb 1: amount=50, MTD=50 (RESET!)
     # Feb 5: amount=75, MTD=125 (50+75)
-    assert results[0][2] == 100  # Jan 5 MTD
-    assert results[1][2] == 250  # Jan 10 MTD
-    assert results[2][2] == 450  # Jan 15 MTD
-    assert results[3][2] == 50  # Feb 1 MTD (reset!)
-    assert results[4][2] == 125  # Feb 5 MTD
+    assert rows[0][2] == 100  # Jan 5 MTD
+    assert rows[1][2] == 250  # Jan 10 MTD
+    assert rows[2][2] == 450  # Jan 15 MTD
+    assert rows[3][2] == 50  # Feb 1 MTD (reset!)
+    assert rows[4][2] == 125  # Feb 5 MTD
 
 
 def test_year_to_date_metric():
@@ -81,17 +83,18 @@ def test_year_to_date_metric():
     sql = generator.generate(metrics=["ytd_revenue"], dimensions=["sales.sale_date"])
 
     conn = duckdb.connect(":memory:")
-    results = conn.execute(sql).fetchdf()
+    result = conn.execute(sql)
+    rows = df_rows(result)
 
-    print("YTD Results:", results)
+    print("YTD Results:", rows)
 
     # YTD should reset at start of 2025
     # Results are (date, amount, ytd_revenue) - find by date
     import datetime
 
-    jan_2024 = [r for r in results if r[0] == datetime.date(2024, 1, 15)][0]
-    jun_2024 = [r for r in results if r[0] == datetime.date(2024, 6, 10)][0]
-    jan_2025 = [r for r in results if r[0] == datetime.date(2025, 1, 5)][0]
+    jan_2024 = [r for r in rows if r[0] == datetime.date(2024, 1, 15)][0]
+    jun_2024 = [r for r in rows if r[0] == datetime.date(2024, 6, 10)][0]
+    jan_2025 = [r for r in rows if r[0] == datetime.date(2025, 1, 5)][0]
 
     assert jan_2024[2] == 100  # 2024-01-15 YTD
     assert jun_2024[2] == 300  # 2024-06-10 YTD (100 + 200)
@@ -125,11 +128,12 @@ def test_fill_nulls_with_zero():
     print(sql)
 
     conn = duckdb.connect(":memory:")
-    results = conn.execute(sql).fetchdf()
+    result = conn.execute(sql)
+    rows = df_rows(result)
 
     # Should have 0 instead of NULL for pending
-    completed = [r for r in results if r[0] == "completed"][0]
-    pending = [r for r in results if r[0] == "pending"][0]
+    completed = [r for r in rows if r[0] == "completed"][0]
+    pending = [r for r in rows if r[0] == "pending"][0]
 
     assert completed[1] == 100
     assert pending[1] == 0  # Filled with 0 instead of NULL!
@@ -157,10 +161,11 @@ def test_fill_nulls_with_string():
     sql = generator.generate(dimensions=["products.name", "products.grade"])
 
     conn = duckdb.connect(":memory:")
-    results = conn.execute(sql).fetchdf()
+    result = conn.execute(sql)
+    rows = df_rows(result)
 
     # Without fill_nulls, grade is NULL
-    gadget = [r for r in results if r[0] == "Gadget"][0]
+    gadget = [r for r in rows if r[0] == "Gadget"][0]
     assert gadget[1] is None
 
 
@@ -200,19 +205,20 @@ def test_offset_ratio_metric():
     print(sql)
 
     conn = duckdb.connect(":memory:")
-    results = conn.execute(sql).fetchdf()
+    result = conn.execute(sql)
+    rows = df_rows(result)
 
-    print("Results:", results)
+    print("Results:", rows)
 
     # Results are (month, revenue, mom_growth)
     # First month has no prior data (NULL)
     # Feb: 150 / 100 = 1.5
     # Mar: 200 / 150 = 1.333...
     # Apr: 180 / 200 = 0.9
-    assert results[0][2] is None  # Jan (no prior)
-    assert abs(results[1][2] - 1.5) < 0.01  # Feb
-    assert abs(results[2][2] - 1.333) < 0.01  # Mar
-    assert abs(results[3][2] - 0.9) < 0.01  # Apr
+    assert rows[0][2] is None  # Jan (no prior)
+    assert abs(rows[1][2] - 1.5) < 0.01  # Feb
+    assert abs(rows[2][2] - 1.333) < 0.01  # Mar
+    assert abs(rows[3][2] - 0.9) < 0.01  # Apr
 
 
 def test_conversion_metric():
@@ -258,15 +264,16 @@ def test_conversion_metric():
     print(sql)
 
     conn = duckdb.connect(":memory:")
-    results = conn.execute(sql).fetchdf()
+    result = conn.execute(sql)
+    rows = df_rows(result)
 
-    print("Results:", results)
+    print("Results:", rows)
 
     # User 1: signup on 01-01, purchase on 01-03 (2 days) - CONVERTED
     # User 2: signup on 01-05, purchase on 01-20 (15 days) - NOT CONVERTED (>7 days)
     # User 3: signup on 01-10, no purchase - NOT CONVERTED
     # Conversion rate: 1/3 = 0.333...
-    assert abs(results[0][0] - 0.333) < 0.01
+    assert abs(rows[0][0] - 0.333) < 0.01
 
 
 def test_yoy_percent_change():
@@ -324,12 +331,13 @@ def test_yoy_percent_change():
     print(sql)
 
     conn = duckdb.connect(":memory:")
-    results = conn.execute(sql).fetchdf()
+    result = conn.execute(sql)
+    rows = df_rows(result)
 
-    print("YoY Results:", results)
+    print("YoY Results:", rows)
 
     # Find 2024 results (dates are datetime objects after month truncation)
-    results_2024 = [r for r in results if r[0].year == 2024]
+    results_2024 = [r for r in rows if r[0].year == 2024]
     assert len(results_2024) == 3
 
     # Check YoY percent changes
@@ -377,9 +385,10 @@ def test_mom_difference():
     print(sql)
 
     conn = duckdb.connect(":memory:")
-    results = conn.execute(sql).fetchdf()
+    result = conn.execute(sql)
+    rows = df_rows(result)
 
-    print("MoM Results:", results)
+    print("MoM Results:", rows)
 
     # Results should be:
     # 2024-01: NULL (no prior month)
@@ -387,10 +396,10 @@ def test_mom_difference():
     # 2024-03: 120 - 150 = -30
     # 2024-04: 180 - 120 = 60
 
-    assert results[0][2] is None  # Jan (no prior)
-    assert results[1][2] == 50  # Feb
-    assert results[2][2] == -30  # Mar
-    assert results[3][2] == 60  # Apr
+    assert rows[0][2] is None  # Jan (no prior)
+    assert rows[1][2] == 50  # Feb
+    assert rows[2][2] == -30  # Mar
+    assert rows[3][2] == 60  # Apr
 
 
 def test_wow_ratio():
@@ -429,9 +438,10 @@ def test_wow_ratio():
     print(sql)
 
     conn = duckdb.connect(":memory:")
-    results = conn.execute(sql).fetchdf()
+    result = conn.execute(sql)
+    rows = df_rows(result)
 
-    print("WoW Results:", results)
+    print("WoW Results:", rows)
 
     # Results should be (with week granularity, LAG offset = 1):
     # Week 1 (2024-01-01): NULL (no prior week)
@@ -439,7 +449,7 @@ def test_wow_ratio():
     # Week 3 (2024-01-15): 120/150 = 0.8
     # Week 4 (2024-01-22): 180/120 = 1.5
 
-    assert results[0][2] is None  # Week 1 (no prior)
-    assert abs(results[1][2] - 1.5) < 0.01  # Week 2
-    assert abs(results[2][2] - 0.8) < 0.01  # Week 3
-    assert abs(results[3][2] - 1.5) < 0.01  # Week 4
+    assert rows[0][2] is None  # Week 1 (no prior)
+    assert abs(rows[1][2] - 1.5) < 0.01  # Week 2
+    assert abs(rows[2][2] - 0.8) < 0.01  # Week 3
+    assert abs(rows[3][2] - 1.5) < 0.01  # Week 4

--- a/tests/metrics/test_cross_model.py
+++ b/tests/metrics/test_cross_model.py
@@ -3,6 +3,7 @@
 import duckdb
 
 from sidemantic import Dimension, Metric, Model, Relationship, SemanticLayer
+from tests.utils import fetch_rows
 
 # Create test data
 conn = duckdb.connect(":memory:")
@@ -97,7 +98,7 @@ result = sl.query(
 )
 
 print("Results:")
-for row in result.fetchdf():
+for row in fetch_rows(result):
     print(f"  {row}")
 print()
 
@@ -133,7 +134,7 @@ result = sl.query(
 )
 
 print("Results (region, revenue, customers, revenue_per_customer):")
-for row in result.fetchdf():
+for row in fetch_rows(result):
     print(f"  {row}")
 print()
 

--- a/tests/metrics/test_symmetric_aggs.py
+++ b/tests/metrics/test_symmetric_aggs.py
@@ -6,6 +6,7 @@ from sidemantic.core.model import Dimension, Metric, Model, Relationship
 from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.core.symmetric_aggregate import build_symmetric_aggregate_sql
 from sidemantic.sql.generator_v2 import SQLGenerator
+from tests.utils import fetch_rows
 
 
 def test_build_symmetric_aggregate_sum():
@@ -294,7 +295,8 @@ def test_symmetric_aggregates_with_data():
     )
 
     # Execute query
-    result = conn.execute(sql).fetchdf()
+    result = conn.execute(sql)
+    rows = fetch_rows(result)
 
     # Without symmetric aggregates:
     # Order 1: revenue would be 100*2*2 = 400 (wrong!)
@@ -304,8 +306,8 @@ def test_symmetric_aggregates_with_data():
     # Order 1: revenue = 100 (correct)
     # Order 2: revenue = 200 (correct)
 
-    assert len(result) == 2
-    revenues = sorted([row[1] for row in result])
+    assert len(rows) == 2
+    revenues = sorted(row[1] for row in rows)
     assert revenues == [100, 200]  # Correct totals, not inflated
 
     conn.close()

--- a/tests/queries/test_view_generation.py
+++ b/tests/queries/test_view_generation.py
@@ -7,6 +7,7 @@ from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.sql.generator_v2 import SQLGenerator
+from tests.utils import fetch_rows
 
 
 def test_generate_view_creates_valid_sql():
@@ -71,10 +72,11 @@ def test_view_can_be_queried():
     conn.execute(view_sql)
 
     # Query the view
-    result = conn.execute("SELECT * FROM revenue_by_status").fetchdf()
+    result = conn.execute("SELECT * FROM revenue_by_status")
+    rows = fetch_rows(result)
 
-    assert len(result) == 1
-    assert result[0][1] == 300  # total revenue
+    assert len(rows) == 1
+    assert rows[0][1] == 300  # total revenue
 
 
 def test_join_view_against_other_tables():
@@ -123,10 +125,11 @@ def test_join_view_against_other_tables():
         FROM sales s
         JOIN product_metrics pm ON s.product_name = pm.name
         ORDER BY revenue DESC
-    """).fetchdf()
+    """)
+    rows = fetch_rows(result)
 
-    assert len(result) == 2
+    assert len(rows) == 2
     # Both have same revenue (100 * 10 = 1000, 50 * 20 = 1000)
     # Just verify the join worked correctly
-    assert result[0][2] in (10, 20)  # avg_price exists
-    assert result[1][2] in (10, 20)  # avg_price exists
+    assert rows[0][2] in (10, 20)  # avg_price exists
+    assert rows[1][2] in (10, 20)  # avg_price exists

--- a/tests/templates/test_parameters.py
+++ b/tests/templates/test_parameters.py
@@ -7,6 +7,7 @@ from sidemantic.core.model import Dimension, Metric, Model
 from sidemantic.core.parameter import Parameter, ParameterSet
 from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.sql.generator_v2 import SQLGenerator
+from tests.utils import fetch_rows
 
 
 def test_parameter_string_type():
@@ -347,11 +348,12 @@ def test_parameters_with_actual_data():
     )
 
     # Execute query
-    result = conn.execute(sql).fetchdf()
+    result = conn.execute(sql)
+    rows = fetch_rows(result)
 
     # Should only get completed orders (2 rows: 200 and 300)
-    assert len(result) == 2
-    assert sum(row[1] for row in result) == 500  # Total revenue
+    assert len(rows) == 2
+    assert sum(row[1] for row in rows) == 500  # Total revenue
 
     conn.close()
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -13,6 +13,7 @@ from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_layer import SemanticLayer
+from tests.utils import fetch_rows
 
 
 @pytest.fixture
@@ -233,7 +234,7 @@ def test_end_to_end_execution_performance(performance_layer):
 
     for _ in range(iterations):
         result = performance_layer.sql(sql)
-        result.fetchdf()
+        fetch_rows(result)
 
     elapsed = time.perf_counter() - start
     avg_ms = (elapsed / iterations) * 1000

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Sequence
+
+
+def _normalize(value: Any) -> Any:
+    """Best-effort conversion of DuckDB result values into Python primitives."""
+
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, memoryview):
+        return value.tobytes()
+    return value
+
+
+def _column_names(result: Any) -> list[str]:
+    if hasattr(result, "columns"):
+        columns = getattr(result, "columns")
+        if isinstance(columns, Sequence):
+            return list(columns)
+    if hasattr(result, "description") and result.description:
+        return [col[0] for col in result.description]
+    raise AttributeError("Result object does not expose column metadata")
+
+
+def fetch_rows(result: Any) -> list[tuple[Any, ...]]:
+    """Return query results as Python tuples with normalized values."""
+
+    rows = result.fetchall()
+    return [tuple(_normalize(value) for value in row) for row in rows]
+
+
+def fetch_dicts(result: Any) -> list[dict[str, Any]]:
+    """Return query results as dictionaries keyed by column name."""
+
+    columns = _column_names(result)
+    return [dict(zip(columns, row)) for row in fetch_rows(result)]
+
+
+def df_rows(result: Any) -> list[tuple[Any, ...]]:
+    """Backwards compatible alias for historical helper name."""
+
+    return fetch_rows(result)
+
+
+def fetch_columns(result: Any) -> list[str]:
+    """Return the column names for a query result."""
+
+    return _column_names(result)


### PR DESCRIPTION
## Summary
- replace the pandas-dependent df_rows helper with duckdb result helpers that expose tuples, dicts, and column names
- rewrite representative test suites to consume fetch_rows/fetch_dicts so they no longer call fetchdf or rely on pandas-specific APIs
- adjust performance tests to execute queries via the new helpers while keeping existing assertions intact

## Testing
- pytest tests/test_with_data.py tests/dates/test_time_comparison.py tests/metrics/test_advanced.py tests/queries/test_sql_rewriter.py -q *(fails: missing sqlglot dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e3f5f20c832686a1f7ffc869be23