### PR TITLE
Fix null safety in all semantic layer adapters

### DIFF
--- a/sidemantic/adapters/hex.py
+++ b/sidemantic/adapters/hex.py
@@ -85,7 +85,7 @@ class HexAdapter(BaseAdapter):
         dimensions = []
         primary_key = "id"  # default
 
-        for dim_def in model_def.get("dimensions", []):
+        for dim_def in model_def.get("dimensions") or []:
             dim = self._parse_dimension(dim_def)
             if dim:
                 dimensions.append(dim)
@@ -96,14 +96,14 @@ class HexAdapter(BaseAdapter):
 
         # Parse measures
         measures = []
-        for measure_def in model_def.get("measures", []):
+        for measure_def in model_def.get("measures") or []:
             measure = self._parse_measure(measure_def)
             if measure:
                 measures.append(measure)
 
         # Parse relations
         relationships = []
-        for relation_def in model_def.get("relations", []):
+        for relation_def in model_def.get("relations") or []:
             relation = self._parse_relation(relation_def)
             if relation:
                 relationships.append(relation)
@@ -228,7 +228,7 @@ class HexAdapter(BaseAdapter):
 
         # Parse filters
         filters = []
-        filter_defs = measure_def.get("filters", [])
+        filter_defs = measure_def.get("filters") or []
         for filter_def in filter_defs:
             if isinstance(filter_def, dict):
                 # Inline dimension definition

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -68,7 +68,7 @@ class LookMLAdapter(BaseAdapter):
             return
 
         # Parse views
-        for view_def in parsed.get("views", []):
+        for view_def in parsed.get("views") or []:
             model = self._parse_view(view_def)
             if model:
                 graph.add_model(model)
@@ -89,7 +89,7 @@ class LookMLAdapter(BaseAdapter):
             return
 
         # Parse explores
-        for explore_def in parsed.get("explores", []):
+        for explore_def in parsed.get("explores") or []:
             self._parse_explore(explore_def, graph)
 
     def _parse_view(self, view_def: dict) -> Model | None:
@@ -118,7 +118,7 @@ class LookMLAdapter(BaseAdapter):
         dimensions = []
         primary_key = "id"  # default
 
-        for dim_def in view_def.get("dimensions", []):
+        for dim_def in view_def.get("dimensions") or []:
             dim = self._parse_dimension(dim_def)
             if dim:
                 dimensions.append(dim)
@@ -128,13 +128,13 @@ class LookMLAdapter(BaseAdapter):
                     primary_key = dim.name
 
         # Parse dimension_group (time dimensions)
-        for dim_group_def in view_def.get("dimension_groups", []):
+        for dim_group_def in view_def.get("dimension_groups") or []:
             dims = self._parse_dimension_group(dim_group_def)
             dimensions.extend(dims)
 
         # Parse measures
         measures = []
-        for measure_def in view_def.get("measures", []):
+        for measure_def in view_def.get("measures") or []:
             measure = self._parse_measure(measure_def)
             if measure:
                 measures.append(measure)
@@ -143,7 +143,7 @@ class LookMLAdapter(BaseAdapter):
         from sidemantic.core.segment import Segment
 
         segments = []
-        for segment_def in view_def.get("filters", []):
+        for segment_def in view_def.get("filters") or []:
             # LookML filters at view level can be used as segments
             segment_name = segment_def.get("name")
             segment_sql = segment_def.get("sql")
@@ -324,7 +324,7 @@ class LookMLAdapter(BaseAdapter):
 
         # Parse filters - lkml parses these as filters__all
         filters = []
-        filters_all = measure_def.get("filters__all", [])
+        filters_all = measure_def.get("filters__all") or []
         if filters_all:
             for filter_list in filters_all:
                 for filter_dict in filter_list:
@@ -374,7 +374,7 @@ class LookMLAdapter(BaseAdapter):
         base_model = graph.models[explore_name]
 
         # Parse joins
-        for join_def in explore_def.get("joins", []):
+        for join_def in explore_def.get("joins") or []:
             relationship = self._parse_join(join_def, explore_name)
             if relationship:
                 # Add relationship to the base model

