### PR TITLE
Fix BigQuery DATE_TRUNC syntax using sqlglot dialect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,28 @@ jobs:
       - name: Run tests
         run: uv run pytest -v --cov=sidemantic --cov-report=term-missing
 
+  check-rust-changes:
+    name: Check Rust/DuckDB changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust_changed: ${{ steps.changes.outputs.rust }}
+      duckdb_changed: ${{ steps.changes.outputs.duckdb }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            rust:
+              - 'sidemantic-rs/**'
+            duckdb:
+              - 'sidemantic-duckdb/**'
+              - 'sidemantic-rs/**'
+
   rust:
     name: Rust (sidemantic-rs)
+    needs: check-rust-changes
+    if: needs.check-rust-changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -75,6 +95,8 @@ jobs:
 
   duckdb-extension:
     name: DuckDB Extension
+    needs: check-rust-changes
+    if: needs.check-rust-changes.outputs.duckdb_changed == 'true'
     runs-on: ubuntu-latest
     env:
       GEN: ninja

--- a/tests/optimizations/test_pre_aggregations.py
+++ b/tests/optimizations/test_pre_aggregations.py
@@ -445,7 +445,7 @@ def test_preagg_granularity_conversion(layer):
 
     # Should use pre-aggregation and convert granularity
     assert "orders_preagg_daily" in sql
-    assert "DATE_TRUNC('month'" in sql
+    assert "DATE_TRUNC('month'" in sql or "DATE_TRUNC('MONTH'" in sql
 
 
 def test_preagg_disabled_by_default(layer):


### PR DESCRIPTION
## Summary

- Use sqlglot's `exp.DateTrunc` for dialect-aware DATE_TRUNC generation in SQLGenerator
- Add dialect parameter to `RelativeDateRange.parse()` and `to_range()` methods
- BigQuery: `DATE_TRUNC(column, MONTH)`
- PostgreSQL/DuckDB: `DATE_TRUNC('month', column)`

## Changes

- Add `_date_trunc()` helper method to SQLGenerator
- Replace hardcoded DATE_TRUNC strings in CTE builder, window functions, and pre-aggregation rollups
- Update RelativeDateRange to generate dialect-specific DATE_TRUNC
- Generator passes dialect to RelativeDateRange calls
- CI: Skip Rust/DuckDB extension jobs when those files haven't changed