### PR TITLE
Add ADBC connection support to config

### DIFF
--- a/examples/adbc_snowflake/.gitignore
+++ b/examples/adbc_snowflake/.gitignore
@@ -1,0 +1,3 @@
+sidemantic.yaml
+snowflake_key.p8
+snowflake_key.pub

--- a/examples/adbc_snowflake/README.md
+++ b/examples/adbc_snowflake/README.md
@@ -1,0 +1,20 @@
+# ADBC + Snowflake Example
+
+Uses ADBC with key-pair auth to connect to Snowflake.
+
+## Prerequisites
+
+```bash
+pip install adbc-driver-manager
+dbc install snowflake
+```
+
+## Config
+
+Copy `sidemantic.yaml.example` to `sidemantic.yaml` and fill in your Snowflake details.
+
+## Usage
+
+```bash
+sidemantic query "SELECT orders.total_revenue, orders.region FROM orders"
+```

--- a/examples/adbc_snowflake/orders.yaml
+++ b/examples/adbc_snowflake/orders.yaml
@@ -1,0 +1,41 @@
+cubes:
+  - name: orders
+    sql_table: demo.orders
+    description: E-commerce orders
+
+    dimensions:
+      - name: order_id
+        sql: order_id
+        type: number
+        primary_key: true
+
+      - name: customer_id
+        sql: customer_id
+        type: number
+
+      - name: status
+        sql: status
+        type: string
+
+      - name: region
+        sql: region
+        type: string
+
+      - name: order_date
+        sql: order_date
+        type: time
+
+    measures:
+      - name: total_orders
+        type: count
+        description: Total number of orders
+
+      - name: total_revenue
+        type: sum
+        sql: amount
+        description: Total revenue from orders
+
+      - name: avg_order_value
+        type: avg
+        sql: amount
+        description: Average order value

--- a/examples/adbc_snowflake/setup.sql
+++ b/examples/adbc_snowflake/setup.sql
@@ -1,0 +1,45 @@
+-- Setup script for ADBC + Snowflake demo
+-- Run this in Snowflake to create test data
+
+-- Create schema if needed
+CREATE SCHEMA IF NOT EXISTS demo;
+
+-- Create orders table
+CREATE OR REPLACE TABLE demo.orders (
+    order_id NUMBER PRIMARY KEY,
+    customer_id NUMBER,
+    status VARCHAR(50),
+    region VARCHAR(50),
+    amount NUMBER(10,2),
+    order_date TIMESTAMP
+);
+
+-- Insert sample data
+INSERT INTO demo.orders (order_id, customer_id, status, region, amount, order_date)
+VALUES
+    (1, 101, 'completed', 'North', 150.00, '2024-01-15 10:30:00'),
+    (2, 102, 'completed', 'South', 275.50, '2024-01-15 14:22:00'),
+    (3, 103, 'pending', 'East', 89.99, '2024-01-16 09:15:00'),
+    (4, 101, 'completed', 'North', 432.00, '2024-01-16 16:45:00'),
+    (5, 104, 'cancelled', 'West', 67.25, '2024-01-17 11:00:00'),
+    (6, 105, 'completed', 'South', 299.99, '2024-01-17 13:30:00'),
+    (7, 102, 'completed', 'East', 185.00, '2024-01-18 10:00:00'),
+    (8, 106, 'pending', 'North', 520.00, '2024-01-18 15:20:00'),
+    (9, 103, 'completed', 'West', 145.75, '2024-01-19 09:45:00'),
+    (10, 107, 'completed', 'South', 88.50, '2024-01-19 14:10:00'),
+    (11, 108, 'completed', 'North', 675.00, '2024-01-20 11:30:00'),
+    (12, 101, 'pending', 'East', 234.99, '2024-01-20 16:00:00'),
+    (13, 109, 'completed', 'West', 412.50, '2024-01-21 10:15:00'),
+    (14, 110, 'cancelled', 'South', 55.00, '2024-01-21 12:45:00'),
+    (15, 102, 'completed', 'North', 189.99, '2024-01-22 09:30:00'),
+    (16, 111, 'completed', 'East', 333.33, '2024-01-22 14:00:00'),
+    (17, 103, 'completed', 'West', 267.80, '2024-01-23 11:20:00'),
+    (18, 112, 'pending', 'South', 445.00, '2024-01-23 15:45:00'),
+    (19, 104, 'completed', 'North', 128.50, '2024-01-24 10:00:00'),
+    (20, 113, 'completed', 'East', 599.99, '2024-01-24 13:30:00');
+
+-- Verify data
+SELECT region, status, COUNT(*) as orders, SUM(amount) as revenue
+FROM demo.orders
+GROUP BY region, status
+ORDER BY region, status;

--- a/examples/adbc_snowflake/sidemantic.yaml.example
+++ b/examples/adbc_snowflake/sidemantic.yaml.example
@@ -1,0 +1,11 @@
+models_dir: .
+
+connection:
+  type: adbc
+  driver: snowflake
+  adbc.snowflake.sql.account: ORG-ACCOUNT
+  adbc.snowflake.sql.db: YOUR_DATABASE
+  adbc.snowflake.sql.warehouse: COMPUTE_WH
+  adbc.snowflake.sql.auth_type: auth_jwt
+  adbc.snowflake.sql.client_option.jwt_private_key: snowflake_key.p8
+  username: your_service_user


### PR DESCRIPTION
## Summary
- Add `ADBCConnection` type for ADBC (Arrow Database Connectivity) drivers
- Support key-pair authentication for Snowflake via `private_key` field
- Auto-resolve relative private_key paths from config directory
- Add `adbc_snowflake` example

## Usage

```yaml
connection:
  type: adbc
  driver: snowflake
  account: ORG-ACCOUNT
  username: service_user
  private_key: snowflake_key.p8
  database: MY_DATABASE
  warehouse: COMPUTE_WH
```

Prerequisites:
```bash
pip install adbc-driver-manager
dbc install snowflake
```