### PR TITLE
Add LSP server for Sidemantic SQL dialect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ spark = [
     "pure-sasl>=0.6.2",  # Pure Python SASL for PyHive (no C deps)
     "pyarrow>=14.0.0",  # For Arrow support
 ]
+lsp = [
+    "lsprotocol>=2025.0.0",
+    "pygls>=2.0.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -1045,5 +1045,33 @@ def refresh(
         raise typer.Exit(1)
 
 
+@app.command()
+def lsp():
+    """
+    Start the LSP server for Sidemantic SQL dialect (.sql definition files).
+
+    This provides editor support for the Sidemantic SQL syntax (MODEL, DIMENSION,
+    METRIC, RELATIONSHIP, SEGMENT statements). It does NOT provide general SQL
+    language support.
+
+    Features:
+    - Autocompletion for MODEL, DIMENSION, METRIC, RELATIONSHIP, SEGMENT
+    - Context-aware property suggestions (name, type, sql, agg, etc.)
+    - Validation errors from pydantic models
+    - Hover documentation for keywords and properties
+
+    Editor setup:
+
+    VS Code: Use a generic LSP client extension pointing to 'sidemantic lsp'
+    Neovim: Add custom server config to nvim-lspconfig
+
+    Examples:
+      sidemantic lsp  # Starts server on stdio
+    """
+    from sidemantic.lsp import main as lsp_main
+
+    lsp_main()
+
+
 if __name__ == "__main__":
     app()

--- a/sidemantic/lsp/__init__.py
+++ b/sidemantic/lsp/__init__.py
@@ -1,0 +1,5 @@
+"""Sidemantic Language Server Protocol implementation."""
+
+from .server import create_server, main
+
+__all__ = ["create_server", "main"]

--- a/sidemantic/lsp/server.py
+++ b/sidemantic/lsp/server.py
@@ -1,0 +1,291 @@
+"""LSP server for the Sidemantic SQL dialect.
+
+Provides editor support for .sql files using Sidemantic syntax:
+- MODEL, DIMENSION, METRIC, RELATIONSHIP, SEGMENT statements
+- Property completions and validation
+- Hover documentation
+
+This is NOT a general SQL language server.
+"""
+
+from lsprotocol import types as lsp
+from pygls.lsp.server import LanguageServer
+
+from sidemantic.core.dialect import DimensionDef, MetricDef, ModelDef, PropertyEQ, RelationshipDef, SegmentDef, parse
+from sidemantic.core.dimension import Dimension
+from sidemantic.core.metric import Metric
+from sidemantic.core.model import Model
+from sidemantic.core.relationship import Relationship
+from sidemantic.core.segment import Segment
+
+# Keywords for top-level statements
+KEYWORDS = ["MODEL", "DIMENSION", "METRIC", "RELATIONSHIP", "SEGMENT"]
+
+# Map definition types to their pydantic models for property lookup
+DEF_TYPE_TO_MODEL = {
+    "MODEL": Model,
+    "DIMENSION": Dimension,
+    "METRIC": Metric,
+    "RELATIONSHIP": Relationship,
+    "SEGMENT": Segment,
+}
+
+
+def get_field_docs(model_class, field_name: str) -> str | None:
+    """Get field description from pydantic model."""
+    field_info = model_class.model_fields.get(field_name)
+    if field_info:
+        return field_info.description
+    return None
+
+
+def get_all_properties(model_class) -> list[tuple[str, str | None]]:
+    """Get all property names and descriptions for a model."""
+    return [(name, field.description) for name, field in model_class.model_fields.items()]
+
+
+def create_server() -> LanguageServer:
+    """Create and configure the LSP server."""
+    server = LanguageServer("sidemantic", "0.1.0")
+
+    @server.feature(lsp.TEXT_DOCUMENT_DID_OPEN)
+    def did_open(params: lsp.DidOpenTextDocumentParams):
+        """Handle document open - run initial diagnostics."""
+        validate_document(server, params.text_document.uri)
+
+    @server.feature(lsp.TEXT_DOCUMENT_DID_CHANGE)
+    def did_change(params: lsp.DidChangeTextDocumentParams):
+        """Handle document change - revalidate."""
+        validate_document(server, params.text_document.uri)
+
+    @server.feature(lsp.TEXT_DOCUMENT_DID_SAVE)
+    def did_save(params: lsp.DidSaveTextDocumentParams):
+        """Handle document save - revalidate."""
+        validate_document(server, params.text_document.uri)
+
+    @server.feature(lsp.TEXT_DOCUMENT_COMPLETION)
+    def completions(params: lsp.CompletionParams) -> lsp.CompletionList:
+        """Provide completions based on context."""
+        document = server.workspace.get_text_document(params.text_document.uri)
+        text = document.source
+        line = params.position.line
+        character = params.position.character
+
+        # Get current line up to cursor
+        lines = text.split("\n")
+        if line >= len(lines):
+            return lsp.CompletionList(is_incomplete=False, items=[])
+
+        # Determine context
+        context = get_completion_context(text, line, character)
+
+        items = []
+
+        if context == "top_level":
+            # Suggest keywords
+            for kw in KEYWORDS:
+                items.append(
+                    lsp.CompletionItem(
+                        label=kw,
+                        kind=lsp.CompletionItemKind.Keyword,
+                        detail="Sidemantic definition",
+                        insert_text=f"{kw} (\n    name $1,\n    $0\n);",
+                        insert_text_format=lsp.InsertTextFormat.Snippet,
+                    )
+                )
+        elif context.startswith("inside_"):
+            # Inside a definition block - suggest properties
+            def_type = context.replace("inside_", "").upper()
+            model_class = DEF_TYPE_TO_MODEL.get(def_type)
+            if model_class:
+                for prop_name, description in get_all_properties(model_class):
+                    items.append(
+                        lsp.CompletionItem(
+                            label=prop_name,
+                            kind=lsp.CompletionItemKind.Property,
+                            detail=description or f"{def_type} property",
+                            insert_text=f"{prop_name} $0,",
+                            insert_text_format=lsp.InsertTextFormat.Snippet,
+                        )
+                    )
+
+        return lsp.CompletionList(is_incomplete=False, items=items)
+
+    @server.feature(lsp.TEXT_DOCUMENT_HOVER)
+    def hover(params: lsp.HoverParams) -> lsp.Hover | None:
+        """Provide hover information for keywords and properties."""
+        document = server.workspace.get_text_document(params.text_document.uri)
+        text = document.source
+        line = params.position.line
+        character = params.position.character
+
+        # Get word at position
+        word = get_word_at_position(text, line, character)
+        if not word:
+            return None
+
+        word_upper = word.upper()
+
+        # Check if it's a keyword
+        if word_upper in KEYWORDS:
+            model_class = DEF_TYPE_TO_MODEL.get(word_upper)
+            if model_class:
+                doc = model_class.__doc__ or f"{word_upper} definition"
+                return lsp.Hover(
+                    contents=lsp.MarkupContent(kind=lsp.MarkupKind.Markdown, value=f"**{word_upper}**\n\n{doc}")
+                )
+
+        # Check if it's a property - need to find context
+        context = get_completion_context(text, line, character)
+        if context.startswith("inside_"):
+            def_type = context.replace("inside_", "").upper()
+            model_class = DEF_TYPE_TO_MODEL.get(def_type)
+            if model_class:
+                description = get_field_docs(model_class, word.lower())
+                if description:
+                    return lsp.Hover(
+                        contents=lsp.MarkupContent(kind=lsp.MarkupKind.Markdown, value=f"**{word}**\n\n{description}")
+                    )
+
+        return None
+
+    return server
+
+
+def validate_document(server: LanguageServer, uri: str):
+    """Validate document and publish diagnostics."""
+    document = server.workspace.get_text_document(uri)
+    text = document.source
+    diagnostics = []
+
+    try:
+        statements = parse(text)
+
+        # Validate each statement
+        for stmt in statements:
+            if isinstance(stmt, (ModelDef, DimensionDef, MetricDef, RelationshipDef, SegmentDef)):
+                # Extract properties
+                props = {}
+                for expr in stmt.expressions:
+                    if isinstance(expr, PropertyEQ):
+                        key = expr.this.this
+                        value = expr.expression.this
+                        props[key] = value
+
+                # Try to create pydantic model for validation
+                def_type = type(stmt).__name__.replace("Def", "").upper()
+                model_class = DEF_TYPE_TO_MODEL.get(def_type)
+
+                if model_class and "name" in props:
+                    try:
+                        # Attempt to create instance for validation
+                        model_class(**props)
+                    except Exception as e:
+                        # Find line number for this definition (approximate)
+                        name = props.get("name", "unknown")
+                        line_num = find_definition_line(text, def_type, name)
+                        diagnostics.append(
+                            lsp.Diagnostic(
+                                range=lsp.Range(
+                                    start=lsp.Position(line=line_num, character=0),
+                                    end=lsp.Position(line=line_num, character=100),
+                                ),
+                                message=str(e),
+                                severity=lsp.DiagnosticSeverity.Error,
+                                source="sidemantic",
+                            )
+                        )
+
+    except Exception as e:
+        # Parse error
+        diagnostics.append(
+            lsp.Diagnostic(
+                range=lsp.Range(
+                    start=lsp.Position(line=0, character=0),
+                    end=lsp.Position(line=0, character=100),
+                ),
+                message=f"Parse error: {e}",
+                severity=lsp.DiagnosticSeverity.Error,
+                source="sidemantic",
+            )
+        )
+
+    server.publish_diagnostics(uri, diagnostics)
+
+
+def get_completion_context(text: str, line: int, character: int) -> str:
+    """Determine completion context based on cursor position."""
+    lines = text.split("\n")
+
+    # Look backwards to find what block we're in
+    paren_depth = 0
+    current_def = None
+
+    for i in range(line, -1, -1):
+        check_line = lines[i] if i < line else lines[i][:character]
+
+        # Count parens (backwards)
+        for char in reversed(check_line):
+            if char == ")":
+                paren_depth += 1
+            elif char == "(":
+                paren_depth -= 1
+
+        # Check for definition start
+        for kw in KEYWORDS:
+            if kw in lines[i].upper() and "(" in lines[i]:
+                if paren_depth < 0:
+                    return f"inside_{kw.lower()}"
+                current_def = kw
+
+    if paren_depth < 0 and current_def:
+        return f"inside_{current_def.lower()}"
+
+    return "top_level"
+
+
+def get_word_at_position(text: str, line: int, character: int) -> str | None:
+    """Get the word at the given position."""
+    lines = text.split("\n")
+    if line >= len(lines):
+        return None
+
+    current_line = lines[line]
+    if character >= len(current_line):
+        character = len(current_line) - 1
+    if character < 0:
+        return None
+
+    # Find word boundaries
+    start = character
+    end = character
+
+    while start > 0 and (current_line[start - 1].isalnum() or current_line[start - 1] == "_"):
+        start -= 1
+
+    while end < len(current_line) and (current_line[end].isalnum() or current_line[end] == "_"):
+        end += 1
+
+    if start == end:
+        return None
+
+    return current_line[start:end]
+
+
+def find_definition_line(text: str, def_type: str, name: str) -> int:
+    """Find the line number of a definition by name."""
+    lines = text.split("\n")
+    for i, line in enumerate(lines):
+        if def_type in line.upper() and name in line:
+            return i
+    return 0
+
+
+def main():
+    """Run the LSP server."""
+    server = create_server()
+    server.start_io()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/lsp/__init__.py
+++ b/tests/lsp/__init__.py
@@ -1,0 +1,1 @@
+"""LSP server tests."""

--- a/tests/lsp/test_server.py
+++ b/tests/lsp/test_server.py
@@ -1,0 +1,103 @@
+"""Tests for the LSP server."""
+
+from sidemantic.core.metric import Metric
+from sidemantic.core.model import Model
+from sidemantic.lsp.server import (
+    DEF_TYPE_TO_MODEL,
+    get_all_properties,
+    get_completion_context,
+    get_field_docs,
+    get_word_at_position,
+)
+
+
+def test_get_completion_context_top_level():
+    """Test context detection at top level."""
+    text = """
+MODEL (
+    name orders
+);
+
+"""
+    # After the MODEL definition, we're at top level
+    assert get_completion_context(text, 5, 0) == "top_level"
+
+
+def test_get_completion_context_inside_model():
+    """Test context detection inside MODEL block."""
+    text = """MODEL (
+    name orders,
+
+);"""
+    # Line 2, inside the MODEL parens
+    assert get_completion_context(text, 2, 4) == "inside_model"
+
+
+def test_get_completion_context_inside_metric():
+    """Test context detection inside METRIC block."""
+    text = """MODEL (name orders);
+
+METRIC (
+    name revenue,
+
+);"""
+    # Line 4, inside the METRIC parens
+    assert get_completion_context(text, 4, 4) == "inside_metric"
+
+
+def test_get_word_at_position():
+    """Test word extraction at cursor position."""
+    text = "MODEL (\n    name orders,\n);"
+
+    # At "MODEL"
+    assert get_word_at_position(text, 0, 2) == "MODEL"
+
+    # At "name"
+    assert get_word_at_position(text, 1, 6) == "name"
+
+    # At "orders"
+    assert get_word_at_position(text, 1, 12) == "orders"
+
+
+def test_get_word_at_position_empty():
+    """Test word extraction returns None for whitespace."""
+    text = "MODEL (  )"
+    # At whitespace
+    assert get_word_at_position(text, 0, 8) is None
+
+
+def test_get_all_properties():
+    """Test getting all properties from a model class."""
+    props = get_all_properties(Model)
+    prop_names = [name for name, _ in props]
+
+    assert "name" in prop_names
+    assert "table" in prop_names
+    assert "primary_key" in prop_names
+    assert "dimensions" in prop_names
+    assert "metrics" in prop_names
+
+
+def test_get_field_docs():
+    """Test getting field documentation."""
+    # Model.name should have a description
+    doc = get_field_docs(Model, "name")
+    assert doc is not None
+    assert "name" in doc.lower() or "model" in doc.lower() or "unique" in doc.lower()
+
+    # Metric.agg should have a description
+    doc = get_field_docs(Metric, "agg")
+    assert doc is not None
+
+
+def test_def_type_to_model_mapping():
+    """Test that all definition types map to valid models."""
+    assert "MODEL" in DEF_TYPE_TO_MODEL
+    assert "DIMENSION" in DEF_TYPE_TO_MODEL
+    assert "METRIC" in DEF_TYPE_TO_MODEL
+    assert "RELATIONSHIP" in DEF_TYPE_TO_MODEL
+    assert "SEGMENT" in DEF_TYPE_TO_MODEL
+
+    # All values should be pydantic model classes
+    for model_class in DEF_TYPE_TO_MODEL.values():
+        assert hasattr(model_class, "model_fields")

--- a/uv.lock
+++ b/uv.lock
@@ -121,6 +121,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cattrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/00/2432bb2d445b39b5407f0a90e01b9a271475eea7caf913d7a86bcb956385/cattrs-25.3.0.tar.gz", hash = "sha256:1ac88d9e5eda10436c4517e390a4142d88638fe682c436c93db7ce4a277b884a", size = 509321, upload-time = "2025-10-07T12:26:08.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/2b/a40e1488fdfa02d3f9a653a61a5935ea08b3c2225ee818db6a76c7ba9695/cattrs-25.3.0-py3-none-any.whl", hash = "sha256:9896e84e0a5bf723bc7b4b68f4481785367ce07a8a02e7e9ee6eb2819bc306ff", size = 70738, upload-time = "2025-10-07T12:26:06.603Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.10.5"
 source = { registry = "https://pypi.org/simple" }
@@ -730,6 +743,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
     { url = "https://files.pythonhosted.org/packages/3f/cc/b07000438a29ac5cfb2194bfc128151d52f333cee74dd7dfe3fb733fc16c/greenlet-3.2.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:55e9c5affaa6775e2c6b67659f3a71684de4c549b3dd9afca3bc773533d284fa", size = 1142073, upload-time = "2025-08-07T13:18:21.737Z" },
+    { url = "https://files.pythonhosted.org/packages/67/24/28a5b2fa42d12b3d7e5614145f0bd89714c34c08be6aabe39c14dd52db34/greenlet-3.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c9c6de1940a7d828635fbd254d69db79e54619f165ee7ce32fda763a9cb6a58c", size = 1548385, upload-time = "2025-11-04T12:42:11.067Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/05/03f2f0bdd0b0ff9a4f7b99333d57b53a7709c27723ec8123056b084e69cd/greenlet-3.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03c5136e7be905045160b1b9fdca93dd6727b180feeafda6818e6496434ed8c5", size = 1613329, upload-time = "2025-11-04T12:42:12.928Z" },
     { url = "https://files.pythonhosted.org/packages/d8/0f/30aef242fcab550b0b3520b8e3561156857c94288f0332a79928c31a52cf/greenlet-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:9c40adce87eaa9ddb593ccb0fa6a07caf34015a29bf8d344811665b573138db9", size = 299100, upload-time = "2025-08-07T13:44:12.287Z" },
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
@@ -739,6 +754,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
     { url = "https://files.pythonhosted.org/packages/3f/c7/12381b18e21aef2c6bd3a636da1088b888b97b7a0362fac2e4de92405f97/greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f", size = 1151142, upload-time = "2025-08-07T13:18:22.981Z" },
+    { url = "https://files.pythonhosted.org/packages/27/45/80935968b53cfd3f33cf99ea5f08227f2646e044568c9b1555b58ffd61c2/greenlet-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee7a6ec486883397d70eec05059353b8e83eca9168b9f3f9a361971e77e0bcd0", size = 1564846, upload-time = "2025-11-04T12:42:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/b7c30e5e04752cb4db6202a3858b149c0710e5453b71a3b2aec5d78a1aab/greenlet-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:326d234cbf337c9c3def0676412eb7040a35a768efc92504b947b3e9cfc7543d", size = 1633814, upload-time = "2025-11-04T12:42:17.175Z" },
     { url = "https://files.pythonhosted.org/packages/e9/08/b0814846b79399e585f974bbeebf5580fbe59e258ea7be64d9dfb253c84f/greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02", size = 299899, upload-time = "2025-08-07T13:38:53.448Z" },
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
@@ -748,6 +765,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
     { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/53/f9c440463b3057485b8594d7a638bed53ba531165ef0ca0e6c364b5cc807/greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b", size = 1564759, upload-time = "2025-11-04T12:42:19.395Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/3bb4240abdd0a8d23f4f88adec746a3099f0d86bfedb623f063b2e3b4df0/greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929", size = 1634288, upload-time = "2025-11-04T12:42:21.174Z" },
     { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
@@ -755,6 +774,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/da/343cd760ab2f92bac1845ca07ee3faea9fe52bee65f7bcb19f16ad7de08b/greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681", size = 1680760, upload-time = "2025-11-04T12:42:25.341Z" },
     { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
 ]
 
@@ -1062,6 +1083,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/b5/212a46bf505f7518fd235f7e3e7355e24f612cdd70cb3f9b254742bf7b9f/loro-1.8.1-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:ce7cfdb085aa9c7f6f16d9090cff64e7a8f5ccde0f11b0cb0f20567f7798c3f3", size = 3440556, upload-time = "2025-09-23T15:51:39.834Z" },
     { url = "https://files.pythonhosted.org/packages/b8/ca/e9184f8a595add3dfa8d0a8bf44e0ae848b18e6758b4a05b9dc1f492221e/loro-1.8.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:a2f8db61477b6951c6ee45b48e7c307014540229b09b17f07c6eea8ced519448", size = 3487021, upload-time = "2025-09-23T15:52:17.245Z" },
     { url = "https://files.pythonhosted.org/packages/f2/89/17dd2c68018d11bcd54e9504a9ae71d8ca520fd78c4769d54aae016946f1/loro-1.8.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:7bc42670b8cc05d7bc26525ea9f0f1404dc49c0f611ea21eb9d551d51d9f0839", size = 3384697, upload-time = "2025-09-23T15:52:53.385Z" },
+]
+
+[[package]]
+name = "lsprotocol"
+version = "2025.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz", hash = "sha256:e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29", size = 74896, upload-time = "2025-06-17T21:30:18.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl", hash = "sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7", size = 76250, upload-time = "2025-06-17T21:30:19.455Z" },
 ]
 
 [[package]]
