### PR TITLE
Add parity parsing and kitchen sink test

### DIFF
--- a/sidemantic/adapters/sidemantic.py
+++ b/sidemantic/adapters/sidemantic.py
@@ -10,10 +10,16 @@ from sidemantic.adapters.base import BaseAdapter
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
+from sidemantic.core.parameter import Parameter
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.segment import Segment
 from sidemantic.core.semantic_graph import SemanticGraph
-from sidemantic.core.sql_definitions import parse_sql_definitions, parse_sql_file_with_frontmatter, parse_sql_model
+from sidemantic.core.sql_definitions import (
+    parse_sql_definitions,
+    parse_sql_file_with_frontmatter_extended,
+    parse_sql_graph_definitions,
+    parse_sql_model,
+)
 
 
 def substitute_env_vars(content: str) -> str:
@@ -117,9 +123,21 @@ class SidemanticAdapter(BaseAdapter):
                 model = parse_sql_model(content)
                 if model:
                     graph.add_model(model)
+                sql_metrics, sql_segments, sql_parameters = parse_sql_graph_definitions(content)
+                if model:
+                    model_metric_names = {metric.name for metric in model.metrics}
+                else:
+                    model_metric_names = set()
+                for metric in sql_metrics:
+                    if metric.name not in model_metric_names:
+                        graph.add_metric(metric)
+                for param in sql_parameters:
+                    graph.add_parameter(param)
             else:
                 # YAML frontmatter + SQL metrics/segments
-                frontmatter, sql_metrics, sql_segments = parse_sql_file_with_frontmatter(source_path)
+                frontmatter, sql_metrics, sql_segments, sql_parameters, sql_preaggs = (
+                    parse_sql_file_with_frontmatter_extended(source_path)
+                )
 
                 # Parse frontmatter as model definition if present
                 if frontmatter:
@@ -128,11 +146,15 @@ class SidemanticAdapter(BaseAdapter):
                         # Add SQL-defined metrics/segments to the model
                         model.metrics.extend(sql_metrics)
                         model.segments.extend(sql_segments)
+                        if sql_preaggs:
+                            model.pre_aggregations.extend(sql_preaggs)
                         graph.add_model(model)
                 else:
                     # No frontmatter - treat as graph-level metrics/segments
                     for metric in sql_metrics:
                         graph.add_metric(metric)
+                    for param in sql_parameters:
+                        graph.add_parameter(param)
                     # Segments need to be attached to models, skip if no model
 
             return graph
@@ -160,6 +182,11 @@ class SidemanticAdapter(BaseAdapter):
             metric = self._parse_metric(metric_def)
             if metric:
                 graph.add_metric(metric)
+        # Parse parameters
+        for parameter_def in data.get("parameters") or []:
+            parameter = self._parse_parameter(parameter_def)
+            if parameter:
+                graph.add_parameter(parameter)
 
         # Parse SQL-defined metrics/segments if present
         if "sql_metrics" in data:
