### PR TITLE
Make adapter dependencies optional for Malloy, LookML, and MetricFlow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,7 @@ dependencies = [
     "pyyaml>=6.0",
     "pydantic>=2.0.0",
     "jinja2>=3.1.0",
-    "lkml>=1.3.7",
     "duckdb>=1.0.0",
-    "inflect>=7.0.0,<7.2.0",  # PYODIDE: <7.2 required - inflect 7.2+ needs typing-extensions>=4.13 but Pyodide has 4.11.0
     "typer>=0.9.0",
 ]
 
@@ -27,6 +25,9 @@ dev = [
     "pandas>=2.2,<3",
     "numpy>=1.26,<3",
     "fakesnow>=0.9.0",  # For Snowflake integration tests
+    "lkml>=1.3.7",
+    "inflect>=7.0.0",
+    "antlr4-python3-runtime>=4.13.2",
 ]
 workbench = [
     "textual[syntax]>=1.0.0",
@@ -79,8 +80,14 @@ lsp = [
     "lsprotocol>=2025.0.0",
     "pygls>=2.0.0",
 ]
+lookml = [
+    "lkml>=1.3.7",
+]
 malloy = [
     "antlr4-python3-runtime>=4.13.2",
+]
+metricflow = [
+    "inflect>=7.0.0",
 ]
 widget = [
     "anywidget>=0.9.0",
@@ -91,7 +98,7 @@ all-databases = [
     "sidemantic[postgres,bigquery,snowflake,clickhouse,databricks,spark,adbc]",
 ]
 full = [
-    "sidemantic[workbench,mcp,charts,lsp,malloy,widget]",
+    "sidemantic[workbench,mcp,charts,lsp,lookml,malloy,metricflow,widget]",
 ]
 
 [build-system]
@@ -156,7 +163,9 @@ prerelease = "if-necessary"
 [dependency-groups]
 dev = [
     "antlr4-python3-runtime>=4.13.2",
+    "inflect>=7.0.0",
     "jupyterlab>=4.5.1",
+    "lkml>=1.3.7",
     "lsprotocol>=2025.0.0",
     "marimo==0.16.5",
     "numpy>=1.26,<3",

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -3,14 +3,21 @@
 import re
 from pathlib import Path
 
-import lkml
-
 from sidemantic.adapters.base import BaseAdapter
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_graph import SemanticGraph
+
+
+def _import_lkml():
+    """Lazily import lkml, raising a clear error if not installed."""
+    try:
+        import lkml
+    except ImportError:
+        raise ImportError('LookML support requires lkml. Install with: pip install "sidemantic[lookml]"') from None
+    return lkml
 
 
 class LookMLAdapter(BaseAdapter):
@@ -63,6 +70,8 @@ class LookMLAdapter(BaseAdapter):
             file_path: Path to .lkml file
             graph: Semantic graph to add models to
         """
+        lkml = _import_lkml()
+
         with open(file_path) as f:
             content = f.read()
 
@@ -88,6 +97,8 @@ class LookMLAdapter(BaseAdapter):
             file_path: Path to .lkml file
             graph: Semantic graph to add relationships to
         """
+        lkml = _import_lkml()
+
         with open(file_path) as f:
             content = f.read()
 
@@ -852,6 +863,7 @@ class LookMLAdapter(BaseAdapter):
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Use lkml to dump to LookML format
+        lkml = _import_lkml()
         with open(output_path, "w") as f:
             lookml_str = lkml.dump(data)
             f.write(lookml_str)

--- a/sidemantic/adapters/metricflow.py
+++ b/sidemantic/adapters/metricflow.py
@@ -675,23 +675,29 @@ class MetricFlowAdapter(BaseAdapter):
         Returns:
             Resolved model name or None if no match found
         """
-        import inflect
-
-        p = inflect.engine()
-
         # Try exact match (case-sensitive)
         if entity_name in model_names:
             return entity_name
 
-        # Try pluralization
-        plural = p.plural(entity_name)
-        if plural in model_names:
-            return plural
+        # Try pluralization/singularization if inflect is available
+        try:
+            import inflect
 
-        # Try singularization
-        singular = p.singular_noun(entity_name)
-        if singular and singular in model_names:
-            return singular
+            p = inflect.engine()
+
+            plural = p.plural(entity_name)
+            if plural in model_names:
+                return plural
+
+            singular = p.singular_noun(entity_name)
+            if singular and singular in model_names:
+                return singular
+        except ImportError:
+            # Without inflect, try basic s-suffix heuristics
+            if entity_name + "s" in model_names:
+                return entity_name + "s"
+            if entity_name.endswith("s") and entity_name[:-1] in model_names:
+                return entity_name[:-1]
 
         # Try case-insensitive match
         entity_lower = entity_name.lower()

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -52,16 +52,8 @@ def load_from_directory(layer: "SemanticLayer", directory: str | Path) -> None:
         if suffix == ".lkml":
             adapter = LookMLAdapter()
         elif suffix == ".malloy":
-            try:
-                from sidemantic.adapters.malloy import MalloyAdapter
-            except ModuleNotFoundError as exc:
-                if exc.name == "antlr4":
-                    print(
-                        "Warning: Malloy support requires antlr4-python3-runtime. "
-                        'Install with `uv add "sidemantic[malloy]"`.'
-                    )
-                    continue
-                raise
+            from sidemantic.adapters.malloy import MalloyAdapter
+
             adapter = MalloyAdapter()
         elif suffix == ".sql":
             # Sidemantic SQL files (pure SQL or with YAML frontmatter)

--- a/uv.lock
+++ b/uv.lock
@@ -3226,9 +3226,7 @@ version = "0.5.11"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
-    { name = "inflect" },
     { name = "jinja2" },
-    { name = "lkml" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "sqlglot" },
@@ -3270,7 +3268,10 @@ databricks = [
     { name = "pyarrow" },
 ]
 dev = [
+    { name = "antlr4-python3-runtime" },
     { name = "fakesnow" },
+    { name = "inflect" },
+    { name = "lkml" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "pytest" },
@@ -3281,6 +3282,8 @@ full = [
     { name = "altair" },
     { name = "antlr4-python3-runtime" },
     { name = "anywidget" },
+    { name = "inflect" },
+    { name = "lkml" },
     { name = "lsprotocol" },
     { name = "mcp", extra = ["cli"] },
     { name = "plotext" },
@@ -3289,6 +3292,9 @@ full = [
     { name = "textual", extra = ["syntax"] },
     { name = "textual-plotext" },
     { name = "vl-convert-python" },
+]
+lookml = [
+    { name = "lkml" },
 ]
 lsp = [
     { name = "lsprotocol" },
@@ -3299,6 +3305,9 @@ malloy = [
 ]
 mcp = [
     { name = "mcp", extra = ["cli"] },
+]
+metricflow = [
+    { name = "inflect" },
 ]
 postgres = [
     { name = "psycopg", extra = ["binary"] },
@@ -3332,7 +3341,9 @@ workbench = [
 [package.dev-dependencies]
 dev = [
     { name = "antlr4-python3-runtime" },
+    { name = "inflect" },
     { name = "jupyterlab" },
+    { name = "lkml" },
     { name = "lsprotocol" },
     { name = "marimo" },
     { name = "numpy" },
@@ -3347,6 +3358,7 @@ dev = [
 requires-dist = [
     { name = "adbc-driver-manager", marker = "extra == 'adbc'", specifier = ">=1.0.0" },
     { name = "altair", marker = "extra == 'charts'", specifier = ">=5.0.0" },
+    { name = "antlr4-python3-runtime", marker = "extra == 'dev'", specifier = ">=4.13.2" },
     { name = "antlr4-python3-runtime", marker = "extra == 'malloy'", specifier = ">=4.13.2" },
     { name = "anywidget", marker = "extra == 'widget'", specifier = ">=0.9.0" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = ">=0.6.0" },
@@ -3354,9 +3366,11 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fakesnow", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3.0.0" },
-    { name = "inflect", specifier = ">=7.0.0,<7.2.0" },
+    { name = "inflect", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "inflect", marker = "extra == 'metricflow'", specifier = ">=7.0.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
-    { name = "lkml", specifier = ">=1.3.7" },
+    { name = "lkml", marker = "extra == 'dev'", specifier = ">=1.3.7" },
+    { name = "lkml", marker = "extra == 'lookml'", specifier = ">=1.3.7" },
     { name = "lsprotocol", marker = "extra == 'lsp'", specifier = ">=2025.0.0" },
     { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.16.0" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=1.26,<3" },
@@ -3382,7 +3396,7 @@ requires-dist = [
     { name = "riffq", marker = "extra == 'serve'", specifier = ">=0.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
     { name = "sidemantic", extras = ["postgres", "bigquery", "snowflake", "clickhouse", "databricks", "spark", "adbc"], marker = "extra == 'all-databases'" },
-    { name = "sidemantic", extras = ["workbench", "mcp", "charts", "lsp", "malloy", "widget"], marker = "extra == 'full'" },
+    { name = "sidemantic", extras = ["workbench", "mcp", "charts", "lsp", "lookml", "malloy", "metricflow", "widget"], marker = "extra == 'full'" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.0.0" },
     { name = "sqlglot", specifier = "==27.12.0" },
     { name = "textual", extras = ["syntax"], marker = "extra == 'workbench'", specifier = ">=1.0.0" },
@@ -3392,12 +3406,14 @@ requires-dist = [
     { name = "typer", specifier = ">=0.9.0" },
     { name = "vl-convert-python", marker = "extra == 'charts'", specifier = ">=1.0.0" },
 ]
-provides-extras = ["dev", "workbench", "mcp", "charts", "serve", "postgres", "bigquery", "snowflake", "clickhouse", "databricks", "spark", "adbc", "lsp", "malloy", "widget", "all-databases", "full"]
+provides-extras = ["dev", "workbench", "mcp", "charts", "serve", "postgres", "bigquery", "snowflake", "clickhouse", "databricks", "spark", "adbc", "lsp", "lookml", "malloy", "metricflow", "widget", "all-databases", "full"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "antlr4-python3-runtime", specifier = ">=4.13.2" },
+    { name = "inflect", specifier = ">=7.0.0" },
     { name = "jupyterlab", specifier = ">=4.5.1" },
+    { name = "lkml", specifier = ">=1.3.7" },
     { name = "lsprotocol", specifier = ">=2025.0.0" },
     { name = "marimo", specifier = "==0.16.5" },
     { name = "numpy", specifier = ">=1.26,<3" },


### PR DESCRIPTION
Moves `lkml` and `inflect` from core dependencies to optional extras, and implements lazy loading for adapter-specific dependencies. This fixes the regression where importing sidemantic would fail if optional adapter dependencies weren't installed.

**Changes:**
- Lazy-load `antlr4` in malloy.py and `lkml` in lookml.py to avoid import errors
- Add graceful fallback in metricflow.py when `inflect` is not available
- New optional extras: `sidemantic[lookml]`, `sidemantic[metricflow]`, `sidemantic[malloy]`
- Removes Pyodide version constraint on inflect (no longer a core dependency)

All tests pass. No breaking changes for users with optional dependencies installed.