--- a/sidemantic/adapters/metricflow.py
+++ b/sidemantic/adapters/metricflow.py
@@ -68,13 +68,13 @@ class MetricFlowAdapter(BaseAdapter):
             return
 
         # Parse semantic models
-        for model_def in data.get("semantic_models", []):
+        for model_def in data.get("semantic_models") or []:
             model = self._parse_semantic_model(model_def)
             if model:
                 graph.add_model(model)
 
         # Parse metrics
-        for metric_def in data.get("metrics", []):
+        for metric_def in data.get("metrics") or []:
             metric = self._parse_metric(metric_def)
             if metric:
                 graph.add_metric(metric)
@@ -113,7 +113,7 @@ class MetricFlowAdapter(BaseAdapter):
         primary_key = "id"  # default
         relationships = []
 
-        for entity_def in model_def.get("entities", []):
+        for entity_def in model_def.get("entities") or []:
             entity_type = entity_def.get("type", "primary")
             entity_name = entity_def.get("name")
             entity_expr = entity_def.get("expr", entity_name)
@@ -127,14 +127,14 @@ class MetricFlowAdapter(BaseAdapter):
 
         # Parse dimensions
         dimensions = []
-        for dim_def in model_def.get("dimensions", []):
+        for dim_def in model_def.get("dimensions") or []:
             dim = self._parse_dimension(dim_def)
             if dim:
                 dimensions.append(dim)
 
         # Parse measures
         measures = []
-        for measure_def in model_def.get("measures", []):
+        for measure_def in model_def.get("measures") or []:
             measure = self._parse_measure(measure_def)
             if measure:
                 measures.append(measure)
@@ -144,7 +144,7 @@ class MetricFlowAdapter(BaseAdapter):
 
         segments = []
         meta = model_def.get("meta", {})
-        for segment_def in meta.get("segments", []):
+        for segment_def in meta.get("segments") or []:
             segment_name = segment_def.get("name")
             segment_sql = segment_def.get("sql")
             if segment_name and segment_sql:

--- a/sidemantic/adapters/omni.py
+++ b/sidemantic/adapters/omni.py
@@ -179,7 +179,7 @@ class OmniAdapter(BaseAdapter):
             sql = re.sub(r"\$\{[^.]+\.([^}]+)\}", r"\1", sql)
 
         # Handle timeframes for time dimensions
-        timeframes = dim_def.get("timeframes", [])
+        timeframes = dim_def.get("timeframes") or []
         granularity = None
         if dim_type == "time" and timeframes:
             # Map first timeframe to granularity
@@ -370,7 +370,7 @@ class OmniAdapter(BaseAdapter):
         if not model_def:
             return
 
-        relationships_list = model_def.get("relationships", [])
+        relationships_list = model_def.get("relationships") or []
 
         for rel_def in relationships_list:
             from_view = rel_def.get("join_from_view")

--- a/sidemantic/adapters/rill.py
+++ b/sidemantic/adapters/rill.py
@@ -75,7 +75,7 @@ class RillAdapter:
         timeseries_column = data.get("timeseries")
         smallest_time_grain = data.get("smallest_time_grain")
 
-        for dim_def in data.get("dimensions", []):
+        for dim_def in data.get("dimensions") or []:
             dimension = self._parse_dimension(dim_def, timeseries_column, smallest_time_grain)
             if dimension:
                 dimensions.append(dimension)
@@ -94,7 +94,7 @@ class RillAdapter:
 
         # Parse measures
         metrics: list[Metric] = []
-        for measure_def in data.get("measures", []):
+        for measure_def in data.get("measures") or []:
             metric = self._parse_measure(measure_def)
             if metric:
                 metrics.append(metric)

--- a/sidemantic/adapters/sidemantic.py
+++ b/sidemantic/adapters/sidemantic.py
@@ -150,13 +150,13 @@ class SidemanticAdapter(BaseAdapter):
             return graph
 
         # Parse models
-        for model_def in data.get("models", []):
+        for model_def in data.get("models") or []:
             model = self._parse_model(model_def)
             if model:
                 graph.add_model(model)
 
         # Parse metrics
