### PR TITLE
Improve semantic SQL queries and compact model blocks

### DIFF
--- a/sidemantic/adapters/sidemantic.py
+++ b/sidemantic/adapters/sidemantic.py
@@ -18,7 +18,7 @@ from sidemantic.core.sql_definitions import (
     parse_sql_definitions,
     parse_sql_file_with_frontmatter_extended,
     parse_sql_graph_definitions,
-    parse_sql_model,
+    parse_sql_models,
 )
 
 
@@ -118,16 +118,13 @@ class SidemanticAdapter(BaseAdapter):
             with open(source_path) as f:
                 content = f.read()
 
-            # Check if file contains MODEL() statement (pure SQL)
-            if "MODEL" in content.upper() and "MODEL (" in content.upper():
-                model = parse_sql_model(content)
-                if model:
+            # Pure SQL model files can use either MODEL(...) or model name from table (...).
+            models = parse_sql_models(content)
+            if models:
+                for model in models:
                     graph.add_model(model)
                 sql_metrics, sql_segments, sql_parameters = parse_sql_graph_definitions(content)
-                if model:
-                    model_metric_names = {metric.name for metric in model.metrics}
-                else:
-                    model_metric_names = set()
+                model_metric_names = {metric.name for model in models for metric in model.metrics}
                 for metric in sql_metrics:
                     if metric.name not in model_metric_names:
                         graph.add_metric(metric)

--- a/sidemantic/core/dialect.py
+++ b/sidemantic/core/dialect.py
@@ -1,7 +1,9 @@
 """SQLGlot dialect extensions for Sidemantic SQL syntax."""
 
+import sqlglot
 from sqlglot import exp, parser, tokens
 from sqlglot.dialects.dialect import Dialect
+from sqlglot.tokens import Token, TokenType
 
 # Property name aliases (SQL syntax -> Python field name)
 # Shared between parser and sql_definitions module
@@ -111,6 +113,65 @@ class PreAggregationDef(exp.Expression):
     arg_types = {"expressions": True}
 
 
+class TableBlockModelDef(exp.Expression):
+    """Compact model block definition.
+
+    Syntax:
+        model orders from orders (
+            primary key (order_id)
+            status
+            sum(amount) as revenue
+        )
+    """
+
+    arg_types = {
+        "this": True,
+        "table": False,
+        "source_sql": False,
+        "expressions": False,
+    }
+
+
+class TableBlockPrimaryKeyDef(exp.Expression):
+    """Primary key declaration inside a compact model block."""
+
+    arg_types = {"columns": True}
+
+
+class TableBlockDefaultTimeDef(exp.Expression):
+    """Default time declaration inside a compact model block."""
+
+    arg_types = {"this": True, "grain": False}
+
+
+class TableBlockSegmentDef(exp.Expression):
+    """Segment declaration inside a compact model block."""
+
+    arg_types = {"this": True, "sql": True}
+
+
+class TableBlockJoinDef(exp.Expression):
+    """Relationship declaration inside a compact model block."""
+
+    arg_types = {
+        "this": True,
+        "relationship_type": True,
+        "local_keys": True,
+        "target_keys": True,
+    }
+
+
+class TableBlockFieldDef(exp.Expression):
+    """Dimension or metric field declaration inside a compact model block."""
+
+    arg_types = {
+        "this": True,
+        "sql": True,
+        "dimension_type": False,
+        "granularity": False,
+    }
+
+
 class PropertyEQ(exp.Expression):
     """Property assignment in METRIC/SEGMENT definitions.
 
@@ -118,6 +179,10 @@ class PropertyEQ(exp.Expression):
     """
 
     arg_types = {"this": True, "expression": True}
+
+
+class TableBlockParseError(ValueError):
+    """Raised when compact table-block model syntax is invalid."""
 
 
 class SidemanticParser(parser.Parser):
@@ -134,12 +199,110 @@ class SidemanticParser(parser.Parser):
         "PRE_AGGREGATION": lambda args: PreAggregationDef(expressions=args),
     }
 
+    _IDENTIFIER_TOKEN_TYPES = {
+        TokenType.IDENTIFIER,
+        TokenType.SCHEMA,
+        TokenType.TABLE,
+        TokenType.VAR,
+    }
+    _TIME_GRAINS = {"second", "minute", "hour", "day", "week", "month", "quarter", "year"}
+    _DIMENSION_TYPES = {"categorical", "time", "boolean", "numeric"}
+    _DIMENSION_TYPE_ALIASES = {
+        "bool": "boolean",
+        "date": "time",
+        "number": "numeric",
+        "string": "categorical",
+    }
+    _CARDINALITY_ALIASES = {
+        "one": "many_to_one",
+        "many": "one_to_many",
+        "many_to_one": "many_to_one",
+        "one_to_many": "one_to_many",
+        "one_to_one": "one_to_one",
+    }
+    _STATEMENT_CONTINUATION_TOKEN_TYPES = {
+        TokenType.ALIAS,
+        TokenType.AND,
+        TokenType.ARROW,
+        TokenType.BETWEEN,
+        TokenType.COLON,
+        TokenType.COMMA,
+        TokenType.DARROW,
+        TokenType.DCOLON,
+        TokenType.DASH,
+        TokenType.DOT,
+        TokenType.ELSE,
+        TokenType.EQ,
+        TokenType.ESCAPE,
+        TokenType.GT,
+        TokenType.GTE,
+        TokenType.ILIKE,
+        TokenType.IN,
+        TokenType.IS,
+        TokenType.L_BRACE,
+        TokenType.L_BRACKET,
+        TokenType.L_PAREN,
+        TokenType.LIKE,
+        TokenType.LT,
+        TokenType.LTE,
+        TokenType.MOD,
+        TokenType.NEQ,
+        TokenType.NOT,
+        TokenType.ON,
+        TokenType.OR,
+        TokenType.PERCENT,
+        TokenType.PLUS,
+        TokenType.RLIKE,
+        TokenType.SLASH,
+        TokenType.STAR,
+        TokenType.THEN,
+        TokenType.WHEN,
+    }
+
+    def parse(self, raw_tokens: list[Token], sql: str | None = None) -> list[exp.Expression | None]:
+        """Parse Sidemantic SQL, including newline-delimited compact model blocks."""
+        if not self._has_table_block_model(raw_tokens):
+            return super().parse(raw_tokens, sql)
+
+        self.reset()
+        self.sql = sql or ""
+        self._index = -1
+        self._tokens = raw_tokens
+        self._advance()
+
+        expressions = []
+        while self._curr:
+            if self._match(TokenType.SEMICOLON):
+                continue
+            statement = self._parse_statement()
+            if statement:
+                expressions.append(statement)
+                continue
+            self.raise_error("Expected Sidemantic SQL statement")
+
+        self.check_errors()
+        return expressions
+
+    @classmethod
+    def _has_table_block_model(cls, raw_tokens: list[Token]) -> bool:
+        for idx, token in enumerate(raw_tokens):
+            if token.text.upper() != "MODEL":
+                continue
+            if idx + 1 >= len(raw_tokens):
+                continue
+            if raw_tokens[idx + 1].token_type != TokenType.L_PAREN:
+                return True
+        return False
+
     def _parse_statement(self) -> exp.Expression | None:
         """Override to handle MODEL, DIMENSION, RELATIONSHIP, METRIC, and SEGMENT as statements."""
         if self._match_texts(
             ("MODEL", "DIMENSION", "RELATIONSHIP", "METRIC", "SEGMENT", "PARAMETER", "PRE_AGGREGATION")
         ):
             func_name = self._prev.text.upper()
+            if func_name == "MODEL" and (not self._curr or self._curr.token_type != tokens.TokenType.L_PAREN):
+                return self._parse_table_block_model()
+
             self._match(tokens.TokenType.L_PAREN)
 
             # Parse properties
@@ -171,6 +334,558 @@ class SidemanticParser(parser.Parser):
                 return PreAggregationDef(expressions=properties)
 
         return super()._parse_statement()
