### PR TITLE
Fix Ruff lint violations and clean up examples

### DIFF
--- a/examples/comprehensive_demo.py
+++ b/examples/comprehensive_demo.py
@@ -29,14 +29,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import duckdb
-from sidemantic.core.relationship import Relationship
-from sidemantic.core.metric import Metric
-from sidemantic.sql.rewriter import SemanticSQLRewriter
 
 from sidemantic.core.dimension import Dimension
+from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
+from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.sql.generator_v2 import SQLGenerator
+from sidemantic.sql.rewriter import SemanticSQLRewriter
 
 
 def print_section(title: str):

--- a/examples/parameters_example.py
+++ b/examples/parameters_example.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Example demonstrating parameters (dynamic user input)."""
 
-# Entity removed - use primary_key parameter
-from sidemantic.core.metric import Metric
-
+# Entities have been replaced by primary_key configuration on models
 from sidemantic.core.dimension import Dimension
+from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.parameter import Parameter
 from sidemantic.core.semantic_graph import SemanticGraph
@@ -40,7 +39,6 @@ orders = Model(
     name="orders",
     table="orders",
     primary_key="id",
-    entities=[Entity(name="order_id", type="primary", sql="id")],
     dimensions=[
         Dimension(name="order_date", type="time", sql="order_date"),
         Dimension(name="status", type="categorical", sql="status"),

--- a/examples/sql_query_example.py
+++ b/examples/sql_query_example.py
@@ -4,11 +4,10 @@ This shows how users can write familiar SQL queries that get automatically
 rewritten to use the semantic layer's metrics and dimensions.
 """
 
-from sidemantic.core.relationship import Relationship
-from sidemantic.core.metric import Metric
-
 from sidemantic.core.dimension import Dimension
+from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
+from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_layer import SemanticLayer
 
 

--- a/examples/streamlit_dashboard.py
+++ b/examples/streamlit_dashboard.py
@@ -19,13 +19,12 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
-# Entity removed - use primary_key parameter
-from sidemantic.core.relationship import Relationship
-from sidemantic.core.metric import Metric
 
 from sidemantic.core.dimension import Dimension
+from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.parameter import Parameter
+from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.sql.generator_v2 import SQLGenerator
 
@@ -156,11 +155,8 @@ def setup_semantic_layer():
         name="orders",
         table="orders",
         primary_key="id",
-        entities=[
-            Entity(name="order_id", type="primary", sql="id"),
-            Entity(name="customer_id", type="foreign", sql="customer_id"),
-        ],
         dimensions=[
+            Dimension(name="customer_id", type="numeric", sql="customer_id"),
             Dimension(name="order_date", type="time", sql="order_date"),
             Dimension(name="status", type="categorical", sql="status"),
         ],
@@ -180,7 +176,6 @@ def setup_semantic_layer():
         name="customers",
         table="customers",
         primary_key="id",