-        for metric_def in data.get("metrics", []):
+        for metric_def in data.get("metrics") or []:
             metric = self._parse_metric(metric_def)
             if metric:
                 graph.add_metric(metric)
@@ -210,7 +210,7 @@ class SidemanticAdapter(BaseAdapter):
 
         # Parse joins
         joins = []
-        for relationship_def in model_def.get("relationships", []):
+        for relationship_def in model_def.get("relationships") or []:
             join = Relationship(
                 name=relationship_def.get("name"),
                 type=relationship_def.get("type"),
@@ -221,7 +221,7 @@ class SidemanticAdapter(BaseAdapter):
 
         # Parse dimensions
         dimensions = []
-        for dim_def in model_def.get("dimensions", []):
+        for dim_def in model_def.get("dimensions") or []:
             dimension = Dimension(
                 name=dim_def.get("name"),
                 type=dim_def.get("type"),
@@ -237,7 +237,7 @@ class SidemanticAdapter(BaseAdapter):
 
         # Parse measures/metrics (support both field names for backwards compatibility)
         measures = []
-        for measure_def in model_def.get("metrics", model_def.get("measures", [])):
+        for measure_def in model_def.get("metrics", model_def.get("measures") or []):
             measure = Metric(
                 name=measure_def.get("name"),
                 agg=measure_def.get("agg"),
@@ -261,7 +261,7 @@ class SidemanticAdapter(BaseAdapter):
 
         # Parse segments
         segments = []
-        for seg_def in model_def.get("segments", []):
+        for seg_def in model_def.get("segments") or []:
             segment = Segment(
                 name=seg_def.get("name"),
                 sql=seg_def.get("sql"),
@@ -283,7 +283,7 @@ class SidemanticAdapter(BaseAdapter):
         from sidemantic.core.pre_aggregation import PreAggregation, RefreshKey
 
         pre_aggregations = []
-        for preagg_def in model_def.get("pre_aggregations", []):
+        for preagg_def in model_def.get("pre_aggregations") or []:
             # Parse refresh_key if present
             refresh_key = None
             if "refresh_key" in preagg_def:
@@ -296,8 +296,8 @@ class SidemanticAdapter(BaseAdapter):
 
             preagg = PreAggregation(
                 name=preagg_def.get("name"),
-                measures=preagg_def.get("measures", []),
-                dimensions=preagg_def.get("dimensions", []),
+                measures=preagg_def.get("measures") or [],
+                dimensions=preagg_def.get("dimensions") or [],
                 time_dimension=preagg_def.get("time_dimension"),
                 granularity=preagg_def.get("granularity"),
                 refresh_key=refresh_key,

--- a/sidemantic/adapters/superset.py
+++ b/sidemantic/adapters/superset.py
@@ -80,7 +80,7 @@ class SupersetAdapter(BaseAdapter):
         primary_key = "id"  # default
         main_dttm_col = dataset.get("main_dttm_col")
 
-        for col_def in dataset.get("columns", []):
+        for col_def in dataset.get("columns") or []:
             dim = self._parse_column(col_def, main_dttm_col)
             if dim:
                 dimensions.append(dim)
@@ -91,7 +91,7 @@ class SupersetAdapter(BaseAdapter):
 
         # Parse metrics
         metrics = []
-        for metric_def in dataset.get("metrics", []):
+        for metric_def in dataset.get("metrics") or []:
             metric = self._parse_metric(metric_def)
             if metric:
                 metrics.append(metric)


### PR DESCRIPTION
Applies the same fix from the Cube adapter (#16) to all other semantic layer adapters.

**Problem:** When YAML has explicit empty sections like `dimensions:` with no value, it parses as `None` instead of a missing key. Using `.get("key", [])` returns `None` (not the default `[]`), causing `TypeError: 'NoneType' object is not iterable`.

**Fix:** Change `.get("key", [])` to `.get("key") or []` which handles both missing keys and explicit `None` values.

**Affected adapters:**
- MetricFlow (dbt semantic layer)
- LookML (Looker)
- Hex
- Sidemantic (native format)
- Superset
- Rill
- Omni

All 196 adapter tests pass.