+
+    def _parse_table_block_model(self) -> TableBlockModelDef:
+        model_name = self._parse_table_block_identifier()
+        if not model_name:
+            raise TableBlockParseError("Compact model block requires a model name")
+
+        if not self._match(TokenType.FROM):
+            raise TableBlockParseError(
+                f"Table-block model '{model_name}' must use `model {model_name} from <table> (...)`"
+            )
+
+        table = None
+        source_sql = None
+        if self._curr and self._curr.token_type == TokenType.L_PAREN:
+            source_sql = self._parse_table_block_derived_source(model_name)
+        else:
+            table = self._parse_table_block_source_table(model_name)
+
+        if not self._curr or self._curr.token_type != TokenType.L_PAREN:
+            source = "derived SQL source" if source_sql else "table source"
+            raise TableBlockParseError(f"Model '{model_name}' must include a body block after the {source}")
+
+        body_tokens = self._consume_balanced_tokens(model_name, "model block")
+        body_expressions = [
+            self._parse_table_block_body_statement(model_name, statement_tokens)
+            for statement_tokens in self._split_table_block_body_statements(body_tokens)
+        ]
+
+        return TableBlockModelDef(
+            this=exp.to_identifier(model_name),
+            table=table,
+            source_sql=source_sql,
+            expressions=body_expressions,
+        )
+
+    def _parse_table_block_derived_source(self, model_name: str) -> str:
+        open_token = self._curr
+        source_tokens = self._consume_balanced_tokens(model_name, "derived SQL source")
+        if not source_tokens:
+            raise TableBlockParseError(f"Derived SQL source for model '{model_name}' cannot be empty")
+
+        close_token = self._tokens[self._index - 1]
+        source_sql = self.sql[open_token.end + 1 : close_token.start].strip()
+        if not source_sql:
+            raise TableBlockParseError(f"Derived SQL source for model '{model_name}' cannot be empty")
+        return source_sql
+
+    def _parse_table_block_source_table(self, model_name: str) -> str:
+        parts = []
+        first = self._parse_table_block_identifier()
+        if not first:
+            raise TableBlockParseError(f"Model '{model_name}' must declare a table or derived SQL source after `from`")
+        parts.append(first)
+
+        while self._match(TokenType.DOT):
+            part = self._parse_table_block_identifier()
+            if not part:
+                raise TableBlockParseError(f"Model '{model_name}' has an invalid table source")
+            parts.append(part)
+
+        return ".".join(parts)
+
+    def _consume_balanced_tokens(self, model_name: str, label: str) -> list[Token]:
+        if not self._match(TokenType.L_PAREN):
+            raise TableBlockParseError(f"Model '{model_name}' must include a {label}")
+
+        body_tokens = []
+        depth = 1
+        while self._curr:
+            if self._curr.token_type == TokenType.L_PAREN:
+                depth += 1
+            elif self._curr.token_type == TokenType.R_PAREN:
+                depth -= 1
+                if depth == 0:
+                    self._advance()
+                    return body_tokens
+
+            body_tokens.append(self._curr)
+            self._advance()
+
+        raise TableBlockParseError(f"Unclosed {label} for model '{model_name}'")
+
+    def _split_table_block_body_statements(self, body_tokens: list[Token]) -> list[list[Token]]:
+        statements = []
+        statement = []
+        depth = 0
+        previous_token = None
+
+        for token in body_tokens:
+            if (
+                previous_token
+                and statement
+                and depth == 0
+                and self._has_statement_separator_between(statement, previous_token, token)
+            ):
+                statements.append(statement)
+                statement = []
+
+            if token.token_type == TokenType.SEMICOLON and depth == 0:
+                if statement:
+                    statements.append(statement)
+                    statement = []
+                previous_token = token
+                continue
+
+            statement.append(token)
+
+            if token.token_type in (TokenType.L_PAREN, TokenType.L_BRACKET, TokenType.L_BRACE):
+                depth += 1
+            elif token.token_type in (TokenType.R_PAREN, TokenType.R_BRACKET, TokenType.R_BRACE):
+                depth = max(depth - 1, 0)
+
+            previous_token = token
+
+        if statement:
+            statements.append(statement)
+
+        return statements
+
+    def _has_statement_separator_between(self, statement_tokens: list[Token], left: Token, right: Token) -> bool:
+        gap = self.sql[left.end + 1 : right.start]
+        if ";" in gap:
+            return True
+        if "\n" not in gap:
+            return False
+        return self._table_block_statement_can_end(statement_tokens) and not self._token_continues_statement(right)
+
+    def _table_block_statement_can_end(self, statement_tokens: list[Token]) -> bool:
+        if not statement_tokens or self._token_continues_statement(statement_tokens[-1]):
+            return False
+
+        first_text = statement_tokens[0].text.lower()
+        first_type = statement_tokens[0].token_type
+
+        if first_type == TokenType.PRIMARY_KEY or first_text == "primary_key":
+            return len(statement_tokens) > 1
+
+        if first_type == TokenType.DEFAULT:
+            return len(statement_tokens) == 3 or len(statement_tokens) == 5
+
+        if first_text == "segment":
+            alias_idx = self._find_top_level_token(statement_tokens, TokenType.ALIAS, start=2)
+            return alias_idx is not None and alias_idx < len(statement_tokens) - 1
+
+        if first_type == TokenType.JOIN:
+            on_idx = self._find_top_level_token(statement_tokens, TokenType.ON, start=1)
+            return on_idx is not None and on_idx < len(statement_tokens) - 1
+
+        colon_idx = self._find_top_level_token(statement_tokens, TokenType.COLON)
+        base_tokens = statement_tokens[:colon_idx] if colon_idx is not None else statement_tokens
+        if not base_tokens:
+            return False
+
+        alias_idx = self._find_top_level_token(base_tokens, TokenType.ALIAS)
+        if alias_idx is not None:
+            name_tokens = base_tokens[alias_idx + 1 :]
+            return alias_idx > 0 and len(name_tokens) == 1 and self._identifier_from_token(name_tokens[0]) is not None
+
+        return len(base_tokens) == 1 and self._identifier_from_token(base_tokens[0]) is not None
+
+    def _token_continues_statement(self, token: Token) -> bool:
+        return token.token_type in self._STATEMENT_CONTINUATION_TOKEN_TYPES
+
+    def _parse_table_block_body_statement(self, model_name: str, statement_tokens: list[Token]) -> exp.Expression:
+        first_text = statement_tokens[0].text.lower()
+        first_type = statement_tokens[0].token_type
+
+        if first_type == TokenType.TABLE:
+            raise TableBlockParseError(
+                f"Model '{model_name}' uses table source inside the block; use `model {model_name} from <table> (...)`"
+            )
+        if first_type == TokenType.PRIMARY_KEY or first_text == "primary_key":
+            return self._parse_table_block_primary_key(model_name, statement_tokens)
+        if first_type == TokenType.DEFAULT:
+            return self._parse_table_block_default_time(model_name, statement_tokens)
+        if first_text == "segment":
+            return self._parse_table_block_segment(model_name, statement_tokens)
+        if first_type == TokenType.JOIN:
+            return self._parse_table_block_join(model_name, statement_tokens)
+
+        field = self._parse_table_block_field(model_name, statement_tokens)
+        if field:
+            return field
+
+        raise TableBlockParseError(
+            f"Unrecognized statement in model '{model_name}': {self._statement_sql(statement_tokens)}"
+        )
+
+    def _parse_table_block_primary_key(
+        self,
+        model_name: str,
+        statement_tokens: list[Token],
+    ) -> TableBlockPrimaryKeyDef:
+        value_tokens = statement_tokens[1:]
+        if not value_tokens:
+            raise TableBlockParseError("Primary key requires at least one column")
+
+        if value_tokens[0].token_type == TokenType.L_PAREN and value_tokens[-1].token_type == TokenType.R_PAREN:
+            value_tokens = value_tokens[1:-1]
+        if not value_tokens:
+            raise TableBlockParseError("Primary key requires at least one column")
+
+        columns = self._parse_identifier_list(value_tokens)
+        if not columns:
+            raise TableBlockParseError("Primary key requires at least one column")
+
+        return TableBlockPrimaryKeyDef(columns=columns)
+
+    def _parse_table_block_default_time(
+        self,
+        model_name: str,
+        statement_tokens: list[Token],
+    ) -> TableBlockDefaultTimeDef:
+        if len(statement_tokens) < 3 or statement_tokens[1].text.lower() != "time":
+            raise TableBlockParseError(
+                f"Invalid default time in model '{model_name}': {self._statement_sql(statement_tokens)}"
+            )
+
+        dimension_name = self._identifier_from_token(statement_tokens[2])
+        if not dimension_name:
+            raise TableBlockParseError(
+                f"Invalid default time in model '{model_name}': {self._statement_sql(statement_tokens)}"
+            )
+
+        grain = None
+        if len(statement_tokens) > 3:
+            if (
+                len(statement_tokens) != 5
+                or statement_tokens[3].text.lower() not in ("grain", "granularity")
+                or not self._identifier_from_token(statement_tokens[4])
+            ):
+                raise TableBlockParseError(
+                    f"Invalid default time in model '{model_name}': {self._statement_sql(statement_tokens)}"
+                )
+            grain = statement_tokens[4].text.lower()
+            self._validate_time_grain(model_name, "default time", grain)
+
+        return TableBlockDefaultTimeDef(this=exp.to_identifier(dimension_name), grain=grain)
+
+    def _parse_table_block_segment(
+        self,
+        model_name: str,
+        statement_tokens: list[Token],
+    ) -> TableBlockSegmentDef:
+        if len(statement_tokens) < 4:
+            raise TableBlockParseError(
+                f"Invalid segment in model '{model_name}': {self._statement_sql(statement_tokens)}"
+            )
+
+        segment_name = self._identifier_from_token(statement_tokens[1])
+        alias_idx = self._find_top_level_token(statement_tokens, TokenType.ALIAS, start=2)
+        if not segment_name or alias_idx is None or alias_idx == len(statement_tokens) - 1:
+            raise TableBlockParseError(
+                f"Invalid segment in model '{model_name}': {self._statement_sql(statement_tokens)}"
+            )
+
+        expression_sql = self._statement_sql(statement_tokens[alias_idx + 1 :])
+        if not expression_sql:
+            raise TableBlockParseError(f"Segment '{segment_name}' in model '{model_name}' requires a SQL expression")
+
+        return TableBlockSegmentDef(this=exp.to_identifier(segment_name), sql=expression_sql)
+
+    def _parse_table_block_join(
+        self,
+        model_name: str,
+        statement_tokens: list[Token],
+    ) -> TableBlockJoinDef:
+        on_idx = self._find_top_level_token(statement_tokens, TokenType.ON, start=1)
+        if on_idx is None or on_idx <= 1 or on_idx == len(statement_tokens) - 1:
+            raise TableBlockParseError(f"Invalid join in model '{model_name}': {self._statement_sql(statement_tokens)}")
+
+        header_tokens = statement_tokens[1:on_idx]
+        cardinality = None
+        target_idx = 0
+        if header_tokens[0].text.lower() in self._CARDINALITY_ALIASES:
+            cardinality = header_tokens[0].text.lower()
+            target_idx = 1
+
+        if target_idx >= len(header_tokens):
+            raise TableBlockParseError(f"Invalid join in model '{model_name}': {self._statement_sql(statement_tokens)}")
+
+        target_model = self._identifier_from_token(header_tokens[target_idx])
+        if not target_model:
+            raise TableBlockParseError(f"Invalid join in model '{model_name}': {self._statement_sql(statement_tokens)}")
+
+        alias = None
+        alias_tokens = header_tokens[target_idx + 1 :]
+        if alias_tokens:
+            if len(alias_tokens) == 2 and alias_tokens[0].token_type == TokenType.ALIAS:
+                alias = self._identifier_from_token(alias_tokens[1])
+            elif len(alias_tokens) == 1:
+                alias = self._identifier_from_token(alias_tokens[0])
+            if not alias:
+                raise TableBlockParseError(
+                    f"Invalid join in model '{model_name}': {self._statement_sql(statement_tokens)}"
+                )
+
+        relationship_type = self._CARDINALITY_ALIASES.get(cardinality or "one", "many_to_one")
+        on_expression = self._statement_sql(statement_tokens[on_idx + 1 :])
+        join_keys = self._extract_table_block_join_keys(
+            on_expression=on_expression,
+            current_model_name=model_name,
+            target_model_name=target_model,
+            target_alias=alias,
+        )
+        if not join_keys:
+            raise TableBlockParseError(
+                f"Join in model '{model_name}' must compare model columns: {self._statement_sql(statement_tokens)}"
+            )
+
+        local_keys, target_keys = join_keys
+        return TableBlockJoinDef(
+            this=exp.to_identifier(target_model),
+            relationship_type=relationship_type,
+            local_keys=local_keys,
+            target_keys=target_keys,
+        )
+
+    def _parse_table_block_field(
+        self,
+        model_name: str,
+        statement_tokens: list[Token],
+    ) -> TableBlockFieldDef | None:
+        colon_idx = self._find_top_level_token(statement_tokens, TokenType.COLON)
+        base_tokens = statement_tokens[:colon_idx] if colon_idx is not None else statement_tokens
+        annotation_tokens = statement_tokens[colon_idx + 1 :] if colon_idx is not None else []
+        if not base_tokens:
+            return None
+
+        dimension_type, granularity = self._parse_table_block_field_annotation(
+            model_name, base_tokens, annotation_tokens
+        )
+        alias_idx = self._find_top_level_token(base_tokens, TokenType.ALIAS)
+        if alias_idx is not None:
+            if alias_idx == 0 or alias_idx == len(base_tokens) - 1:
+                return None
+            name_tokens = base_tokens[alias_idx + 1 :]
+            if len(name_tokens) != 1:
+                return None
+            name = self._identifier_from_token(name_tokens[0])
+            if not name:
+                return None
+            return TableBlockFieldDef(
+                this=exp.to_identifier(name),
+                sql=self._statement_sql(base_tokens[:alias_idx]),
+                dimension_type=dimension_type,
+                granularity=granularity,
+            )
+
+        if len(base_tokens) == 1:
+            name = self._identifier_from_token(base_tokens[0])
+            if name:
+                return TableBlockFieldDef(
+                    this=exp.to_identifier(name),
+                    sql=name,
+                    dimension_type=dimension_type,
+                    granularity=granularity,
+                )
+
+        return None
+
+    def _parse_table_block_field_annotation(
+        self,
+        model_name: str,
+        base_tokens: list[Token],
+        annotation_tokens: list[Token],
+    ) -> tuple[str | None, str | None]:
+        if not annotation_tokens:
+            return None, None
+
+        field_name = self._statement_sql(base_tokens)
+        dimension_type = None
+        granularity = None
+        idx = 0
+
+        while idx < len(annotation_tokens):
+            token = annotation_tokens[idx].text.lower()
+            normalized_type = self._DIMENSION_TYPE_ALIASES.get(token, token)
+
+            if normalized_type in self._DIMENSION_TYPES:
+                if dimension_type and dimension_type != normalized_type:
+                    raise TableBlockParseError(
+                        f"Field '{field_name}' in model '{model_name}' has conflicting type annotations"
+                    )
+                dimension_type = normalized_type
+                idx += 1
+                continue
+
+            if token in ("grain", "granularity"):
+                if idx + 1 >= len(annotation_tokens):
+                    raise TableBlockParseError(
+                        f"Field '{field_name}' in model '{model_name}' is missing a {token} value"
+                    )
+                grain = annotation_tokens[idx + 1].text.lower()
+                self._validate_time_grain(model_name, field_name, grain)
+                granularity = grain
+                if not dimension_type:
+                    dimension_type = "time"
+                elif dimension_type != "time":
+                    raise TableBlockParseError(
+                        f"Field '{field_name}' in model '{model_name}' cannot use grain with type '{dimension_type}'"
+                    )
+                idx += 2
+                continue
+
+            raise TableBlockParseError(
+                f"Field '{field_name}' in model '{model_name}' has unknown annotation '{annotation_tokens[idx].text}'"
+            )
+
+        return dimension_type, granularity
+
+    def _extract_table_block_join_keys(
+        self,
+        on_expression: str,
+        current_model_name: str,
+        target_model_name: str,
+        target_alias: str | None,
+    ) -> tuple[list[str], list[str]] | None:
+        try:
+            parsed = sqlglot.parse_one(on_expression, read="duckdb")
+        except Exception:
+            return None
+
+        equalities = self._table_block_join_equalities(parsed)
+        if equalities is None:
+            return None
+
+        local_keys = []
+        target_keys = []
+        for equality in equalities:
+            left = equality.left
+            right = equality.right
+            if not isinstance(left, exp.Column) or not isinstance(right, exp.Column):
+                return None
+
+            left_side = self._classify_join_column(left, current_model_name, target_model_name, target_alias)
+            right_side = self._classify_join_column(right, current_model_name, target_model_name, target_alias)
+            if left_side == "local" and right_side == "target":
+                local_keys.append(left.name)
+                target_keys.append(right.name)
+                continue
+            if left_side == "target" and right_side == "local":
+                local_keys.append(right.name)
+                target_keys.append(left.name)
+                continue
+            return None
+
+        if not local_keys:
+            return None
+        return local_keys, target_keys
+
+    def _table_block_join_equalities(self, expression: exp.Expression) -> list[exp.EQ] | None:
+        expression = self._unwrap_table_block_join_expression(expression)
+        if isinstance(expression, exp.EQ):
+            return [expression]
+        if isinstance(expression, exp.And):
+            left = self._table_block_join_equalities(expression.left)
+            right = self._table_block_join_equalities(expression.right)
+            if left is None or right is None:
+                return None
+            return left + right
+        return None
+
+    def _unwrap_table_block_join_expression(self, expression: exp.Expression) -> exp.Expression:
+        while isinstance(expression, exp.Paren) and isinstance(expression.this, exp.Expression):
+            expression = expression.this
+        return expression
+
+    def _classify_join_column(
+        self,
+        column: exp.Column,
+        current_model_name: str,
+        target_model_name: str,
+        target_alias: str | None,
+    ) -> str | None:
+        table = column.table
+        if not table or table == current_model_name:
+            return "local"
+        if table == target_model_name or table == target_alias:
+            return "target"
+        return None
+
+    def _find_top_level_token(
+        self,
+        statement_tokens: list[Token],
+        token_type: TokenType,
+        start: int = 0,
+    ) -> int | None:
+        depth = 0
+        for idx, token in enumerate(statement_tokens[start:], start=start):
+            if token.token_type in (TokenType.L_PAREN, TokenType.L_BRACKET, TokenType.L_BRACE):
+                depth += 1
+                continue
+            if token.token_type in (TokenType.R_PAREN, TokenType.R_BRACKET, TokenType.R_BRACE):
+                depth = max(depth - 1, 0)
+                continue
+            if depth == 0 and token.token_type == token_type:
+                return idx
+        return None
+
+    def _parse_identifier_list(self, value_tokens: list[Token]) -> list[str]:
+        columns = []
+        current = []
+        depth = 0
+
+        for token in value_tokens:
+            if token.token_type == TokenType.COMMA and depth == 0:
+                column = self._identifier_from_tokens(current)
+                if not column:
+                    return []
+                columns.append(column)
+                current = []
+                continue
+
+            if token.token_type in (TokenType.L_PAREN, TokenType.L_BRACKET, TokenType.L_BRACE):
+                depth += 1
+            elif token.token_type in (TokenType.R_PAREN, TokenType.R_BRACKET, TokenType.R_BRACE):
+                depth = max(depth - 1, 0)
+            current.append(token)
+
+        column = self._identifier_from_tokens(current)
+        if not column:
+            return []
+        columns.append(column)
+        return columns
+
+    def _identifier_from_tokens(self, value_tokens: list[Token]) -> str | None:
+        if len(value_tokens) != 1:
+            return None
+        return self._identifier_from_token(value_tokens[0])
+
+    def _parse_table_block_identifier(self) -> str | None:
+        if not self._curr:
+            return None
+        identifier = self._identifier_from_token(self._curr)
+        if identifier:
+            self._advance()
+        return identifier
+
+    def _identifier_from_token(self, token: Token) -> str | None:
+        if token.token_type not in self._IDENTIFIER_TOKEN_TYPES:
+            return None
+        return token.text
+
+    def _statement_sql(self, statement_tokens: list[Token]) -> str:
+        if not statement_tokens:
+            return ""
+        return self.sql[statement_tokens[0].start : statement_tokens[-1].end + 1].strip()
+
+    def _validate_time_grain(self, model_name: str, field_name: str, grain: str) -> None:
+        if grain not in self._TIME_GRAINS:
+            raise TableBlockParseError(f"Field '{field_name}' in model '{model_name}' uses invalid grain '{grain}'")
 
     def _parse_property(self) -> exp.Expression | None:
         """Parse property assignment: name value or name 'value'."""

