### PR TITLE
Move default_time_dimension from Metric to Model

### DIFF
--- a/docs/advanced-features.qmd
+++ b/docs/advanced-features.qmd
@@ -254,15 +254,30 @@ metrics:
     non_additive_dimension: "date"  # Don't sum averages across time!
 ```
 
-### Default Dimensions
+### Default Time Dimension
 
-Specify default time dimension and granularity:
+Specify default time dimension and granularity at the model level. When querying metrics from this model without explicitly selecting a time dimension, the default will be auto-included:
 
 ```yaml
-metrics:
-  - name: daily_revenue
-    agg: sum
-    sql: amount
+models:
+  - name: orders
+    table: orders_table
     default_time_dimension: "order_date"
-    default_grain: "day"
+    default_grain: "month"
+    dimensions:
+      - name: order_date
+        type: time
+        granularity: day
+    metrics:
+      - name: revenue
+        agg: sum
+        sql: amount
+```
+
+```python
+# Auto-includes orders.order_date__month
+layer.compile(metrics=["orders.revenue"])
+
+# Override with different granularity
+layer.compile(metrics=["orders.revenue"], dimensions=["orders.order_date__week"])
 ```

--- a/docs/models.qmd
+++ b/docs/models.qmd
@@ -58,6 +58,8 @@ orders = Model(
 - **relationships**: Relationships to other models (see [Relationships](relationships.qmd))
 - **dimensions**: Attributes for grouping and filtering
 - **metrics**: Model-level aggregations
+- **default_time_dimension**: Default time dimension to auto-include in queries
+- **default_grain**: Default granularity for the time dimension (`hour`, `day`, `week`, `month`, `quarter`, `year`)
 
 ## Dimensions
 

--- a/docs/python-api.qmd
+++ b/docs/python-api.qmd
@@ -331,8 +331,6 @@ formatted_revenue = Metric(
     value_format_name="usd",
     drill_fields=["order_id", "customer_id", "order_date"],
     non_additive_dimension="customer_id",
-    default_time_dimension="order_date",
-    default_grain="day"
 )
 
 # With inheritance
@@ -386,8 +384,6 @@ extended_revenue = Metric(
 - **value_format_name**: Named format (e.g., `"usd"`, `"percent"`)
 - **drill_fields**: List of field names for drill-down
 - **non_additive_dimension**: Dimension this metric cannot be summed across
-- **default_time_dimension**: Default time dimension for this metric
-- **default_grain**: Default time granularity (`hour`, `day`, `week`, `month`, `quarter`, `year`)
 
 #### Inheritance
 

--- a/sidemantic/adapters/omni.py
+++ b/sidemantic/adapters/omni.py
@@ -533,9 +533,8 @@ class OmniAdapter(BaseAdapter):
                 time_offset = metric.time_offset or self._comparison_type_to_offset(metric.comparison_type)
 
                 # Find the time dimension to apply the offset to
-                # Typically this would be the model's default time dimension
-                # For now, use a generic name - user may need to adjust
-                time_field = metric.default_time_dimension or "created_at"
+                # Use the model's default time dimension
+                time_field = model.default_time_dimension or "created_at"
 
                 measure_def["filters"] = {
                     time_field: {

--- a/sidemantic/adapters/sidemantic.py
+++ b/sidemantic/adapters/sidemantic.py
@@ -249,8 +249,6 @@ class SidemanticAdapter(BaseAdapter):
                 value_format_name=measure_def.get("value_format_name"),
                 drill_fields=measure_def.get("drill_fields"),
                 non_additive_dimension=measure_def.get("non_additive_dimension"),
-                default_time_dimension=measure_def.get("default_time_dimension"),
-                default_grain=measure_def.get("default_grain"),
             )
             measures.append(measure)
 
@@ -313,6 +311,8 @@ class SidemanticAdapter(BaseAdapter):
             metrics=measures,
             segments=segments,
             pre_aggregations=pre_aggregations,
+            default_time_dimension=model_def.get("default_time_dimension"),
+            default_grain=model_def.get("default_grain"),
         )
 
     def _parse_metric(self, metric_def: dict) -> Metric | None:
@@ -424,11 +424,13 @@ class SidemanticAdapter(BaseAdapter):
                     measure_def["drill_fields"] = measure.drill_fields
                 if measure.non_additive_dimension:
                     measure_def["non_additive_dimension"] = measure.non_additive_dimension
-                if measure.default_time_dimension:
-                    measure_def["default_time_dimension"] = measure.default_time_dimension
-                if measure.default_grain:
-                    measure_def["default_grain"] = measure.default_grain
                 result["metrics"].append(measure_def)
+
+        # Export model-level default_time_dimension
+        if model.default_time_dimension:
+            result["default_time_dimension"] = model.default_time_dimension
+        if model.default_grain:
+            result["default_grain"] = model.default_grain
 
         # Export segments
         if model.segments:

--- a/sidemantic/core/metric.py
+++ b/sidemantic/core/metric.py
@@ -144,12 +144,6 @@ class Metric(BaseModel):
         description="Dimension across which this metric cannot be summed (e.g., time for averages)",
     )
 
-    # Defaults
-    default_time_dimension: str | None = Field(None, description="Default time dimension for this metric")
-    default_grain: Literal["hour", "day", "week", "month", "quarter", "year"] | None = Field(
-        None, description="Default time granularity for this metric"
-    )
-
     def __hash__(self) -> int:
         return hash((self.name, self.agg, self.sql))
 

--- a/sidemantic/core/model.py
+++ b/sidemantic/core/model.py
@@ -1,5 +1,7 @@
 """Model definitions."""
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 from sidemantic.core.dimension import Dimension
@@ -33,6 +35,14 @@ class Model(BaseModel):
     segments: list[Segment] = Field(default_factory=list, description="Segment (named filter) definitions")
     pre_aggregations: list[PreAggregation] = Field(
         default_factory=list, description="Pre-aggregation definitions for query optimization"
+    )
+
+    # Default time dimension for all metrics in this model
+    default_time_dimension: str | None = Field(
+        None, description="Default time dimension for metrics (auto-included in queries)"
+    )
+    default_grain: Literal["hour", "day", "week", "month", "quarter", "year"] | None = Field(
+        None, description="Default time granularity when using default_time_dimension"
     )
 
     def __init__(self, **data):

--- a/tests/adapters/test_metadata_adapter_roundtrip.py
+++ b/tests/adapters/test_metadata_adapter_roundtrip.py
@@ -16,6 +16,8 @@ def test_metadata_roundtrip_sidemantic_adapter():
         table="orders_table",
         primary_key="order_id",
         description="Order data",
+        default_time_dimension="created_at",
+        default_grain="day",
         dimensions=[
             Dimension(
                 name="status",
@@ -44,8 +46,6 @@ def test_metadata_roundtrip_sidemantic_adapter():
                 format="$#,##0.00",
                 value_format_name="usd",
                 drill_fields=["status", "customer_id"],
-                default_time_dimension="created_at",
-                default_grain="day",
             ),
             Metric(
                 name="avg_order_value",
@@ -119,8 +119,10 @@ def test_metadata_roundtrip_sidemantic_adapter():
     assert revenue.format == "$#,##0.00"
     assert revenue.value_format_name == "usd"
     assert revenue.drill_fields == ["status", "customer_id"]
-    assert revenue.default_time_dimension == "created_at"
-    assert revenue.default_grain == "day"
+
+    # Verify model-level default_time_dimension
+    assert imported.default_time_dimension == "created_at"
+    assert imported.default_grain == "day"
 
     avg_value = imported.get_metric("avg_order_value")
     assert avg_value is not None
@@ -219,7 +221,10 @@ def test_empty_metadata_roundtrip():
     user_count = imported.get_metric("user_count")
     assert user_count.format is None
     assert user_count.drill_fields is None
-    assert user_count.default_grain is None
+
+    # default_time_dimension is now on model, not metric
+    assert imported.default_time_dimension is None
+    assert imported.default_grain is None
 
     status = imported.get_dimension("status")
     assert status.format is None

--- a/tests/core/test_sql_definitions.py
+++ b/tests/core/test_sql_definitions.py
@@ -61,9 +61,7 @@ def test_parse_metric_all_fields():
         format '$#,##0.00',
         filters status = 'completed',
         fill_nulls_with 0,
-        non_additive_dimension time,
-        default_time_dimension order_date,
-        default_grain day
+        non_additive_dimension time
     );
     """
 
@@ -79,8 +77,6 @@ def test_parse_metric_all_fields():
     assert metric.filters == ["status = 'completed'"]
     assert metric.fill_nulls_with == 0
     assert metric.non_additive_dimension == "time"
-    assert metric.default_time_dimension == "order_date"
-    assert metric.default_grain == "day"
 
 
 def test_parse_ratio_metric():

--- a/tests/metrics/test_default_time_dimension.py
+++ b/tests/metrics/test_default_time_dimension.py
@@ -1,0 +1,201 @@
+"""Test default_time_dimension auto-inclusion from Model."""
+
+from sidemantic import Dimension, Metric, Model
+
+
+def test_default_time_dimension_auto_included(layer):
+    """Test that model's default_time_dimension is auto-included when not specified."""
+    orders = Model(
+        name="orders",
+        table="orders_table",
+        primary_key="order_id",
+        default_time_dimension="order_date",
+        dimensions=[
+            Dimension(name="order_date", type="time", granularity="day"),
+            Dimension(name="status", type="categorical"),
+        ],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+        ],
+    )
+
+    layer.add_model(orders)
+
+    # Query without specifying time dimension
+    sql = layer.compile(metrics=["orders.revenue"])
+
+    print("SQL with auto-included time dimension:")
+    print(sql)
+
+    # Should include order_date in the query
+    assert "order_date" in sql
+    # Should be in GROUP BY
+    assert "GROUP BY" in sql
+
+
+def test_default_time_dimension_with_grain(layer):
+    """Test that default_grain is applied to auto-included time dimension."""
+    orders = Model(
+        name="orders",
+        table="orders_table",
+        primary_key="order_id",
+        default_time_dimension="order_date",
+        default_grain="month",
+        dimensions=[
+            Dimension(name="order_date", type="time", granularity="day"),
+        ],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+        ],
+    )
+
+    layer.add_model(orders)
+
+    sql = layer.compile(metrics=["orders.revenue"])
+
+    print("SQL with default grain:")
+    print(sql)
+
+    # Should include order_date__month
+    assert "order_date__month" in sql
+
+
+def test_default_time_dimension_override(layer):
+    """Test that user-specified time dimension overrides default."""
+    orders = Model(
+        name="orders",
+        table="orders_table",
+        primary_key="order_id",
+        default_time_dimension="order_date",
+        default_grain="month",
+        dimensions=[
+            Dimension(name="order_date", type="time", granularity="day"),
+            Dimension(name="created_at", type="time", granularity="day"),
+        ],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+        ],
+    )
+
+    layer.add_model(orders)
+
+    # User explicitly specifies a different time dimension
+    sql = layer.compile(
+        metrics=["orders.revenue"],
+        dimensions=["orders.created_at__week"],
+    )
+
+    print("SQL with user override:")
+    print(sql)
+
+    # Should use user's choice, not default
+    assert "created_at__week" in sql
+    # Should NOT auto-add order_date__month since user provided a time dim
+    assert "order_date__month" not in sql
+
+
+def test_default_time_dimension_same_override(layer):
+    """Test that user can override default with different granularity."""
+    orders = Model(
+        name="orders",
+        table="orders_table",
+        primary_key="order_id",
+        default_time_dimension="order_date",
+        default_grain="month",
+        dimensions=[
+            Dimension(name="order_date", type="time", granularity="day"),
+        ],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+        ],
+    )
+
+    layer.add_model(orders)
+
+    # User specifies same dimension but different grain
+    sql = layer.compile(
+        metrics=["orders.revenue"],
+        dimensions=["orders.order_date__week"],
+    )
+
+    print("SQL with same dim different grain:")
+    print(sql)
+
+    # Should use user's week granularity
+    assert "order_date__week" in sql
+    # Should NOT add month since user already specified order_date
+    assert "order_date__month" not in sql
+
+
+def test_no_default_time_dimension(layer):
+    """Test models without default_time_dimension work normally."""
+    orders = Model(
+        name="orders",
+        table="orders_table",
+        primary_key="order_id",
+        dimensions=[
+            Dimension(name="order_date", type="time", granularity="day"),
+            Dimension(name="status", type="categorical"),
+        ],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+        ],
+    )
+
+    layer.add_model(orders)
+
+    # Query without time dimension - should work, just aggregate all
+    sql = layer.compile(metrics=["orders.revenue"])
+
+    print("SQL without default time dimension:")
+    print(sql)
+
+    # Should not have GROUP BY since no dimensions
+    assert "revenue" in sql
+
+
+def test_multiple_models_different_defaults(layer):
+    """Test multiple models with different default_time_dimensions."""
+    orders = Model(
+        name="orders",
+        table="orders_table",
+        primary_key="order_id",
+        default_time_dimension="order_date",
+        default_grain="month",
+        dimensions=[
+            Dimension(name="order_date", type="time", granularity="day"),
+            Dimension(name="customer_id", type="categorical"),
+        ],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+        ],
+    )
+
+    customers = Model(
+        name="customers",
+        table="customers_table",
+        primary_key="customer_id",
+        default_time_dimension="created_at",
+        default_grain="week",
+        dimensions=[
+            Dimension(name="created_at", type="time", granularity="day"),
+        ],
+        metrics=[
+            Metric(name="customer_count", agg="count"),
+        ],
+    )
+
+    layer.add_model(orders)
+    layer.add_model(customers)
+
+    # Query orders metric - should use orders' default
+    sql = layer.compile(metrics=["orders.revenue"])
+    print("Orders SQL:")
+    print(sql)
+    assert "order_date__month" in sql
+
+    # Query customers metric - should use customers' default
+    sql2 = layer.compile(metrics=["customers.customer_count"])
+    print("Customers SQL:")
+    print(sql2)
+    assert "created_at__week" in sql2


### PR DESCRIPTION
## Summary

**Breaking change**: `default_time_dimension` and `default_grain` are now model-level settings, not per-metric.

This aligns with MetricFlow's approach (`defaults.agg_time_dimension`) where all metrics in a semantic model share the same default time dimension.

## Changes

- Removed `default_time_dimension` and `default_grain` from `Metric`
- Added `default_time_dimension` and `default_grain` to `Model`
- Generator auto-includes default time dimension when querying metrics
- Updated MetricFlow adapter to use `defaults.agg_time_dimension`
- Updated Sidemantic adapter for model-level defaults
- Updated Omni adapter to use model's default

## Example

```yaml
models:
  - name: orders
    default_time_dimension: order_date
    default_grain: month
    dimensions:
      - name: order_date
        type: time
    metrics:
      - name: revenue
        agg: sum
        sql: amount
```

```python
# Auto-includes orders.order_date__month
layer.compile(metrics=["orders.revenue"])

# Override with different granularity
layer.compile(metrics=["orders.revenue"], dimensions=["orders.order_date__week"])
```