### PR TITLE
Move heavy deps to optional extras for faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --extra dev
 
       - name: Check version consistency
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,6 @@ dependencies = [
     "duckdb>=1.0.0",
     "inflect>=7.0.0,<7.2.0",  # PYODIDE: <7.2 required - inflect 7.2+ needs typing-extensions>=4.13 but Pyodide has 4.11.0
     "typer>=0.9.0",
-    "textual[syntax]>=1.0.0",
-    "plotext>=5.3.2",
-    "textual-plotext>=1.0.1",
-    "mcp[cli]>=1.16.0",
-    "altair>=5.0.0",
-    "vl-convert-python>=1.0.0",
 ]
 
 [project.scripts]
@@ -33,6 +27,18 @@ dev = [
     "pandas>=2.2,<3",
     "numpy>=1.26,<3",
     "fakesnow>=0.9.0",  # For Snowflake integration tests
+]
+workbench = [
+    "textual[syntax]>=1.0.0",
+    "plotext>=5.3.2",
+    "textual-plotext>=1.0.1",
+]
+mcp = [
+    "mcp[cli]>=1.16.0",
+]
+charts = [
+    "altair>=5.0.0",
+    "vl-convert-python>=1.0.0",
 ]
 serve = [
     "riffq>=0.1.0",
@@ -79,6 +85,13 @@ malloy = [
 widget = [
     "anywidget>=0.9.0",
     "pyarrow>=14.0.0",
+]
+# Convenience bundles
+all-databases = [
+    "sidemantic[postgres,bigquery,snowflake,clickhouse,databricks,spark,adbc]",
+]
+full = [
+    "sidemantic[workbench,mcp,charts,lsp,malloy,widget]",
 ]
 
 [build-system]

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -30,6 +30,7 @@ models:
 
 
 def test_workbench_calls_runner(monkeypatch, tmp_path):
+    pytest.importorskip("textual")
     called = {}
 
     def fake_run_workbench(directory, demo_mode=False, connection=None):
@@ -49,6 +50,7 @@ def test_workbench_calls_runner(monkeypatch, tmp_path):
 
 
 def test_validate_calls_runner(monkeypatch, tmp_path):
+    pytest.importorskip("textual")
     called = {}
 
     def fake_run_validation(directory, verbose=False):
@@ -101,6 +103,7 @@ def test_serve_calls_start_server(monkeypatch, tmp_path):
 
 
 def test_mcp_serve_calls_initialize(monkeypatch, tmp_path):
+    pytest.importorskip("mcp")
     called = {}
 
     def fake_initialize_layer(directory, db_path=None):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("mcp")  # Skip if mcp extra not installed
+
 from sidemantic.mcp_server import create_chart, get_models, initialize_layer, list_models, run_query
 
 

--- a/tests/test_mcp_server_errors.py
+++ b/tests/test_mcp_server_errors.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+pytest.importorskip("mcp")  # Skip if mcp extra not installed
+
 from sidemantic import mcp_server
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1035,6 +1035,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1045,6 +1046,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1055,6 +1057,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1065,6 +1068,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -3225,20 +3229,14 @@ name = "sidemantic"
 version = "0.5.2"
 source = { editable = "." }
 dependencies = [
-    { name = "altair" },
     { name = "duckdb" },
     { name = "inflect" },
     { name = "jinja2" },
     { name = "lkml" },
-    { name = "mcp", extra = ["cli"] },
-    { name = "plotext" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "sqlglot" },
-    { name = "textual", extra = ["syntax"] },
-    { name = "textual-plotext" },
     { name = "typer" },
-    { name = "vl-convert-python" },
 ]
 
 [package.optional-dependencies]
@@ -3246,9 +3244,26 @@ adbc = [
     { name = "adbc-driver-manager" },
     { name = "pyarrow" },
 ]
+all-databases = [
+    { name = "adbc-driver-manager" },
+    { name = "clickhouse-connect" },
+    { name = "databricks-sql-connector" },
+    { name = "google-cloud-bigquery" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "pure-sasl" },
+    { name = "pyarrow" },
+    { name = "pyhive" },
+    { name = "snowflake-connector-python" },
+    { name = "thrift" },
+    { name = "thrift-sasl" },
+]
 bigquery = [
     { name = "google-cloud-bigquery" },
     { name = "pyarrow" },
+]
+charts = [
+    { name = "altair" },
+    { name = "vl-convert-python" },
 ]
 clickhouse = [
     { name = "clickhouse-connect" },
@@ -3266,12 +3281,28 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+full = [
+    { name = "altair" },
+    { name = "antlr4-python3-runtime" },
+    { name = "anywidget" },
+    { name = "lsprotocol" },
+    { name = "mcp", extra = ["cli"] },
+    { name = "plotext" },
+    { name = "pyarrow" },
+    { name = "pygls" },
+    { name = "textual", extra = ["syntax"] },
+    { name = "textual-plotext" },
+    { name = "vl-convert-python" },
+]
 lsp = [
     { name = "lsprotocol" },
     { name = "pygls" },
 ]
 malloy = [
     { name = "antlr4-python3-runtime" },
+]
+mcp = [
+    { name = "mcp", extra = ["cli"] },
 ]
 postgres = [
     { name = "psycopg", extra = ["binary"] },
@@ -3296,6 +3327,11 @@ widget = [
     { name = "anywidget" },
     { name = "pyarrow" },
 ]
+workbench = [
+    { name = "plotext" },
+    { name = "textual", extra = ["syntax"] },
+    { name = "textual-plotext" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -3314,7 +3350,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "adbc-driver-manager", marker = "extra == 'adbc'", specifier = ">=1.0.0" },
-    { name = "altair", specifier = ">=5.0.0" },
+    { name = "altair", marker = "extra == 'charts'", specifier = ">=5.0.0" },
     { name = "antlr4-python3-runtime", marker = "extra == 'malloy'", specifier = ">=4.13.2" },
     { name = "anywidget", marker = "extra == 'widget'", specifier = ">=0.9.0" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = ">=0.6.0" },
@@ -3326,10 +3362,10 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "lkml", specifier = ">=1.3.7" },
     { name = "lsprotocol", marker = "extra == 'lsp'", specifier = ">=2025.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.16.0" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.16.0" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=1.26,<3" },
     { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.2,<3" },
-    { name = "plotext", specifier = ">=5.3.2" },
+    { name = "plotext", marker = "extra == 'workbench'", specifier = ">=5.3.2" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.0.0" },
     { name = "pure-sasl", marker = "extra == 'spark'", specifier = ">=0.6.2" },
     { name = "pyarrow", marker = "extra == 'adbc'", specifier = ">=14.0.0" },
@@ -3349,16 +3385,18 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "riffq", marker = "extra == 'serve'", specifier = ">=0.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
+    { name = "sidemantic", extras = ["postgres", "bigquery", "snowflake", "clickhouse", "databricks", "spark", "adbc"], marker = "extra == 'all-databases'" },
+    { name = "sidemantic", extras = ["workbench", "mcp", "charts", "lsp", "malloy", "widget"], marker = "extra == 'full'" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.0.0" },
     { name = "sqlglot", specifier = ">=25.0.0" },
-    { name = "textual", extras = ["syntax"], specifier = ">=1.0.0" },
-    { name = "textual-plotext", specifier = ">=1.0.1" },
+    { name = "textual", extras = ["syntax"], marker = "extra == 'workbench'", specifier = ">=1.0.0" },
+    { name = "textual-plotext", marker = "extra == 'workbench'", specifier = ">=1.0.1" },
     { name = "thrift", marker = "extra == 'spark'", specifier = ">=0.16.0" },
     { name = "thrift-sasl", marker = "extra == 'spark'", specifier = ">=0.4.3" },
     { name = "typer", specifier = ">=0.9.0" },
-    { name = "vl-convert-python", specifier = ">=1.0.0" },
+    { name = "vl-convert-python", marker = "extra == 'charts'", specifier = ">=1.0.0" },
 ]
-provides-extras = ["dev", "serve", "postgres", "bigquery", "snowflake", "clickhouse", "databricks", "spark", "adbc", "lsp", "malloy", "widget"]
+provides-extras = ["dev", "workbench", "mcp", "charts", "serve", "postgres", "bigquery", "snowflake", "clickhouse", "databricks", "spark", "adbc", "lsp", "malloy", "widget", "all-databases", "full"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Move textual, plotext, textual-plotext to `[workbench]` extra
- Move mcp[cli] to `[mcp]` extra
- Move altair, vl-convert-python to `[charts]` extra
- Add convenience bundles: `[all-databases]`, `[full]`
- Change CI from `--all-extras` to `--extra dev`
- Add pytest.importorskip for tests requiring optional deps

## Why
Python 3.11 CI was taking **13+ minutes** because riffq (in `[serve]` extra) has no wheel for cp311 Linux and compiles from Rust source (~11 min). Since `--all-extras` was used, every CI run installed riffq.

Now CI only installs lightweight dev deps (pytest, ruff, pandas, numpy, fakesnow), which should complete in ~1-2 min for both Python versions.

## New Extras Structure

| Extra | Packages | Use Case |
|-------|----------|----------|
| `workbench` | textual[syntax], plotext, textual-plotext | `sidemantic workbench` TUI |
| `mcp` | mcp[cli] | `sidemantic mcp-serve` |
| `charts` | altair, vl-convert-python | Chart generation |
| `all-databases` | postgres, bigquery, snowflake, clickhouse, databricks, spark, adbc | All DB connectors |
| `full` | workbench, mcp, charts, lsp, malloy, widget | All features |

## Install Examples
```bash
pip install sidemantic                    # Core only
pip install sidemantic[workbench]         # With TUI
pip install sidemantic[mcp,charts]        # With MCP + charts
pip install sidemantic[full]              # Everything
pip install sidemantic[full,all-databases] # Kitchen sink
```