-        entities=[Entity(name="customer_id", type="primary", sql="id")],
         dimensions=[
             Dimension(name="name", type="categorical", sql="name"),
             Dimension(name="region", type="categorical", sql="region"),
@@ -194,7 +189,6 @@ def setup_semantic_layer():
         name="order_items",
         table="order_items",
         primary_key="id",
-        entities=[Entity(name="item_id", type="primary", sql="id")],
         dimensions=[Dimension(name="product_id", type="numeric", sql="product_id")],
         metrics=[
             Metric(name="total_quantity", agg="sum", sql="quantity"),

--- a/examples/symmetric_aggregates_example.py
+++ b/examples/symmetric_aggregates_example.py
@@ -11,12 +11,11 @@ to multiple "many" side tables, creating a fan-out effect.
 """
 
 import duckdb
-# Entity removed - use primary_key parameter
-from sidemantic.core.relationship import Relationship
-from sidemantic.core.metric import Metric
 
 from sidemantic.core.dimension import Dimension
+from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
+from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.sql.generator_v2 import SQLGenerator
 
@@ -76,8 +75,10 @@ orders = Model(
     name="orders",
     table="orders",
     primary_key="id",
-    entities=[Entity(name="order_id", type="primary", sql="id")],
-    dimensions=[Dimension(name="order_date", type="time", sql="order_date")],
+    dimensions=[
+        Dimension(name="order_id", type="numeric", sql="id"),
+        Dimension(name="order_date", type="time", sql="order_date"),
+    ],
     metrics=[Metric(name="revenue", agg="sum", sql="amount")],
     relationships=[
         Relationship(name="order_items", type="one_to_many", foreign_key="order_id"),
@@ -90,8 +91,9 @@ order_items = Model(
     name="order_items",
     table="order_items",
     primary_key="id",
-    entities=[Entity(name="item_id", type="primary", sql="id")],
-    dimensions=[],
+    dimensions=[
+        Dimension(name="item_id", type="numeric", sql="id"),
+    ],
     metrics=[Metric(name="total_quantity", agg="sum", sql="quantity")],
     relationships=[Relationship(name="orders", type="many_to_one", foreign_key="order_id")],
 )
@@ -101,8 +103,9 @@ shipments = Model(
     name="shipments",
     table="shipments",
     primary_key="id",
-    entities=[Entity(name="shipment_id", type="primary", sql="id")],
-    dimensions=[],
+    dimensions=[
+        Dimension(name="shipment_id", type="numeric", sql="id"),
+    ],
     metrics=[Metric(name="shipment_count", agg="count", sql="*")],
     relationships=[Relationship(name="orders", type="many_to_one", foreign_key="order_id")],
 )

--- a/sidemantic/__init__.py
+++ b/sidemantic/__init__.py
@@ -10,6 +10,7 @@ from sidemantic.core.pre_aggregation import PreAggregation, RefreshKey, RefreshR
 from sidemantic.core.preagg_recommender import PreAggRecommendation, PreAggregationRecommender, QueryPattern
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.segment import Segment
+
 # Backwards compatibility alias
 Measure = Metric
 

--- a/sidemantic/adapters/rill.py
+++ b/sidemantic/adapters/rill.py
@@ -178,7 +178,7 @@ class RillAdapter:
             parsed = sqlglot.parse_one(expression, read="duckdb")
 
             # Check if this is a simple aggregation function
-            if isinstance(parsed, (exp.Sum, exp.Avg, exp.Count, exp.Min, exp.Max)):
+            if isinstance(parsed, exp.Sum | exp.Avg | exp.Count | exp.Min | exp.Max):
                 # Map sqlglot aggregation types to Sidemantic agg types
                 if isinstance(parsed, exp.Sum):
                     agg_type = "sum"

--- a/sidemantic/core/parameter.py
+++ b/sidemantic/core/parameter.py
@@ -7,7 +7,6 @@ Parameters will be removed in a future version.
 """
 
 import warnings
-
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
@@ -71,7 +70,7 @@ class Parameter(BaseModel):
             return f"'{value}'"
         elif self.type == "number":
             # Validate that value is actually numeric to prevent SQL injection
-            if isinstance(value, (int, float)):
+            if isinstance(value, int | float):
                 return str(value)
             elif isinstance(value, str):
                 # Try to parse as float to ensure it's valid

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -10,6 +10,8 @@ from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.sql.generator_v2 import SQLGenerator
+
+
 class SemanticLayer:
     """Main semantic layer interface.
 
@@ -304,7 +306,7 @@ class SemanticLayer:
         return get_catalog_metadata(self.graph, schema=schema)
 
     @classmethod
-    def from_yaml(cls, path: str | Path, connection: str = "duckdb:///:memory:") -> "SemanticLayer":
+    def from_yaml(cls, path: str | Path, connection: str = "duckdb:///:memory:") -> SemanticLayer:
         """Load semantic layer from native YAML file.
 
         Args:

--- a/sidemantic/sql/query_rewriter.py
+++ b/sidemantic/sql/query_rewriter.py
@@ -278,7 +278,7 @@ class QueryRewriter:
         where = select.args["where"].this
 
         # Handle compound conditions (AND/OR)
-        if isinstance(where, (exp.And, exp.Or)):
+        if isinstance(where, exp.And | exp.Or):
             return self._extract_compound_filters(where)
 
         # Single condition
@@ -298,7 +298,7 @@ class QueryRewriter:
         if isinstance(condition, exp.And):
             # Split AND into separate filters
             for expr in [condition.left, condition.right]:
-                if isinstance(expr, (exp.And, exp.Or)):
+                if isinstance(expr, exp.And | exp.Or):
                     filters.extend(self._extract_compound_filters(expr))
                 else:
                     filters.append(expr.sql(dialect=self.dialect))

--- a/tests/dates/test_time_comparison.py
+++ b/tests/dates/test_time_comparison.py
@@ -1,7 +1,8 @@
 """Test that time_comparison metrics defined in model.metrics are auto-registered at graph level."""
 
-import duckdb
 import math
+
+import duckdb
 
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.metric import Metric

--- a/tests/test_critical_fixes.py
+++ b/tests/test_critical_fixes.py
@@ -1,7 +1,6 @@
 """Tests for critical production bug fixes."""
 
 import duckdb
-import pytest
 
 from sidemantic import Dimension, Metric, Model, Relationship, SemanticLayer
 from tests.utils import df_rows
@@ -158,8 +157,8 @@ def test_duplicate_column_names_get_prefixed():
         final_select = sql[final_select_start:]
         # Get lines with aliases in the final SELECT
         lines = final_select.split("\n")
-        select_lines = [l for l in lines if " AS " in l and not l.strip().startswith("--")]
-        aliases = [l.split(" AS ")[-1].strip().rstrip(",") for l in select_lines]
+        select_lines = [line for line in lines if " AS " in line and not line.strip().startswith("--")]
+        aliases = [line.split(" AS ")[-1].strip().rstrip(",") for line in select_lines]
 
         # Check for duplicates in final SELECT
         assert len(aliases) == len(set(aliases)), f"Duplicate column aliases in final SELECT: {aliases}"

--- a/tests/test_metric_auto_registration.py
+++ b/tests/test_metric_auto_registration.py
@@ -1,7 +1,5 @@
 """Tests for metric auto-registration."""
 
-import pytest
-
 from sidemantic import Dimension, Metric, Model, SemanticLayer
 
 
@@ -25,7 +23,7 @@ def test_standalone_metric_auto_registers_with_auto_register_param():
     layer = SemanticLayer(auto_register=True)
 
     # First create the model that the metric depends on
-    orders = Model(
+    Model(
         name="orders",
         table="orders_table",
         primary_key="id",
@@ -37,7 +35,7 @@ def test_standalone_metric_auto_registers_with_auto_register_param():
     )
 
     # Now create a standalone ratio metric - should auto-register
-    margin_pct = Metric(
+    Metric(
         name="margin_pct",
         type="ratio",
         numerator="orders.profit",
@@ -52,7 +50,7 @@ def test_model_metrics_dont_auto_register():
     """Test that model-level metrics don't auto-register at graph level."""
     with SemanticLayer() as layer:
         # Create model with metrics - simple aggregations should not auto-register at graph level
-        orders = Model(
+        Model(
             name="orders",
             table="orders_table",
             primary_key="id",
@@ -88,7 +86,7 @@ def test_no_auto_register_without_context():
 def test_time_comparison_metrics_auto_register():
     """Test that time_comparison metrics in models auto-register at graph level."""
     with SemanticLayer() as layer:
-        orders = Model(
+        Model(
             name="orders",
             table="orders_table",
             primary_key="id",
@@ -106,7 +104,7 @@ def test_time_comparison_metrics_auto_register():
 def test_conversion_metrics_auto_register():
     """Test that conversion metrics in models auto-register at graph level."""
     with SemanticLayer() as layer:
-        events = Model(
+        Model(
             name="events",
             table="events_table",
             primary_key="id",

--- a/tests/test_sql_generation_security.py
+++ b/tests/test_sql_generation_security.py
@@ -6,8 +6,8 @@ These should have been included in the original commit but weren't.
 import pytest
 
 from sidemantic import Dimension, Metric, Model, SemanticLayer
-from sidemantic.sql.table_calc_processor import TableCalculationProcessor
 from sidemantic.core.table_calculation import TableCalculation
+from sidemantic.sql.table_calc_processor import TableCalculationProcessor
 
 
 def test_count_without_sql_generates_valid_cte():
@@ -210,7 +210,6 @@ def test_end_to_end_duckdb_coverage():
     Fix: Implemented real tests with data verification.
     """
     # This is tested in test_with_data.py - just verify that file has real tests
-    import importlib.util
     import os
 
     test_file = os.path.join(os.path.dirname(__file__), "test_with_data.py")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from decimal import Decimal
-from typing import Any, Sequence
+from typing import Any
 
 
 def _normalize(value: Any) -> Any:


### PR DESCRIPTION
## Summary
- organize imports across examples, tests, and package modules to satisfy Ruff
- remove deprecated `Entity` usage from examples in favor of primary key metadata
- update type checks and helper code to align with Python 3.11 typing expectations

## Testing
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68e2f969d08883268864aa0f3793626a