### PR TITLE
Add version bump dropdown to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,14 @@ name: Publish to PyPI
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to publish (leave empty to use pyproject.toml version)'
-        required: false
-        type: string
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   publish:
@@ -32,19 +36,28 @@ jobs:
           CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Auto-increment version if not specified
+      - name: Calculate new version
         id: version
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            NEW_VERSION="${{ inputs.version }}"
-          else
-            CURRENT="${{ steps.get_version.outputs.current_version }}"
-            # Parse version (assumes semver: major.minor.patch)
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-            # Increment patch version
-            PATCH=$((PATCH + 1))
-            NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-          fi
+          CURRENT="${{ steps.get_version.outputs.current_version }}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+          case "${{ inputs.bump }}" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "VERSION=$NEW_VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
Replace free-form version input with a required dropdown allowing users to select patch, minor, or major version bumps. The workflow automatically calculates the new version and resets lower version components appropriately.