### PR TITLE
Fix release CI: proper versioning and GitHub Releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,3 +74,11 @@ jobs:
           git tag -a "v${{ steps.version.outputs.new_version }}" -m "Release v${{ steps.version.outputs.new_version }}"
           git push origin main
           git push origin "v${{ steps.version.outputs.new_version }}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.new_version }}" \
+            --title "v${{ steps.version.outputs.new_version }}" \
+            --generate-notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sidemantic"
-version = "v0.4.1"
+version = "0.4.1"
 description = "Universal semantic layer - import from Cube, dbt, LookML, Hex, and more"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/sidemantic/__init__.py
+++ b/sidemantic/__init__.py
@@ -1,6 +1,6 @@
 """Sidemantic: Universal semantic layer - import from Cube, dbt, LookML, Hex, and more."""
 
-__version__ = "v0.4.1"
+__version__ = "0.4.1"
 
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.metric import Metric


### PR DESCRIPTION
## Summary
- Remove `v` prefix from version in pyproject.toml and __init__.py (was `v0.4.1`, now `0.4.1`)
- Add step to create GitHub Releases with auto-generated notes after publishing
- Deleted the malformed `vv0.4.1` tag that was created by the broken workflow

The version parsing was broken because pyproject.toml had `version = "v0.4.1"` but semver should be `0.4.1`. The workflow then created tags like `v$VERSION` resulting in `vv0.4.1`.