### PR TITLE
Improve demos section formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,17 +114,54 @@ sidemantic migrator --queries legacy/ --generate-models output/
 
 ## Demos
 
-| Demo | Command |
-|------|---------|
-| Interactive workbench | `uvx sidemantic workbench --demo` |
-| PostgreSQL server | `uvx sidemantic serve --demo --port 5433` |
-| SQL syntax example | `uv run https://raw.githubusercontent.com/sidequery/sidemantic/main/examples/sql/sql_syntax_example.py` |
-| Comprehensive demo | `uv run https://raw.githubusercontent.com/sidequery/sidemantic/main/examples/advanced/comprehensive_demo.py` |
-| Symmetric aggregates | `uv run https://raw.githubusercontent.com/sidequery/sidemantic/main/examples/features/symmetric_aggregates_example.py` |
-| Rill Developer (Docker) | `git clone ... && uv run examples/rill_demo/run_demo.py` |
-| Cube Playground (Docker) | `git clone ... && uv run examples/cube_demo/run_demo.py` |
-| SQL + DuckDB notebook | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/sidequery/sidemantic/blob/main/examples/notebooks/sidemantic_sql_duckdb_demo.ipynb) |
-| LookML multi-entity notebook | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/sidequery/sidemantic/blob/main/examples/notebooks/lookml_multi_entity_duckdb_demo.ipynb) |
+**Workbench** (TUI with SQL editor + charts):
+```bash
+uvx sidemantic workbench --demo
+```
+
+**PostgreSQL server** (connect Tableau, DBeaver, etc.):
+```bash
+uvx sidemantic serve --demo --port 5433
+```
+
+**Colab notebooks:**
+
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/sidequery/sidemantic/blob/main/examples/notebooks/sidemantic_sql_duckdb_demo.ipynb) SQL + DuckDB
+
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/sidequery/sidemantic/blob/main/examples/notebooks/lookml_multi_entity_duckdb_demo.ipynb) LookML multi-entity
+
+**SQL syntax:**
+```bash
+uv run https://raw.githubusercontent.com/sidequery/sidemantic/main/examples/sql/sql_syntax_example.py
+```
+
+**Comprehensive demo:**
+```bash
+uv run https://raw.githubusercontent.com/sidequery/sidemantic/main/examples/advanced/comprehensive_demo.py
+```
+
+**Symmetric aggregates:**
+```bash
+uv run https://raw.githubusercontent.com/sidequery/sidemantic/main/examples/features/symmetric_aggregates_example.py
+```
+
+**Superset with DuckDB:**
+```bash
+git clone https://github.com/sidequery/sidemantic.git && cd sidemantic
+uv run examples/superset_demo/run_demo.py
+```
+
+**Cube Playground:**
+```bash
+git clone https://github.com/sidequery/sidemantic.git && cd sidemantic
+uv run examples/cube_demo/run_demo.py
+```
+
+**Rill Developer:**
+```bash
+git clone https://github.com/sidequery/sidemantic.git && cd sidemantic
+uv run examples/rill_demo/run_demo.py
+```
 
 ## Core Features
 


### PR DESCRIPTION
## Summary
- Replace table with individual sections for each demo with descriptive headers
- Add full clone URLs for Docker-based integrations (Superset, Cube Playground, Rill Developer)
- Each demo now has context about what it does