@@ -1821,6 +1855,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pygls"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "lsprotocol" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/50/2bfc32f3acbc8941042919b59c9f592291127b55d7331b72e67ce7b62f08/pygls-2.0.0.tar.gz", hash = "sha256:99accd03de1ca76fe1e7e317f0968ebccf7b9955afed6e2e3e188606a20b4f07", size = 55796, upload-time = "2025-10-17T19:22:47.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/09/14feafc13bebb9c85b29b374889c1549d3700cb572f2d43a1bb940d70315/pygls-2.0.0-py3-none-any.whl", hash = "sha256:b4e54bba806f76781017ded8fd07463b98670f959042c44170cd362088b200cc", size = 69533, upload-time = "2025-10-17T19:22:46.63Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2279,6 +2327,10 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+lsp = [
+    { name = "lsprotocol" },
+    { name = "pygls" },
+]
 postgres = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pyarrow" },
@@ -2316,6 +2368,7 @@ requires-dist = [
     { name = "inflect", specifier = ">=7.0.0,<7.2.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "lkml", specifier = ">=1.3.7" },
+    { name = "lsprotocol", marker = "extra == 'lsp'", specifier = ">=2025.0.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.16.0" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=1.26,<3" },
     { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.2,<3" },
@@ -2330,6 +2383,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'snowflake'", specifier = ">=14.0.0" },
     { name = "pyarrow", marker = "extra == 'spark'", specifier = ">=14.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pygls", marker = "extra == 'lsp'", specifier = ">=2.0.0" },
     { name = "pyhive", marker = "extra == 'spark'", specifier = ">=0.7.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -2345,7 +2399,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.9.0" },
     { name = "vl-convert-python", specifier = ">=1.0.0" },
 ]
-provides-extras = ["dev", "serve", "postgres", "bigquery", "snowflake", "clickhouse", "databricks", "spark"]
+provides-extras = ["dev", "serve", "postgres", "bigquery", "snowflake", "clickhouse", "databricks", "spark", "lsp"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds a Language Server Protocol (LSP) server for editor support when writing Sidemantic SQL definition files (`.sql` files using MODEL, DIMENSION, METRIC syntax).

**Features:**
- Autocompletion for keywords: MODEL, DIMENSION, METRIC, RELATIONSHIP, SEGMENT
- Context-aware property suggestions with documentation (name, type, sql, agg, etc.)
- Validation errors via pydantic model checks
- Hover documentation for keywords and properties

**Usage:**
```bash
sidemantic lsp  # Starts server on stdio
```

**Note:** This is specifically for the Sidemantic SQL dialect, NOT a general SQL language server.

## New dependency

- `pygls` and `lsprotocol` added as optional `[lsp]` extra