--- a/sidemantic/core/sql_definitions.py
+++ b/sidemantic/core/sql_definitions.py
@@ -1,8 +1,10 @@
 """Parse SQL-based metric and segment definitions."""
 
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
+import sqlglot
 import yaml
 from sqlglot import exp
 
@@ -16,6 +18,13 @@ from sidemantic.core.dialect import (
     PropertyEQ,
     RelationshipDef,
     SegmentDef,
+    TableBlockDefaultTimeDef,
+    TableBlockFieldDef,
+    TableBlockJoinDef,
+    TableBlockModelDef,
+    TableBlockParseError,
+    TableBlockPrimaryKeyDef,
+    TableBlockSegmentDef,
     parse,
 )
 from sidemantic.core.dimension import Dimension
@@ -25,6 +34,7 @@ from sidemantic.core.parameter import Parameter
 from sidemantic.core.pre_aggregation import Index, PreAggregation, RefreshKey
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.segment import Segment
+from sidemantic.sql.aggregation_detection import sql_has_aggregate
 
 
 def _split_top_level(text: str, delimiter: str = ",") -> list[str]:
@@ -177,8 +187,422 @@ def _normalize_list(value: object | None) -> list[object] | None:
     return [value]
 
 
+_TIME_GRAINS = {"second", "minute", "hour", "day", "week", "month", "quarter", "year"}
+
+
+@dataclass(frozen=True)
+class TableBlockFieldAnnotation:
+    dimension_type: str | None = None
+    granularity: str | None = None
+
+
+def parse_sql_models(sql: str) -> list[Model]:
+    """Parse SQL string containing one or more complete model definitions."""
+    try:
+        statements = parse(sql)
+    except TableBlockParseError:
+        raise
+    except Exception:
+        return []
+
+    if any(isinstance(stmt, (TableBlockModelDef, ModelDef)) for stmt in statements):
+        return _parse_mixed_sql_models(statements)
+    return []
+
+
+def _parse_mixed_sql_models(statements: list[exp.Expression | None]) -> list[Model]:
+    models = []
+    legacy_statements: list[exp.Expression | None] = []
+
+    def flush_legacy_model() -> None:
+        if not legacy_statements:
+            return
+
+        model_def, dimensions, relationships, metrics, segments, _, pre_aggregations = _parse_statement_defs(
+            legacy_statements
+        )
+        legacy_statements.clear()
+        if not model_def:
+            return
+
+        if dimensions:
+            model_def.dimensions.extend(dimensions)
+        if relationships:
+            model_def.relationships.extend(relationships)
+        if metrics:
+            model_def.metrics.extend(metrics)
+        if segments:
+            model_def.segments.extend(segments)
+        if pre_aggregations:
+            model_def.pre_aggregations.extend(pre_aggregations)
+
+        models.append(model_def)
+
+    for statement in statements:
+        if isinstance(statement, TableBlockModelDef):
+            flush_legacy_model()
+            models.append(_parse_table_block_model_def(statement))
+            continue
+
+        if isinstance(statement, ModelDef):
+            flush_legacy_model()
+            legacy_statements.append(statement)
+            continue
+
+        if legacy_statements and isinstance(
+            statement, (DimensionDef, RelationshipDef, MetricDef, SegmentDef, PreAggregationDef)
+        ):
+            legacy_statements.append(statement)
+
+    flush_legacy_model()
+    return models
+
+
+def _parse_table_block_model_def(model_def: TableBlockModelDef) -> Model:
+    model_name = model_def.this.name
+    table = model_def.args.get("table")
+    source_sql = model_def.args.get("source_sql")
+    primary_key: str | list[str] = "id"
+    default_time_dimension: str | None = None
+    default_grain: str | None = None
+    relationships: list[Relationship] = []
+    segments: list[Segment] = []
+    field_declarations: list[tuple[int, str, str, TableBlockFieldAnnotation | None]] = []
+    parsed_fields: list[tuple[int, str, Dimension | Metric]] = []
+    seen_fields: set[str] = set()
+    seen_segments: set[str] = set()
+    seen_primary_key = False
+    seen_default_time = False
+
+    for statement_idx, statement in enumerate(model_def.expressions):
+        if isinstance(statement, TableBlockPrimaryKeyDef):
+            if seen_primary_key:
+                raise TableBlockParseError(f"Model '{model_name}' defines primary key more than once")
+            seen_primary_key = True
+            primary_key = _collapse_table_block_key_columns(statement.args["columns"])
+            continue
+
+        if isinstance(statement, TableBlockDefaultTimeDef):
+            if seen_default_time:
+                raise TableBlockParseError(f"Model '{model_name}' defines default time more than once")
+            seen_default_time = True
+            default_time_dimension = statement.this.name
+            default_grain = statement.args.get("grain")
+            continue
+
+        if isinstance(statement, TableBlockSegmentDef):
+            segment = Segment(name=statement.this.name, sql=statement.args["sql"])
+            if segment.name in seen_segments:
+                raise TableBlockParseError(f"Model '{model_name}' defines segment '{segment.name}' more than once")
+            seen_segments.add(segment.name)
+            segments.append(segment)
+            continue
+
+        if isinstance(statement, TableBlockJoinDef):
+            relationship = _parse_table_block_join_def(statement)
+            relationships.append(relationship)
+            continue
+
+        if isinstance(statement, TableBlockFieldDef):
+            name = statement.this.name
+            if name in seen_fields:
+                raise TableBlockParseError(f"Model '{model_name}' defines field '{name}' more than once")
+            seen_fields.add(name)
+            annotation = _table_block_field_annotation(statement)
+            field_declarations.append((statement_idx, name, statement.args["sql"], annotation))
+            continue
+
+        raise TableBlockParseError(f"Unrecognized statement in model '{model_name}': {statement.sql()}")
+
+    parsed_fields.extend(_classify_table_block_fields(model_name, field_declarations))
+    parsed_fields.sort(key=lambda item: item[0])
+
+    dimensions = [field for _, kind, field in parsed_fields if kind == "dimension"]
+    metrics = [field for _, kind, field in parsed_fields if kind == "metric"]
+    _validate_table_block_default_time(model_name, default_time_dimension, dimensions)
+
+    return Model(
+        name=model_name,
+        table=table,
+        sql=source_sql,
+        primary_key=primary_key,
+        dimensions=dimensions,
+        relationships=relationships,
+        metrics=metrics,
+        segments=segments,
+        default_time_dimension=default_time_dimension,
+        default_grain=default_grain,
+    )
+
+
+def _table_block_field_annotation(field_def: TableBlockFieldDef) -> TableBlockFieldAnnotation | None:
+    dimension_type = field_def.args.get("dimension_type")
+    granularity = field_def.args.get("granularity")
+    if not dimension_type and not granularity:
+        return None
+    return TableBlockFieldAnnotation(dimension_type=dimension_type, granularity=granularity)
+
+
+def _parse_table_block_join_def(join_def: TableBlockJoinDef) -> Relationship:
+    relationship_type = join_def.args["relationship_type"]
+    local_keys = join_def.args["local_keys"]
+    target_keys = join_def.args["target_keys"]
+    if relationship_type in ("many_to_one", "one_to_one"):
+        return Relationship(
+            name=join_def.this.name,
+            type=relationship_type,
+            foreign_key=_collapse_table_block_key_columns(local_keys),
+            primary_key=_collapse_table_block_key_columns(target_keys),
+        )
+
+    return Relationship(
+        name=join_def.this.name,
+        type=relationship_type,
+        foreign_key=_collapse_table_block_key_columns(target_keys),
+        primary_key=_collapse_table_block_key_columns(local_keys),
+    )
+
+
+def _validate_table_block_default_time(
+    model_name: str,
+    default_time_dimension: str | None,
+    dimensions: list[Dimension],
+) -> None:
+    if not default_time_dimension:
+        return
+
+    dimension_by_name = {dimension.name: dimension for dimension in dimensions}
+    dimension = dimension_by_name.get(default_time_dimension)
+    if not dimension:
+        raise TableBlockParseError(
+            f"Default time dimension '{default_time_dimension}' in model '{model_name}' is not defined"
+        )
+    if dimension.type != "time":
+        raise TableBlockParseError(
+            f"Default time dimension '{default_time_dimension}' in model '{model_name}' must be a time dimension"
+        )
+
+
+def _classify_table_block_fields(
+    model_name: str, field_declarations: list[tuple[int, str, str, TableBlockFieldAnnotation | None]]
+) -> list[tuple[int, str, Dimension | Metric]]:
+    parsed_fields: list[tuple[int, str, Dimension | Metric]] = []
+    pending_fields: list[tuple[int, str, str, TableBlockFieldAnnotation | None]] = []
+    metric_names: set[str] = set()
+    field_names = {field_name for _, field_name, _, _ in field_declarations}
+
+    for statement_idx, name, expression, annotation in field_declarations:
+        if sql_has_aggregate(expression, dialect="duckdb"):
+            _validate_no_dimension_annotation_on_metric(model_name, name, annotation)
+            metric = Metric(name=name, sql=expression)
+            parsed_fields.append((statement_idx, "metric", metric))
+            metric_names.add(name)
+        else:
+            pending_fields.append((statement_idx, name, expression, annotation))
+
+    changed = True
+    while changed and pending_fields:
+        changed = False
+        next_pending: list[tuple[int, str, str, TableBlockFieldAnnotation | None]] = []
+
+        for statement_idx, name, expression, annotation in pending_fields:
+            if _expression_references_metric(expression, metric_names):
+                _validate_no_dimension_annotation_on_metric(model_name, name, annotation)
+                metric = Metric(name=name, type="derived", sql=expression)
+                parsed_fields.append((statement_idx, "metric", metric))
+                metric_names.add(name)
+                changed = True
+            else:
+                next_pending.append((statement_idx, name, expression, annotation))
+
+        pending_fields = next_pending
+
+    for statement_idx, name, expression, annotation in pending_fields:
+        if _expression_references_declared_field(expression, field_names):
+            _validate_table_block_dimension_expression(model_name, name, expression, metric_names)
+        parsed_fields.append((statement_idx, "dimension", _parse_table_block_dimension(name, expression, annotation)))
+
+    return parsed_fields
+
+
+def _validate_no_dimension_annotation_on_metric(
+    model_name: str,
+    field_name: str,
+    annotation: TableBlockFieldAnnotation | None,
+) -> None:
+    if annotation and annotation.dimension_type:
+        raise TableBlockParseError(
+            f"Field '{field_name}' in model '{model_name}' is a metric and cannot use dimension annotation"
+        )
+
+
+def _parse_table_block_dimension(
+    name: str,
+    expression: str,
+    annotation: TableBlockFieldAnnotation | None = None,
+) -> Dimension:
+    dimension_type = (
+        annotation.dimension_type
+        if annotation and annotation.dimension_type
+        else _infer_dimension_type(name, expression)
+    )
+    granularity = None
+    if dimension_type == "time":
+        granularity = (
+            annotation.granularity if annotation and annotation.granularity else _infer_time_granularity(expression)
+        )
+
+    return Dimension(
+        name=name,
+        type=dimension_type,
+        sql=None if expression == name else expression,
+        granularity=granularity,
+    )
+
+
+def _collapse_table_block_key_columns(columns: list[str]) -> str | list[str]:
+    if len(columns) == 1:
+        return columns[0]
+    return columns
+
+
+def _expression_references_metric(expression: str, metric_names: set[str]) -> bool:
+    if not metric_names:
+        return False
+
+    try:
+        parsed = sqlglot.parse_one(expression, read="duckdb")
+    except Exception:
+        tokens = set(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", expression))
+        return bool(tokens & metric_names)
+
+    return any(column.name in metric_names for column in parsed.find_all(exp.Column))
+
+
+def _expression_references_declared_field(expression: str, field_names: set[str]) -> bool:
+    if not field_names:
+        return False
+
+    try:
+        parsed = sqlglot.parse_one(expression, read="duckdb")
+    except Exception:
+        tokens = set(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", expression))
+        return bool(tokens & field_names)
+
+    return any(column.name in field_names for column in parsed.find_all(exp.Column))
+
+
+def _validate_table_block_dimension_expression(
+    model_name: str,
+    field_name: str,
+    expression: str,
+    metric_names: set[str],
+) -> None:
+    referenced_metric_names = _referenced_metric_names(expression, metric_names)
+    if referenced_metric_names:
+        refs = ", ".join(sorted(referenced_metric_names))
+        raise TableBlockParseError(
+            f"Field '{field_name}' in model '{model_name}' references metric(s) {refs} but could not be classified"
+        )
+
+
+def _referenced_metric_names(expression: str, metric_names: set[str]) -> set[str]:
+    if not metric_names:
+        return set()
+
+    try:
+        parsed = sqlglot.parse_one(expression, read="duckdb")
+    except Exception:
+        tokens = set(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", expression))
+        return tokens & metric_names
+
+    return {column.name for column in parsed.find_all(exp.Column) if column.name in metric_names}
+
+
+def _infer_dimension_type(name: str, expression: str) -> str:
+    lowered_name = name.lower()
+    lowered_expression = expression.lower()
+
+    if _looks_like_time_expression(lowered_name, lowered_expression):
+        return "time"
+
+    try:
+        parsed = sqlglot.parse_one(expression, read="duckdb")
+    except Exception:
+        return _infer_dimension_type_from_text(lowered_name, lowered_expression)
+
+    if isinstance(parsed, (exp.Predicate, exp.Boolean)):
+        return "boolean"
+
+    if any(isinstance(node, (exp.Add, exp.Sub, exp.Mul, exp.Div, exp.Mod)) for node in parsed.walk()):
+        return "numeric"
+
+    return _infer_dimension_type_from_text(lowered_name, lowered_expression)
+
+
+def _infer_dimension_type_from_text(name: str, expression: str) -> str:
+    if _looks_like_time_expression(name, expression):
+        return "time"
+    if re.search(r"\s(=|<>|!=|>|<|>=|<=)\s|\bis\s+not\b|\bis\b|\bin\s*\(", expression):
+        return "boolean"
+    if any(operator in expression for operator in (" + ", " - ", " * ", " / ")):
+        return "numeric"
+    return "categorical"
+
+
+def _looks_like_time_expression(name: str, expression: str) -> bool:
+    time_markers = ("date", "time", "timestamp", "_at", "created", "updated")
+    return (
+        "date_trunc" in expression
+        or "::date" in expression
+        or "::timestamp" in expression
+        or any(marker in name for marker in time_markers)
+    )
+
+
+def _infer_time_granularity(expression: str) -> str | None:
+    try:
+        parsed = sqlglot.parse_one(expression, read="duckdb")
+    except Exception:
+        match = re.search(r"date_trunc\s*\(\s*['\"]([A-Za-z_]+)['\"]", expression, flags=re.IGNORECASE)
+        if match and match.group(1).lower() in _TIME_GRAINS:
+            return match.group(1).lower()
+        return None
+
+    for node in parsed.walk():
+        if not node.__class__.__name__.lower().endswith("trunc"):
+            continue
+        unit = node.args.get("unit")
+        if not unit:
+            continue
+
+        if isinstance(unit, (exp.Literal, exp.Var)):
+            grain = str(unit.this).lower()
+        else:
+            grain = unit.sql(dialect="duckdb").strip("'\"").lower()
+
+        if grain in _TIME_GRAINS:
+            return grain
+
+    return None
+
+
 def _parse_sql_statements(
     sql: str,
+) -> tuple[
+    Model | None,
+    list[Dimension],
+    list[Relationship],
+    list[Metric],
+    list[Segment],
+    list[Parameter],
+    list[PreAggregation],
+]:
+    return _parse_statement_defs(parse(sql))
+
+
+def _parse_statement_defs(
+    statements: list[exp.Expression | None],
 ) -> tuple[
     Model | None,
     list[Dimension],
@@ -195,8 +619,6 @@ def _parse_sql_statements(
     segments: list[Segment] = []
     parameters: list[Parameter] = []
     pre_aggregations: list[PreAggregation] = []
-
-    statements = parse(sql)
 
     for stmt in statements:
         if isinstance(stmt, ModelDef):
@@ -266,7 +688,8 @@ def parse_sql_graph_definitions(sql: str) -> tuple[list[Metric], list[Segment], 
 def parse_sql_model(sql: str) -> Model | None:
     """Parse SQL string containing a complete model definition.
 
-    Expects MODEL(), DIMENSION(), RELATIONSHIP(), METRIC(), and SEGMENT() statements.
+    Supports both compact ``model name from table (...)`` blocks and the legacy
+    MODEL(), DIMENSION(), RELATIONSHIP(), METRIC(), and SEGMENT() statements.
 
     Args:
         sql: SQL string with model definition
@@ -274,27 +697,10 @@ def parse_sql_model(sql: str) -> Model | None:
     Returns:
         Model instance or None
     """
-    try:
-        model_def, dimensions, relationships, metrics, segments, _, pre_aggregations = _parse_sql_statements(sql)
-    except Exception:
+    models = parse_sql_models(sql)
+    if not models:
         return None
-
-    if not model_def:
-        return None
-
-    # Merge parsed definitions with model
-    if dimensions:
-        model_def.dimensions.extend(dimensions)
-    if relationships:
-        model_def.relationships.extend(relationships)
-    if metrics:
-        model_def.metrics.extend(metrics)
-    if segments:
-        model_def.segments.extend(segments)
-    if pre_aggregations:
-        model_def.pre_aggregations.extend(pre_aggregations)
-
-    return model_def
+    return models[0]
 
 
 def parse_sql_file_with_frontmatter_extended(

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -1229,10 +1229,10 @@ class SQLGenerator:
                     ):
                         # Other model expects this model to have a foreign key
                         # For has_many/has_one, foreign_key is the FK column in THIS model
-                        fk = other_join.foreign_key or other_join.sql_expr
-                        if fk not in columns_added:
-                            select_cols.append(f"{self._quote_identifier(fk)} AS {self._quote_alias(fk)}")
-                            columns_added.add(fk)
+                        for fk in other_join.foreign_key_columns:
+                            if fk not in columns_added:
+                                select_cols.append(f"{self._quote_identifier(fk)} AS {self._quote_alias(fk)}")
+                                columns_added.add(fk)
 
             for other_model_name, other_model in self.graph.models.items():
                 if other_model_name not in all_models:

--- a/sidemantic/sql/query_rewriter.py
+++ b/sidemantic/sql/query_rewriter.py
@@ -153,6 +153,38 @@ class QueryRewriter:
         # Otherwise, treat as simple semantic layer query
         return self._rewrite_simple_query(parsed)
 
+    def _source_aliases(self, select: exp.Select) -> dict[str, str]:
+        """Map source aliases in this SELECT scope to semantic model names."""
+        aliases: dict[str, str] = {}
+
+        def add_table(table_expr: exp.Expression | None) -> None:
+            if not isinstance(table_expr, exp.Table):
+                return
+            model_name = table_expr.name
+            if model_name in self.graph.models or model_name == "metrics":
+                aliases[table_expr.alias_or_name] = model_name
+                aliases[model_name] = model_name
+
+        from_clause = select.args.get("from")
+        if from_clause:
+            add_table(from_clause.this)
+        for join in select.args.get("joins") or []:
+            add_table(join.this)
+
+        return aliases
+
+    def _normalize_source_aliases(self, expression: exp.Expression) -> exp.Expression:
+        """Rewrite table aliases in column refs to semantic model names."""
+        aliases = getattr(self, "table_aliases", {})
+        if not aliases:
+            return expression
+
+        rewritten = expression.copy()
+        for column in rewritten.find_all(exp.Column):
+            if column.table in aliases:
+                column.set("table", exp.to_identifier(aliases[column.table]))
+        return rewritten
+
     def _looks_like_yardstick_query(self, sql: str) -> bool:
         """Return True if query appears to use Yardstick query syntax."""
         try:
@@ -1957,8 +1989,11 @@ class QueryRewriter:
     def _generated_cte_names_for_semantic_select(self, select: exp.Select) -> set[str]:
         had_inferred_table = hasattr(self, "inferred_table")
         previous_inferred_table = getattr(self, "inferred_table", None)
+        had_table_aliases = hasattr(self, "table_aliases")
+        previous_table_aliases = getattr(self, "table_aliases", None)
         try:
             self.inferred_table = self._extract_from_table(select)
+            self.table_aliases = self._source_aliases(select)
             metrics, dimensions, _aliases = self._extract_metrics_and_dimensions(select)
             filters = self._extract_filters(select)
             model_names = self.generator._find_required_models(metrics, dimensions, filters)
@@ -1972,6 +2007,10 @@ class QueryRewriter:
                 self.inferred_table = previous_inferred_table
             elif hasattr(self, "inferred_table"):
                 del self.inferred_table
+            if had_table_aliases:
+                self.table_aliases = previous_table_aliases
+            elif hasattr(self, "table_aliases"):
+                del self.table_aliases
 
     def _rewrite_with_rust(self, sql: str, strict: bool = True) -> str | None:
         """Rewrite using sidemantic-rs bindings, returning None to allow Python fallback."""
@@ -2087,23 +2126,20 @@ class QueryRewriter:
         Returns:
             Rewritten SQL using semantic layer
         """
-        # Check for explicit JOINs - these are not supported
+        explicit_join_filters = []
         if parsed.args.get("joins"):
-            raise ValueError(
-                "Explicit JOIN syntax is not supported. "
-                "Joins are automatic based on model relationships.\n\n"
-                "Instead of:\n"
-                "  SELECT orders.revenue, customers.name FROM orders JOIN customers ON ...\n\n"
-                "Use:\n"
-                "  SELECT orders.revenue, customers.name FROM orders"
-            )
+            explicit_join_filters = self._validate_explicit_semantic_joins(parsed)
 
         # Extract FROM table for inference
         self.inferred_table = self._extract_from_table(parsed)
+        self.table_aliases = self._source_aliases(parsed)
+
+        if self._needs_expression_postprocess(parsed):
+            return self._rewrite_expression_query(parsed, extra_filters=explicit_join_filters)
 
         # Extract components
         metrics, dimensions, aliases = self._extract_metrics_and_dimensions(parsed)
-        filters = self._extract_filters(parsed)
+        filters = [*self._extract_filters(parsed), *explicit_join_filters]
         order_by = self._extract_order_by(parsed)
         limit = self._extract_limit(parsed)
         offset = self._extract_offset(parsed)
@@ -2122,6 +2158,323 @@ class QueryRewriter:
             offset=offset,
             aliases=aliases,
         )
+
+    def _validate_explicit_semantic_joins(self, select: exp.Select) -> list[str]:
+        """Allow explicit joins only when they point at modeled semantic relationships."""
+        from_clause = select.args.get("from")
+        if not from_clause or not isinstance(from_clause.this, exp.Table):
+            raise ValueError("Explicit JOIN syntax is only supported from a semantic model table")
+
+        base_model = from_clause.this.name
+        if base_model not in self.graph.models:
+            return []
+
+        source_aliases = self._source_aliases(select)
+        known_aliases = {from_clause.this.alias_or_name: base_model, base_model: base_model}
+        join_filters = []
+
+        for join in select.args.get("joins") or []:
+            if not isinstance(join.this, exp.Table):
+                raise ValueError(
+                    "Explicit JOINs from semantic models only support direct model tables. "
+                    "Use a semantic subquery first when joining arbitrary SQL."
+                )
+
+            joined_model = join.this.name
+            if joined_model not in self.graph.models:
+                raise ValueError(
+                    "Explicit JOINs from semantic models only support modeled semantic tables. "
+                    "Use a semantic subquery first when joining arbitrary SQL."
+                )
+
+            joined_alias = join.this.alias_or_name
+            on_expr = join.args.get("on")
+            if on_expr and not self._join_on_matches_relationship(on_expr, joined_model, source_aliases, known_aliases):
+                raise ValueError(
+                    f"Explicit JOIN from semantic model '{base_model}' to '{joined_model}' does not match a declared relationship"
+                )
+
+            if not on_expr:
+                # No ON clause: still require that a modeled path exists.
+                try:
+                    self.graph.find_relationship_path(base_model, joined_model)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Explicit JOIN from semantic model '{base_model}' to '{joined_model}' has no declared relationship path"
+                    ) from exc
+
+            known_aliases[joined_alias] = joined_model
+            known_aliases[joined_model] = joined_model
+            join_filters.extend(self._explicit_join_filters(join, joined_model))
+
+        return join_filters
+
+    def _explicit_join_filters(self, join: exp.Join, joined_model: str) -> list[str]:
+        side = (join.args.get("side") or "").upper()
+        kind = (join.args.get("kind") or "").upper()
+
+        if side and side != "LEFT":
+            raise ValueError("Explicit semantic JOINs support INNER and LEFT joins only")
+        if kind and kind not in ("INNER", "OUTER"):
+            raise ValueError("Explicit semantic JOINs support INNER and LEFT joins only")
+        if side == "LEFT":
+            return []
+
+        model = self.graph.get_model(joined_model)
+        return [f"{joined_model}.{column} IS NOT NULL" for column in model.primary_key_columns]
+
+    def _join_on_matches_relationship(
+        self,
+        on_expr: exp.Expression,
+        joined_model: str,
+        source_aliases: dict[str, str],
+        known_aliases: dict[str, str],
+    ) -> bool:
+        pairs = self._extract_join_equality_pairs(on_expr)
+        if not pairs:
+            return False
+
+        other_model: str | None = None
+        actual_pairs: set[tuple[str, str]] = set()
+        for left_col, right_col in pairs:
+            if not left_col.table or not right_col.table:
+                return False
+            left_model = source_aliases.get(left_col.table)
+            right_model = source_aliases.get(right_col.table)
+            if not left_model or not right_model:
+                return False
+            if joined_model not in {left_model, right_model}:
+                return False
+
+            current_other_model = right_model if left_model == joined_model else left_model
+            if current_other_model not in known_aliases.values():
+                return False
+            if other_model and current_other_model != other_model:
+                return False
+            other_model = current_other_model
+
+            if left_model == joined_model:
+                actual_pairs.add((right_col.name, left_col.name))
+            else:
+                actual_pairs.add((left_col.name, right_col.name))
+
+        if not other_model:
+            return False
+
+        expected_pairs = self._direct_relationship_key_pairs(other_model, joined_model)
+        return actual_pairs == expected_pairs
+
+    def _extract_join_equality_pairs(self, expression: exp.Expression) -> list[tuple[exp.Column, exp.Column]]:
+        pairs: list[tuple[exp.Column, exp.Column]] = []
+        expression = self._unwrap_join_predicate(expression)
+
+        for part in expression.flatten() if isinstance(expression, exp.And) else [expression]:
+            part = self._unwrap_join_predicate(part)
+            if not isinstance(part, exp.EQ):
+                return []
+            left = part.left
+            right = part.right
+            if not isinstance(left, exp.Column) or not isinstance(right, exp.Column):
+                return []
+            pairs.append((left, right))
+
+        return pairs
+
+    def _unwrap_join_predicate(self, expression: exp.Expression) -> exp.Expression:
+        while isinstance(expression, exp.Paren) and isinstance(expression.this, exp.Expression):
+            expression = expression.this
+        return expression
+
+    def _direct_relationship_key_pairs(
+        self,
+        from_model: str,
+        to_model: str,
+    ) -> set[tuple[str, str]]:
+        try:
+            path = self.graph.find_relationship_path(from_model, to_model)
+        except ValueError:
+            return set()
+        if len(path) != 1:
+            return set()
+        hop = path[0]
+        return set(zip(hop.from_columns, hop.to_columns, strict=False))
+
+    def _needs_expression_postprocess(self, select: exp.Select) -> bool:
+        for projection in select.expressions:
+            node = projection.this if isinstance(projection, exp.Alias) else projection
+            if isinstance(node, (exp.Column, exp.Star)):
+                continue
+            return True
+        return False
+
+    def _rewrite_expression_query(self, parsed: exp.Select, extra_filters: list[str] | None = None) -> str:
+        """Compile semantic dependencies, then evaluate SQL expressions over the result."""
+        from sidemantic.core.metric import Metric
+
+        metrics: list[str] = []
+        dimensions: list[str] = []
+        aliases: dict[str, str] = {}
+        ref_aliases: dict[str, str] = {}
+        projection_aliases: set[str] = set()
+        adhoc_metrics: list[tuple[str, Metric]] = []
+        alias_index = 0
+        adhoc_index = 0
+
+        def next_alias(prefix: str = "__sd_expr") -> str:
+            nonlocal alias_index
+            value = f"{prefix}_{alias_index}"
+            alias_index += 1
+            return value
+
+        def add_ref(ref: str) -> str:
+            if ref not in ref_aliases:
+                ref_aliases[ref] = next_alias("__sd_field")
+                aliases[ref] = ref_aliases[ref]
+                if "." not in ref:
+                    metrics.append(ref)
+                    return ref_aliases[ref]
+
+                model_name, field_name = ref.split(".", 1)
+                base_field_name = field_name.rsplit("__", 1)[0] if "__" in field_name else field_name
+                model = self.graph.get_model(model_name)
+                if model.get_metric(base_field_name) or f"{model_name}.{base_field_name}" in self.graph.metrics:
+                    metrics.append(ref)
+                elif model.get_dimension(base_field_name):
+                    dimensions.append(ref)
+                else:
+                    raise ValueError(
+                        f"Field '{model_name}.{base_field_name}' not found. "
+                        f"Must be a metric, measure, or dimension in model '{model_name}'"
+                    )
+            return ref_aliases[ref]
+
+        def normalize_adhoc_metric_sql(node: exp.AggFunc, model_name: str) -> str:
+            metric_expr = node.copy()
+            for column in metric_expr.find_all(exp.Column):
+                if column.table:
+                    resolved_model = getattr(self, "table_aliases", {}).get(column.table, column.table)
+                    if resolved_model == model_name:
+                        column.set("table", None)
+            return metric_expr.sql(dialect=self.dialect)
+
+        def ad_hoc_metric_model(node: exp.AggFunc) -> str:
+            if not self.inferred_table or self.inferred_table == "metrics":
+                raise ValueError("Ad hoc aggregate expressions require a single semantic model in FROM")
+
+            referenced_models = set()
+            for column in node.find_all(exp.Column):
+                if column.table:
+                    referenced_models.add(getattr(self, "table_aliases", {}).get(column.table, column.table))
+                else:
+                    referenced_models.add(self.inferred_table)
+
+            if not referenced_models:
+                return self.inferred_table
+
+            if len(referenced_models) != 1:
+                raise ValueError("Ad hoc aggregate expressions can only reference one semantic model")
+
+            model_name = next(iter(referenced_models))
+            if model_name != self.inferred_table:
+                raise ValueError(
+                    "Ad hoc aggregate expressions can only reference columns from the base semantic model. "
+                    f"Define a metric on '{model_name}' to aggregate joined-model columns."
+                )
+
+            return model_name
+
+        def add_adhoc_metric(node: exp.AggFunc) -> str:
+            nonlocal adhoc_index
+            model_name = ad_hoc_metric_model(node)
+
+            metric_name = f"__adhoc_metric_{adhoc_index}"
+            adhoc_index += 1
+            metric = Metric(name=metric_name, sql=normalize_adhoc_metric_sql(node, model_name))
+            model = self.graph.get_model(model_name)
+            model.metrics.append(metric)
+            adhoc_metrics.append((model_name, metric))
+            ref = f"{model_name}.{metric_name}"
+            metrics.append(ref)
+            alias = next_alias("__sd_metric")
+            aliases[ref] = alias
+            return alias
+
+        def transform_for_outer(expression: exp.Expression) -> exp.Expression:
+            rewritten = expression.copy()
+
+            def replace_node(node: exp.Expression) -> exp.Expression:
+                if isinstance(node, exp.AggFunc):
+                    return exp.column(add_adhoc_metric(node))
+                if isinstance(node, exp.Column):
+                    ref = self._resolve_column(node)
+                    if not ref:
+                        raise ValueError(f"Cannot resolve column: {node.sql(dialect=self.dialect)}")
+                    return exp.column(add_ref(ref))
+                return node
+
+            return rewritten.transform(replace_node)
+
+        outer_projections: list[exp.Expression] = []
+        try:
+            for projection in parsed.expressions:
+                custom_alias = projection.alias if isinstance(projection, exp.Alias) else None
+                node = projection.this if isinstance(projection, exp.Alias) else projection
+
+                if isinstance(node, exp.Star):
+                    raise ValueError("SELECT * is not supported in semantic expression queries")
+
+                outer_expr = transform_for_outer(node)
+                if custom_alias:
+                    projection_aliases.add(custom_alias)
+                    outer_projections.append(exp.alias_(outer_expr, custom_alias, quoted=False))
+                elif isinstance(node, exp.Column):
+                    projection_aliases.add(node.name)
+                    outer_projections.append(exp.alias_(outer_expr, node.name, quoted=False))
+                elif isinstance(node, exp.AggFunc):
+                    projection_aliases.add(node.key.lower())
+                    outer_projections.append(exp.alias_(outer_expr, node.key.lower(), quoted=False))
+                else:
+                    outer_projections.append(outer_expr)
+
+            filters = [*self._extract_filters(parsed), *(extra_filters or [])]
+            inner_sql = self.generator.generate(
+                metrics=metrics,
+                dimensions=dimensions,
+                filters=filters,
+                aliases=aliases,
+            )
+
+            projection_sql = ",\n  ".join(projection.sql(dialect=self.dialect) for projection in outer_projections)
+            outer_sql = f"SELECT\n  {projection_sql}\nFROM (\n{inner_sql}\n) AS __sdq"
+
+            order_clause = parsed.args.get("order")
+            if order_clause:
+                outer_order = []
+                for order_expr in order_clause.expressions:
+                    transformed = order_expr.copy()
+                    if (
+                        isinstance(order_expr.this, exp.Column)
+                        and not order_expr.this.table
+                        and order_expr.this.name in projection_aliases
+                    ):
+                        transformed.set("this", order_expr.this.copy())
+                    else:
+                        transformed.set("this", transform_for_outer(order_expr.this))
+                    outer_order.append(transformed)
+                outer_sql += "\nORDER BY " + ", ".join(expr.sql(dialect=self.dialect) for expr in outer_order)
+
+            limit = self._extract_limit(parsed)
+            offset = self._extract_offset(parsed)
+            if limit:
+                outer_sql += f"\nLIMIT {limit}"
+            if offset:
+                outer_sql += f"\nOFFSET {offset}"
+
+            return outer_sql
+        finally:
+            for model_name, metric in adhoc_metrics:
+                model = self.graph.get_model(model_name)
+                model.metrics = [existing for existing in model.metrics if existing is not metric]
 
     def _extract_metrics_and_dimensions(self, select: exp.Select) -> tuple[list[str], list[str], dict[str, str]]:
         """Extract metrics and dimensions from SELECT clause.
@@ -2246,7 +2599,7 @@ class QueryRewriter:
         if not select.args.get("where"):
             return []
 
-        where = select.args["where"].this
+        where = self._normalize_source_aliases(select.args["where"].this)
 
         # Handle compound conditions (AND/OR)
         if isinstance(where, (exp.And, exp.Or)):
@@ -2297,12 +2650,12 @@ class QueryRewriter:
         for order_expr in select.args["order"].expressions:
             # Get column (might have ASC/DESC)
             if isinstance(order_expr, exp.Ordered):
-                column = order_expr.this
+                column = self._normalize_source_aliases(order_expr.this)
                 desc = order_expr.args.get("desc", False)
                 col_name = self._get_column_name(column)
                 order_expressions.append(f"{col_name} {'DESC' if desc else 'ASC'}")
             else:
-                col_name = self._get_column_name(order_expr)
+                col_name = self._get_column_name(self._normalize_source_aliases(order_expr))
                 order_expressions.append(col_name)
 
         return order_expressions if order_expressions else None
@@ -2386,6 +2739,7 @@ class QueryRewriter:
             name = column.name
 
             if table:
+                table = getattr(self, "table_aliases", {}).get(table, table)
                 # Explicit table.column (may include __granularity suffix)
                 return f"{table}.{name}"
             else:

--- a/tests/core/test_sql_definitions.py
+++ b/tests/core/test_sql_definitions.py
@@ -6,12 +6,22 @@ from pathlib import Path
 import pytest
 
 from sidemantic.adapters.sidemantic import SidemanticAdapter
+from sidemantic.core.dialect import (
+    MetricDef,
+    TableBlockFieldDef,
+    TableBlockJoinDef,
+    TableBlockModelDef,
+)
+from sidemantic.core.dialect import (
+    parse as parse_sidemantic_sql,
+)
 from sidemantic.core.semantic_layer import SemanticLayer
 from sidemantic.core.sql_definitions import (
     parse_sql_definitions,
     parse_sql_file_with_frontmatter,
     parse_sql_graph_definitions,
     parse_sql_model,
+    parse_sql_models,
 )
 
 
@@ -630,6 +640,455 @@ SEGMENT (
 
     assert len(model.segments) == 1
     assert model.segments[0].name == "completed"
+
+
+def test_parse_table_block_sql_model():
+    """Test parsing compact SQL-ish model blocks."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id)
+  default time order_date grain day
+
+  status
+  date_trunc('day', created_at) as order_date : time grain day
+  status = 'completed' as is_complete : boolean
+  amount - discount as net_amount : numeric
+
+  segment completed as status = 'completed'
+
+  join one customers on customer_id = customers.id
+  join many order_items on order_id = order_items.order_id and store_id = order_items.store_id
+
+  revenue / order_count as average_order_value
+  sum(amount) as revenue
+  count(*) as order_count
+)
+"""
+
+    model = parse_sql_model(sql_content)
+
+    assert model is not None
+    assert model.name == "orders"
+    assert model.table == "orders"
+    assert model.primary_key == "order_id"
+    assert model.default_time_dimension == "order_date"
+    assert model.default_grain == "day"
+
+    dimensions = {dimension.name: dimension for dimension in model.dimensions}
+    assert dimensions["status"].type == "categorical"
+    assert dimensions["status"].sql is None
+    assert dimensions["order_date"].type == "time"
+    assert dimensions["order_date"].sql == "date_trunc('day', created_at)"
+    assert dimensions["order_date"].granularity == "day"
+    assert dimensions["is_complete"].type == "boolean"
+    assert dimensions["is_complete"].sql == "status = 'completed'"
+    assert dimensions["net_amount"].type == "numeric"
+    assert dimensions["net_amount"].sql == "amount - discount"
+
+    assert len(model.relationships) == 2
+    relationships = {relationship.name: relationship for relationship in model.relationships}
+    assert relationships["customers"].type == "many_to_one"
+    assert relationships["customers"].foreign_key == "customer_id"
+    assert relationships["customers"].primary_key == "id"
+    assert relationships["order_items"].type == "one_to_many"
+    assert relationships["order_items"].foreign_key == ["order_id", "store_id"]
+    assert relationships["order_items"].primary_key == ["order_id", "store_id"]
+
+    metrics = {metric.name: metric for metric in model.metrics}
+    assert list(metrics) == ["average_order_value", "revenue", "order_count"]
+    assert metrics["revenue"].agg == "sum"
+    assert metrics["revenue"].sql == "amount"
+    assert metrics["order_count"].agg == "count"
+    assert metrics["order_count"].sql == "*"
+    assert metrics["average_order_value"].type == "derived"
+    assert metrics["average_order_value"].sql == "revenue / order_count"
+
+    assert len(model.segments) == 1
+    assert model.segments[0].name == "completed"
+    assert model.segments[0].sql == "status = 'completed'"
+
+
+def test_dialect_parses_table_block_sql_model():
+    """Test compact model blocks are parsed by the Sidemantic SQL dialect."""
+    statements = parse_sidemantic_sql(
+        """
+model orders from orders (
+  primary key (order_id)
+  status
+  join one customers on customer_id = customers.id
+  sum(amount) as revenue
+)
+"""
+    )
+
+    assert len(statements) == 1
+    model_def = statements[0]
+    assert isinstance(model_def, TableBlockModelDef)
+    assert model_def.this.name == "orders"
+    assert model_def.args["table"] == "orders"
+    assert any(isinstance(expression, TableBlockFieldDef) for expression in model_def.expressions)
+    assert any(isinstance(expression, TableBlockJoinDef) for expression in model_def.expressions)
+
+
+def test_dialect_parses_table_block_with_graph_definition():
+    """Test compact model blocks can be followed by graph-level definitions."""
+    statements = parse_sidemantic_sql(
+        """
+model orders from orders (
+  primary key (order_id)
+  sum(amount) as revenue
+)
+
+METRIC (
+  name total_revenue,
+  sql orders.revenue
+)
+"""
+    )
+
+    assert len(statements) == 2
+    assert isinstance(statements[0], TableBlockModelDef)
+    assert isinstance(statements[1], MetricDef)
+
+
+def test_parse_graph_definitions_after_table_block():
+    """Test graph definitions after compact model blocks are not dropped."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id)
+  sum(amount) as revenue
+)
+
+METRIC (
+  name total_revenue,
+  sql orders.revenue
+)
+"""
+
+    metrics, segments, parameters = parse_sql_graph_definitions(sql_content)
+
+    assert len(metrics) == 1
+    assert metrics[0].name == "total_revenue"
+    assert segments == []
+    assert parameters == []
+
+
+def test_parse_table_block_multiline_field_expression():
+    """Test compact field expressions can span lines before their alias."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id)
+  amount
+    - discount as net_amount : numeric
+  sum(amount) as revenue
+)
+"""
+
+    model = parse_sql_model(sql_content)
+
+    assert model is not None
+    dimensions = {dimension.name: dimension for dimension in model.dimensions}
+    assert dimensions["net_amount"].type == "numeric"
+    assert "amount" in dimensions["net_amount"].sql
+    assert "- discount" in dimensions["net_amount"].sql
+
+
+def test_adapter_parse_table_block_sql_file():
+    """Test SidemanticAdapter parsing compact SQL-ish model blocks."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id)
+  status
+  join one customers on customer_id = customers.id
+  sum(amount) as revenue
+)
+
+model customers from public.customers (
+  primary key (id)
+  region
+)
+"""
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".sql", delete=False) as f:
+        f.write(sql_content)
+        temp_path = Path(f.name)
+
+    try:
+        adapter = SidemanticAdapter()
+        graph = adapter.parse(temp_path)
+
+        assert len(graph.models) == 2
+        assert "orders" in graph.models
+        assert "customers" in graph.models
+        orders = graph.models["orders"]
+        assert orders.primary_key == "order_id"
+        assert orders.dimensions[0].name == "status"
+        assert orders.metrics[0].name == "revenue"
+        assert orders.metrics[0].agg == "sum"
+        assert orders.relationships[0].name == "customers"
+        assert graph.models["customers"].table == "public.customers"
+
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def test_parse_table_block_sql_models():
+    """Test parsing multiple compact SQL-ish model blocks."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id)
+  sum(amount) as revenue
+)
+
+model customers from customers (
+  primary key (id)
+  region
+)
+"""
+
+    models = parse_sql_models(sql_content)
+
+    assert [model.name for model in models] == ["orders", "customers"]
+    assert models[0].metrics[0].name == "revenue"
+    assert models[1].dimensions[0].name == "region"
+
+
+def test_parse_table_block_parenthesized_composite_join():
+    """Test compact composite joins can wrap ON predicates in parentheses."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id, store_id)
+  join many order_items on (order_id = order_items.order_id and store_id = order_items.store_id)
+  sum(amount) as revenue
+)
+"""
+
+    model = parse_sql_model(sql_content)
+
+    assert model is not None
+    assert len(model.relationships) == 1
+    relationship = model.relationships[0]
+    assert relationship.name == "order_items"
+    assert relationship.type == "one_to_many"
+    assert relationship.foreign_key == ["order_id", "store_id"]
+    assert relationship.primary_key == ["order_id", "store_id"]
+
+
+def test_parse_sql_models_mixed_table_block_and_model_statement():
+    """Test compact and MODEL() definitions can coexist in one SQL file."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id)
+  sum(amount) as revenue
+)
+
+MODEL (
+  name customers,
+  table customers,
+  primary_key id
+);
+
+DIMENSION (
+  name region,
+  type categorical,
+  sql region
+);
+"""
+
+    models = parse_sql_models(sql_content)
+
+    assert [model.name for model in models] == ["orders", "customers"]
+    assert models[0].metrics[0].name == "revenue"
+    assert models[1].dimensions[0].name == "region"
+
+
+def test_parse_sql_models_multiple_legacy_models():
+    """Test multiple legacy MODEL() blocks retain their own fields."""
+    sql_content = """
+MODEL (
+  name orders,
+  table orders,
+  primary_key order_id
+);
+
+DIMENSION (
+  name status,
+  type categorical,
+  sql status
+);
+
+METRIC (
+  name revenue,
+  agg sum,
+  sql amount
+);
+
+MODEL (
+  name customers,
+  table customers,
+  primary_key id
+);
+
+DIMENSION (
+  name region,
+  type categorical,
+  sql region
+);
+"""
+
+    models = parse_sql_models(sql_content)
+
+    assert [model.name for model in models] == ["orders", "customers"]
+    assert models[0].dimensions[0].name == "status"
+    assert models[0].metrics[0].name == "revenue"
+    assert models[1].dimensions[0].name == "region"
+    assert models[1].metrics == []
+
+
+def test_parse_table_block_derived_sql_source():
+    """Test compact model blocks can use derived SQL sources."""
+    sql_content = """
+model completed_orders from (
+  select *
+  from raw.orders
+  where status = 'completed'
+) (
+  primary key (order_id)
+  created_at as order_date : time grain day
+  sum(amount) as revenue
+)
+"""
+
+    model = parse_sql_model(sql_content)
+
+    assert model is not None
+    assert model.name == "completed_orders"
+    assert model.table is None
+    assert model.sql == "select *\n  from raw.orders\n  where status = 'completed'"
+    assert model.dimensions[0].name == "order_date"
+    assert model.dimensions[0].type == "time"
+    assert model.dimensions[0].granularity == "day"
+    assert model.metrics[0].name == "revenue"
+
+
+def test_table_block_requires_from_source():
+    """Test table-block models require source in the header."""
+    sql_content = """
+model orders (
+  primary key (order_id)
+  sum(amount) as revenue
+)
+"""
+
+    with pytest.raises(ValueError, match="must use `model orders from <table>"):
+        parse_sql_model(sql_content)
+
+
+def test_table_block_rejects_table_statement():
+    """Test table-block model sources are declared with from, not table statements."""
+    sql_content = """
+model orders from orders (
+  table orders
+  primary key (order_id)
+)
+"""
+
+    with pytest.raises(ValueError, match="use `model orders from <table>"):
+        parse_sql_model(sql_content)
+
+
+def test_table_block_rejects_bad_join():
+    """Test table-block joins fail instead of being ignored."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id)
+  join one customers on customer_id = 1
+)
+"""
+
+    with pytest.raises(ValueError, match="must compare model columns"):
+        parse_sql_model(sql_content)
+
+
+def test_table_block_rejects_unknown_statement():
+    """Test table-block unknown statements fail instead of being ignored."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id)
+  description 'Orders table'
+)
+"""
+
+    with pytest.raises(ValueError, match="Unrecognized statement"):
+        parse_sql_model(sql_content)
+
+
+def test_table_block_rejects_duplicate_field():
+    """Test table-block duplicate fields fail clearly."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id)
+  status
+  status = 'completed' as status
+)
+"""
+
+    with pytest.raises(ValueError, match="defines field 'status' more than once"):
+        parse_sql_model(sql_content)
+
+
+def test_table_block_rejects_empty_primary_key():
+    """Test table-block primary key requires at least one column."""
+    sql_content = """
+model orders from orders (
+  primary key ()
+  sum(amount) as revenue
+)
+"""
+
+    with pytest.raises(ValueError, match="Primary key requires at least one column"):
+        parse_sql_model(sql_content)
+
+
+def test_table_block_rejects_invalid_field_annotation():
+    """Test compact field annotations fail clearly."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id)
+  amount as net_amount : numeric grain day
+)
+"""
+
+    with pytest.raises(ValueError, match="cannot use grain with type 'numeric'"):
+        parse_sql_model(sql_content)
+
+
+def test_table_block_rejects_default_time_for_non_time_dimension():
+    """Test default time must reference a time dimension."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id)
+  default time status
+  status
+)
+"""
+
+    with pytest.raises(ValueError, match="must be a time dimension"):
+        parse_sql_model(sql_content)
+
+
+def test_table_block_rejects_duplicate_segment():
+    """Test duplicate compact segments fail clearly."""
+    sql_content = """
+model orders from orders (
+  primary key (order_id)
+  segment completed as status = 'completed'
+  segment completed as completed_at is not null
+)
+"""
+
+    with pytest.raises(ValueError, match="defines segment 'completed' more than once"):
+        parse_sql_model(sql_content)
 
 
 def test_adapter_parse_pure_sql_file():

--- a/tests/queries/test_sql_rewriter.py
+++ b/tests/queries/test_sql_rewriter.py
@@ -207,24 +207,151 @@ def test_missing_table_prefix(semantic_layer):
     assert len(rows) == 1  # Should aggregate all rows
 
 
-def test_unsupported_aggregation(semantic_layer):
-    """Test error for unsupported aggregation function."""
+def test_ad_hoc_count_aggregation(semantic_layer):
+    """Test ad hoc COUNT aggregation without predefining a metric."""
     sql = "SELECT COUNT(*) FROM orders"
 
-    with pytest.raises(ValueError, match="must be defined as a metric"):
-        semantic_layer.sql(sql)
+    result = semantic_layer.sql(sql)
+    rows = _rows(result)
+
+    assert rows[0]["count"] == 3
 
 
-def test_explicit_join_not_supported(semantic_layer):
-    """Test that explicit JOIN syntax is rejected."""
+def test_explicit_join_matching_relationship_supported(semantic_layer):
+    """Test explicit JOIN syntax when it matches a declared relationship."""
     sql = """
         SELECT orders.revenue, customers.region
         FROM orders
         JOIN customers ON orders.customer_id = customers.id
     """
 
-    with pytest.raises(ValueError, match="Explicit JOIN syntax is not supported"):
+    result = semantic_layer.sql(sql)
+    rows = _rows(result)
+
+    assert len(rows) == 2
+    assert {row["region"] for row in rows} == {"US", "EU"}
+
+
+def test_explicit_join_with_aliases_supported(semantic_layer):
+    """Test explicit JOIN syntax with SQL table aliases."""
+    sql = """
+        SELECT o.revenue, c.region
+        FROM orders AS o
+        JOIN customers AS c ON o.customer_id = c.id
+    """
+
+    result = semantic_layer.sql(sql)
+    rows = _rows(result)
+
+    assert len(rows) == 2
+    assert {row["region"] for row in rows} == {"US", "EU"}
+
+
+def test_explicit_join_accepts_parenthesized_on_clause(semantic_layer):
+    """Test explicit JOIN validation accepts parenthesized relationship predicates."""
+    sql = """
+        SELECT orders.revenue, customers.region
+        FROM orders
+        JOIN customers ON (orders.customer_id = customers.id)
+    """
+
+    result = semantic_layer.sql(sql)
+    rows = _rows(result)
+
+    assert len(rows) == 2
+    assert {row["region"] for row in rows} == {"US", "EU"}
+
+
+def test_explicit_inner_join_preserves_existence_filter(semantic_layer):
+    """Test explicit INNER JOIN keeps join-existence semantics."""
+    semantic_layer.conn.execute("INSERT INTO orders VALUES (4, 999, 'orphaned', '2024-01-04', 50.00)")
+
+    sql = """
+        SELECT orders.revenue
+        FROM orders
+        JOIN customers ON orders.customer_id = customers.id
+    """
+
+    result = semantic_layer.sql(sql)
+    rows = _rows(result)
+
+    assert len(rows) == 1
+    assert rows[0]["revenue"] == 450.00
+
+
+def test_explicit_left_join_preserves_base_rows(semantic_layer):
+    """Test explicit LEFT JOIN does not add an existence filter."""
+    semantic_layer.conn.execute("INSERT INTO orders VALUES (4, 999, 'orphaned', '2024-01-04', 50.00)")
+
+    sql = """
+        SELECT orders.revenue
+        FROM orders
+        LEFT JOIN customers ON orders.customer_id = customers.id
+    """
+
+    result = semantic_layer.sql(sql)
+    rows = _rows(result)
+
+    assert len(rows) == 1
+    assert rows[0]["revenue"] == 500.00
+
+
+def test_explicit_join_rejects_unsupported_join_type(semantic_layer):
+    """Test unsupported explicit semantic join types fail clearly."""
+    sql = """
+        SELECT orders.revenue
+        FROM orders
+        RIGHT JOIN customers ON orders.customer_id = customers.id
+    """
+
+    with pytest.raises(ValueError, match="INNER and LEFT"):
         semantic_layer.sql(sql)
+
+
+def test_explicit_join_requires_complete_composite_relationship():
+    """Test explicit JOIN syntax must include all keys for composite relationships."""
+    layer = SemanticLayer(auto_register=False)
+    orders = Model(
+        name="orders",
+        table="orders",
+        primary_key=["id", "store_id"],
+        dimensions=[Dimension(name="status", type="categorical", sql="status")],
+        metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        relationships=[
+            Relationship(
+                name="order_items",
+                type="one_to_many",
+                foreign_key=["order_id", "store_id"],
+                primary_key=["id", "store_id"],
+            )
+        ],
+    )
+    order_items = Model(
+        name="order_items",
+        table="order_items",
+        primary_key=["order_id", "store_id"],
+        dimensions=[Dimension(name="sku", type="categorical", sql="sku")],
+        metrics=[Metric(name="count", agg="count")],
+    )
+    layer.add_model(orders)
+    layer.add_model(order_items)
+    rewriter = QueryRewriter(layer.graph)
+
+    incomplete_sql = """
+        SELECT orders.revenue, order_items.sku
+        FROM orders
+        JOIN order_items ON orders.id = order_items.order_id
+    """
+    with pytest.raises(ValueError, match="does not match a declared relationship"):
+        rewriter.rewrite(incomplete_sql)
+
+    complete_sql = """
+        SELECT orders.revenue, order_items.sku
+        FROM orders
+        JOIN order_items ON orders.id = order_items.order_id AND orders.store_id = order_items.store_id
+    """
+    rewritten = rewriter.rewrite(complete_sql)
+    assert "order_items" in rewritten
 
 
 def test_rewriter_directly(layer):
@@ -451,6 +578,93 @@ def test_column_alias(semantic_layer):
     assert "order_status" in columns
     assert "revenue" not in columns
     assert "status" not in columns
+
+
+def test_semantic_scalar_expression_over_measures(semantic_layer):
+    """Test scalar SQL expressions over self-aggregating measures."""
+    sql = """
+        SELECT
+            orders.status,
+            orders.revenue / orders.count AS average_order_value
+        FROM orders
+    """
+
+    result = semantic_layer.sql(sql)
+    rows = _rows(result)
+    columns = _columns(result)
+
+    assert "average_order_value" in columns
+    completed = [row for row in rows if row["status"] == "completed"][0]
+    assert completed["average_order_value"] == 125.00
+
+
+def test_semantic_expression_order_by_projection_alias(semantic_layer):
+    """Test expression-mode ORDER BY can reference a SELECT alias."""
+    sql = """
+        SELECT
+            orders.status,
+            orders.revenue / orders.count AS aov
+        FROM orders
+        ORDER BY aov DESC
+    """
+
+    result = semantic_layer.sql(sql)
+    rows = _rows(result)
+
+    assert [row["status"] for row in rows] == ["pending", "completed"]
+    assert rows[0]["aov"] == 200.00
+    assert rows[1]["aov"] == 125.00
+
+
+def test_semantic_scalar_function_over_measure(semantic_layer):
+    """Test arbitrary scalar SQL functions over semantic measures."""
+    sql = "SELECT ROUND(orders.revenue / orders.count, 2) AS aov FROM orders"
+
+    result = semantic_layer.sql(sql)
+    rows = _rows(result)
+
+    assert len(rows) == 1
+    assert rows[0]["aov"] == 150.00
+
+
+def test_semantic_ad_hoc_aggregate_expression(semantic_layer):
+    """Test ad hoc aggregate expressions without predefining a metric."""
+    sql = "SELECT SUM(orders.amount) AS total_amount FROM orders"
+
+    result = semantic_layer.sql(sql)
+    rows = _rows(result)
+
+    assert len(rows) == 1
+    assert rows[0]["total_amount"] == 450.00
+
+
+def test_semantic_ad_hoc_aggregate_expression_with_dimension(semantic_layer):
+    """Test ad hoc aggregate expressions grouped by a semantic dimension."""
+    sql = """
+        SELECT
+            orders.status,
+            SUM(orders.amount) AS total_amount
+        FROM orders
+    """
+
+    result = semantic_layer.sql(sql)
+    rows = _rows(result)
+
+    assert len(rows) == 2
+    completed = [row for row in rows if row["status"] == "completed"][0]
+    assert completed["total_amount"] == 250.00
+
+
+def test_semantic_ad_hoc_aggregate_rejects_joined_model_column(semantic_layer):
+    """Test ad hoc aggregates fail early when they target a joined model."""
+    sql = """
+        SELECT SUM(customers.id) AS customer_id_sum
+        FROM orders
+        JOIN customers ON orders.customer_id = customers.id
+    """
+
+    with pytest.raises(ValueError, match="base semantic model"):
+        semantic_layer.sql(sql)
 
 
 def test_graph_level_metrics(semantic_layer):
@@ -1367,7 +1581,7 @@ def test_dry_run_with_postprocess_subquery(semantic_layer):
 
 
 def test_semantic_root_with_join_subquery_rejected(semantic_layer):
-    """Explicit JOINs on semantic models are rejected even when JOIN has a subquery."""
+    """Explicit JOINs on semantic roots reject arbitrary SQL joins."""
     semantic_layer.conn.execute("""
         CREATE TABLE IF NOT EXISTS lookup AS SELECT 1 AS id, 'x' AS val
     """)
@@ -1376,7 +1590,7 @@ def test_semantic_root_with_join_subquery_rejected(semantic_layer):
         FROM orders
         JOIN (SELECT * FROM lookup) AS lk ON 1 = 1
     """
-    with pytest.raises(ValueError, match="Explicit JOIN syntax is not supported"):
+    with pytest.raises(ValueError, match="only support direct model tables"):
         semantic_layer.sql(sql)
 
 


### PR DESCRIPTION
Adds stricter semantic SQL support for modeled explicit joins, table aliases, scalar measure expressions, and ad hoc aggregate expressions.

Expands compact SQL model blocks with derived SQL sources, multiple models per file, sparse field annotations, default time settings, segments, composite joins, and clearer validation errors.

Also fixes composite relationship handling so explicit joins and generated CTEs require and use the full key set.