### PR TITLE
Fix Claude Desktop dropping tools

### DIFF
--- a/sidemantic/mcp_server.py
+++ b/sidemantic/mcp_server.py
@@ -152,7 +152,7 @@ def _format_join_condition(model_name: str, rel, models: dict[str, Any]) -> str 
 mcp = FastMCP("sidemantic")
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def get_models(model_names: list[str]) -> dict[str, Any]:
     """Get detailed information about one or more models.
 
@@ -320,15 +320,15 @@ def get_models(model_names: list[str]) -> dict[str, Any]:
     return {"models": details}
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def run_query(
-    dimensions: list[str] | None = None,
-    metrics: list[str] | None = None,
-    where: str | None = None,
-    segments: list[str] | None = None,
-    order_by: list[str] | None = None,
-    limit: int | None = None,
-    offset: int | None = None,
+    dimensions: list[str] = [],
+    metrics: list[str] = [],
+    where: str = "",
+    segments: list[str] = [],
+    order_by: list[str] = [],
+    limit: int = 0,
+    offset: int = 0,
     ungrouped: bool = False,
     dry_run: bool = False,
 ) -> dict[str, Any]:
@@ -368,8 +368,8 @@ def run_query(
         filters=[where] if where else None,
         segments=segments,
         order_by=order_by,
-        limit=limit,
-        offset=offset,
+        limit=limit or None,
+        offset=offset or None,
         ungrouped=ungrouped,
     )
 
@@ -391,17 +391,17 @@ def run_query(
     }
 
 
-@mcp.tool(meta={"ui": {"resourceUri": "ui://sidemantic/chart"}})
+@mcp.tool(structured_output=False, meta={"ui": {"resourceUri": "ui://sidemantic/chart"}})
 def create_chart(
-    dimensions: list[str] | None = None,
-    metrics: list[str] | None = None,
-    where: str | None = None,
-    segments: list[str] | None = None,
-    order_by: list[str] | None = None,
-    limit: int | None = None,
-    offset: int | None = None,
+    dimensions: list[str] = [],
+    metrics: list[str] = [],
+    where: str = "",
+    segments: list[str] = [],
+    order_by: list[str] = [],
+    limit: int = 0,
+    offset: int = 0,
     chart_type: Literal["auto", "bar", "line", "area", "scatter", "point"] = "auto",
-    title: str | None = None,
+    title: str = "",
     width: int = 600,
     height: int = 400,
 ) -> dict[str, Any]:
@@ -449,8 +449,8 @@ def create_chart(
         filters=[where] if where else None,
         segments=segments,
         order_by=order_by,
-        limit=limit,
-        offset=offset,
+        limit=limit or None,
+        offset=offset or None,
     )
 
     result = layer.adapter.execute(sql)
@@ -466,7 +466,7 @@ def create_chart(
         )
 
     # Auto-generate title if not provided
-    if title is None:
+    if not title:
         title = _generate_chart_title(dimensions or [], metrics or [])
 
     # Create chart with beautiful defaults
@@ -536,7 +536,7 @@ def _format_field_name(field: str) -> str:
     return field.replace("_", " ").title()
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def run_sql(query: str) -> dict[str, Any]:
     """Execute a SQL query rewritten through the semantic layer.
 
@@ -578,10 +578,10 @@ def run_sql(query: str) -> dict[str, Any]:
     }
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def validate_query(
-    dimensions: list[str] | None = None,
-    metrics: list[str] | None = None,
+    dimensions: list[str] = [],
+    metrics: list[str] = [],
 ) -> dict[str, Any]:
     """Validate dimension and metric references before running a query.
 
@@ -614,7 +614,7 @@ def validate_query(
     }
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def get_semantic_graph() -> dict[str, Any]:
     """Discover the semantic layer: all models, relationships, and available fields.
 

--- a/sidemantic/mcp_server.py
+++ b/sidemantic/mcp_server.py
@@ -153,7 +153,7 @@ mcp = FastMCP("sidemantic")
 
 
 @mcp.tool()
-def get_models(model_names: list[str]) -> list[dict[str, Any]]:
+def get_models(model_names: list[str]) -> dict[str, Any]:
     """Get detailed information about one or more models.
 
     Returns full definitions including all dimensions (with types, SQL, granularity),
@@ -317,7 +317,7 @@ def get_models(model_names: list[str]) -> list[dict[str, Any]]:
 
         details.append(detail)
 
-    return details
+    return {"models": details}
 
 
 @mcp.tool()
@@ -404,7 +404,7 @@ def create_chart(
     title: str | None = None,
     width: int = 600,
     height: int = 400,
-) -> dict[str, Any] | list[Any]:
+) -> dict[str, Any]:
     """Generate a chart from a semantic layer query, producing a Vega-Lite spec and PNG.
 
     Query parameters work the same as run_query (model.field_name references,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -116,7 +116,8 @@ def test_discover_models_via_semantic_graph(demo_layer):
 
 def test_get_models(demo_layer):
     """Test getting detailed model information."""
-    models = get_models(["orders"])
+    result = get_models(["orders"])
+    models = result["models"]
 
     assert len(models) == 1
     model = models[0]
@@ -145,15 +146,15 @@ def test_get_models(demo_layer):
 
 def test_get_models_nonexistent(demo_layer):
     """Test getting a model that doesn't exist."""
-    models = get_models(["nonexistent"])
-    assert len(models) == 0
+    result = get_models(["nonexistent"])
+    assert len(result["models"]) == 0
 
 
 def test_get_models_multiple(demo_layer):
     """Test getting multiple models (only one exists)."""
-    models = get_models(["orders", "nonexistent"])
-    assert len(models) == 1
-    assert models[0]["name"] == "orders"
+    result = get_models(["orders", "nonexistent"])
+    assert len(result["models"]) == 1
+    assert result["models"][0]["name"] == "orders"
 
 
 def test_run_query_basic(demo_layer):
@@ -455,8 +456,8 @@ def test_validate_query_invalid_metric(demo_layer):
 
 def test_segments_via_get_models(demo_layer):
     """Test that segments are accessible via get_models (replaces list_segments)."""
-    models = get_models(["orders"])
-    model = models[0]
+    result = get_models(["orders"])
+    model = result["models"][0]
 
     assert "segments" in model
     assert len(model["segments"]) == 2
@@ -489,8 +490,8 @@ def test_get_semantic_graph(demo_layer):
 
 def test_get_models_enriched(demo_layer):
     """Test that get_models returns enriched model data."""
-    models = get_models(["orders"])
-    model = models[0]
+    result = get_models(["orders"])
+    model = result["models"][0]
 
     # Check new fields
     assert model["primary_key"] == "id"


### PR DESCRIPTION
## Summary

Claude Desktop silently drops MCP tools from its UI when:
1. `outputSchema` is present in the tools/list response (auto-generated by mcp==1.26.0)
2. `anyOf` appears in inputSchema (from `T | None` type annotations)

This caused only 3 of 6 tools to appear in Claude Desktop.

- Add `structured_output=False` to all `@mcp.tool()` decorators to suppress outputSchema
- Replace `| None` optional params with falsy defaults (`[]`, `0`, `""`) to eliminate anyOf schemas
- Runtime behavior unchanged: falsy defaults convert back via `or None` where needed