@@ -228,8 +255,9 @@ class SidemanticAdapter(BaseAdapter):
             dimension = Dimension(
                 name=dim_def.get("name"),
                 type=dim_def.get("type", "categorical"),  # Default to categorical
-                sql=dim_def.get("sql"),
+                sql=dim_def.get("sql") or dim_def.get("expr"),
                 granularity=dim_def.get("granularity"),
+                supported_granularities=dim_def.get("supported_granularities"),
                 description=dim_def.get("description"),
                 label=dim_def.get("label"),
                 format=dim_def.get("format"),
@@ -243,10 +271,12 @@ class SidemanticAdapter(BaseAdapter):
         for measure_def in model_def.get("metrics", model_def.get("measures") or []):
             measure = Metric(
                 name=measure_def.get("name"),
+                extends=measure_def.get("extends"),
                 agg=measure_def.get("agg"),
-                sql=measure_def.get("sql"),
+                sql=measure_def.get("sql") or measure_def.get("expr"),
                 type=measure_def.get("type"),
                 filters=measure_def.get("filters"),
+                fill_nulls_with=measure_def.get("fill_nulls_with"),
                 description=measure_def.get("description"),
                 label=measure_def.get("label"),
                 format=measure_def.get("format"),
@@ -257,6 +287,8 @@ class SidemanticAdapter(BaseAdapter):
                 comparison_type=measure_def.get("comparison_type"),
                 time_offset=measure_def.get("time_offset"),
                 calculation=measure_def.get("calculation"),
+                numerator=measure_def.get("numerator"),
+                denominator=measure_def.get("denominator"),
                 entity=measure_def.get("entity"),
                 base_event=measure_def.get("base_event"),
                 conversion_event=measure_def.get("conversion_event"),
@@ -304,15 +336,20 @@ class SidemanticAdapter(BaseAdapter):
                     refresh_key = RefreshKey(
                         every=refresh_key_def.get("every"),
                         sql=refresh_key_def.get("sql"),
+                        incremental=refresh_key_def.get("incremental", False),
+                        update_window=refresh_key_def.get("update_window"),
                     )
 
             preagg = PreAggregation(
                 name=preagg_def.get("name"),
+                type=preagg_def.get("type", "rollup"),
                 measures=preagg_def.get("measures") or [],
                 dimensions=preagg_def.get("dimensions") or [],
                 time_dimension=preagg_def.get("time_dimension"),
                 granularity=preagg_def.get("granularity"),
+                partition_granularity=preagg_def.get("partition_granularity"),
                 refresh_key=refresh_key,
+                scheduled_refresh=preagg_def.get("scheduled_refresh", True),
                 indexes=preagg_def.get("indexes"),
                 build_range_start=preagg_def.get("build_range_start"),
                 build_range_end=preagg_def.get("build_range_end"),
@@ -325,6 +362,7 @@ class SidemanticAdapter(BaseAdapter):
             sql=model_def.get("sql"),
             source_uri=model_def.get("source_uri"),
             description=model_def.get("description"),
+            extends=model_def.get("extends"),
             primary_key=model_def.get("primary_key", "id"),
             relationships=joins,
             dimensions=dimensions,
@@ -352,10 +390,12 @@ class SidemanticAdapter(BaseAdapter):
 
         return Metric(
             name=name,
+            extends=metric_def.get("extends"),
             type=metric_type,
             description=metric_def.get("description"),
             label=metric_def.get("label"),
-            sql=metric_def.get("sql") or metric_def.get("measure"),
+            sql=metric_def.get("sql") or metric_def.get("expr") or metric_def.get("measure"),
+            agg=metric_def.get("agg"),
             numerator=metric_def.get("numerator"),
             denominator=metric_def.get("denominator"),
             base_metric=metric_def.get("base_metric"),
@@ -368,7 +408,41 @@ class SidemanticAdapter(BaseAdapter):
             conversion_window=metric_def.get("conversion_window"),
             offset_window=metric_def.get("offset_window"),
             window=metric_def.get("window"),
+            grain_to_date=metric_def.get("grain_to_date"),
+            window_expression=metric_def.get("window_expression"),
+            window_frame=metric_def.get("window_frame"),
+            window_order=metric_def.get("window_order"),
             filters=metric_def.get("filters"),
+            fill_nulls_with=metric_def.get("fill_nulls_with"),
+            format=metric_def.get("format"),
+            value_format_name=metric_def.get("value_format_name"),
+            drill_fields=metric_def.get("drill_fields"),
+            non_additive_dimension=metric_def.get("non_additive_dimension"),
+        )
+
+    def _parse_parameter(self, parameter_def: dict) -> Parameter | None:
+        """Parse parameter definition.
+
+        Args:
+            parameter_def: Parameter definition dictionary
+
+        Returns:
+            Parameter instance or None
+        """
+        name = parameter_def.get("name")
+        param_type = parameter_def.get("type")
+
+        if not name or not param_type:
+            return None
+
+        return Parameter(
+            name=name,
+            type=param_type,
+            description=parameter_def.get("description"),
+            label=parameter_def.get("label"),
+            default_value=parameter_def.get("default_value"),
+            allowed_values=parameter_def.get("allowed_values"),
+            default_to_today=parameter_def.get("default_to_today", False),
         )
 
     def _export_model(self, model: Model) -> dict:

--- a/tests/core/test_parity_roundtrip.py
+++ b/tests/core/test_parity_roundtrip.py
@@ -1,0 +1,565 @@
+"""Kitchen sink parity tests across Python, YAML, and SQL definitions."""
+
+import tempfile
+import warnings
+from pathlib import Path
+
+from sidemantic.adapters.sidemantic import SidemanticAdapter
+from sidemantic.core.dimension import Dimension
+from sidemantic.core.metric import Metric
+from sidemantic.core.model import Model
+from sidemantic.core.parameter import Parameter
+from sidemantic.core.pre_aggregation import Index, PreAggregation, RefreshKey
+from sidemantic.core.relationship import Relationship
+from sidemantic.core.segment import Segment
+from sidemantic.core.semantic_graph import SemanticGraph
+
+
+def _normalize_sql_text(value: object) -> object:
+    if not isinstance(value, str):
+        return value
+    try:
+        import sqlglot
+
+        parsed = sqlglot.parse_one(value, read="duckdb")
+        return parsed.sql(dialect="duckdb")
+    except Exception:
+        return value
+
+
+def _normalize_model(model: Model) -> dict:
+    data = model.model_dump()
+
+    for key in ("dimensions", "metrics", "segments", "relationships", "pre_aggregations"):
+        items = data.get(key)
+        if items:
+            data[key] = sorted(items, key=lambda item: item["name"])
+
+    for preagg in data.get("pre_aggregations") or []:
+        if preagg.get("indexes"):
+            preagg["indexes"] = sorted(preagg["indexes"], key=lambda item: item["name"])
+        if preagg.get("build_range_start"):
+            preagg["build_range_start"] = _normalize_sql_text(preagg["build_range_start"])
+        if preagg.get("build_range_end"):
+            preagg["build_range_end"] = _normalize_sql_text(preagg["build_range_end"])
+
+    for dim in data.get("dimensions") or []:
+        if dim.get("sql"):
+            dim["sql"] = _normalize_sql_text(dim["sql"])
+
+    for metric in data.get("metrics") or []:
+        if metric.get("sql"):
+            metric["sql"] = _normalize_sql_text(metric["sql"])
+        if metric.get("window_expression"):
+            metric["window_expression"] = _normalize_sql_text(metric["window_expression"])
+        if metric.get("filters"):
+            metric["filters"] = [_normalize_sql_text(item) for item in metric["filters"]]
+
+    return data
+
+
+def _normalize_graph(graph: SemanticGraph) -> dict:
+    return {
+        "models": {name: _normalize_model(model) for name, model in graph.models.items()},
+        "metrics": {
+            name: {
+                **metric.model_dump(),
+                "sql": _normalize_sql_text(metric.sql) if metric.sql else None,
+            }
+            for name, metric in graph.metrics.items()
+        },
+        "parameters": {name: param.model_dump() for name, param in graph.parameters.items()},
+    }
+
+
+def _merge_graphs(graphs: list[SemanticGraph]) -> SemanticGraph:
+    merged = SemanticGraph()
+    for graph in graphs:
+        for model in graph.models.values():
+            merged.add_model(model)
+        for metric in graph.metrics.values():
+            if metric.name not in merged.metrics:
+                merged.add_metric(metric)
+        for param in graph.parameters.values():
+            if param.name not in merged.parameters:
+                merged.add_parameter(param)
+    return merged
+
+
+def _build_python_graph() -> SemanticGraph:
+    model = Model(
+        name="orders",
+        table="orders",
+        source_uri="s3://warehouse/orders",
+        description="Orders model",
+        extends="base_orders",
+        primary_key="order_id",
+        default_time_dimension="order_date",
+        default_grain="day",
+        relationships=[
+            Relationship(
+                name="customers",
+                type="many_to_one",
+                foreign_key="customer_id",
+                primary_key="id",
+            )
+        ],
+        dimensions=[
+            Dimension(
+                name="status",
+                type="categorical",
+                sql="status",
+                description="Order status",
+                label="Status",
+            ),
+            Dimension(
+                name="order_date",
+                type="time",
+                sql="order_date",
+                granularity="day",
+                supported_granularities=["day", "week", "month"],
+                description="Order date",
+            ),
+            Dimension(
+                name="is_priority",
+                type="boolean",
+                sql="is_priority",
+                description="Priority flag",
+            ),
+            Dimension(
+                name="amount",
+                type="numeric",
+                sql="amount",
+                format="$#,##0.00",
+                value_format_name="usd",
+            ),
+        ],
+        metrics=[
+            Metric(
+                name="revenue",
+                agg="sum",
+                sql="amount",
+                filters=["status = completed", "status = pending"],
+                fill_nulls_with=0,
+                description="Total revenue",
+                label="Revenue",
+                format="$#,##0.00",
+                value_format_name="usd",
+                drill_fields=["order_id", "status"],
+                non_additive_dimension="order_date",
+            ),
+            Metric(
+                name="order_count",
+                agg="count",
+                sql="order_id",
+            ),
+            Metric(
+                name="conversion_rate",
+                type="ratio",
+                numerator="completed_orders",
+                denominator="order_count",
+                offset_window="1 month",
+            ),
+            Metric(
+                name="profit_margin",
+                type="derived",
+                sql="(revenue - cost) / revenue",
+            ),
+            Metric(
+                name="running_revenue",
+                type="cumulative",
+                sql="revenue",
+                window="7 days",
+                grain_to_date="month",
+                window_expression="SUM(revenue)",
+                window_frame="RANGE BETWEEN INTERVAL 6 DAY PRECEDING AND CURRENT ROW",
+                window_order="order_date",
+            ),
+            Metric(
+                name="revenue_yoy",
+                type="time_comparison",
+                base_metric="revenue",
+                comparison_type="yoy",
+                calculation="percent_change",
+                time_offset="1 year",
+            ),
+            Metric(
+                name="signup_to_purchase",
+                type="conversion",
+                entity="user_id",
+                base_event="event_type = signup",
+                conversion_event="event_type = purchase",
+                conversion_window="30 days",
+            ),
+        ],
+        segments=[
+            Segment(
+                name="completed",
+                sql="status = completed",
+                description="Completed orders only",
+                public=False,
+            )
+        ],
+        pre_aggregations=[
+            PreAggregation(
+                name="daily_rollup",
+                type="rollup",
+                measures=["order_count", "revenue"],
+                dimensions=["status", "is_priority"],
+                time_dimension="order_date",
+                granularity="day",
+                partition_granularity="month",
+                refresh_key=RefreshKey(every="1 hour", incremental=True, update_window="7 day"),
+                scheduled_refresh=False,
+                indexes=[Index(name="idx_status", columns=["status"], type="regular")],
+                build_range_start="date_trunc('month',current_date - interval '6 month')",
+                build_range_end="current_date",
+            )
+        ],
+    )
+
+    graph = SemanticGraph()
+    graph.add_model(model)
+
+    graph_metric = Metric(
+        name="total_revenue_graph",
+        type="derived",
+        sql="orders.revenue",
+        description="Graph-level revenue",
+    )
+    graph.add_metric(graph_metric)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        graph.add_parameter(
+            Parameter(
+                name="region",
+                type="string",
+                allowed_values=["us", "eu"],
+                default_value="us",
+                description="Region filter",
+            )
+        )
+
+    return graph
+
+
+def _parse_yaml_graph() -> SemanticGraph:
+    model_yaml = """
+models:
+  - name: orders
+    table: orders
+    source_uri: s3://warehouse/orders
+    description: Orders model
+    extends: base_orders
+    primary_key: order_id
+    default_time_dimension: order_date
+    default_grain: day
+    relationships:
+      - name: customers
+        type: many_to_one
+        foreign_key: customer_id
+        primary_key: id
+    dimensions:
+      - name: status
+        type: categorical
+        sql: status
+        description: Order status
+        label: Status
+      - name: order_date
+        type: time
+        sql: order_date
+        granularity: day
+        supported_granularities: [day, week, month]
+        description: Order date
+      - name: is_priority
+        type: boolean
+        sql: is_priority
+        description: Priority flag
+      - name: amount
+        type: numeric
+        sql: amount
+        format: "$#,##0.00"
+        value_format_name: usd
+    metrics:
+      - name: revenue
+        agg: sum
+        sql: amount
+        filters: [status = completed, status = pending]
+        fill_nulls_with: 0
+        description: Total revenue
+        label: Revenue
+        format: "$#,##0.00"
+        value_format_name: usd
+        drill_fields: [order_id, status]
+        non_additive_dimension: order_date
+      - name: order_count
+        agg: count
+        sql: order_id
+      - name: conversion_rate
+        type: ratio
+        numerator: completed_orders
+        denominator: order_count
+        offset_window: 1 month
+      - name: profit_margin
+        type: derived
+        sql: "(revenue - cost) / revenue"
+      - name: running_revenue
+        type: cumulative
+        sql: revenue
+        window: 7 days
+        grain_to_date: month
+        window_expression: SUM(revenue)
+        window_frame: RANGE BETWEEN INTERVAL 6 DAY PRECEDING AND CURRENT ROW
+        window_order: order_date
+      - name: revenue_yoy
+        type: time_comparison
+        base_metric: revenue
+        comparison_type: yoy
+        calculation: percent_change
+        time_offset: 1 year
+      - name: signup_to_purchase
+        type: conversion
+        entity: user_id
+        base_event: event_type = signup
+        conversion_event: event_type = purchase
+        conversion_window: 30 days
+    segments:
+      - name: completed
+        sql: status = completed
+        description: Completed orders only
+        public: false
+    pre_aggregations:
+      - name: daily_rollup
+        type: rollup
+        measures: [order_count, revenue]
+        dimensions: [status, is_priority]
+        time_dimension: order_date
+        granularity: day
+        partition_granularity: month
+        refresh_key:
+          every: 1 hour
+          incremental: true
+          update_window: 7 day
+        scheduled_refresh: false
+        indexes:
+          - name: idx_status
+            columns: [status]
+            type: regular
+        build_range_start: "date_trunc('month',current_date - interval '6 month')"
+        build_range_end: current_date
+"""
+
+    graph_yaml = """
+metrics:
+  - name: total_revenue_graph
+    type: derived
+    sql: orders.revenue
+    description: Graph-level revenue
+
+parameters:
+  - name: region
+    type: string
+    allowed_values: [us, eu]
+    default_value: us
+    description: Region filter
+"""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        model_path = tmpdir_path / "orders.yml"
+        graph_path = tmpdir_path / "graph.yml"
+        model_path.write_text(model_yaml)
+        graph_path.write_text(graph_yaml)
+
+        adapter = SidemanticAdapter()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            model_graph = adapter.parse(model_path)
+            graph_graph = adapter.parse(graph_path)
+
+        return _merge_graphs([model_graph, graph_graph])
+
+
+def _parse_sql_graph() -> SemanticGraph:
+    model_sql = """
+MODEL (
+  name orders,
+  table orders,
+  source_uri 's3://warehouse/orders',
+  description 'Orders model',
+  extends base_orders,
+  primary_key order_id,
+  default_time_dimension order_date,
+  default_grain day
+);
+
+RELATIONSHIP (
+  name customers,
+  type many_to_one,
+  foreign_key customer_id,
+  primary_key id
+);
+
+DIMENSION (
+  name status,
+  type categorical,
+  sql status,
+  description 'Order status',
+  label 'Status'
+);
+
+DIMENSION (
+  name order_date,
+  type time,
+  sql order_date,
+  granularity day,
+  supported_granularities [day, week, month],
+  description 'Order date'
+);
+
+DIMENSION (
+  name is_priority,
+  type boolean,
+  sql is_priority,
+  description 'Priority flag'
+);
+
+DIMENSION (
+  name amount,
+  type numeric,
+  sql amount,
+  format '$#,##0.00',
+  value_format_name usd
+);
+
+METRIC (
+  name revenue,
+  agg sum,
+  sql amount,
+  filters ['status = completed', 'status = pending'],
+  fill_nulls_with 0,
+  description 'Total revenue',
+  label 'Revenue',
+  format '$#,##0.00',
+  value_format_name usd,
+  drill_fields [order_id, status],
+  non_additive_dimension order_date
+);
+
+METRIC (
+  name order_count,
+  agg count,
+  sql order_id
+);
+
+METRIC (
+  name conversion_rate,
+  type ratio,
+  numerator completed_orders,
+  denominator order_count,
+  offset_window '1 month'
+);
+
+METRIC (
+  name profit_margin,
+  type derived,
+  sql (revenue - cost) / revenue
+);
+
+METRIC (
+  name running_revenue,
+  type cumulative,
+  sql revenue,
+  window '7 days',
+  grain_to_date month,
+  window_expression SUM(revenue),
+  window_frame 'RANGE BETWEEN INTERVAL 6 DAY PRECEDING AND CURRENT ROW',
+  window_order order_date
+);
+
+METRIC (
+  name revenue_yoy,
+  type time_comparison,
+  base_metric revenue,
+  comparison_type yoy,
+  calculation percent_change,
+  time_offset '1 year'
+);
+
+METRIC (
+  name signup_to_purchase,
+  type conversion,
+  entity user_id,
+  base_event event_type = signup,
+  conversion_event event_type = purchase,
+  conversion_window '30 days'
+);
+
+SEGMENT (
+  name completed,
+  expression status = completed,
+  description 'Completed orders only',
+  public false
+);
+
+PRE_AGGREGATION (
+  name daily_rollup,
+  type rollup,
+  measures [order_count, revenue],
+  dimensions [status, is_priority],
+  time_dimension order_date,
+  granularity day,
+  partition_granularity month,
+  refresh_key { every '1 hour', incremental true, update_window '7 day' },
+  scheduled_refresh false,
+  indexes [{ name idx_status, columns [status], type regular }],
+  build_range_start date_trunc('month',current_date - interval '6 month'),
+  build_range_end current_date
+);
+"""
+
+    graph_sql = """
+METRIC (
+  name total_revenue_graph,
+  type derived,
+  sql orders.revenue,
+  description 'Graph-level revenue'
+);
+
+PARAMETER (
+  name region,
+  type string,
+  allowed_values [us, eu],
+  default_value 'us',
+  description 'Region filter'
+);
+"""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        model_path = tmpdir_path / "orders.sql"
+        graph_path = tmpdir_path / "graph.sql"
+        model_path.write_text(model_sql)
+        graph_path.write_text(graph_sql)
+
+        adapter = SidemanticAdapter()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            model_graph = adapter.parse(model_path)
+            graph_graph = adapter.parse(graph_path)
+
+        return _merge_graphs([model_graph, graph_graph])
+
+
+def test_kitchen_sink_parity_roundtrip():
+    expected_graph = _build_python_graph()
+    yaml_graph = _parse_yaml_graph()
+    sql_graph = _parse_sql_graph()
+
+    expected = _normalize_graph(expected_graph)
+    yaml_result = _normalize_graph(yaml_graph)
+    sql_result = _normalize_graph(sql_graph)
+
+    assert yaml_result == expected
+    assert sql_result == expected


### PR DESCRIPTION
Add SQL/YAML parity parsing for parameters, pre-aggregations, and list/object literals. Extend the YAML adapter and SQL definition parser, and add a kitchen-sink parity roundtrip test across Python/YAML/SQL. Tests: uv run pytest tests/core/test_sql_definitions.py -v; uv run pytest tests/core/test_parity_roundtrip.py -v.