### PR TITLE
Fix aggregation parsing for complex expressions

### DIFF
--- a/tests/adapters/rill/test_kitchen_sink.py
+++ b/tests/adapters/rill/test_kitchen_sink.py
@@ -1,0 +1,289 @@
+"""Kitchen sink tests for Rill adapter using real-world patterns.
+
+These tests use expressions from rill-examples to find holes in the implementation.
+The goal is to find bugs, not conform tests to bugs.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from sidemantic import SemanticLayer
+from sidemantic.adapters.rill import RillAdapter
+
+
+@pytest.fixture
+def kitchen_sink_layer():
+    """Load kitchen sink fixture."""
+    adapter = RillAdapter()
+    graph = adapter.parse("tests/fixtures/rill/kitchen_sink.yaml")
+    layer = SemanticLayer()
+    layer.graph = graph
+    return layer
+
+
+class TestKitchenSinkParsing:
+    """Test that the kitchen sink fixture parses correctly."""
+
+    def test_model_loads(self, kitchen_sink_layer):
+        """Verify the model loads."""
+        assert "kitchen_sink" in kitchen_sink_layer.graph.models
+
+    def test_dimension_count(self, kitchen_sink_layer):
+        """Verify all dimensions loaded."""
+        model = kitchen_sink_layer.graph.models["kitchen_sink"]
+        # 5 explicit dimensions + 1 auto-created timeseries
+        assert len(model.dimensions) >= 5
+
+    def test_metric_count(self, kitchen_sink_layer):
+        """Verify all metrics loaded."""
+        model = kitchen_sink_layer.graph.models["kitchen_sink"]
+        assert len(model.metrics) >= 20
+
+
+class TestSimpleAggregations:
+    """Test simple aggregation expressions."""
+
+    def test_count_star(self, kitchen_sink_layer):
+        """COUNT(*) should work."""
+        sql = kitchen_sink_layer.compile(metrics=["kitchen_sink.total_records"])
+        assert "COUNT(" in sql.upper()
+
+    def test_sum(self, kitchen_sink_layer):
+        """SUM(column) should work."""
+        sql = kitchen_sink_layer.compile(metrics=["kitchen_sink.total_revenue"])
+        assert "SUM(" in sql.upper()
+
+    def test_avg(self, kitchen_sink_layer):
+        """AVG(column) should work."""
+        sql = kitchen_sink_layer.compile(metrics=["kitchen_sink.avg_amount"])
+        assert "AVG(" in sql.upper()
+
+    def test_min(self, kitchen_sink_layer):
+        """MIN(column) should work."""
+        sql = kitchen_sink_layer.compile(metrics=["kitchen_sink.min_amount"])
+        assert "MIN(" in sql.upper()
+
+    def test_max(self, kitchen_sink_layer):
+        """MAX(column) should work."""
+        sql = kitchen_sink_layer.compile(metrics=["kitchen_sink.max_amount"])
+        assert "MAX(" in sql.upper()
+
+    def test_median(self, kitchen_sink_layer):
+        """MEDIAN(column) should work."""
+        sql = kitchen_sink_layer.compile(metrics=["kitchen_sink.median_duration"])
+        assert "MEDIAN(" in sql.upper()
+
+
+class TestCountDistinct:
+    """Test COUNT DISTINCT expressions."""
+
+    def test_count_distinct_simple(self, kitchen_sink_layer):
+        """COUNT(DISTINCT col) should produce valid SQL."""
+        sql = kitchen_sink_layer.compile(metrics=["kitchen_sink.unique_users"])
+        # Should have COUNT and DISTINCT
+        assert "COUNT(" in sql.upper()
+        assert "DISTINCT" in sql.upper()
+        # Should NOT have broken SQL like "DISTINCT user_id AS"
+        assert "DISTINCT user_id AS" not in sql
+
+    def test_count_distinct_with_function(self, kitchen_sink_layer):
+        """COUNT(DISTINCT CONCAT(...)) from rill-311-ops."""
+        sql = kitchen_sink_layer.compile(metrics=["kitchen_sink.unique_locations"])
+        assert "COUNT(" in sql.upper()
+        assert "DISTINCT" in sql.upper()
+        assert "CONCAT" in sql.upper()
+
+
+class TestArithmeticExpressions:
+    """Test expressions with arithmetic operators.
+
+    These are the patterns that break with the greedy regex bug.
+    """
+
+    def test_division_of_sums(self, kitchen_sink_layer):
+        """SUM(x) / SUM(y) from rill-github-analytics.
+
+        BUG: Greedy regex in Metric class matches first SUM( to last ),
+        extracting 'deletions) / SUM(changes' as the inner expression.
+        """
+        model = kitchen_sink_layer.graph.models["kitchen_sink"]
+        metric = model.get_metric("deletion_pct")
+
+        # The expression should be preserved as-is (no agg extraction)
+        # OR properly parsed as a ratio
+        assert metric is not None
+
+        # If parsed as expression without agg:
+        if metric.agg is None:
+            assert metric.sql == "SUM(deletions) / SUM(changes)"
+        else:
+            # Should NOT have broken SQL
+            assert ") / SUM(" not in (metric.sql or "")
+
+    def test_subtraction_of_sums(self, kitchen_sink_layer):
+        """SUM(x) - SUM(y) from rill-cost-monitoring."""
+        model = kitchen_sink_layer.graph.models["kitchen_sink"]
+        metric = model.get_metric("net_revenue")
+
+        assert metric is not None
+        if metric.agg is None:
+            assert metric.sql == "SUM(revenue) - SUM(cost)"
+        else:
+            assert ") - SUM(" not in (metric.sql or "")
+
+    def test_division_of_counts(self, kitchen_sink_layer):
+        """COUNT(*) / COUNT(DISTINCT x) from rill-github-analytics."""
+        model = kitchen_sink_layer.graph.models["kitchen_sink"]
+        metric = model.get_metric("files_per_commit")
+
+        assert metric is not None
+        if metric.agg is None:
+            assert "COUNT(*)" in metric.sql
+            assert "COUNT(DISTINCT" in metric.sql
+        else:
+            assert ") / COUNT(" not in (metric.sql or "")
+
+    def test_sum_with_division(self, kitchen_sink_layer):
+        """SUM(x)/1000 from rill-openrtb-prog-ads."""
+        model = kitchen_sink_layer.graph.models["kitchen_sink"]
+        metric = model.get_metric("ad_spend")
+
+        assert metric is not None
+        # Should either preserve full expression or work correctly
+        sql = kitchen_sink_layer.compile(metrics=["kitchen_sink.ad_spend"])
+        # Should not error and should contain the division
+        assert "/1000" in sql or "/ 1000" in sql
+
+    def test_ratio_with_multiplier(self, kitchen_sink_layer):
+        """SUM(x)*1.0/SUM(y)*1.0 from rill-app-engagement."""
+        model = kitchen_sink_layer.graph.models["kitchen_sink"]
+        metric = model.get_metric("conversion_rate")
+
+        assert metric is not None
+        # Full expression should be preserved
+        if metric.agg is None:
+            assert "*1.0" in metric.sql
+
+    def test_margin_calculation(self, kitchen_sink_layer):
+        """(SUM(x) - SUM(y))/SUM(x) from rill-cost-monitoring."""
+        model = kitchen_sink_layer.graph.models["kitchen_sink"]
+        metric = model.get_metric("margin")
+
+        assert metric is not None
+        # Complex expression - should be preserved
+        if metric.agg is None:
+            assert "SUM(revenue)" in metric.sql
+            assert "SUM(cost)" in metric.sql
+
+
+class TestConditionalAggregations:
+    """Test aggregations with CASE expressions."""
+
+    def test_count_with_case(self, kitchen_sink_layer):
+        """COUNT(CASE WHEN ... END) should work."""
+        sql = kitchen_sink_layer.compile(metrics=["kitchen_sink.completed_orders"])
+        assert "COUNT(" in sql.upper()
+        assert "CASE" in sql.upper()
+
+    def test_sum_with_case(self, kitchen_sink_layer):
+        """SUM(CASE WHEN ... END) should work."""
+        sql = kitchen_sink_layer.compile(metrics=["kitchen_sink.completed_revenue"])
+        assert "SUM(" in sql.upper()
+        assert "CASE" in sql.upper()
+
+
+class TestDerivedMetrics:
+    """Test derived/calculated metrics."""
+
+    def test_derived_metric_references(self, kitchen_sink_layer):
+        """Derived metric referencing other metrics."""
+        model = kitchen_sink_layer.graph.models["kitchen_sink"]
+        metric = model.get_metric("revenue_per_user")
+
+        assert metric is not None
+        assert metric.type == "derived"
+
+    def test_derived_metric_sql(self, kitchen_sink_layer):
+        """Derived metric should compile."""
+        sql = kitchen_sink_layer.compile(metrics=["kitchen_sink.revenue_per_user"])
+        # Should reference the base metrics
+        assert sql is not None
+
+
+class TestWindowFunctions:
+    """Test window function metrics."""
+
+    def test_window_metric_parsing(self, kitchen_sink_layer):
+        """Window function metrics should parse."""
+        model = kitchen_sink_layer.graph.models["kitchen_sink"]
+        metric = model.get_metric("rolling_7day_revenue")
+
+        assert metric is not None
+        assert metric.type == "cumulative"
+
+
+class TestSQLGeneration:
+    """Test that generated SQL is syntactically valid."""
+
+    def test_all_metrics_compile(self, kitchen_sink_layer):
+        """All metrics should compile without errors."""
+        model = kitchen_sink_layer.graph.models["kitchen_sink"]
+
+        failed = []
+        for metric in model.metrics:
+            try:
+                sql = kitchen_sink_layer.compile(metrics=[f"kitchen_sink.{metric.name}"])
+                # Basic syntax check - should have SELECT
+                assert "SELECT" in sql.upper()
+            except Exception as e:
+                failed.append((metric.name, str(e)))
+
+        if failed:
+            msg = "\n".join(f"  {name}: {err}" for name, err in failed)
+            pytest.fail(f"Failed to compile metrics:\n{msg}")
+
+    def test_sql_is_parseable(self, kitchen_sink_layer):
+        """Generated SQL should be parseable by sqlglot."""
+        import sqlglot
+
+        model = kitchen_sink_layer.graph.models["kitchen_sink"]
+
+        failed = []
+        for metric in model.metrics:
+            try:
+                sql = kitchen_sink_layer.compile(metrics=[f"kitchen_sink.{metric.name}"])
+                # Strip the comment line
+                sql_no_comment = "\n".join(line for line in sql.split("\n") if not line.strip().startswith("--"))
+                sqlglot.parse_one(sql_no_comment, read="duckdb")
+            except Exception as e:
+                failed.append((metric.name, str(e)))
+
+        if failed:
+            msg = "\n".join(f"  {name}: {err}" for name, err in failed)
+            pytest.fail(f"Generated invalid SQL:\n{msg}")
+
+
+class TestRoundtrip:
+    """Test export and re-import."""
+
+    def test_roundtrip_preserves_expressions(self, kitchen_sink_layer):
+        """Complex expressions should survive roundtrip."""
+        adapter = RillAdapter()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adapter.export(kitchen_sink_layer.graph, tmpdir)
+            graph2 = adapter.parse(Path(tmpdir) / "kitchen_sink.yaml")
+
+            model1 = kitchen_sink_layer.graph.models["kitchen_sink"]
+            model2 = graph2.models["kitchen_sink"]
+
+            # Check a complex metric survived
+            m1 = model1.get_metric("margin")
+            m2 = model2.get_metric("margin")
+
+            assert m1 is not None
+            assert m2 is not None
+            # Both should have the full expression (not broken)
+            # Either both have agg=None with full SQL, or both properly decomposed

--- a/tests/fixtures/rill/kitchen_sink.yaml
+++ b/tests/fixtures/rill/kitchen_sink.yaml
@@ -1,0 +1,189 @@
+# Kitchen sink Rill metrics view based on real rill-examples patterns
+# Tests edge cases and complex expressions from:
+# - rill-311-ops (MEDIAN, COUNT DISTINCT CONCAT)
+# - rill-app-engagement (ratios with *1.0, count with space)
+# - rill-cost-monitoring (arithmetic expressions, margin calculations)
+# - rill-github-analytics (division ratios, count(*))
+# - rill-openrtb-prog-ads (complex nested arithmetic)
+
+type: metrics_view
+name: kitchen_sink
+display_name: Kitchen Sink Analytics
+description: Comprehensive test of Rill adapter edge cases
+model: kitchen_sink_model
+timeseries: event_time
+smallest_time_grain: hour
+default_time_range: P1W
+
+dimensions:
+  # Simple column reference
+  - name: status
+    display_name: Status
+    description: Current status
+    column: status
+
+  # Expression-based dimension (CASE)
+  - name: status_type
+    display_name: Status Type
+    expression: |
+      CASE
+        WHEN LOWER(status) IN ('open', 'new', 'in progress') THEN 'Active'
+        WHEN status IS NULL THEN 'Unknown'
+        ELSE 'Closed'
+      END
+
+  # Concatenation in dimension
+  - name: full_location
+    display_name: Full Location
+    expression: CONCAT(city, ', ', state)
+
+  # Boolean dimension
+  - name: is_merge_commit
+    display_name: Merge Commit
+    column: is_merge_commit
+    description: True if the commit is a merge commit
+
+  # Nested CASE expression
+  - name: size_bucket
+    display_name: Size Bucket
+    expression: |
+      CASE
+        WHEN amount < 100 THEN 'small'
+        WHEN amount < 1000 THEN 'medium'
+        WHEN amount < 10000 THEN 'large'
+        ELSE 'enterprise'
+      END
+
+measures:
+  # Simple COUNT(*)
+  - name: total_records
+    display_name: Total Records
+    expression: COUNT(*)
+    format_preset: humanize
+
+  # COUNT DISTINCT
+  - name: unique_users
+    display_name: Unique Users
+    expression: COUNT(DISTINCT user_id)
+    format_preset: humanize
+
+  # COUNT DISTINCT with CONCAT (from rill-311-ops)
+  - name: unique_locations
+    display_name: Unique Locations
+    expression: COUNT(DISTINCT CONCAT(latitude, longitude))
+    format_preset: humanize
+
+  # MEDIAN aggregation (from rill-311-ops)
+  - name: median_duration
+    display_name: Median Duration (Hours)
+    expression: MEDIAN(duration_hours)
+    format_preset: humanize
+
+  # Simple SUM
+  - name: total_revenue
+    display_name: Total Revenue
+    expression: SUM(revenue)
+    format_preset: currency_usd
+
+  # SUM with division constant (from rill-openrtb-prog-ads)
+  - name: ad_spend
+    display_name: Advertising Spend
+    expression: SUM(media_spend_usd)/1000
+    format_preset: currency_usd
+
+  # Ratio with *1.0 pattern (from rill-app-engagement)
+  - name: conversion_rate
+    display_name: Conversion Rate
+    expression: SUM(clicks)*1.0/SUM(views)*1.0
+    format_preset: percentage
+
+  # Simple ratio (from rill-github-analytics)
+  - name: deletion_pct
+    display_name: Deletion Percentage
+    expression: SUM(deletions) / SUM(changes)
+    format_preset: percentage
+
+  # Complex arithmetic (from rill-cost-monitoring)
+  - name: margin
+    display_name: Margin
+    expression: (SUM(revenue) - SUM(cost))/SUM(revenue)
+    format_preset: percentage
+
+  # Net calculation
+  - name: net_revenue
+    display_name: Net Revenue
+    expression: SUM(revenue) - SUM(cost)
+    format_preset: currency_usd
+
+  # Division in AVG context (from rill-openrtb-prog-ads)
+  - name: avg_bid_price
+    display_name: Average Bid Price
+    expression: SUM(bid_price_usd)*1.0/SUM(bid_cnt)/1000
+    format_preset: currency_usd
+
+  # Files per commit ratio (from rill-github-analytics)
+  - name: files_per_commit
+    display_name: Files per Commit
+    expression: COUNT(*) / COUNT(DISTINCT commit_hash)
+    format_preset: humanize
+
+  # Count with space before parenthesis (from rill-app-engagement)
+  - name: unique_visitors
+    display_name: Unique Visitors
+    expression: count (distinct visitor_id)
+    format_preset: humanize
+
+  # Completion rate with count distinct ratio
+  - name: completion_rate
+    display_name: Completion Rate
+    expression: count (distinct completed_id)*1.0/count (distinct started_id) *1.0
+    format_preset: percentage
+
+  # Derived measure referencing other measures
+  - name: revenue_per_user
+    display_name: Revenue per User
+    type: derived
+    expression: total_revenue / unique_users
+    format_preset: currency_usd
+    requires:
+      - total_revenue
+      - unique_users
+
+  # Window function / rolling average
+  - name: rolling_7day_revenue
+    display_name: 7-Day Rolling Revenue
+    expression: AVG(total_revenue)
+    requires:
+      - total_revenue
+    window:
+      order: event_time
+      frame: RANGE BETWEEN INTERVAL 6 DAY PRECEDING AND CURRENT ROW
+
+  # MIN/MAX aggregations
+  - name: min_amount
+    display_name: Minimum Amount
+    expression: MIN(amount)
+    format_preset: currency_usd
+
+  - name: max_amount
+    display_name: Maximum Amount
+    expression: MAX(amount)
+    format_preset: currency_usd
+
+  # AVG aggregation
+  - name: avg_amount
+    display_name: Average Amount
+    expression: AVG(amount)
+    format_preset: currency_usd
+
+  # Conditional count (CASE in COUNT)
+  - name: completed_orders
+    display_name: Completed Orders
+    expression: COUNT(CASE WHEN status = 'completed' THEN 1 END)
+    format_preset: humanize
+
+  # SUM with CASE
+  - name: completed_revenue
+    display_name: Completed Revenue
+    expression: SUM(CASE WHEN status = 'completed' THEN revenue ELSE 0 END)
+    format_preset: currency_usd


### PR DESCRIPTION
## Summary
- Replace greedy regex with sqlglot in Metric class to properly handle expressions like `SUM(x) / SUM(y)` without mangling them
- Fix COUNT DISTINCT detection using `isinstance(parsed.this, exp.Distinct)`
- Add expression metric support in SQL generator for metrics with inline aggregations
- Fix dependency analyzer to skip resolution for expression metrics with inline aggregations
- Fix cumulative metrics to properly resolve references to other measures and generate valid aliases
- Add kitchen sink tests using patterns from rill-examples to catch edge cases

## Bugs Fixed
1. **Greedy regex**: `SUM(deletions) / SUM(changes)` was being parsed as `agg=sum, sql=deletions) / SUM(changes`
2. **COUNT DISTINCT**: `COUNT(DISTINCT user_id)` was parsed as `agg=count, sql=DISTINCT user_id` instead of `agg=count_distinct, sql=user_id`
3. **Expression metrics**: Metrics with full SQL expressions (no agg, no type) couldn't be queried
4. **Window functions over measures**: Cumulative metrics referencing other measures failed to resolve

## Test Results
- 42/42 Rill adapter tests pass
- 25/25 new kitchen sink tests pass