### PR TITLE
Implement semantic SQL rewrite planner

### DIFF
--- a/scripts/benchmark_semantic_sql_planner.py
+++ b/scripts/benchmark_semantic_sql_planner.py
@@ -17,7 +17,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any
+from typing import Any, Literal
 
 from sidemantic import Dimension, Metric, Model, PreAggregation, Relationship, SemanticLayer
 from sidemantic.sql.query_rewriter import QueryRewriter
@@ -29,7 +29,12 @@ class BenchmarkCase:
     wrapped_sql: str
     baseline_sql: Callable[[SemanticLayer], str]
     use_preaggregations: bool = False
-    expected_rule: str | None = None
+    case_type: Literal["smoke", "performance"] = "smoke"
+    expected_plan: str | None = None
+    expected_rules: tuple[str, ...] = ()
+    expected_sql_contains: str | tuple[str, ...] | None = None
+    forbidden_sql_contains: str | tuple[str, ...] | None = None
+    min_speedup: float | None = None
 
 
 def _normalize(value: Any) -> Any:
@@ -66,13 +71,22 @@ def _subquery(sql: str) -> str:
     return "(\n" + sql.rstrip() + "\n)"
 
 
+def _fragments(value: str | tuple[str, ...] | None) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    return value
+
+
 def _build_layer(row_count: int) -> SemanticLayer:
     layer = SemanticLayer(auto_register=False, use_preaggregations=True)
     orders = Model(
         name="orders",
         table="orders",
-        primary_key="id",
+        primary_key="wide_id",
         dimensions=[
+            Dimension(name="customer_id", type="numeric", sql="customer_id"),
             Dimension(name="status", type="categorical", sql="status"),
             Dimension(name="order_date", type="time", sql="order_date", granularity="day"),
         ],
@@ -86,7 +100,30 @@ def _build_layer(row_count: int) -> SemanticLayer:
                 name="by_status",
                 measures=["revenue"],
                 dimensions=["status"],
-            )
+            ),
+            PreAggregation(
+                name="by_status_day",
+                measures=["revenue"],
+                dimensions=["status"],
+                time_dimension="order_date",
+                granularity="day",
+            ),
+            PreAggregation(
+                name="daily_revenue",
+                measures=["revenue"],
+                time_dimension="order_date",
+                granularity="day",
+            ),
+            PreAggregation(
+                name="total_revenue",
+                measures=["revenue"],
+                dimensions=[],
+            ),
+            PreAggregation(
+                name="by_customer",
+                measures=["revenue"],
+                dimensions=["customer_id"],
+            ),
         ],
     )
     customers = Model(
@@ -99,9 +136,22 @@ def _build_layer(row_count: int) -> SemanticLayer:
         ],
         metrics=[Metric(name="count", agg="count")],
         relationships=[Relationship(name="orders", type="one_to_many", foreign_key="customer_id")],
+        pre_aggregations=[
+            PreAggregation(
+                name="by_region",
+                measures=["count"],
+                dimensions=["region"],
+            ),
+            PreAggregation(
+                name="total_count",
+                measures=["count"],
+                dimensions=[],
+            ),
+        ],
     )
     layer.add_model(orders)
     layer.add_model(customers)
+    layer.add_metric(Metric(name="running_total_revenue", type="cumulative", sql="orders.revenue"))
 
     layer.conn.execute("""
         CREATE TABLE customers AS
@@ -115,6 +165,7 @@ def _build_layer(row_count: int) -> SemanticLayer:
         CREATE TABLE orders AS
         SELECT
             i::INTEGER AS id,
+            LPAD(CAST(i AS VARCHAR), 512, '0') AS wide_id,
             (((i - 1) % 1000) + 1)::INTEGER AS customer_id,
             CASE
                 WHEN i % 3 = 0 THEN 'completed'
@@ -132,6 +183,51 @@ def _build_layer(row_count: int) -> SemanticLayer:
             SUM(amount) AS revenue_raw
         FROM orders
         GROUP BY status
+    """)
+    layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status_day AS
+        SELECT
+            status,
+            DATE_TRUNC('day', order_date) AS order_date_day,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY 1, 2
+    """)
+    layer.conn.execute("""
+        CREATE TABLE orders_preagg_daily_revenue AS
+        SELECT
+            DATE_TRUNC('day', order_date) AS order_date_day,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY 1
+    """)
+    layer.conn.execute("""
+        CREATE TABLE orders_preagg_total_revenue AS
+        SELECT
+            SUM(amount) AS revenue_raw
+        FROM orders
+    """)
+    layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_customer AS
+        SELECT
+            customer_id,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY customer_id
+    """)
+    layer.conn.execute("""
+        CREATE TABLE customers_preagg_by_region AS
+        SELECT
+            region,
+            COUNT(*) AS count_raw
+        FROM customers
+        GROUP BY region
+    """)
+    layer.conn.execute("""
+        CREATE TABLE customers_preagg_total_count AS
+        SELECT
+            COUNT(*) AS count_raw
+        FROM customers
     """)
     return layer
 
@@ -151,7 +247,27 @@ def _cases(layer: SemanticLayer) -> list[BenchmarkCase]:
                 _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders", use_preaggregations=False)
             )
             + " sq WHERE status = 'completed' ORDER BY status",
-            expected_rule="safe_filter_pushdown",
+            expected_plan="direct_semantic",
+            expected_rules=("safe_filter_pushdown",),
+            forbidden_sql_contains="FROM (",
+        ),
+        BenchmarkCase(
+            name="wrapper_metric_filter_having_pushdown",
+            wrapped_sql="""
+                SELECT *
+                FROM (SELECT orders.revenue, orders.status FROM orders) sq
+                WHERE revenue > 33000000
+                ORDER BY status
+            """,
+            baseline_sql=lambda layer: "SELECT * FROM "
+            + _subquery(
+                _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders", use_preaggregations=False)
+            )
+            + " sq WHERE revenue > 33000000 ORDER BY status",
+            expected_plan="direct_semantic",
+            expected_rules=("safe_metric_filter_having_pushdown",),
+            expected_sql_contains="HAVING",
+            forbidden_sql_contains="FROM (",
         ),
         BenchmarkCase(
             name="safe_order_limit_pushdown",
@@ -166,7 +282,158 @@ def _cases(layer: SemanticLayer) -> list[BenchmarkCase]:
                 _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders", use_preaggregations=False)
             )
             + " sq ORDER BY status DESC LIMIT 2",
-            expected_rule="safe_order_pushdown",
+            expected_plan="direct_semantic",
+            expected_rules=("safe_order_pushdown", "safe_limit_pushdown"),
+            forbidden_sql_contains="FROM (",
+        ),
+        BenchmarkCase(
+            name="linear_cte_chain_preaggregation",
+            wrapped_sql="""
+                WITH base AS (
+                    SELECT orders.revenue, orders.status FROM orders
+                ),
+                filtered AS (
+                    SELECT * FROM base WHERE status = 'completed'
+                )
+                SELECT status, revenue FROM filtered ORDER BY revenue DESC
+            """,
+            baseline_sql=lambda layer: "WITH base AS "
+            + _subquery(
+                _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders", use_preaggregations=False)
+            )
+            + ", filtered AS (SELECT * FROM base WHERE status = 'completed') "
+            + "SELECT status, revenue FROM filtered ORDER BY revenue DESC",
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="single_model_preaggregation",
+            expected_rules=("linear_cte_chain_flattening", "safe_filter_pushdown", "preaggregation_route_selection"),
+            expected_sql_contains=("orders_preagg_by_status", "WHERE status = 'completed'"),
+            forbidden_sql_contains=("WITH base", "FROM orders\n"),
+            min_speedup=1.2,
+        ),
+        BenchmarkCase(
+            name="multi_semantic_cte_island_preaggregation",
+            wrapped_sql="""
+                WITH
+                orders_agg AS (
+                    SELECT orders.revenue, orders.status FROM orders
+                ),
+                customers_agg AS (
+                    SELECT customers.count, customers.region FROM customers
+                )
+                SELECT o.status, c.region, o.revenue, c.count
+                FROM orders_agg o
+                JOIN customers_agg c ON o.status IS NOT NULL
+                ORDER BY o.status, c.region
+            """,
+            baseline_sql=lambda layer: "WITH orders_agg AS "
+            + _subquery(
+                _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders", use_preaggregations=False)
+            )
+            + ", customers_agg AS "
+            + _subquery(
+                _inner_sql(layer, "SELECT customers.count, customers.region FROM customers", use_preaggregations=False)
+            )
+            + " SELECT o.status, c.region, o.revenue, c.count"
+            + " FROM orders_agg o JOIN customers_agg c ON o.status IS NOT NULL"
+            + " ORDER BY o.status, c.region",
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="semantic_plus_postprocess",
+            expected_rules=("semantic_island_optimization", "preaggregation_route_selection"),
+            expected_sql_contains=("orders_preagg_by_status", "customers_preagg_by_region"),
+            forbidden_sql_contains=("FROM orders\n", "FROM customers\n"),
+            min_speedup=1.05,
+        ),
+        BenchmarkCase(
+            name="dimension_distinct_wrapper",
+            wrapped_sql="""
+                SELECT DISTINCT status
+                FROM (SELECT orders.status FROM orders) sq
+                ORDER BY status
+            """,
+            baseline_sql=lambda layer: "SELECT DISTINCT status FROM "
+            + _subquery(_inner_sql(layer, "SELECT orders.status FROM orders", use_preaggregations=False))
+            + " sq ORDER BY status",
+            expected_plan="direct_semantic",
+            expected_rules=("dimension_distinct_wrapper",),
+            forbidden_sql_contains=("DISTINCT", "FROM ("),
+        ),
+        BenchmarkCase(
+            name="dimension_slicer_null_search_limit",
+            wrapped_sql="""
+                SELECT DISTINCT status
+                FROM (SELECT orders.status FROM orders) sq
+                WHERE status IS NOT NULL AND LOWER(status) LIKE 'comp%'
+                ORDER BY status
+                LIMIT 1000
+            """,
+            baseline_sql=lambda layer: "SELECT DISTINCT status FROM "
+            + _subquery(_inner_sql(layer, "SELECT orders.status FROM orders", use_preaggregations=False))
+            + " sq WHERE status IS NOT NULL AND LOWER(status) LIKE 'comp%' ORDER BY status LIMIT 1000",
+            case_type="performance",
+            expected_plan="direct_semantic",
+            expected_rules=("dimension_distinct_wrapper", "safe_filter_pushdown", "safe_limit_pushdown"),
+            expected_sql_contains=("LOWER(status) LIKE 'comp%'", "LIMIT 1000"),
+            forbidden_sql_contains=("DISTINCT", "FROM ("),
+            min_speedup=1.05,
+        ),
+        BenchmarkCase(
+            name="global_row_number_topn",
+            wrapped_sql="""
+                SELECT status, revenue
+                FROM (
+                    SELECT
+                        status,
+                        revenue,
+                        ROW_NUMBER() OVER (ORDER BY revenue DESC) AS rn
+                    FROM (SELECT orders.revenue, orders.status FROM orders) semantic_result
+                ) ranked
+                WHERE rn <= 2
+                ORDER BY revenue DESC
+            """,
+            baseline_sql=lambda layer: (
+                "SELECT status, revenue FROM ("
+                "SELECT status, revenue, ROW_NUMBER() OVER (ORDER BY revenue DESC) AS rn FROM "
+                + _subquery(
+                    _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders", use_preaggregations=False)
+                )
+                + " semantic_result) ranked WHERE rn <= 2 ORDER BY revenue DESC"
+            ),
+            expected_plan="direct_semantic",
+            expected_rules=("global_row_number_topn", "safe_order_pushdown", "safe_limit_pushdown"),
+            expected_sql_contains="LIMIT 2",
+            forbidden_sql_contains=("ROW_NUMBER", "FROM ("),
+        ),
+        BenchmarkCase(
+            name="topn_pagination_preaggregation",
+            wrapped_sql="""
+                SELECT status, revenue
+                FROM (
+                    SELECT
+                        status,
+                        revenue,
+                        ROW_NUMBER() OVER (ORDER BY revenue DESC) AS rn
+                    FROM (SELECT orders.revenue, orders.status FROM orders) semantic_result
+                ) ranked
+                WHERE rn BETWEEN 2 AND 2
+                ORDER BY revenue DESC
+            """,
+            baseline_sql=lambda layer: (
+                "SELECT status, revenue FROM ("
+                "SELECT status, revenue, ROW_NUMBER() OVER (ORDER BY revenue DESC) AS rn FROM "
+                + _subquery(
+                    _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders", use_preaggregations=False)
+                )
+                + " semantic_result) ranked WHERE rn BETWEEN 2 AND 2 ORDER BY revenue DESC"
+            ),
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="single_model_preaggregation",
+            expected_rules=("global_row_number_topn", "safe_limit_pushdown", "preaggregation_route_selection"),
+            expected_sql_contains=("orders_preagg_by_status", "LIMIT 1", "OFFSET 1"),
+            forbidden_sql_contains=("ROW_NUMBER", "FROM orders\n"),
+            min_speedup=1.05,
         ),
         BenchmarkCase(
             name="projection_metric_pruning",
@@ -184,7 +451,38 @@ def _cases(layer: SemanticLayer) -> list[BenchmarkCase]:
                 )
             )
             + " sq ORDER BY status",
-            expected_rule="wrapper_projection_flattening",
+            expected_plan="direct_semantic",
+            expected_rules=("wrapper_projection_flattening",),
+            forbidden_sql_contains="COUNT(*)",
+        ),
+        BenchmarkCase(
+            name="projection_width_reduction_wide_key",
+            wrapped_sql="""
+                SELECT *
+                FROM (SELECT orders.revenue, orders.status FROM orders) sq
+                ORDER BY status
+            """,
+            baseline_sql=lambda _layer: """
+                WITH orders_cte AS MATERIALIZED (
+                  SELECT
+                    wide_id AS wide_id,
+                    status AS status,
+                    amount AS revenue_raw
+                  FROM orders
+                )
+                SELECT
+                  orders_cte.status AS status,
+                  SUM(orders_cte.revenue_raw) AS revenue
+                FROM orders_cte
+                GROUP BY orders_cte.status
+                ORDER BY status
+            """,
+            case_type="performance",
+            expected_plan="direct_semantic",
+            expected_rules=("trivial_wrapper_flattening",),
+            expected_sql_contains=("status AS status", "amount AS revenue_raw"),
+            forbidden_sql_contains=("wide_id AS wide_id", "FROM ("),
+            min_speedup=1.2,
         ),
         BenchmarkCase(
             name="wrapped_preaggregation",
@@ -199,7 +497,38 @@ def _cases(layer: SemanticLayer) -> list[BenchmarkCase]:
             )
             + " sq",
             use_preaggregations=True,
-            expected_rule="preaggregation_route_selection",
+            case_type="performance",
+            expected_plan="single_model_preaggregation",
+            expected_rules=("preaggregation_route_selection",),
+            expected_sql_contains="orders_preagg_by_status",
+            forbidden_sql_contains="FROM orders\n",
+            min_speedup=1.2,
+        ),
+        BenchmarkCase(
+            name="root_having_metric_preagg",
+            wrapped_sql="""
+                SELECT orders.revenue, orders.status
+                FROM orders
+                HAVING orders.revenue > 33000000
+                ORDER BY status
+            """,
+            baseline_sql=lambda layer: _inner_sql(
+                layer,
+                """
+                    SELECT orders.revenue, orders.status
+                    FROM orders
+                    HAVING orders.revenue > 33000000
+                    ORDER BY orders.status
+                """,
+                use_preaggregations=False,
+            ),
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="single_model_preaggregation",
+            expected_rules=("preaggregation_route_selection",),
+            expected_sql_contains=("orders_preagg_by_status", "HAVING SUM(revenue_raw) > 33000000"),
+            forbidden_sql_contains="FROM orders\n",
+            min_speedup=1.2,
         ),
         BenchmarkCase(
             name="wrapped_fanout_strategy",
@@ -209,7 +538,274 @@ def _cases(layer: SemanticLayer) -> list[BenchmarkCase]:
                 _inner_sql(layer, "SELECT orders.revenue, customers.count FROM orders", use_preaggregations=False)
             )
             + " sq",
-            expected_rule="fanout_strategy_selection",
+            expected_plan="fanout_preaggregation",
+            expected_rules=("fanout_strategy_selection",),
+        ),
+        BenchmarkCase(
+            name="aggregate_boundary_sum_rollup_raw",
+            wrapped_sql="""
+                SELECT status, SUM(revenue) AS revenue
+                FROM (
+                    SELECT orders.revenue, orders.status, orders.order_date__day FROM orders
+                ) sq
+                GROUP BY status
+                ORDER BY status
+            """,
+            baseline_sql=lambda layer: "SELECT status, SUM(revenue) AS revenue FROM "
+            + _subquery(
+                _inner_sql(
+                    layer,
+                    "SELECT orders.revenue, orders.status, orders.order_date__day FROM orders",
+                    use_preaggregations=False,
+                )
+            )
+            + " sq GROUP BY status ORDER BY status",
+            case_type="performance",
+            expected_plan="direct_semantic",
+            expected_rules=("aggregate_boundary_rollup", "additive_metric_rollup"),
+            forbidden_sql_contains="orders.order_date__day",
+            min_speedup=1.05,
+        ),
+        BenchmarkCase(
+            name="aggregate_boundary_sum_rollup_preagg",
+            wrapped_sql="""
+                SELECT status, SUM(revenue) AS revenue
+                FROM (
+                    SELECT orders.revenue, orders.status, orders.order_date__day FROM orders
+                ) sq
+                GROUP BY status
+                ORDER BY status
+            """,
+            baseline_sql=lambda layer: "SELECT status, SUM(revenue) AS revenue FROM "
+            + _subquery(
+                _inner_sql(
+                    layer,
+                    "SELECT orders.revenue, orders.status, orders.order_date__day FROM orders",
+                    use_preaggregations=False,
+                )
+            )
+            + " sq GROUP BY status ORDER BY status",
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="single_model_preaggregation",
+            expected_rules=("aggregate_boundary_rollup", "additive_metric_rollup", "preaggregation_route_selection"),
+            expected_sql_contains="orders_preagg_by_status",
+            forbidden_sql_contains="FROM orders\n",
+            min_speedup=1.2,
+        ),
+        BenchmarkCase(
+            name="additive_total_union_preaggregation",
+            wrapped_sql="""
+                SELECT status, revenue
+                FROM (SELECT orders.revenue, orders.status FROM orders) detail
+                UNION ALL
+                SELECT NULL AS status, SUM(revenue) AS revenue
+                FROM (SELECT orders.revenue, orders.status FROM orders) detail_total
+                ORDER BY status
+            """,
+            baseline_sql=lambda layer: "SELECT status, revenue FROM "
+            + _subquery(
+                _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders", use_preaggregations=False)
+            )
+            + " detail UNION ALL SELECT NULL AS status, SUM(revenue) AS revenue FROM "
+            + _subquery(
+                _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders", use_preaggregations=False)
+            )
+            + " detail_total ORDER BY status",
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="semantic_plus_postprocess",
+            expected_rules=("semantic_island_optimization", "preaggregation_route_selection"),
+            expected_sql_contains=("orders_preagg_by_status", "UNION ALL"),
+            forbidden_sql_contains="FROM orders\n",
+            min_speedup=1.05,
+        ),
+        BenchmarkCase(
+            name="virtual_dataset_time_rls_preaggregation",
+            wrapped_sql="""
+                SELECT *
+                FROM (
+                    SELECT orders.revenue, orders.order_date__day, orders.status FROM orders
+                ) virtual_table
+                WHERE order_date__day >= DATE '2024-01-01'
+                  AND order_date__day < DATE '2024-02-01'
+                  AND status = 'completed'
+                ORDER BY order_date__day
+            """,
+            baseline_sql=lambda layer: "SELECT * FROM "
+            + _subquery(
+                _inner_sql(
+                    layer,
+                    "SELECT orders.revenue, orders.order_date__day, orders.status FROM orders",
+                    use_preaggregations=False,
+                )
+            )
+            + " virtual_table WHERE order_date__day >= DATE '2024-01-01'"
+            + " AND order_date__day < DATE '2024-02-01'"
+            + " AND status = 'completed' ORDER BY order_date__day",
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="single_model_preaggregation",
+            expected_rules=("safe_filter_pushdown", "preaggregation_route_selection"),
+            expected_sql_contains=("orders_preagg_by_status_day", "WHERE"),
+            forbidden_sql_contains="FROM orders\n",
+            min_speedup=1.05,
+        ),
+        BenchmarkCase(
+            name="conditional_pivot_preaggregation",
+            wrapped_sql="""
+                SELECT
+                    SUM(CASE WHEN status = 'completed' THEN revenue ELSE 0 END) AS completed_revenue,
+                    SUM(CASE WHEN status = 'pending' THEN revenue ELSE 0 END) AS pending_revenue
+                FROM (
+                    SELECT orders.revenue, orders.status FROM orders
+                ) sq
+            """,
+            baseline_sql=lambda layer: "SELECT "
+            + "SUM(CASE WHEN status = 'completed' THEN revenue ELSE 0 END) AS completed_revenue, "
+            + "SUM(CASE WHEN status = 'pending' THEN revenue ELSE 0 END) AS pending_revenue FROM "
+            + _subquery(
+                _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders", use_preaggregations=False)
+            )
+            + " sq",
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="semantic_plus_postprocess",
+            expected_rules=("conditional_aggregate_wrapper", "preaggregation_route_selection"),
+            expected_sql_contains=("orders_preagg_by_status", "completed_revenue"),
+            forbidden_sql_contains="FROM orders\n",
+            min_speedup=1.05,
+        ),
+        BenchmarkCase(
+            name="time_expression_grain_rollup_preaggregation",
+            wrapped_sql="""
+                SELECT DATE_TRUNC('month', order_date__day) AS order_month, SUM(revenue) AS revenue
+                FROM (
+                    SELECT orders.order_date__day, orders.revenue FROM orders
+                ) sq
+                GROUP BY 1
+                ORDER BY order_month
+            """,
+            baseline_sql=lambda layer: "SELECT DATE_TRUNC('month', order_date__day) AS order_month, "
+            + "SUM(revenue) AS revenue FROM "
+            + _subquery(
+                _inner_sql(
+                    layer,
+                    "SELECT orders.order_date__day, orders.revenue FROM orders",
+                    use_preaggregations=False,
+                )
+            )
+            + " sq GROUP BY 1 ORDER BY order_month",
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="single_model_preaggregation",
+            expected_rules=("aggregate_boundary_rollup", "time_grain_rollup", "preaggregation_route_selection"),
+            expected_sql_contains=("orders_preagg_daily_revenue", "DATE_TRUNC('MONTH', order_date_day)"),
+            forbidden_sql_contains="FROM orders\n",
+            min_speedup=1.05,
+        ),
+        BenchmarkCase(
+            name="union_branch_semantic_islands_preaggregation",
+            wrapped_sql="""
+                SELECT status, revenue
+                FROM (SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'completed') completed
+                UNION ALL
+                SELECT status, revenue
+                FROM (SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'pending') pending
+            """,
+            baseline_sql=lambda layer: "SELECT status, revenue FROM "
+            + _subquery(
+                _inner_sql(
+                    layer,
+                    "SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'completed'",
+                    use_preaggregations=False,
+                )
+            )
+            + " completed UNION ALL SELECT status, revenue FROM "
+            + _subquery(
+                _inner_sql(
+                    layer,
+                    "SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'pending'",
+                    use_preaggregations=False,
+                )
+            )
+            + " pending",
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="semantic_plus_postprocess",
+            expected_rules=("set_operation_branch_optimization", "preaggregation_route_selection"),
+            expected_sql_contains=("orders_preagg_by_status", "UNION ALL"),
+            forbidden_sql_contains="FROM orders\n",
+            min_speedup=1.05,
+        ),
+        BenchmarkCase(
+            name="window_inner_preaggregation",
+            wrapped_sql="""
+                SELECT *
+                FROM (SELECT running_total_revenue, orders.order_date__day FROM metrics) sq
+                ORDER BY order_date__day
+            """,
+            baseline_sql=lambda layer: "SELECT * FROM "
+            + _subquery(
+                _inner_sql(
+                    layer,
+                    "SELECT running_total_revenue, orders.order_date__day FROM metrics",
+                    use_preaggregations=False,
+                )
+            )
+            + " sq ORDER BY order_date__day",
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="window_metric",
+            expected_rules=("safe_order_pushdown",),
+            expected_sql_contains="orders_preagg_daily_revenue",
+            forbidden_sql_contains="FROM orders\n",
+            min_speedup=1.05,
+        ),
+        BenchmarkCase(
+            name="fanout_child_preaggregation",
+            wrapped_sql="""
+                SELECT *
+                FROM (
+                    SELECT orders.revenue AS total_revenue, customers.count AS customer_count FROM orders
+                ) sq
+            """,
+            baseline_sql=lambda layer: "SELECT * FROM "
+            + _subquery(
+                _inner_sql(
+                    layer,
+                    "SELECT orders.revenue AS total_revenue, customers.count AS customer_count FROM orders",
+                    use_preaggregations=False,
+                )
+            )
+            + " sq",
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="fanout_preaggregation",
+            expected_rules=("fanout_strategy_selection",),
+            expected_sql_contains=("orders_preagg_total_revenue", "customers_preagg_total_count"),
+            forbidden_sql_contains=("FROM orders\n", "FROM customers\n"),
+            min_speedup=1.05,
+        ),
+        BenchmarkCase(
+            name="fanout_join_key_preagg_region",
+            wrapped_sql="""
+                SELECT orders.revenue, customers.region
+                FROM orders
+                ORDER BY customers.region
+            """,
+            baseline_sql=lambda layer: _inner_sql(
+                layer,
+                "SELECT orders.revenue, customers.region FROM orders ORDER BY customers.region",
+                use_preaggregations=False,
+            ),
+            use_preaggregations=True,
+            case_type="performance",
+            expected_plan="join_key_preaggregation",
+            expected_rules=("join_key_preaggregation_route_selection",),
+            expected_sql_contains=("orders_preagg_by_customer", "LEFT JOIN customers AS customers"),
+            forbidden_sql_contains="FROM orders\n",
+            min_speedup=1.2,
         ),
     ]
 
@@ -233,19 +829,38 @@ def run_benchmarks(row_count: int, iterations: int) -> list[dict[str, Any]]:
         baseline_ms = _median_ms(layer, baseline_sql, iterations)
         optimized_ms = _median_ms(layer, optimized_sql, iterations)
         speedup = baseline_ms / optimized_ms if optimized_ms else None
+        expected_fragments = _fragments(case.expected_sql_contains)
+        forbidden_fragments = _fragments(case.forbidden_sql_contains)
+        expected_fragments_present = (
+            all(fragment in optimized_sql for fragment in expected_fragments) if expected_fragments else None
+        )
+        forbidden_fragments_absent = (
+            all(fragment not in optimized_sql for fragment in forbidden_fragments) if forbidden_fragments else None
+        )
+        expected_rules_present = all(rule in explanation.applied_rules for rule in case.expected_rules)
+        chosen_plan_matches = explanation.chosen_plan == case.expected_plan if case.expected_plan else None
+        speedup_floor_met = speedup >= case.min_speedup if speedup is not None and case.min_speedup else None
 
         results.append(
             {
                 "name": case.name,
+                "case_type": case.case_type,
                 "chosen_plan": explanation.chosen_plan,
-                "expected_rule_present": case.expected_rule in explanation.applied_rules
-                if case.expected_rule
-                else None,
+                "expected_plan": case.expected_plan,
+                "chosen_plan_matches": chosen_plan_matches,
+                "expected_rules": list(case.expected_rules),
+                "expected_rules_present": expected_rules_present,
+                "expected_fragments": list(expected_fragments),
+                "expected_fragments_present": expected_fragments_present,
+                "forbidden_fragments": list(forbidden_fragments),
+                "forbidden_fragments_absent": forbidden_fragments_absent,
                 "applied_rules": explanation.applied_rules,
                 "rows_equal": rows_equal,
                 "baseline_ms": round(baseline_ms, 3),
                 "optimized_ms": round(optimized_ms, 3),
                 "speedup": round(speedup, 3) if speedup else None,
+                "min_speedup": case.min_speedup,
+                "speedup_floor_met": speedup_floor_met,
                 "sql_changed": baseline_sql.strip() != optimized_sql.strip(),
             }
         )
@@ -256,11 +871,35 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--rows", type=int, default=200_000, help="Number of synthetic orders to generate")
     parser.add_argument("--iterations", type=int, default=5, help="Timing iterations per query")
+    parser.add_argument(
+        "--enforce-speedups",
+        action="store_true",
+        help="Fail when a performance case with min_speedup misses its floor",
+    )
     args = parser.parse_args()
 
     results = run_benchmarks(row_count=args.rows, iterations=args.iterations)
-    failed = [result for result in results if not result["rows_equal"] or result["expected_rule_present"] is False]
-    print(json.dumps({"rows": args.rows, "iterations": args.iterations, "results": results}, indent=2))
+    failed = [
+        result
+        for result in results
+        if not result["rows_equal"]
+        or result["chosen_plan_matches"] is False
+        or result["expected_rules_present"] is False
+        or result["expected_fragments_present"] is False
+        or result["forbidden_fragments_absent"] is False
+        or (args.enforce_speedups and result["speedup_floor_met"] is False)
+    ]
+    print(
+        json.dumps(
+            {
+                "rows": args.rows,
+                "iterations": args.iterations,
+                "enforce_speedups": args.enforce_speedups,
+                "results": results,
+            },
+            indent=2,
+        )
+    )
     if failed:
         raise SystemExit(1)
 

--- a/scripts/benchmark_semantic_sql_planner.py
+++ b/scripts/benchmark_semantic_sql_planner.py
@@ -1,0 +1,269 @@
+"""Benchmark semantic SQL wrapper rewrites against legacy wrapper-shaped SQL.
+
+Run with:
+    uv run scripts/benchmark_semantic_sql_planner.py --rows 200000 --iterations 5
+
+The baseline SQL here approximates the old post-process shape: compile the
+inner semantic query, then apply the user wrapper outside it. The optimized SQL
+is produced by QueryRewriter.explain() on the wrapped semantic SQL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from sidemantic import Dimension, Metric, Model, PreAggregation, Relationship, SemanticLayer
+from sidemantic.sql.query_rewriter import QueryRewriter
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    name: str
+    wrapped_sql: str
+    baseline_sql: Callable[[SemanticLayer], str]
+    use_preaggregations: bool = False
+    expected_rule: str | None = None
+
+
+def _normalize(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return float(value)
+    return value
+
+
+def _fetch_dicts(layer: SemanticLayer, sql: str) -> list[dict[str, Any]]:
+    result = layer.conn.execute(sql)
+    columns = [col[0] for col in result.description]
+    return [dict(zip(columns, [_normalize(value) for value in row])) for row in result.fetchall()]
+
+
+def _median_ms(layer: SemanticLayer, sql: str, iterations: int) -> float:
+    layer.conn.execute(sql).fetchall()
+    timings: list[float] = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        layer.conn.execute(sql).fetchall()
+        timings.append((time.perf_counter() - start) * 1000)
+    return statistics.median(timings)
+
+
+def _inner_sql(layer: SemanticLayer, sql: str, use_preaggregations: bool = False) -> str:
+    return QueryRewriter(
+        layer.graph,
+        dialect=layer.dialect,
+        use_preaggregations=use_preaggregations,
+    ).rewrite(sql)
+
+
+def _subquery(sql: str) -> str:
+    return "(\n" + sql.rstrip() + "\n)"
+
+
+def _build_layer(row_count: int) -> SemanticLayer:
+    layer = SemanticLayer(auto_register=False, use_preaggregations=True)
+    orders = Model(
+        name="orders",
+        table="orders",
+        primary_key="id",
+        dimensions=[
+            Dimension(name="status", type="categorical", sql="status"),
+            Dimension(name="order_date", type="time", sql="order_date", granularity="day"),
+        ],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+            Metric(name="count", agg="count"),
+        ],
+        relationships=[Relationship(name="customers", type="many_to_one", foreign_key="customer_id")],
+        pre_aggregations=[
+            PreAggregation(
+                name="by_status",
+                measures=["revenue"],
+                dimensions=["status"],
+            )
+        ],
+    )
+    customers = Model(
+        name="customers",
+        table="customers",
+        primary_key="id",
+        dimensions=[
+            Dimension(name="region", type="categorical", sql="region"),
+            Dimension(name="tier", type="categorical", sql="tier"),
+        ],
+        metrics=[Metric(name="count", agg="count")],
+        relationships=[Relationship(name="orders", type="one_to_many", foreign_key="customer_id")],
+    )
+    layer.add_model(orders)
+    layer.add_model(customers)
+
+    layer.conn.execute("""
+        CREATE TABLE customers AS
+        SELECT
+            i::INTEGER AS id,
+            CASE WHEN i % 2 = 0 THEN 'US' ELSE 'EU' END AS region,
+            CASE WHEN i % 5 = 0 THEN 'premium' ELSE 'standard' END AS tier
+        FROM range(1, 1001) AS t(i)
+    """)
+    layer.conn.execute(f"""
+        CREATE TABLE orders AS
+        SELECT
+            i::INTEGER AS id,
+            (((i - 1) % 1000) + 1)::INTEGER AS customer_id,
+            CASE
+                WHEN i % 3 = 0 THEN 'completed'
+                WHEN i % 3 = 1 THEN 'pending'
+                ELSE 'returned'
+            END AS status,
+            DATE '2024-01-01' + CAST(i % 365 AS INTEGER) AS order_date,
+            CAST((i % 1000) + 1 AS DECIMAL(10, 2)) AS amount
+        FROM range(1, {row_count + 1}) AS t(i)
+    """)
+    layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    return layer
+
+
+def _cases(layer: SemanticLayer) -> list[BenchmarkCase]:
+    return [
+        BenchmarkCase(
+            name="safe_filter_pushdown",
+            wrapped_sql="""
+                SELECT *
+                FROM (SELECT orders.revenue, orders.status FROM orders) sq
+                WHERE status = 'completed'
+                ORDER BY status
+            """,
+            baseline_sql=lambda layer: "SELECT * FROM "
+            + _subquery(
+                _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders", use_preaggregations=False)
+            )
+            + " sq WHERE status = 'completed' ORDER BY status",
+            expected_rule="safe_filter_pushdown",
+        ),
+        BenchmarkCase(
+            name="safe_order_limit_pushdown",
+            wrapped_sql="""
+                SELECT *
+                FROM (SELECT orders.revenue, orders.status FROM orders) sq
+                ORDER BY status DESC
+                LIMIT 2
+            """,
+            baseline_sql=lambda layer: "SELECT * FROM "
+            + _subquery(
+                _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders", use_preaggregations=False)
+            )
+            + " sq ORDER BY status DESC LIMIT 2",
+            expected_rule="safe_order_pushdown",
+        ),
+        BenchmarkCase(
+            name="projection_metric_pruning",
+            wrapped_sql="""
+                SELECT status, revenue
+                FROM (SELECT orders.revenue, orders.count, orders.status FROM orders) sq
+                ORDER BY status
+            """,
+            baseline_sql=lambda layer: "SELECT status, revenue FROM "
+            + _subquery(
+                _inner_sql(
+                    layer,
+                    "SELECT orders.revenue, orders.count, orders.status FROM orders",
+                    use_preaggregations=False,
+                )
+            )
+            + " sq ORDER BY status",
+            expected_rule="wrapper_projection_flattening",
+        ),
+        BenchmarkCase(
+            name="wrapped_preaggregation",
+            wrapped_sql="""
+                SELECT *
+                FROM (SELECT orders.revenue, orders.status FROM orders) sq
+                ORDER BY status
+            """,
+            baseline_sql=lambda layer: "SELECT * FROM "
+            + _subquery(
+                _inner_sql(layer, "SELECT orders.revenue, orders.status FROM orders ORDER BY orders.status", False)
+            )
+            + " sq",
+            use_preaggregations=True,
+            expected_rule="preaggregation_route_selection",
+        ),
+        BenchmarkCase(
+            name="wrapped_fanout_strategy",
+            wrapped_sql="SELECT * FROM (SELECT orders.revenue, customers.count FROM orders) sq",
+            baseline_sql=lambda layer: "SELECT * FROM "
+            + _subquery(
+                _inner_sql(layer, "SELECT orders.revenue, customers.count FROM orders", use_preaggregations=False)
+            )
+            + " sq",
+            expected_rule="fanout_strategy_selection",
+        ),
+    ]
+
+
+def run_benchmarks(row_count: int, iterations: int) -> list[dict[str, Any]]:
+    layer = _build_layer(row_count)
+    results = []
+    for case in _cases(layer):
+        rewriter = QueryRewriter(
+            layer.graph,
+            dialect=layer.dialect,
+            use_preaggregations=case.use_preaggregations,
+        )
+        explanation = rewriter.explain(case.wrapped_sql)
+        optimized_sql = explanation.rewritten_sql
+        baseline_sql = case.baseline_sql(layer)
+
+        optimized_rows = _fetch_dicts(layer, optimized_sql)
+        baseline_rows = _fetch_dicts(layer, baseline_sql)
+        rows_equal = optimized_rows == baseline_rows
+        baseline_ms = _median_ms(layer, baseline_sql, iterations)
+        optimized_ms = _median_ms(layer, optimized_sql, iterations)
+        speedup = baseline_ms / optimized_ms if optimized_ms else None
+
+        results.append(
+            {
+                "name": case.name,
+                "chosen_plan": explanation.chosen_plan,
+                "expected_rule_present": case.expected_rule in explanation.applied_rules
+                if case.expected_rule
+                else None,
+                "applied_rules": explanation.applied_rules,
+                "rows_equal": rows_equal,
+                "baseline_ms": round(baseline_ms, 3),
+                "optimized_ms": round(optimized_ms, 3),
+                "speedup": round(speedup, 3) if speedup else None,
+                "sql_changed": baseline_sql.strip() != optimized_sql.strip(),
+            }
+        )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rows", type=int, default=200_000, help="Number of synthetic orders to generate")
+    parser.add_argument("--iterations", type=int, default=5, help="Timing iterations per query")
+    args = parser.parse_args()
+
+    results = run_benchmarks(row_count=args.rows, iterations=args.iterations)
+    failed = [result for result in results if not result["rows_equal"] or result["expected_rule_present"] is False]
+    print(json.dumps({"rows": args.rows, "iterations": args.iterations, "results": results}, indent=2))
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_semantic_sql_planner.py
+++ b/scripts/benchmark_semantic_sql_planner.py
@@ -803,7 +803,10 @@ def _cases(layer: SemanticLayer) -> list[BenchmarkCase]:
             case_type="performance",
             expected_plan="join_key_preaggregation",
             expected_rules=("join_key_preaggregation_route_selection",),
-            expected_sql_contains=("orders_preagg_by_customer", "LEFT JOIN customers AS customers"),
+            expected_sql_contains=(
+                "FROM customers AS customers",
+                "LEFT JOIN orders_preagg_by_customer AS orders_rollup",
+            ),
             forbidden_sql_contains="FROM orders\n",
             min_speedup=1.2,
         ),

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -69,6 +69,54 @@ def _resolve_engine_options(engine: str | None, fallback: bool | None) -> tuple[
     return resolved_engine, resolved_fallback
 
 
+def _load_query_layer(
+    models: Path,
+    connection: str | None = None,
+    db: Path | None = None,
+    use_preaggregations: bool = False,
+    engine: str | None = None,
+    fallback: bool | None = None,
+) -> SemanticLayer:
+    """Load a semantic layer for CLI query/explain commands."""
+    engine, resolved_fallback = _resolve_engine_options(engine, fallback)
+    _configure_engine_environment(engine, resolved_fallback)
+
+    connection_str = None
+    init_sql = None
+    if connection:
+        connection_str = connection
+    elif db:
+        connection_str = f"duckdb:///{db.absolute()}"
+    elif _loaded_config and _loaded_config.connection:
+        connection_str = build_connection_string(_loaded_config)
+        init_sql = get_init_sql(_loaded_config)
+    else:
+        data_dir = models / "data"
+        if data_dir.exists():
+            db_files = list(data_dir.glob("*.db"))
+            if db_files:
+                connection_str = f"duckdb:///{db_files[0].absolute()}"
+
+    preagg_db = _loaded_config.preagg_database if _loaded_config else None
+    preagg_sch = _loaded_config.preagg_schema if _loaded_config else None
+    layer_kwargs = {
+        "preagg_database": preagg_db,
+        "preagg_schema": preagg_sch,
+        "use_preaggregations": use_preaggregations,
+        "engine": engine,
+        "fallback": resolved_fallback,
+    }
+    if connection_str:
+        layer = SemanticLayer(connection=connection_str, init_sql=init_sql, **layer_kwargs)
+    else:
+        layer = SemanticLayer(**layer_kwargs)
+
+    load_from_directory(layer, str(models))
+    if not layer.graph.models:
+        raise ValueError("No models found")
+    return layer
+
+
 @app.callback()
 def main(
     version: bool = typer.Option(
@@ -501,6 +549,9 @@ def query(
     dry_run: bool = typer.Option(False, "--dry-run", help="Show generated SQL without executing"),
     engine: str = typer.Option(None, "--engine", help="Runtime engine: python, rust, or auto"),
     fallback: bool | None = typer.Option(None, "--fallback/--no-fallback", help="Allow Rust engine fallback to Python"),
+    use_preaggregations: bool = typer.Option(
+        False, "--use-preaggregations", help="Enable automatic pre-aggregation routing"
+    ),
 ):
     """
     Execute a SQL query and output results as CSV.
@@ -512,61 +563,31 @@ def query(
       sidemantic query "SELECT revenue FROM orders" --connection "postgres://localhost:5432/db"
       sidemantic query "SELECT revenue FROM orders" --db data.duckdb
       sidemantic query "SELECT revenue FROM orders" --dry-run
+      sidemantic query "SELECT revenue FROM orders" --use-preaggregations --dry-run
     """
     if not models.exists():
         typer.echo(f"Error: Directory {models} does not exist", err=True)
         raise typer.Exit(1)
 
     try:
-        engine, fallback = _resolve_engine_options(engine, fallback)
-        _configure_engine_environment(engine, fallback)
-
-        # Build connection string from args or config
-        connection_str = None
-        init_sql = None
-        if connection:
-            # Explicit --connection arg provided
-            connection_str = connection
-        elif db:
-            # Explicit --db arg provided
-            connection_str = f"duckdb:///{db.absolute()}"
-        elif _loaded_config and _loaded_config.connection:
-            # Use connection from config
-            connection_str = build_connection_string(_loaded_config)
-            init_sql = get_init_sql(_loaded_config)
-        else:
-            # Try to find database file in data/
-            data_dir = models / "data"
-            if data_dir.exists():
-                db_files = list(data_dir.glob("*.db"))
-                if db_files:
-                    connection_str = f"duckdb:///{db_files[0].absolute()}"
-
-        # Load semantic layer (only pass connection if not None)
-        preagg_db = _loaded_config.preagg_database if _loaded_config else None
-        preagg_sch = _loaded_config.preagg_schema if _loaded_config else None
-        if connection_str:
-            layer = SemanticLayer(
-                connection=connection_str,
-                preagg_database=preagg_db,
-                preagg_schema=preagg_sch,
-                init_sql=init_sql,
-                engine=engine,
-                fallback=fallback,
-            )
-        else:
-            layer = SemanticLayer(preagg_database=preagg_db, preagg_schema=preagg_sch, engine=engine, fallback=fallback)
-        load_from_directory(layer, str(models))
-
-        if not layer.graph.models:
-            typer.echo("Error: No models found", err=True)
-            raise typer.Exit(1)
+        layer = _load_query_layer(
+            models,
+            connection=connection,
+            db=db,
+            use_preaggregations=use_preaggregations,
+            engine=engine,
+            fallback=fallback,
+        )
 
         # Dry run: show generated SQL without executing
         if dry_run:
             from sidemantic.sql.query_rewriter import QueryRewriter
 
-            rewriter = QueryRewriter(layer.graph, dialect=layer.adapter.dialect)
+            rewriter = QueryRewriter(
+                layer.graph,
+                dialect=layer.adapter.dialect,
+                use_preaggregations=layer.use_preaggregations,
+            )
             rewritten_sql = rewriter.rewrite(sql)
             typer.echo(rewritten_sql)
             return
@@ -592,6 +613,48 @@ def query(
             writer = csv.writer(sys.stdout)
             writer.writerow(columns)
             writer.writerows(rows)
+
+    except Exception as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@app.command("explain-sql")
+def explain_sql_command(
+    sql: str = typer.Argument(..., help="SQL query to explain"),
+    models: Path = typer.Option(".", "--models", "-m", help="Directory containing semantic layer files"),
+    connection: str = typer.Option(
+        None, "--connection", help="Database connection string (e.g., postgres://host/db, bigquery://project/dataset)"
+    ),
+    db: Path = typer.Option(None, "--db", help="Path to DuckDB database file (shorthand for duckdb:/// connection)"),
+    use_preaggregations: bool = typer.Option(
+        False, "--use-preaggregations", help="Enable automatic pre-aggregation routing"
+    ),
+    strict: bool = typer.Option(True, "--strict/--no-strict", help="Fail on unsupported semantic SQL"),
+):
+    """
+    Explain semantic SQL rewrite planning as JSON without executing the query.
+
+    Examples:
+      sidemantic explain-sql "SELECT revenue FROM orders"
+      sidemantic explain-sql "SELECT * FROM (SELECT revenue, status FROM orders) sq WHERE status = 'completed'"
+      sidemantic explain-sql "SELECT revenue, status FROM orders" --use-preaggregations
+    """
+    if not models.exists():
+        typer.echo(f"Error: Directory {models} does not exist", err=True)
+        raise typer.Exit(1)
+
+    try:
+        import json
+
+        layer = _load_query_layer(
+            models,
+            connection=connection,
+            db=db,
+            use_preaggregations=use_preaggregations,
+        )
+        explanation = layer.explain_sql(sql, strict=strict)
+        typer.echo(json.dumps(explanation.to_dict(), indent=2, default=str))
 
     except Exception as e:
         typer.echo(f"Error: {e}", err=True)

--- a/sidemantic/core/pre_aggregation.py
+++ b/sidemantic/core/pre_aggregation.py
@@ -179,6 +179,11 @@ class PreAggregation(BaseModel):
                     if agg_type == "COUNT" and not measure.sql:
                         # COUNT(*) case
                         select_exprs.append(f"COUNT(*) as {measure_name}_raw")
+                    elif agg_type == "AVG":
+                        # Store AVG as additive sum state. A compatible count
+                        # measure must also be present before query planning can
+                        # roll this up safely.
+                        select_exprs.append(f"SUM({measure.sql_expr}) as {measure_name}_raw")
                     elif agg_type == "COUNT_DISTINCT":
                         select_exprs.append(f"COUNT(DISTINCT {measure.sql_expr}) as {measure_name}_raw")
                     else:

--- a/sidemantic/core/preagg_matcher.py
+++ b/sidemantic/core/preagg_matcher.py
@@ -128,6 +128,13 @@ class PreAggregationMatcher:
             if not metric:
                 return False
 
+            if metric.agg == "count_distinct":
+                if metric.name not in (preagg.measures or []):
+                    return False
+                if not self._is_exact_grain(preagg, query_dimensions, query_granularity):
+                    return False
+                continue
+
             if not self._is_measure_derivable(metric, preagg):
                 return False
 
@@ -142,9 +149,7 @@ class PreAggregationMatcher:
         # All filter columns must be available in the pre-agg
         if filters:
             filter_columns = self._extract_filter_columns(filters)
-            available_columns = set(preagg.dimensions or [])
-            if preagg.time_dimension:
-                available_columns.add(preagg.time_dimension)
+            available_columns = self._available_filter_columns(preagg)
 
             for col in filter_columns:
                 if col not in available_columns:
@@ -165,15 +170,36 @@ class PreAggregationMatcher:
 
         columns = set()
         for filter_expr in filters:
-            # Remove model prefix if present (e.g., "orders.status" -> "status")
-            # Simple regex to extract column names before operators
-            # This handles: column = value, column >= value, etc.
-            matches = re.findall(r"(\w+\.)?(\w+)\s*[=<>!]", filter_expr)
-            for match in matches:
-                # match[0] is model prefix (optional), match[1] is column name
-                columns.add(match[1])
+            try:
+                import sqlglot
+                from sqlglot import exp
+
+                parsed = sqlglot.parse_one(filter_expr)
+                parsed_columns = set()
+                for column in parsed.find_all(exp.Column):
+                    if column.find_ancestor(exp.Select):
+                        continue
+                    parsed_columns.add(column.name)
+                if parsed_columns:
+                    columns.update(parsed_columns)
+                    continue
+            except Exception:
+                pass
+
+            # Fallback for malformed or dialect-specific predicates.
+            matches = re.findall(r"(?:(\w+)\.)?(\w+)\s*(?:=|<>|!=|<=|>=|<|>|IN|BETWEEN|LIKE|IS)\b", filter_expr, re.I)
+            for _table_name, column_name in matches:
+                columns.add(column_name)
 
         return columns
+
+    def _available_filter_columns(self, preagg: PreAggregation) -> set[str]:
+        available_columns = set(preagg.dimensions or [])
+        if preagg.time_dimension:
+            available_columns.add(preagg.time_dimension)
+            if preagg.granularity:
+                available_columns.add(f"{preagg.time_dimension}__{preagg.granularity}")
+        return available_columns
 
     def _is_measure_derivable(self, query_metric: Metric, preagg: PreAggregation) -> bool:
         """Check if a metric can be derived from pre-aggregation measures.
@@ -187,6 +213,13 @@ class PreAggregationMatcher:
         """
         preagg_measures = preagg.measures or []
 
+        # Complex metrics can be rebuilt from additive leaf state even when
+        # the derived metric itself is not materialized.
+        if query_metric.type in {"ratio", "derived"} or (
+            not query_metric.type and not query_metric.agg and query_metric.sql
+        ):
+            return self._complex_metric_derivable(query_metric, preagg)
+
         # Check if metric is in the pre-agg measures list
         if query_metric.name not in preagg_measures:
             return False
@@ -195,9 +228,6 @@ class PreAggregationMatcher:
         agg_type = query_metric.agg
 
         if not agg_type:
-            # Complex metric types (ratio, derived, etc.)
-            # For now, conservatively require all component metrics to be present
-            # TODO: More sophisticated logic for derived metrics
             return True
 
         # Simple aggregations
@@ -218,6 +248,23 @@ class PreAggregationMatcher:
             return False
 
         # Default: allow if present
+        return True
+
+    def _complex_metric_derivable(self, query_metric: Metric, preagg: PreAggregation) -> bool:
+        preagg_measures = set(preagg.measures or [])
+        dependencies = query_metric.get_dependencies(model_context=self.model.name)
+        if not dependencies:
+            return query_metric.name in preagg_measures
+
+        for dependency in dependencies:
+            dep_name = dependency.split(".", 1)[1] if "." in dependency else dependency
+            dep_metric = self.model.get_metric(dep_name)
+            if not dep_metric:
+                return False
+            if dep_metric.agg not in {"sum", "count"}:
+                return False
+            if dep_name not in preagg_measures:
+                return False
         return True
 
     def _find_count_measure_for_avg(self, avg_metric: Metric, preagg_measures: list[str]) -> str | None:
@@ -261,6 +308,22 @@ class PreAggregationMatcher:
                 return measure
 
         return None
+
+    def _is_exact_grain(
+        self,
+        preagg: PreAggregation,
+        query_dimensions: list[str],
+        query_granularity: str | None,
+    ) -> bool:
+        preagg_dims = set(preagg.dimensions or [])
+        query_dims = set(query_dimensions)
+        if preagg.time_dimension:
+            query_dims.discard(preagg.time_dimension)
+        if query_dims != preagg_dims:
+            return False
+        if preagg.time_dimension or query_granularity:
+            return bool(preagg.time_dimension) and query_granularity == preagg.granularity
+        return True
 
     def _is_granularity_compatible(
         self,
@@ -345,6 +408,10 @@ class PreAggregationMatcher:
                 query_level = GRANULARITY_HIERARCHY.get(query_granularity, 0)
                 preagg_level = GRANULARITY_HIERARCHY.get(preagg.granularity, 0)
                 score -= abs(query_level - preagg_level) * 5
+        elif not query_granularity and preagg.granularity:
+            # A total query can be answered from a time rollup, but an
+            # otherwise-equivalent total rollup is smaller and should win.
+            score -= 20
 
         return score
 
@@ -399,10 +466,16 @@ class PreAggregationMatcher:
             if not metric:
                 measure_details.append(f"{metric_name} (not found)")
                 measures_ok = False
+            elif metric.agg == "count_distinct" and metric.name in (preagg.measures or []):
+                if self._is_exact_grain(preagg, query_dimensions, query_granularity):
+                    measure_details.append(f"{metric_name} (count_distinct exact grain)")
+                else:
+                    measure_details.append(f"{metric_name} (count_distinct_not_rollup_safe)")
+                    measures_ok = False
             elif not self._is_measure_derivable(metric, preagg):
                 agg = metric.agg or "complex"
                 if agg == "count_distinct":
-                    measure_details.append(f"{metric_name} (count_distinct not derivable from preagg)")
+                    measure_details.append(f"{metric_name} (count_distinct_not_rollup_safe)")
                 elif agg == "avg":
                     measure_details.append(f"{metric_name} (avg needs companion count measure)")
                 elif metric.name not in (preagg.measures or []):
@@ -443,9 +516,7 @@ class PreAggregationMatcher:
         filters = filters or []
         if filters:
             filter_columns = self._extract_filter_columns(filters)
-            available_columns = set(preagg.dimensions or [])
-            if preagg.time_dimension:
-                available_columns.add(preagg.time_dimension)
+            available_columns = self._available_filter_columns(preagg)
 
             missing_cols = {col for col in filter_columns if col not in available_columns}
             filters_ok = len(missing_cols) == 0

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -1246,19 +1246,36 @@ class SemanticLayer:
         cache_key = (
             getattr(self.graph, "_version", 0),
             self.dialect,
+            self.use_preaggregations,
             os.getenv("SIDEMANTIC_RS_REWRITER", "0"),
             os.getenv("SIDEMANTIC_RS_NO_FALLBACK", "0"),
             query,
         )
         rewritten_sql = self._sql_rewrite_cache.get(cache_key)
         if rewritten_sql is None:
-            rewriter = QueryRewriter(self.graph, dialect=self.dialect)
+            rewriter = QueryRewriter(self.graph, dialect=self.dialect, use_preaggregations=self.use_preaggregations)
             rewritten_sql = rewriter.rewrite(query)
             if len(self._sql_rewrite_cache) >= self._sql_rewrite_cache_limit:
                 self._sql_rewrite_cache.pop(next(iter(self._sql_rewrite_cache)))
             self._sql_rewrite_cache[cache_key] = rewritten_sql
 
         return self.adapter.execute(rewritten_sql)
+
+    def explain_sql(self, query: str, strict: bool = True):
+        """Explain semantic SQL rewrite planning without executing the query.
+
+        Args:
+            query: SQL query like "SELECT orders.revenue, orders.status FROM orders"
+            strict: If True, raise errors for invalid SQL or unsupported rewrites.
+                    If False, return a passthrough explanation when possible.
+
+        Returns:
+            RewriteExplanation with the chosen plan, candidate plans, and rewritten SQL.
+        """
+        from sidemantic.sql.query_rewriter import QueryRewriter
+
+        rewriter = QueryRewriter(self.graph, dialect=self.dialect, use_preaggregations=self.use_preaggregations)
+        return rewriter.explain(query, strict=strict)
 
     def to_yaml(self, path: str | Path) -> None:
         """Export semantic layer to native YAML file.

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -536,7 +536,16 @@ class SQLGenerator:
         if needs_window_functions:
             return self._cache_generate_result(
                 cache_key,
-                self._generate_with_window_functions(metrics, dimensions, filters, order_by, limit, offset, aliases),
+                self._generate_with_window_functions(
+                    metrics,
+                    dimensions,
+                    filters,
+                    order_by,
+                    limit,
+                    offset,
+                    aliases,
+                    use_preaggregations=use_preaggregations,
+                ),
             )
 
         # Parse dimension references and extract granularities
@@ -544,6 +553,22 @@ class SQLGenerator:
 
         # Find all models needed for the query
         model_names = self._find_required_models(metrics, dimensions, filters)
+
+        if use_preaggregations and not ungrouped:
+            join_key_preagg_sql = self._try_use_join_key_preaggregation(
+                metrics=metrics,
+                dimensions=dimensions,
+                filters=filters,
+                order_by=order_by,
+                limit=limit,
+                offset=offset,
+                aliases=aliases,
+            )
+            if join_key_preagg_sql:
+                instrumentation = self._generate_instrumentation_comment(
+                    models=model_names, metrics=metrics, dimensions=dimensions, used_preagg=True
+                )
+                return self._cache_generate_result(cache_key, join_key_preagg_sql + "\n" + instrumentation)
 
         # Check if we need symmetric aggregation (pre-aggregation approach)
         # This is needed when metrics come from different models at different join levels
@@ -559,6 +584,7 @@ class SQLGenerator:
                     limit=limit,
                     offset=offset,
                     aliases=aliases,
+                    use_preaggregations=use_preaggregations,
                 ),
             )
 
@@ -572,6 +598,7 @@ class SQLGenerator:
                 order_by=order_by,
                 limit=limit,
                 offset=offset,
+                aliases=aliases,
             )
             if preagg_sql:
                 # Add instrumentation comment
@@ -661,6 +688,7 @@ class SQLGenerator:
                 order_by=order_by,
                 all_models=all_models,
                 metric_filter_columns=metric_filter_cols,
+                ungrouped=ungrouped,
             )
             cte_sqls.append(cte_sql)
 
@@ -1181,6 +1209,7 @@ class SQLGenerator:
         order_by: list[str] | None = None,
         all_models: set[str] | None = None,
         metric_filter_columns: set[str] | None = None,
+        ungrouped: bool = False,
     ) -> str:
         """Build CTE SQL for a model with optional filter pushdown.
 
@@ -1192,6 +1221,7 @@ class SQLGenerator:
             order_by: Order by fields (for determining needed dimensions)
             all_models: All models in query (for determining if joins needed)
             metric_filter_columns: Columns needed for metric-level filters
+            ungrouped: Whether the query is returning raw ungrouped rows
 
         Returns:
             CTE SQL string
@@ -1211,11 +1241,12 @@ class SQLGenerator:
         # Track all columns added (not just join keys) to avoid duplicates
         columns_added = set()
 
-        # Include this model's primary key columns (always needed for joins/grouping)
-        for pk_col in model.primary_key_columns:
-            if pk_col not in columns_added:
-                select_cols.append(f"{self._quote_identifier(pk_col)} AS {self._quote_alias(pk_col)}")
-                columns_added.add(pk_col)
+        include_primary_keys = needs_joins or ungrouped or bool(model.sql)
+        if include_primary_keys:
+            for pk_col in model.primary_key_columns:
+                if pk_col not in columns_added:
+                    select_cols.append(f"{self._quote_identifier(pk_col)} AS {self._quote_alias(pk_col)}")
+                    columns_added.add(pk_col)
 
         # Include foreign keys if we're joining OR if they're explicitly requested as dimensions
         for relationship in model.relationships:
@@ -1625,6 +1656,7 @@ class SQLGenerator:
         limit: int | None = None,
         offset: int | None = None,
         aliases: dict[str, str] | None = None,
+        use_preaggregations: bool = False,
     ) -> str:
         """Generate SQL using pre-aggregation to avoid fan-out.
 
@@ -1640,6 +1672,7 @@ class SQLGenerator:
             limit: Maximum number of rows
             offset: Number of rows to skip
             aliases: Custom aliases for fields
+            use_preaggregations: Try materialized pre-aggregation routing for each child query
 
         Returns:
             SQL query string
@@ -1668,6 +1701,7 @@ class SQLGenerator:
                 limit=limit,
                 offset=offset,
                 aliases=aliases,
+                use_preaggregations=use_preaggregations,
             )
 
         # Resolve segments to SQL filters
@@ -1708,6 +1742,7 @@ class SQLGenerator:
                 limit=None,
                 offset=None,
                 aliases=aliases,
+                use_preaggregations=use_preaggregations,
             )
 
             # Remove the instrumentation comment from sub-query
@@ -1720,15 +1755,40 @@ class SQLGenerator:
 
         # Build the final SELECT that joins all pre-aggregated CTEs
         select_exprs = []
+        output_names: dict[str, str] = {}
+
+        def register_output_name(output_name: str, *refs: str) -> None:
+            for ref in refs:
+                if ref:
+                    output_names[ref] = output_name
+
+        def dimension_output_name(dim_ref: str, dim_name: str, gran: str | None) -> str:
+            if gran:
+                full_ref = f"{dim_ref}__{gran}"
+                default = f"{dim_name}__{gran}"
+            else:
+                full_ref = dim_ref
+                default = dim_name
+
+            canonical_ref = full_ref
+            return aliases.get(full_ref) or aliases.get(canonical_ref) or default
+
+        def metric_source_name(metric_ref: str, metric_name: str) -> str:
+            return aliases.get(metric_ref) or aliases.get(f"{metric_ref.split('.')[0]}.{metric_name}") or metric_name
 
         # Add dimensions - use COALESCE across all CTEs
         for dim_ref, gran in parsed_dims:
             dim_name = dim_ref.split(".")[1] if "." in dim_ref else dim_ref
             col_name = f"{dim_name}__{gran}" if gran else dim_name
+            output_name = dimension_output_name(dim_ref, dim_name, gran)
+            full_ref = f"{dim_ref}__{gran}" if gran else dim_ref
+            canonical_ref = full_ref
+            register_output_name(output_name, full_ref, canonical_ref, dim_name, col_name, output_name)
 
             # Build COALESCE expression
-            coalesce_parts = [f"{cte}.{col_name}" for cte in cte_names]
-            select_exprs.append(f"COALESCE({', '.join(coalesce_parts)}) AS {col_name}")
+            quoted_source = self._quote_identifier(output_name)
+            coalesce_parts = [f"{cte}.{quoted_source}" for cte in cte_names]
+            select_exprs.append(f"COALESCE({', '.join(coalesce_parts)}) AS {self._quote_alias(output_name)}")
 
         # Check for metric name collisions across models
         metric_name_counts: dict[str, int] = {}
@@ -1742,6 +1802,7 @@ class SQLGenerator:
             cte_name = f"{model_name}_preagg"
             for metric_ref in model_metrics:
                 metric_name = metric_ref.split(".")[1] if "." in metric_ref else metric_ref
+                source_name = metric_source_name(metric_ref, metric_name)
                 # Check for custom alias first
                 if metric_ref in aliases:
                     alias = aliases[metric_ref]
@@ -1750,7 +1811,8 @@ class SQLGenerator:
                     alias = f"{model_name}_{metric_name}"
                 else:
                     alias = metric_name
-                select_exprs.append(f"{cte_name}.{metric_name} AS {alias}")
+                register_output_name(alias, metric_ref, f"{model_name}.{metric_name}", metric_name, alias)
+                select_exprs.append(f"{cte_name}.{self._quote_identifier(source_name)} AS {self._quote_alias(alias)}")
 
         # Build FROM clause with FULL OUTER JOINs (or CROSS JOIN if no dimensions)
         # Start with first CTE
@@ -1767,10 +1829,10 @@ class SQLGenerator:
                 join_conditions = []
                 for dim_ref, gran in parsed_dims:
                     dim_name = dim_ref.split(".")[1] if "." in dim_ref else dim_ref
-                    col_name = f"{dim_name}__{gran}" if gran else dim_name
+                    col_name = dimension_output_name(dim_ref, dim_name, gran)
                     # NULL-safe equality that works for all column types
-                    lhs = exp.Column(this=col_name, table=cte_names[0])
-                    rhs = exp.Column(this=col_name, table=cte_name)
+                    lhs = exp.column(col_name, table=cte_names[0])
+                    rhs = exp.column(col_name, table=cte_name)
                     join_conditions.append(exp.NullSafeEQ(this=lhs, expression=rhs).sql(dialect=self.dialect))
 
                 join_clause = " AND ".join(join_conditions)
@@ -1812,11 +1874,16 @@ class SQLGenerator:
         if order_by:
             order_clauses = []
             for field in order_by:
-                if "." in field:
-                    field_name = field.split(".", 1)[1]
-                else:
-                    field_name = field
-                order_clauses.append(field_name)
+                parts = field.rsplit(" ", 1)
+                direction = ""
+                field_ref = field
+                if len(parts) == 2 and parts[1].upper() in {"ASC", "DESC"}:
+                    field_ref = parts[0]
+                    direction = f" {parts[1].upper()}"
+
+                field_name = field_ref.split(".", 1)[1] if "." in field_ref else field_ref
+                output_name = output_names.get(field_ref) or output_names.get(field_name) or field_ref
+                order_clauses.append(f"{self._quote_alias(output_name)}{direction}")
             final_query += f"\nORDER BY {', '.join(order_clauses)}"
 
         # Add LIMIT and OFFSET
@@ -3518,6 +3585,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
         limit: int | None = None,
         offset: int | None = None,
         aliases: dict[str, str] | None = None,
+        use_preaggregations: bool = False,
     ) -> str:
         """Generate SQL with window functions for cumulative metrics.
 
@@ -3532,6 +3600,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
             order_by: List of fields to order by
             limit: Maximum number of rows to return
             aliases: Custom aliases for fields (dict mapping field reference to alias)
+            use_preaggregations: Try materialized pre-aggregation routing for the inner base query
 
         Returns:
             SQL query string
@@ -3796,6 +3865,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
             filters=filters,
             order_by=None,  # Apply ordering in outer query
             limit=None,  # Apply limit in outer query
+            use_preaggregations=use_preaggregations,
         )
 
         # Parse dimensions for outer SELECT
@@ -4265,6 +4335,372 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
 
         return outer_query
 
+    def _split_preaggregation_filters(self, model, filters: list[str]) -> tuple[list[str], list[str]]:
+        row_filters: list[str] = []
+        aggregate_filters: list[str] = []
+        for filter_expr in filters:
+            if self._filter_references_model_metric(model, filter_expr):
+                aggregate_filters.append(filter_expr)
+            else:
+                row_filters.append(filter_expr)
+        return row_filters, aggregate_filters
+
+    def _filter_references_model_metric(self, model, filter_expr: str) -> bool:
+        try:
+            parsed = sqlglot.parse_one(filter_expr, dialect=self.dialect)
+        except Exception:
+            return False
+
+        for column in parsed.find_all(exp.Column):
+            table_name = column.table.replace("_cte", "") if column.table else None
+            field_name = column.name.rsplit("__", 1)[0] if "__" in column.name else column.name
+            if table_name and table_name != model.name:
+                continue
+            if model.get_metric(field_name):
+                return True
+        return False
+
+    def _preaggregation_metric_expression(self, model, preagg, metric_name: str) -> str:
+        metric = model.get_metric(metric_name)
+        raw_col = f"{metric_name}_raw"
+        if not metric:
+            return raw_col
+        if metric.type == "ratio":
+            numerator = self._preaggregation_metric_expression(model, preagg, (metric.numerator or "").split(".")[-1])
+            denominator = self._preaggregation_metric_expression(
+                model,
+                preagg,
+                (metric.denominator or "").split(".")[-1],
+            )
+            return f"{numerator} / NULLIF({denominator}, 0)"
+        if metric.type == "derived" or (not metric.type and not metric.agg and metric.sql):
+            return self._preaggregation_derived_metric_expression(model, preagg, metric)
+        if metric.agg in {"sum", "count"}:
+            return f"SUM({raw_col})"
+        if metric.agg == "avg":
+            matcher = PreAggregationMatcher(model)
+            count_measure = matcher._find_count_measure_for_avg(metric, preagg.measures or []) or "count"
+            return f"SUM({raw_col}) / NULLIF(SUM({count_measure}_raw), 0)"
+        if metric.agg in {"min", "max"}:
+            return f"{metric.agg.upper()}({raw_col})"
+        return f"SUM({raw_col})"
+
+    def _preaggregation_derived_metric_expression(self, model, preagg, metric) -> str:
+        if not metric.sql:
+            return f"SUM({metric.name}_raw)"
+        try:
+            expression = sqlglot.parse_one(metric.sql, dialect=self.dialect)
+        except Exception:
+            return metric.sql
+
+        def replace_column(node):
+            if not isinstance(node, exp.Column):
+                return node
+            field_name = node.name
+            if model.get_metric(field_name):
+                return sqlglot.parse_one(
+                    self._preaggregation_metric_expression(model, preagg, field_name),
+                    dialect=self.dialect,
+                )
+            return node
+
+        return expression.transform(replace_column).sql(dialect=self.dialect)
+
+    def _rewrite_preaggregation_aggregate_filter(self, model, preagg, filter_expr: str) -> str:
+        try:
+            parsed = sqlglot.parse_one(filter_expr, dialect=self.dialect)
+        except Exception:
+            return filter_expr.replace(f"{model.name}_cte.", "").replace(f"{model.name}.", "")
+
+        def replace_column(node):
+            if not isinstance(node, exp.Column):
+                return node
+
+            table_name = node.table.replace("_cte", "") if node.table else None
+            if table_name and table_name != model.name:
+                return node
+
+            field_name = node.name.rsplit("__", 1)[0] if "__" in node.name else node.name
+            if model.get_metric(field_name):
+                return sqlglot.parse_one(
+                    self._preaggregation_metric_expression(model, preagg, field_name),
+                    dialect=self.dialect,
+                )
+
+            if preagg.time_dimension and preagg.granularity and field_name == preagg.time_dimension:
+                return exp.column(f"{preagg.time_dimension}_{preagg.granularity}")
+            return exp.column(node.name)
+
+        return parsed.transform(replace_column).sql(dialect=self.dialect)
+
+    def explain_join_key_preaggregation(
+        self,
+        metrics: list[str],
+        dimensions: list[str],
+        filters: list[str] | None = None,
+        aliases: dict[str, str] | None = None,
+    ) -> dict[str, object]:
+        route, reason = self._join_key_preaggregation_route(metrics, dimensions, filters or [], aliases or {})
+        if route is None:
+            return {"eligible": False, "reason": reason}
+
+        preagg = route["preagg"]
+        join_path = route["join_path"]
+        return {
+            "eligible": True,
+            "reason": "matching_join_key_preaggregation",
+            "model": route["metric_model_name"],
+            "remote_model": route["remote_model_name"],
+            "preaggregation": preagg.name,
+            "preaggregation_dimensions": route["preaggregation_dimensions"],
+            "join_keys": [
+                {
+                    "from_model": hop.from_model,
+                    "to_model": hop.to_model,
+                    "from_columns": hop.from_columns,
+                    "to_columns": hop.to_columns,
+                    "relationship": hop.relationship,
+                }
+                for hop in join_path
+            ],
+        }
+
+    def _try_use_join_key_preaggregation(
+        self,
+        metrics: list[str],
+        dimensions: list[str],
+        filters: list[str] | None = None,
+        order_by: list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        aliases: dict[str, str] | None = None,
+    ) -> str | None:
+        route, _reason = self._join_key_preaggregation_route(metrics, dimensions, filters or [], aliases or {})
+        if route is None:
+            return None
+        return self._generate_join_key_preaggregation(
+            route=route,
+            metrics=metrics,
+            dimensions=dimensions,
+            order_by=order_by,
+            limit=limit,
+            offset=offset,
+            aliases=aliases or {},
+        )
+
+    def _join_key_preaggregation_route(
+        self,
+        metrics: list[str],
+        dimensions: list[str],
+        filters: list[str],
+        aliases: dict[str, str],
+    ) -> tuple[dict[str, object] | None, str]:
+        if filters:
+            return None, "filters_not_supported"
+
+        metric_models = []
+        metric_names = []
+        for metric_ref in metrics:
+            if "." not in metric_ref:
+                return None, "graph_metrics_not_supported"
+            model_name, metric_name = metric_ref.split(".", 1)
+            if model_name not in metric_models:
+                metric_models.append(model_name)
+            metric_names.append(metric_name)
+
+        if len(metric_models) != 1:
+            return None, "not_single_metric_model_query"
+        if not dimensions:
+            return None, "no_remote_dimensions"
+
+        metric_model_name = metric_models[0]
+        metric_model = self.graph.get_model(metric_model_name)
+        if not metric_model.pre_aggregations:
+            return None, "model_has_no_preaggregations"
+
+        parsed_dims = self._parse_dimension_refs(dimensions)
+        local_preagg_dimensions: list[str] = []
+        remote_model_name: str | None = None
+        join_path = None
+        remote_dimensions: list[tuple[str, str | None]] = []
+        join_keys: list[str] = []
+
+        for dim_ref, granularity in parsed_dims:
+            if "." not in dim_ref:
+                return None, "unqualified_dimensions_not_supported"
+            dim_model_name, dim_name = dim_ref.split(".", 1)
+            if dim_model_name == metric_model_name:
+                local_preagg_dimensions.append(dim_name)
+                continue
+
+            try:
+                path = self.graph.find_relationship_path(metric_model_name, dim_model_name)
+            except (KeyError, ValueError):
+                return None, "remote_dimension_not_reachable"
+
+            if len(path) != 1:
+                return None, "multi_hop_remote_dimension_not_supported"
+            if path[0].relationship != "many_to_one":
+                return None, "remote_dimension_not_many_to_one"
+            if remote_model_name and remote_model_name != dim_model_name:
+                return None, "multiple_remote_models_not_supported"
+
+            remote_model_name = dim_model_name
+            join_path = path
+            remote_dimensions.append((dim_ref, granularity))
+            for join_key in path[0].from_columns:
+                if join_key not in join_keys:
+                    join_keys.append(join_key)
+
+        if not remote_model_name or not join_path:
+            return None, "no_remote_dimensions"
+
+        preaggregation_dimensions = [*local_preagg_dimensions, *join_keys]
+        matcher = PreAggregationMatcher(metric_model)
+        preagg = matcher.find_matching_preagg(
+            metrics=metric_names,
+            dimensions=preaggregation_dimensions,
+            filters=[],
+        )
+        if not preagg:
+            return None, "missing_join_key_preaggregation"
+
+        return (
+            {
+                "metric_model_name": metric_model_name,
+                "metric_model": metric_model,
+                "remote_model_name": remote_model_name,
+                "remote_model": self.graph.get_model(remote_model_name),
+                "join_path": join_path,
+                "preagg": preagg,
+                "parsed_dims": parsed_dims,
+                "remote_dimensions": remote_dimensions,
+                "preaggregation_dimensions": preaggregation_dimensions,
+                "aliases": aliases,
+            },
+            "matching_join_key_preaggregation",
+        )
+
+    def _generate_join_key_preaggregation(
+        self,
+        route: dict[str, object],
+        metrics: list[str],
+        dimensions: list[str],
+        order_by: list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        aliases: dict[str, str] | None = None,
+    ) -> str:
+        aliases = aliases or {}
+        metric_model = route["metric_model"]
+        metric_model_name = route["metric_model_name"]
+        remote_model = route["remote_model"]
+        remote_model_name = route["remote_model_name"]
+        preagg = route["preagg"]
+        join_path = route["join_path"]
+        parsed_dims = route["parsed_dims"]
+
+        rollup_alias = f"{metric_model_name}_rollup"
+        remote_alias = remote_model_name
+        preagg_table = preagg.get_table_name(
+            metric_model.name,
+            database=self.preagg_database,
+            schema=self.preagg_schema,
+        )
+
+        select_exprs: list[str] = []
+        output_names: dict[str, str] = {}
+
+        def register_output_name(output_name: str, *refs: str) -> None:
+            for ref in refs:
+                if ref:
+                    output_names[ref] = output_name
+
+        def dimension_output_name(dim_ref: str, dim_name: str, granularity: str | None) -> str:
+            full_ref = f"{dim_ref}__{granularity}" if granularity else dim_ref
+            default = f"{dim_name}__{granularity}" if granularity else dim_name
+            return aliases.get(full_ref) or aliases.get(dim_ref) or default
+
+        for dim_ref, granularity in parsed_dims:
+            dim_model_name, dim_name = dim_ref.split(".", 1)
+            output_name = dimension_output_name(dim_ref, dim_name, granularity)
+            full_ref = f"{dim_ref}__{granularity}" if granularity else dim_ref
+            default_name = f"{dim_name}__{granularity}" if granularity else dim_name
+            register_output_name(output_name, full_ref, dim_ref, dim_name, default_name, output_name)
+
+            if dim_model_name == metric_model_name:
+                column_expr = f"{rollup_alias}.{self._quote_identifier(dim_name)}"
+            else:
+                dimension = remote_model.get_dimension(dim_name)
+                dimension_sql = dimension.sql if dimension and dimension.sql else dim_name
+                column_expr = self._qualify_model_expression(dimension_sql, remote_model_name, remote_alias)
+
+            if granularity:
+                column_expr = self._date_trunc(granularity, column_expr)
+            select_exprs.append(f"{column_expr} AS {self._quote_alias(output_name)}")
+
+        for metric_ref in metrics:
+            _model_name, metric_name = metric_ref.split(".", 1)
+            output_name = aliases.get(metric_ref) or metric_name
+            register_output_name(output_name, metric_ref, metric_name, output_name)
+            metric_expr = self._preaggregation_metric_expression(metric_model, preagg, metric_name)
+            metric_expr = self._qualify_model_expression(metric_expr, metric_model_name, rollup_alias)
+            select_exprs.append(f"{metric_expr} AS {self._quote_alias(output_name)}")
+
+        hop = join_path[0]
+        join_conditions = [
+            f"{rollup_alias}.{self._quote_identifier(from_column)} = {remote_alias}.{self._quote_identifier(to_column)}"
+            for from_column, to_column in zip(hop.from_columns, hop.to_columns)
+        ]
+
+        group_by_clause = ""
+        if parsed_dims:
+            group_by_clause = "\nGROUP BY " + ", ".join(str(i) for i in range(1, len(parsed_dims) + 1))
+
+        order_by_clause = ""
+        if order_by:
+            order_clauses = []
+            for field in order_by:
+                parts = field.rsplit(" ", 1)
+                direction = ""
+                field_ref = field
+                if len(parts) == 2 and parts[1].upper() in {"ASC", "DESC"}:
+                    field_ref = parts[0]
+                    direction = f" {parts[1].upper()}"
+                field_name = field_ref.split(".", 1)[1] if "." in field_ref else field_ref
+                output_name = output_names.get(field_ref) or output_names.get(field_name) or field_ref
+                order_clauses.append(f"{self._quote_alias(output_name)}{direction}")
+            order_by_clause = "\nORDER BY " + ", ".join(order_clauses)
+
+        limit_clause = ""
+        if limit:
+            limit_clause = f"\nLIMIT {limit}"
+        if offset:
+            limit_clause += f"\nOFFSET {offset}"
+
+        select_exprs_str = ",\n  ".join(select_exprs)
+        return f"""SELECT
+  {select_exprs_str}
+FROM {preagg_table} AS {rollup_alias}
+LEFT JOIN {remote_model.table} AS {remote_alias}
+  ON {" AND ".join(join_conditions)}{group_by_clause}{order_by_clause}{limit_clause}"""
+
+    def _qualify_model_expression(self, expression_sql: str, model_name: str, alias: str) -> str:
+        expression_sql = expression_sql.replace("{model}", alias)
+        try:
+            expression = sqlglot.parse_one(expression_sql, dialect=self.dialect)
+        except Exception:
+            if self._is_simple_identifier(expression_sql):
+                return f"{alias}.{self._quote_identifier(expression_sql)}"
+            return expression_sql
+
+        for column in expression.find_all(exp.Column):
+            if not column.table:
+                column.set("table", exp.to_identifier(alias))
+            elif column.table == model_name:
+                column.set("table", exp.to_identifier(alias))
+        return expression.sql(dialect=self.dialect)
+
     def _try_use_preaggregation(
         self,
         model_name: str,
@@ -4274,6 +4710,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
         order_by: list[str] | None = None,
         limit: int | None = None,
         offset: int | None = None,
+        aliases: dict[str, str] | None = None,
     ) -> str | None:
         """Try to generate query using a pre-aggregation.
 
@@ -4319,11 +4756,14 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
                 metric_name = m
             metric_names.append(metric_name)
 
-        # Try to find matching pre-aggregation
-        # Need to extract filter column names (without model prefix) for compatibility checking
+        row_filters, aggregate_filters = self._split_preaggregation_filters(model, filters or [])
+
+        # Try to find matching pre-aggregation. Only row-stage filters constrain
+        # matching dimensions; aggregate-stage metric filters are rendered as
+        # HAVING over derivable rollup measures.
         filter_exprs = []
-        if filters:
-            for f in filters:
+        if row_filters:
+            for f in row_filters:
                 # Strip model prefix for filter compatibility check
                 # e.g., "orders.status = 'completed'" -> "status = 'completed'"
                 filter_expr = f.replace(f"{model_name}.", "").replace(f"{model_name}_cte.", "")
@@ -4346,10 +4786,12 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
             preagg=preagg,
             metrics=metrics,
             parsed_dims=parsed_dims,
-            filters=filters,
+            filters=row_filters,
+            aggregate_filters=aggregate_filters,
             order_by=order_by,
             limit=limit,
             offset=offset,
+            aliases=aliases,
         )
 
     def _generate_from_preaggregation(
@@ -4359,9 +4801,11 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
         metrics: list[str],
         parsed_dims: list[tuple[str, str | None]],
         filters: list[str] | None = None,
+        aggregate_filters: list[str] | None = None,
         order_by: list[str] | None = None,
         limit: int | None = None,
         offset: int | None = None,
+        aliases: dict[str, str] | None = None,
     ) -> str:
         """Generate SQL query from a pre-aggregation.
 
@@ -4370,7 +4814,8 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
             preagg: The pre-aggregation to use
             metrics: List of metric references
             parsed_dims: Parsed dimension references with granularities
-            filters: List of filter expressions
+            filters: List of row-stage filter expressions
+            aggregate_filters: List of metric-stage filter expressions
             order_by: List of fields to order by
             limit: Maximum number of rows
             offset: Number of rows to skip
@@ -4378,10 +4823,32 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
         Returns:
             SQL query string
         """
+        aliases = aliases or {}
         preagg_table = preagg.get_table_name(model.name, database=self.preagg_database, schema=self.preagg_schema)
 
         # Build SELECT clause
         select_exprs = []
+        output_names: dict[str, str] = {}
+
+        def register_output_name(output_name: str, *refs: str) -> None:
+            for ref in refs:
+                if ref:
+                    output_names[ref] = output_name
+
+        def dimension_output_name(dim_ref: str, dim_name: str, gran: str | None) -> str:
+            if gran:
+                full_ref = f"{dim_ref}__{gran}"
+                default = f"{dim_name}__{gran}"
+            else:
+                full_ref = dim_ref
+                default = dim_name
+
+            canonical_ref = full_ref if "." in full_ref else f"{model.name}.{full_ref}"
+            return aliases.get(full_ref) or aliases.get(canonical_ref) or default
+
+        def metric_output_name(metric_ref: str, metric_name: str) -> str:
+            canonical_ref = metric_ref if "." in metric_ref else f"{model.name}.{metric_ref}"
+            return aliases.get(metric_ref) or aliases.get(canonical_ref) or metric_name
 
         # Add dimensions
         for dim_ref, gran in parsed_dims:
@@ -4391,6 +4858,12 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
             else:
                 dim_name = dim_ref
 
+            output_name = dimension_output_name(dim_ref, dim_name, gran)
+            full_ref = f"{dim_ref}__{gran}" if gran else dim_ref
+            canonical_ref = full_ref if "." in full_ref else f"{model.name}.{full_ref}"
+            default_name = f"{dim_name}__{gran}" if gran else dim_name
+            register_output_name(output_name, full_ref, canonical_ref, dim_name, default_name, output_name)
+
             # Check if this is the time dimension and needs granularity conversion
             if gran and preagg.time_dimension == dim_name:
                 # Need to convert from pre-agg granularity to query granularity
@@ -4398,14 +4871,17 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
 
                 if gran == preagg.granularity:
                     # Exact match - use as is with proper alias
-                    select_exprs.append(f"{preagg_col} as {dim_name}__{gran}")
+                    select_exprs.append(f"{preagg_col} AS {self._quote_alias(output_name)}")
                 else:
                     # Roll up to coarser granularity
                     date_trunc_expr = self._date_trunc(gran, preagg_col)
-                    select_exprs.append(f"{date_trunc_expr} as {dim_name}__{gran}")
+                    select_exprs.append(f"{date_trunc_expr} AS {self._quote_alias(output_name)}")
             else:
                 # Regular dimension - use as is
-                select_exprs.append(f"{dim_name}")
+                if output_name == dim_name:
+                    select_exprs.append(f"{dim_name}")
+                else:
+                    select_exprs.append(f"{dim_name} AS {self._quote_alias(output_name)}")
 
         # Add metrics
         for metric_ref in metrics:
@@ -4419,34 +4895,12 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
             if not metric:
                 continue
 
-            # Get the raw column name from pre-agg
-            raw_col = f"{metric_name}_raw"
+            output_name = metric_output_name(metric_ref, metric_name)
+            canonical_ref = metric_ref if "." in metric_ref else f"{model.name}.{metric_ref}"
+            register_output_name(output_name, metric_ref, canonical_ref, metric_name, output_name)
 
-            # Determine aggregation based on metric type
-            if metric.agg == "sum":
-                select_exprs.append(f"SUM({raw_col}) as {metric_name}")
-            elif metric.agg == "count":
-                select_exprs.append(f"SUM({raw_col}) as {metric_name}")
-            elif metric.agg == "avg":
-                # AVG = SUM(sum_raw) / SUM(count_raw)
-                # Need to find the correct count measure from pre-agg
-                from sidemantic.core.preagg_matcher import PreAggregationMatcher
-
-                matcher = PreAggregationMatcher(model)
-                count_measure = matcher._find_count_measure_for_avg(metric, preagg.measures or [])
-
-                if not count_measure:
-                    # Fallback to hard-coded count_raw (old behavior)
-                    count_measure = "count"
-
-                sum_col = f"{metric_name}_raw"
-                count_col = f"{count_measure}_raw"
-                select_exprs.append(f"SUM({sum_col}) / NULLIF(SUM({count_col}), 0) as {metric_name}")
-            elif metric.agg in ["min", "max"]:
-                select_exprs.append(f"{metric.agg.upper()}({raw_col}) as {metric_name}")
-            else:
-                # Default to SUM
-                select_exprs.append(f"SUM({raw_col}) as {metric_name}")
+            metric_expr = self._preaggregation_metric_expression(model, preagg, metric_name)
+            select_exprs.append(f"{metric_expr} AS {self._quote_alias(output_name)}")
 
         # Build FROM clause
         from_clause = preagg_table
@@ -4484,16 +4938,29 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
         if group_by_exprs:
             group_by_clause = f"\nGROUP BY {', '.join(group_by_exprs)}"
 
+        # Build HAVING clause for aggregate-stage metric filters
+        having_clause = ""
+        if aggregate_filters:
+            rewritten_having_filters = [
+                self._rewrite_preaggregation_aggregate_filter(model, preagg, f) for f in aggregate_filters
+            ]
+            having_clause = f"\nHAVING {' AND '.join(rewritten_having_filters)}"
+
         # Build ORDER BY clause
         order_by_clause = ""
         if order_by:
             order_clauses = []
             for field in order_by:
-                if "." in field:
-                    field_name = field.split(".", 1)[1]
-                else:
-                    field_name = field
-                order_clauses.append(field_name)
+                parts = field.rsplit(" ", 1)
+                direction = ""
+                field_ref = field
+                if len(parts) == 2 and parts[1].upper() in {"ASC", "DESC"}:
+                    field_ref = parts[0]
+                    direction = f" {parts[1].upper()}"
+
+                field_name = field_ref.split(".", 1)[1] if "." in field_ref else field_ref
+                output_name = output_names.get(field_ref) or output_names.get(field_name) or field_ref
+                order_clauses.append(f"{self._quote_alias(output_name)}{direction}")
             order_by_clause = f"\nORDER BY {', '.join(order_clauses)}"
 
         # Build LIMIT/OFFSET clause
@@ -4507,7 +4974,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
         select_exprs_str = ",\n  ".join(select_exprs)
         query = f"""SELECT
   {select_exprs_str}
-FROM {from_clause}{where_clause}{group_by_clause}{order_by_clause}{limit_clause}"""
+FROM {from_clause}{where_clause}{group_by_clause}{having_clause}{order_by_clause}{limit_clause}"""
 
         return query
 

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -49,6 +49,19 @@ class SQLGenerator:
             )
         raise ValueError(f"Model '{model.name}' must define table or sql for query compilation")
 
+    def _model_source_as(self, model, alias: str) -> str:
+        quoted_alias = self._quote_identifier(alias)
+        if model.sql:
+            return f"({model.sql}) AS {quoted_alias}"
+        if model.table:
+            return f"{model.table} AS {quoted_alias}"
+        if model.source_uri:
+            raise ValueError(
+                f"Model '{model.name}' uses source_uri '{model.source_uri}', but Python SQL generation does not "
+                "load source_uri data. Define table or sql for query compilation."
+            )
+        raise ValueError(f"Model '{model.name}' must define table or sql for query compilation")
+
     @staticmethod
     def _freeze_cache_value(value):
         if isinstance(value, dict):
@@ -4533,10 +4546,11 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
             if dim_model_name == metric_model_name:
                 local_preagg_dimensions.append(dim_name)
                 dimension = metric_model.get_dimension(dim_name)
-                if granularity and dimension and dimension.type == "time":
-                    if local_time_granularity and local_time_granularity != granularity:
+                if dimension and dimension.type == "time":
+                    effective_granularity = granularity or dimension.granularity
+                    if local_time_granularity and local_time_granularity != effective_granularity:
                         return None, "multiple_local_time_granularities_not_supported"
-                    local_time_granularity = granularity
+                    local_time_granularity = effective_granularity
                 continue
 
             try:
@@ -4637,7 +4651,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
 
             if dim_model_name == metric_model_name:
                 column_name = dim_name
-                if granularity and preagg.time_dimension == dim_name and preagg.granularity:
+                if preagg.time_dimension == dim_name and preagg.granularity:
                     column_name = f"{dim_name}_{preagg.granularity}"
                 column_expr = f"{rollup_alias}.{self._quote_identifier(column_name)}"
             else:
@@ -4689,10 +4703,11 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
             limit_clause += f"\nOFFSET {offset}"
 
         select_exprs_str = ",\n  ".join(select_exprs)
+        remote_source = self._model_source_as(remote_model, remote_alias)
         return f"""SELECT
   {select_exprs_str}
-FROM {preagg_table} AS {rollup_alias}
-LEFT JOIN {remote_model.table} AS {remote_alias}
+FROM {remote_source}
+LEFT JOIN {preagg_table} AS {rollup_alias}
   ON {" AND ".join(join_conditions)}{group_by_clause}{order_by_clause}{limit_clause}"""
 
     def _qualify_model_expression(self, expression_sql: str, model_name: str, alias: str) -> str:

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -4520,6 +4520,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
 
         parsed_dims = self._parse_dimension_refs(dimensions)
         local_preagg_dimensions: list[str] = []
+        local_time_granularity: str | None = None
         remote_model_name: str | None = None
         join_path = None
         remote_dimensions: list[tuple[str, str | None]] = []
@@ -4531,6 +4532,11 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
             dim_model_name, dim_name = dim_ref.split(".", 1)
             if dim_model_name == metric_model_name:
                 local_preagg_dimensions.append(dim_name)
+                dimension = metric_model.get_dimension(dim_name)
+                if granularity and dimension and dimension.type == "time":
+                    if local_time_granularity and local_time_granularity != granularity:
+                        return None, "multiple_local_time_granularities_not_supported"
+                    local_time_granularity = granularity
                 continue
 
             try:
@@ -4560,6 +4566,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
         preagg = matcher.find_matching_preagg(
             metrics=metric_names,
             dimensions=preaggregation_dimensions,
+            time_granularity=local_time_granularity,
             filters=[],
         )
         if not preagg:
@@ -4629,7 +4636,10 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
             register_output_name(output_name, full_ref, dim_ref, dim_name, default_name, output_name)
 
             if dim_model_name == metric_model_name:
-                column_expr = f"{rollup_alias}.{self._quote_identifier(dim_name)}"
+                column_name = dim_name
+                if granularity and preagg.time_dimension == dim_name and preagg.granularity:
+                    column_name = f"{dim_name}_{preagg.granularity}"
+                column_expr = f"{rollup_alias}.{self._quote_identifier(column_name)}"
             else:
                 dimension = remote_model.get_dimension(dim_name)
                 dimension_sql = dimension.sql if dimension and dimension.sql else dim_name

--- a/sidemantic/sql/planner.py
+++ b/sidemantic/sql/planner.py
@@ -1,0 +1,78 @@
+"""Planning structures for semantic SQL rewrites."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass
+class CandidatePlan:
+    """A deterministic rewrite candidate considered by the semantic SQL planner."""
+
+    name: str
+    valid: bool
+    reason: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class SemanticQueryPlan:
+    """Structured plan extracted from a primary semantic SQL SELECT."""
+
+    source_sql: str
+    source_kind: str
+    metrics: list[str] = field(default_factory=list)
+    dimensions: list[str] = field(default_factory=list)
+    filters: list[str] = field(default_factory=list)
+    order_by: list[str] | None = None
+    limit: int | None = None
+    offset: int | None = None
+    aliases: dict[str, str] = field(default_factory=dict)
+    candidate_kind: str = "direct_semantic"
+    candidate_plans: list[CandidatePlan] = field(default_factory=list)
+    eligibility: dict[str, Any] = field(default_factory=dict)
+    applied_rules: list[str] = field(default_factory=list)
+    rejected_rules: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class RewriteExplanation:
+    """Machine-testable explanation for a semantic SQL rewrite decision."""
+
+    input_sql: str
+    chosen_plan: str
+    rewritten_sql: str | None = None
+    source_kind: str = "unknown"
+    metrics: list[str] = field(default_factory=list)
+    dimensions: list[str] = field(default_factory=list)
+    filters: list[str] = field(default_factory=list)
+    order_by: list[str] | None = None
+    limit: int | None = None
+    offset: int | None = None
+    aliases: dict[str, str] = field(default_factory=dict)
+    candidate_plans: list[CandidatePlan] = field(default_factory=list)
+    semantic_scopes: list[SemanticQueryPlan] = field(default_factory=list)
+    pushed_filters: list[str] = field(default_factory=list)
+    post_process: str | None = None
+    preaggregation: dict[str, Any] = field(default_factory=dict)
+    fanout: dict[str, Any] = field(default_factory=dict)
+    applied_rules: list[str] = field(default_factory=list)
+    rejected_rules: dict[str, str] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+__all__ = [
+    "CandidatePlan",
+    "RewriteExplanation",
+    "SemanticQueryPlan",
+]

--- a/sidemantic/sql/planner.py
+++ b/sidemantic/sql/planner.py
@@ -28,6 +28,8 @@ class SemanticQueryPlan:
     metrics: list[str] = field(default_factory=list)
     dimensions: list[str] = field(default_factory=list)
     filters: list[str] = field(default_factory=list)
+    row_filters: list[str] = field(default_factory=list)
+    aggregate_filters: list[str] = field(default_factory=list)
     order_by: list[str] | None = None
     limit: int | None = None
     offset: int | None = None
@@ -53,12 +55,15 @@ class RewriteExplanation:
     metrics: list[str] = field(default_factory=list)
     dimensions: list[str] = field(default_factory=list)
     filters: list[str] = field(default_factory=list)
+    row_filters: list[str] = field(default_factory=list)
+    aggregate_filters: list[str] = field(default_factory=list)
     order_by: list[str] | None = None
     limit: int | None = None
     offset: int | None = None
     aliases: dict[str, str] = field(default_factory=dict)
     candidate_plans: list[CandidatePlan] = field(default_factory=list)
     semantic_scopes: list[SemanticQueryPlan] = field(default_factory=list)
+    semantic_islands: list[dict[str, Any]] = field(default_factory=list)
     pushed_filters: list[str] = field(default_factory=list)
     post_process: str | None = None
     preaggregation: dict[str, Any] = field(default_factory=dict)

--- a/sidemantic/sql/query_rewriter.py
+++ b/sidemantic/sql/query_rewriter.py
@@ -5,6 +5,7 @@ Parses user SQL and rewrites it to use the semantic layer.
 
 import os
 from dataclasses import dataclass
+from typing import Any
 
 import sqlglot
 from sqlglot import exp
@@ -43,11 +44,66 @@ class _ProjectionAnalysis:
 
 
 @dataclass
+class _AggregateBoundaryAnalysis:
+    metrics: list[str]
+    dimensions: list[str]
+    aliases: dict[str, str]
+    visible_name_to_ref: dict[str, str]
+    projected_refs: set[str]
+    row_filters: list[str]
+    aggregate_filters: list[str]
+    applied_rules: list[str]
+
+    @property
+    def pushed_filters(self) -> list[str]:
+        return [*self.row_filters, *self.aggregate_filters]
+
+
+@dataclass
+class _FilterTranslation:
+    row_filters: list[str]
+    aggregate_filters: list[str]
+
+    @property
+    def filters(self) -> list[str]:
+        return [*self.row_filters, *self.aggregate_filters]
+
+
+@dataclass
 class _WrappedOptimization:
     plan: SemanticQueryPlan
     pushed_filters: list[str]
     applied_rules: list[str]
     rejected_rules: dict[str, str]
+
+
+@dataclass
+class _SemanticIslandRewrite:
+    name: str
+    source_kind: str
+    source_sql: str
+    rewritten_sql: str
+    plan: SemanticQueryPlan
+    applied_rules: list[str]
+    rejected_rules: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "source_kind": self.source_kind,
+            "source_sql": self.source_sql,
+            "rewritten_sql": self.rewritten_sql,
+            "chosen_plan": self.plan.candidate_kind,
+            "metrics": list(self.plan.metrics),
+            "dimensions": list(self.plan.dimensions),
+            "filters": list(self.plan.filters),
+            "row_filters": list(self.plan.row_filters),
+            "aggregate_filters": list(self.plan.aggregate_filters),
+            "applied_rules": list(self.applied_rules),
+            "rejected_rules": dict(self.rejected_rules),
+            "preaggregation": dict(self.plan.eligibility.get("single_model_preaggregation", {})),
+            "fanout": dict(self.plan.eligibility.get("fanout_preaggregation", {})),
+        }
 
 
 class QueryRewriter:
@@ -135,11 +191,17 @@ class QueryRewriter:
             # In non-strict mode, pass through unparseable SQL (e.g., SHOW, SET commands)
             return sql
 
-        if not isinstance(parsed, exp.Select):
+        if not isinstance(parsed, (exp.Select, exp.SetOperation)):
             if strict:
                 raise ValueError("Only SELECT queries are supported")
             # In non-strict mode, pass through non-SELECT queries
             return sql
+
+        if isinstance(parsed, exp.SetOperation):
+            if not self._expression_tree_references_semantic_model(parsed):
+                return sql
+            self._raise_on_user_cte_name_collision(parsed)
+            return self._rewrite_set_operation(parsed)
 
         if self._contains_implicit_yardstick_measure_query(parsed):
             try:
@@ -280,10 +342,16 @@ class QueryRewriter:
                 warning=f"SQL parse failed: {e}",
             )
 
-        if not isinstance(parsed, exp.Select):
+        if not isinstance(parsed, (exp.Select, exp.SetOperation)):
             if strict:
                 raise ValueError("Only SELECT queries are supported")
             return self._passthrough_explanation(sql, reason="not_select")
+
+        if isinstance(parsed, exp.SetOperation):
+            if not self._expression_tree_references_semantic_model(parsed):
+                return self._passthrough_explanation(sql, reason="no_semantic_model_reference")
+            self._raise_on_user_cte_name_collision(parsed)
+            return self._explain_set_operation(sql, parsed)
 
         if self._contains_implicit_yardstick_measure_query(parsed):
             try:
@@ -387,10 +455,16 @@ class QueryRewriter:
             explanation.rejected_rules = optimization.rejected_rules
             return explanation
 
-        semantic_scopes, warnings = self._collect_semantic_scopes(parsed)
         root_references_semantic_model = self._references_semantic_model(parsed)
 
-        rewritten_sql = self._rewrite_with_ctes_or_subqueries(parsed.copy())
+        rewritten_sql, semantic_islands, island_rejected_rules, warnings = (
+            self._rewrite_with_ctes_or_subqueries_and_islands(parsed.copy())
+        )
+        semantic_scopes = [island.plan for island in semantic_islands]
+        if not semantic_scopes:
+            semantic_scopes, scope_warnings = self._collect_semantic_scopes(parsed)
+            warnings.extend(scope_warnings)
+        rejected_rules = {**rejected_rules, **island_rejected_rules}
 
         if root_references_semantic_model and len(semantic_scopes) == 1:
             chosen_plan = semantic_scopes[0].candidate_kind
@@ -408,9 +482,67 @@ class QueryRewriter:
             metrics=self._dedupe([metric for scope in semantic_scopes for metric in scope.metrics]),
             dimensions=self._dedupe([dimension for scope in semantic_scopes for dimension in scope.dimensions]),
             filters=self._dedupe([filter_expr for scope in semantic_scopes for filter_expr in scope.filters]),
+            row_filters=self._dedupe([filter_expr for scope in semantic_scopes for filter_expr in scope.row_filters]),
+            aggregate_filters=self._dedupe(
+                [filter_expr for scope in semantic_scopes for filter_expr in scope.aggregate_filters]
+            ),
             candidate_plans=candidate_plans,
             semantic_scopes=semantic_scopes,
+            semantic_islands=[island.to_dict() for island in semantic_islands],
             post_process=parsed.sql(dialect=self.dialect) if not root_references_semantic_model else None,
+            applied_rules=self._dedupe(
+                [
+                    *(
+                        ["set_operation_branch_optimization"]
+                        if any(island.source_kind == "set_operation_branch" for island in semantic_islands)
+                        else []
+                    ),
+                    *[rule for island in semantic_islands for rule in island.applied_rules],
+                ]
+            ),
+            rejected_rules=rejected_rules,
+            warnings=warnings,
+        )
+
+    def _explain_set_operation(self, sql: str, parsed: exp.SetOperation) -> RewriteExplanation:
+        rewritten_sql, semantic_islands, rejected_rules, warnings = self._rewrite_set_operation_with_islands(
+            parsed.copy()
+        )
+        semantic_scopes = [island.plan for island in semantic_islands]
+        chosen_plan = "semantic_plus_postprocess" if semantic_scopes else "passthrough_plain_sql"
+        candidate_plans = self._candidate_plans_for_scopes(semantic_scopes, chosen_plan)
+        if semantic_scopes:
+            candidate_plans.append(
+                CandidatePlan(
+                    name="set_operation_branch_optimization",
+                    valid=True,
+                    reason="semantic branches inside a set operation were optimized independently",
+                    details={"island_count": len(semantic_islands)},
+                )
+            )
+
+        return RewriteExplanation(
+            input_sql=sql,
+            rewritten_sql=rewritten_sql,
+            chosen_plan=chosen_plan,
+            source_kind="set_operation",
+            metrics=self._dedupe([metric for scope in semantic_scopes for metric in scope.metrics]),
+            dimensions=self._dedupe([dimension for scope in semantic_scopes for dimension in scope.dimensions]),
+            filters=self._dedupe([filter_expr for scope in semantic_scopes for filter_expr in scope.filters]),
+            row_filters=self._dedupe([filter_expr for scope in semantic_scopes for filter_expr in scope.row_filters]),
+            aggregate_filters=self._dedupe(
+                [filter_expr for scope in semantic_scopes for filter_expr in scope.aggregate_filters]
+            ),
+            candidate_plans=candidate_plans,
+            semantic_scopes=semantic_scopes,
+            semantic_islands=[island.to_dict() for island in semantic_islands],
+            post_process=parsed.sql(dialect=self.dialect),
+            applied_rules=self._dedupe(
+                [
+                    *(["set_operation_branch_optimization"] if semantic_scopes else []),
+                    *[rule for island in semantic_islands for rule in island.applied_rules],
+                ]
+            ),
             rejected_rules=rejected_rules,
             warnings=warnings,
         )
@@ -419,11 +551,21 @@ class QueryRewriter:
         self, parsed: exp.Select
     ) -> tuple[_WrappedOptimization | None, dict[str, str]]:
         rejected_rules: dict[str, str] = {}
+
+        qualify_topn_optimization = self._optimize_qualify_row_number_topn(parsed, rejected_rules)
+        if qualify_topn_optimization is not None:
+            return qualify_topn_optimization, rejected_rules
+
+        topn_optimization = self._optimize_global_row_number_topn(parsed, rejected_rules)
+        if topn_optimization is not None:
+            return topn_optimization, rejected_rules
+
+        cte_chain_optimization = self._optimize_linear_cte_chain(parsed, rejected_rules)
+        if cte_chain_optimization is not None:
+            return cte_chain_optimization, rejected_rules
+
         source = self._wrapped_semantic_source(parsed, rejected_rules)
         if source is None:
-            return None, rejected_rules
-
-        if self._wrapper_has_blocking_features(parsed, rejected_rules):
             return None, rejected_rules
 
         try:
@@ -433,6 +575,164 @@ class QueryRewriter:
             return None, rejected_rules
 
         output_name_to_ref = self._plan_output_name_to_ref(plan)
+
+        if self._outer_has_aggregate_boundary(parsed):
+            same_grain = self._analyze_same_grain_aggregate_wrapper(
+                parsed,
+                source,
+                plan,
+                output_name_to_ref,
+                rejected_rules,
+            )
+            if same_grain is not None:
+                plan.metrics = same_grain.metrics
+                plan.dimensions = same_grain.dimensions
+                plan.aliases = same_grain.aliases
+
+                applied_rules = ["wrapper_flattening", *same_grain.applied_rules]
+                pushed_filters: list[str] = []
+
+                filters = self._translated_outer_filters(parsed, source, plan, output_name_to_ref, rejected_rules)
+                if filters is None:
+                    return None, rejected_rules
+                if filters.filters:
+                    plan.filters = [*plan.filters, *filters.filters]
+                    plan.row_filters = [*plan.row_filters, *filters.row_filters]
+                    plan.aggregate_filters = [*plan.aggregate_filters, *filters.aggregate_filters]
+                    pushed_filters = filters.filters
+                    if filters.row_filters:
+                        applied_rules.append("safe_filter_pushdown")
+                    if filters.aggregate_filters:
+                        applied_rules.append("safe_metric_filter_having_pushdown")
+
+                order_by = self._translated_outer_order_by(
+                    parsed,
+                    source,
+                    same_grain.visible_name_to_ref,
+                    output_name_to_ref,
+                    same_grain.projected_refs,
+                    rejected_rules,
+                )
+                if order_by is None:
+                    return None, rejected_rules
+                if order_by:
+                    plan.order_by = order_by
+                    applied_rules.append("safe_order_pushdown")
+
+                if not self._apply_outer_limit_offset(parsed, plan, rejected_rules):
+                    return None, rejected_rules
+                if parsed.args.get("limit") is not None or parsed.args.get("offset") is not None:
+                    applied_rules.append("safe_limit_pushdown")
+
+                plan.eligibility = self._plan_eligibility(plan)
+                plan.candidate_kind = self._chosen_candidate_kind(plan)
+                plan.candidate_plans = self._candidate_plans_for_plan(plan)
+                plan.candidate_plans.append(
+                    CandidatePlan(
+                        name="same_grain_metric_wrapper",
+                        valid=True,
+                        reason="outer GROUP BY repeats the inner semantic output grain",
+                    )
+                )
+                if plan.candidate_kind == "single_model_preaggregation":
+                    applied_rules.append("preaggregation_route_selection")
+                if plan.candidate_kind == "join_key_preaggregation":
+                    applied_rules.append("join_key_preaggregation_route_selection")
+                if plan.candidate_kind == "fanout_preaggregation":
+                    applied_rules.append("fanout_strategy_selection")
+                plan.applied_rules = self._dedupe(applied_rules)
+                plan.rejected_rules = rejected_rules
+
+                return (
+                    _WrappedOptimization(
+                        plan=plan,
+                        pushed_filters=pushed_filters,
+                        applied_rules=plan.applied_rules,
+                        rejected_rules=rejected_rules,
+                    ),
+                    rejected_rules,
+                )
+
+            aggregate_boundary = self._analyze_wrapper_aggregate_boundary(
+                parsed,
+                source,
+                plan,
+                output_name_to_ref,
+                rejected_rules,
+            )
+            if aggregate_boundary is None:
+                return None, rejected_rules
+
+            plan.metrics = aggregate_boundary.metrics
+            plan.dimensions = aggregate_boundary.dimensions
+            plan.aliases = aggregate_boundary.aliases
+            if aggregate_boundary.pushed_filters:
+                plan.filters = [*plan.filters, *aggregate_boundary.pushed_filters]
+                plan.row_filters = [*plan.row_filters, *aggregate_boundary.row_filters]
+                plan.aggregate_filters = [*plan.aggregate_filters, *aggregate_boundary.aggregate_filters]
+
+            applied_rules = ["wrapper_flattening", *aggregate_boundary.applied_rules]
+
+            order_by = self._translated_outer_order_by(
+                parsed,
+                source,
+                aggregate_boundary.visible_name_to_ref,
+                output_name_to_ref,
+                aggregate_boundary.projected_refs,
+                rejected_rules,
+            )
+            if order_by is None:
+                return None, rejected_rules
+            if order_by:
+                plan.order_by = order_by
+                applied_rules.append("safe_order_pushdown")
+
+            if not self._apply_outer_limit_offset(parsed, plan, rejected_rules):
+                return None, rejected_rules
+            if parsed.args.get("limit") is not None or parsed.args.get("offset") is not None:
+                applied_rules.append("safe_limit_pushdown")
+
+            plan.eligibility = self._plan_eligibility(plan)
+            plan.candidate_kind = self._chosen_candidate_kind(plan)
+            plan.candidate_plans = self._candidate_plans_for_plan(plan)
+            plan.candidate_plans.append(
+                CandidatePlan(
+                    name="aggregate_boundary_rollup",
+                    valid=True,
+                    reason="outer aggregate rolls up semantic metric outputs",
+                )
+            )
+            if plan.candidate_kind == "single_model_preaggregation":
+                applied_rules.append("preaggregation_route_selection")
+            if plan.candidate_kind == "join_key_preaggregation":
+                applied_rules.append("join_key_preaggregation_route_selection")
+            if plan.candidate_kind == "fanout_preaggregation":
+                applied_rules.append("fanout_strategy_selection")
+            plan.applied_rules = self._dedupe(applied_rules)
+            plan.rejected_rules = rejected_rules
+
+            return (
+                _WrappedOptimization(
+                    plan=plan,
+                    pushed_filters=aggregate_boundary.pushed_filters,
+                    applied_rules=plan.applied_rules,
+                    rejected_rules=rejected_rules,
+                ),
+                rejected_rules,
+            )
+
+        if self._wrapper_has_blocking_features(parsed, rejected_rules):
+            distinct_optimization = self._optimize_dimension_distinct_wrapper(
+                parsed,
+                source,
+                plan,
+                output_name_to_ref,
+                rejected_rules,
+            )
+            if distinct_optimization is not None:
+                return distinct_optimization, rejected_rules
+            return None, rejected_rules
+
         projection = self._analyze_wrapper_projection(parsed, source, plan, output_name_to_ref, rejected_rules)
         if projection is None:
             return None, rejected_rules
@@ -447,10 +747,15 @@ class QueryRewriter:
         filters = self._translated_outer_filters(parsed, source, plan, output_name_to_ref, rejected_rules)
         if filters is None:
             return None, rejected_rules
-        if filters:
-            plan.filters = [*plan.filters, *filters]
-            pushed_filters = filters
-            applied_rules.append("safe_filter_pushdown")
+        if filters.filters:
+            plan.filters = [*plan.filters, *filters.filters]
+            plan.row_filters = [*plan.row_filters, *filters.row_filters]
+            plan.aggregate_filters = [*plan.aggregate_filters, *filters.aggregate_filters]
+            pushed_filters = filters.filters
+            if filters.row_filters:
+                applied_rules.append("safe_filter_pushdown")
+            if filters.aggregate_filters:
+                applied_rules.append("safe_metric_filter_having_pushdown")
 
         order_by = self._translated_outer_order_by(
             parsed,
@@ -476,6 +781,8 @@ class QueryRewriter:
         plan.candidate_plans = self._candidate_plans_for_plan(plan)
         if plan.candidate_kind == "single_model_preaggregation":
             applied_rules.append("preaggregation_route_selection")
+        if plan.candidate_kind == "join_key_preaggregation":
+            applied_rules.append("join_key_preaggregation_route_selection")
         if plan.candidate_kind == "fanout_preaggregation":
             applied_rules.append("fanout_strategy_selection")
         plan.applied_rules = self._dedupe(applied_rules)
@@ -490,6 +797,726 @@ class QueryRewriter:
             ),
             rejected_rules,
         )
+
+    def _finalize_wrapped_optimization(
+        self,
+        plan: SemanticQueryPlan,
+        applied_rules: list[str],
+        pushed_filters: list[str],
+        rejected_rules: dict[str, str],
+        extra_candidate: CandidatePlan | None = None,
+    ) -> _WrappedOptimization:
+        plan.eligibility = self._plan_eligibility(plan)
+        plan.candidate_kind = self._chosen_candidate_kind(plan)
+        plan.candidate_plans = self._candidate_plans_for_plan(plan)
+        if extra_candidate is not None:
+            plan.candidate_plans.append(extra_candidate)
+        if plan.candidate_kind == "single_model_preaggregation":
+            applied_rules.append("preaggregation_route_selection")
+        if plan.candidate_kind == "join_key_preaggregation":
+            applied_rules.append("join_key_preaggregation_route_selection")
+        if plan.candidate_kind == "fanout_preaggregation":
+            applied_rules.append("fanout_strategy_selection")
+        plan.applied_rules = self._dedupe(applied_rules)
+        plan.rejected_rules = rejected_rules
+        return _WrappedOptimization(
+            plan=plan,
+            pushed_filters=pushed_filters,
+            applied_rules=plan.applied_rules,
+            rejected_rules=rejected_rules,
+        )
+
+    def _optimize_linear_cte_chain(
+        self,
+        parsed: exp.Select,
+        rejected_rules: dict[str, str],
+    ) -> _WrappedOptimization | None:
+        with_clause = parsed.args.get("with")
+        if not with_clause or len(with_clause.expressions) < 2:
+            return None
+
+        from_clause = parsed.args.get("from")
+        if not from_clause or not isinstance(from_clause.this, exp.Table):
+            rejected_rules["linear_cte_chain_flattening"] = "root query does not read from a CTE"
+            return None
+
+        ctes_by_name = {cte.alias: cte for cte in with_clause.expressions}
+        if len(ctes_by_name) != len(with_clause.expressions):
+            rejected_rules["linear_cte_chain_flattening"] = "duplicate CTE aliases are not supported"
+            return None
+
+        root_name = from_clause.this.name
+        if root_name not in ctes_by_name:
+            return None
+
+        cte_names = set(ctes_by_name)
+        reference_counts = {name: 0 for name in cte_names}
+        for table in parsed.find_all(exp.Table):
+            if table.name in reference_counts:
+                reference_counts[table.name] += 1
+        multi_refs = [name for name, count in reference_counts.items() if count > 1]
+        if multi_refs:
+            rejected_rules["linear_cte_chain_flattening"] = "CTE referenced more than once"
+            return None
+
+        chain_names_reversed: list[str] = []
+        current_name = root_name
+        base_cte = None
+        while current_name in ctes_by_name:
+            cte = ctes_by_name[current_name]
+            cte_select = cte.this
+            if not isinstance(cte_select, exp.Select):
+                rejected_rules["linear_cte_chain_flattening"] = "chain CTE is not a SELECT"
+                return None
+            chain_names_reversed.append(current_name)
+            if self._references_semantic_model(cte_select):
+                base_cte = cte
+                break
+            cte_from = cte_select.args.get("from")
+            if (
+                not cte_from
+                or not isinstance(cte_from.this, exp.Table)
+                or cte_from.this.name not in ctes_by_name
+                or cte_select.args.get("joins")
+            ):
+                rejected_rules["linear_cte_chain_flattening"] = "CTE chain is not linear"
+                return None
+            current_name = cte_from.this.name
+
+        if base_cte is None:
+            rejected_rules["linear_cte_chain_flattening"] = "chain does not start from a semantic CTE"
+            return None
+
+        chain_names = list(reversed(chain_names_reversed))
+        if set(chain_names) != cte_names:
+            rejected_rules["linear_cte_chain_flattening"] = "WITH contains CTEs outside the linear chain"
+            return None
+
+        try:
+            plan = self._plan_simple_query(base_cte.this.copy())
+        except Exception as e:
+            rejected_rules["linear_cte_chain_flattening"] = f"base semantic CTE cannot be planned: {e}"
+            return None
+
+        applied_rules = ["wrapper_flattening", "linear_cte_chain_flattening"]
+        pushed_filters: list[str] = []
+        previous_name = chain_names[0]
+        for step_name in chain_names[1:]:
+            step = ctes_by_name[step_name].this.copy()
+            step_filters = self._apply_linear_wrapper_step(
+                plan,
+                step,
+                previous_name,
+                rejected_rules,
+                applied_rules,
+            )
+            if step_filters is None:
+                return None
+            pushed_filters.extend(step_filters)
+            previous_name = step_name
+
+        root_step = parsed.copy()
+        root_step.set("with", None)
+        root_filters = self._apply_linear_wrapper_step(
+            plan,
+            root_step,
+            previous_name,
+            rejected_rules,
+            applied_rules,
+        )
+        if root_filters is None:
+            return None
+        pushed_filters.extend(root_filters)
+
+        return self._finalize_wrapped_optimization(
+            plan=plan,
+            applied_rules=applied_rules,
+            pushed_filters=pushed_filters,
+            rejected_rules=rejected_rules,
+            extra_candidate=CandidatePlan(
+                name="linear_cte_chain_flattening",
+                valid=True,
+                reason="linear CTE wrapper chain composed into one semantic plan",
+            ),
+        )
+
+    def _apply_linear_wrapper_step(
+        self,
+        plan: SemanticQueryPlan,
+        select: exp.Select,
+        source_name: str,
+        rejected_rules: dict[str, str],
+        applied_rules: list[str],
+    ) -> list[str] | None:
+        rule_name = "linear_cte_chain_flattening"
+        if select.args.get("with"):
+            rejected_rules[rule_name] = "nested WITH is not supported in a linear CTE step"
+            return None
+        if self._outer_has_aggregate_boundary(select):
+            rejected_rules[rule_name] = "aggregate wrapper step is not supported"
+            return None
+        if self._wrapper_has_blocking_features(select, rejected_rules):
+            rejected_rules[rule_name] = rejected_rules.get("wrapper_flattening", "wrapper step has blocking features")
+            return None
+        if (plan.limit is not None or plan.offset is not None) and (
+            select.args.get("where") is not None or select.args.get("order") is not None
+        ):
+            rejected_rules[rule_name] = "filter or order after LIMIT is not safely composable"
+            return None
+
+        output_name_to_ref = self._plan_output_name_to_ref(plan)
+        source = _WrappedSemanticSource(
+            inner_select=exp.select("*"),
+            source_name=source_name,
+            source_kind="cte_chain",
+        )
+        projection = self._analyze_wrapper_projection(select, source, plan, output_name_to_ref, rejected_rules)
+        if projection is None:
+            rejected_rules[rule_name] = rejected_rules.get("wrapper_flattening", "projection step is not supported")
+            return None
+
+        plan.metrics = projection.metrics
+        plan.dimensions = projection.dimensions
+        plan.aliases = projection.aliases
+        applied_rules.extend(projection.applied_rules)
+
+        output_name_to_ref = self._plan_output_name_to_ref(plan)
+        filters = self._translated_outer_filters(select, source, plan, output_name_to_ref, rejected_rules)
+        if filters is None:
+            rejected_rules[rule_name] = rejected_rules.get("safe_filter_pushdown", "filter step is not supported")
+            return None
+        if filters.filters:
+            plan.filters = [*plan.filters, *filters.filters]
+            plan.row_filters = [*plan.row_filters, *filters.row_filters]
+            plan.aggregate_filters = [*plan.aggregate_filters, *filters.aggregate_filters]
+            if filters.row_filters:
+                applied_rules.append("safe_filter_pushdown")
+            if filters.aggregate_filters:
+                applied_rules.append("safe_metric_filter_having_pushdown")
+
+        order_by = self._translated_outer_order_by(
+            select,
+            source,
+            projection.visible_name_to_ref,
+            output_name_to_ref,
+            projection.projected_refs,
+            rejected_rules,
+        )
+        if order_by is None:
+            rejected_rules[rule_name] = rejected_rules.get("safe_order_pushdown", "order step is not supported")
+            return None
+        if order_by:
+            plan.order_by = order_by
+            applied_rules.append("safe_order_pushdown")
+
+        if not self._apply_outer_limit_offset(select, plan, rejected_rules):
+            rejected_rules[rule_name] = rejected_rules.get("safe_limit_pushdown", "limit step is not supported")
+            return None
+        if select.args.get("limit") is not None or select.args.get("offset") is not None:
+            applied_rules.append("safe_limit_pushdown")
+
+        return filters.filters
+
+    def _optimize_dimension_distinct_wrapper(
+        self,
+        parsed: exp.Select,
+        source: _WrappedSemanticSource,
+        plan: SemanticQueryPlan,
+        output_name_to_ref: dict[str, str],
+        rejected_rules: dict[str, str],
+    ) -> _WrappedOptimization | None:
+        rule_name = "dimension_distinct_wrapper"
+        if not parsed.args.get("distinct"):
+            return None
+        if plan.metrics:
+            rejected_rules[rule_name] = "inner semantic query projects metrics"
+            return None
+        if parsed.args.get("joins"):
+            rejected_rules[rule_name] = "outer query joins to another relation"
+            return None
+        if parsed.args.get("group") or parsed.args.get("having"):
+            rejected_rules[rule_name] = "outer query changes aggregation"
+            return None
+        if parsed.args.get("qualify"):
+            rejected_rules[rule_name] = "outer query uses QUALIFY"
+            return None
+        if any(parsed.find_all(exp.Window)):
+            rejected_rules[rule_name] = "outer query contains window functions"
+            return None
+        if source.inner_select.args.get("limit") or source.inner_select.args.get("offset"):
+            rejected_rules[rule_name] = "inner semantic query limits row membership"
+            return None
+
+        projection = self._analyze_wrapper_projection(parsed, source, plan, output_name_to_ref, rejected_rules)
+        if projection is None:
+            rejected_rules[rule_name] = rejected_rules.get("wrapper_flattening", "distinct projection is not supported")
+            return None
+        if projection.metrics:
+            rejected_rules[rule_name] = "distinct metric projection is not rollup-safe"
+            return None
+
+        plan.metrics = []
+        plan.dimensions = projection.dimensions
+        plan.aliases = projection.aliases
+
+        applied_rules = ["wrapper_flattening", rule_name, *projection.applied_rules]
+        pushed_filters: list[str] = []
+
+        filters = self._translated_outer_filters(parsed, source, plan, output_name_to_ref, rejected_rules)
+        if filters is None:
+            rejected_rules[rule_name] = rejected_rules.get("safe_filter_pushdown", "distinct filter is not supported")
+            return None
+        if filters.filters:
+            plan.filters = [*plan.filters, *filters.filters]
+            plan.row_filters = [*plan.row_filters, *filters.row_filters]
+            plan.aggregate_filters = [*plan.aggregate_filters, *filters.aggregate_filters]
+            pushed_filters = filters.filters
+            if filters.row_filters:
+                applied_rules.append("safe_filter_pushdown")
+            if filters.aggregate_filters:
+                rejected_rules[rule_name] = "distinct metric filters are not supported"
+                return None
+
+        order_by = self._translated_outer_order_by(
+            parsed,
+            source,
+            projection.visible_name_to_ref,
+            output_name_to_ref,
+            projection.projected_refs,
+            rejected_rules,
+        )
+        if order_by is None:
+            rejected_rules[rule_name] = rejected_rules.get("safe_order_pushdown", "distinct order is not supported")
+            return None
+        if order_by:
+            plan.order_by = order_by
+            applied_rules.append("safe_order_pushdown")
+
+        if not self._apply_outer_limit_offset(parsed, plan, rejected_rules):
+            rejected_rules[rule_name] = rejected_rules.get("safe_limit_pushdown", "distinct limit is not supported")
+            return None
+        if parsed.args.get("limit") is not None or parsed.args.get("offset") is not None:
+            applied_rules.append("safe_limit_pushdown")
+
+        return self._finalize_wrapped_optimization(
+            plan=plan,
+            applied_rules=applied_rules,
+            pushed_filters=pushed_filters,
+            rejected_rules=rejected_rules,
+            extra_candidate=CandidatePlan(
+                name=rule_name,
+                valid=True,
+                reason="dimension-only DISTINCT wrapper has the same grain as a semantic dimension query",
+            ),
+        )
+
+    def _optimize_global_row_number_topn(
+        self,
+        parsed: exp.Select,
+        rejected_rules: dict[str, str],
+    ) -> _WrappedOptimization | None:
+        from_clause = parsed.args.get("from")
+        if not from_clause or not isinstance(from_clause.this, exp.Subquery):
+            return None
+
+        ranked_subquery = from_clause.this
+        ranked_select = ranked_subquery.this
+        if not isinstance(ranked_select, exp.Select):
+            return None
+        if not any(isinstance(self._projection_expression(expr), exp.Window) for expr in ranked_select.expressions):
+            return None
+
+        rule_name = "global_row_number_topn"
+        if (
+            parsed.args.get("joins")
+            or parsed.args.get("group")
+            or parsed.args.get("having")
+            or parsed.args.get("qualify")
+        ):
+            rejected_rules[rule_name] = "outer query has blocking features"
+            return None
+        if parsed.args.get("distinct") or parsed.args.get("limit") or parsed.args.get("offset"):
+            rejected_rules[rule_name] = "outer DISTINCT/LIMIT/OFFSET is not supported"
+            return None
+
+        topn_limit, topn_offset, row_number_alias = self._extract_row_number_topn_filter(
+            parsed, ranked_subquery.alias_or_name
+        )
+        if topn_limit is None or row_number_alias is None:
+            rejected_rules[rule_name] = "outer WHERE is not a simple row_number upper bound"
+            return None
+
+        source = self._wrapped_semantic_source(ranked_select, rejected_rules)
+        if source is None:
+            rejected_rules[rule_name] = "ranked source is not a direct semantic wrapper"
+            return None
+
+        try:
+            plan = self._plan_simple_query(source.inner_select.copy())
+        except Exception as e:
+            rejected_rules[rule_name] = f"ranked semantic source cannot be planned: {e}"
+            return None
+
+        ranked_projection = self._analyze_ranked_topn_projection(
+            ranked_select,
+            source,
+            plan,
+            row_number_alias,
+            rejected_rules,
+        )
+        if ranked_projection is None:
+            return None
+
+        plan.metrics = ranked_projection.metrics
+        plan.dimensions = ranked_projection.dimensions
+        plan.aliases = ranked_projection.aliases
+
+        order_by = self._translated_row_number_order_by(
+            ranked_select,
+            row_number_alias,
+            ranked_projection.visible_name_to_ref,
+            ranked_projection.projected_refs,
+            rejected_rules,
+        )
+        if order_by is None:
+            return None
+        plan.order_by = order_by
+        plan.limit = topn_limit
+        plan.offset = topn_offset
+
+        outer_source = _WrappedSemanticSource(
+            inner_select=ranked_select,
+            source_name=ranked_subquery.alias_or_name or "",
+            source_kind="row_number_topn",
+        )
+        output_name_to_ref = dict(ranked_projection.visible_name_to_ref)
+        outer_projection = self._analyze_wrapper_projection(
+            parsed,
+            outer_source,
+            plan,
+            output_name_to_ref,
+            rejected_rules,
+        )
+        if outer_projection is None:
+            rejected_rules[rule_name] = rejected_rules.get(
+                "wrapper_flattening", "outer top-N projection is not supported"
+            )
+            return None
+
+        plan.metrics = outer_projection.metrics
+        plan.dimensions = outer_projection.dimensions
+        plan.aliases = outer_projection.aliases
+
+        outer_order_by = self._translated_outer_order_by(
+            parsed,
+            outer_source,
+            outer_projection.visible_name_to_ref,
+            output_name_to_ref,
+            outer_projection.projected_refs,
+            rejected_rules,
+        )
+        if outer_order_by is None:
+            rejected_rules[rule_name] = rejected_rules.get("safe_order_pushdown", "outer top-N order is not supported")
+            return None
+        if outer_order_by and outer_order_by != order_by:
+            rejected_rules[rule_name] = "outer ORDER BY differs from row_number order"
+            return None
+
+        return self._finalize_wrapped_optimization(
+            plan=plan,
+            applied_rules=[
+                "wrapper_flattening",
+                rule_name,
+                "safe_order_pushdown",
+                "safe_limit_pushdown",
+                *ranked_projection.applied_rules,
+                *outer_projection.applied_rules,
+            ],
+            pushed_filters=[],
+            rejected_rules=rejected_rules,
+            extra_candidate=CandidatePlan(
+                name=rule_name,
+                valid=True,
+                reason="global ROW_NUMBER filter is equivalent to ORDER BY plus LIMIT",
+            ),
+        )
+
+    def _extract_row_number_topn_filter(
+        self,
+        select: exp.Select,
+        source_name: str,
+    ) -> tuple[int | None, int | None, str | None]:
+        where_clause = select.args.get("where")
+        if not where_clause:
+            return None, None, None
+        predicate = where_clause.this
+
+        if isinstance(predicate, exp.Between):
+            row_number = predicate.this
+            low = predicate.args.get("low")
+            high = predicate.args.get("high")
+            if (
+                not isinstance(row_number, exp.Column)
+                or not isinstance(low, exp.Literal)
+                or not isinstance(high, exp.Literal)
+                or not low.is_int
+                or not high.is_int
+            ):
+                return None, None, None
+            if row_number.table and row_number.table != source_name:
+                return None, None, None
+            start = int(low.this)
+            end = int(high.this)
+            if start <= 0 or end < start:
+                return None, None, None
+            return end - start + 1, start - 1, row_number.name
+
+        if not isinstance(predicate, (exp.LTE, exp.LT)):
+            return None, None, None
+
+        left = predicate.this
+        right = predicate.expression
+        if not isinstance(left, exp.Column) or not isinstance(right, exp.Literal) or not right.is_int:
+            return None, None, None
+        if left.table and left.table != source_name:
+            return None, None, None
+
+        value = int(right.this)
+        if isinstance(predicate, exp.LT):
+            value -= 1
+        if value <= 0:
+            return None, None, None
+        return value, None, left.name
+
+    def _optimize_qualify_row_number_topn(
+        self,
+        parsed: exp.Select,
+        rejected_rules: dict[str, str],
+    ) -> _WrappedOptimization | None:
+        qualify_clause = parsed.args.get("qualify")
+        if not qualify_clause:
+            return None
+
+        rule_name = "qualify_row_number_topn"
+        if parsed.args.get("joins") or parsed.args.get("group") or parsed.args.get("having"):
+            rejected_rules[rule_name] = "outer query has blocking features"
+            return None
+        if parsed.args.get("distinct") or parsed.args.get("limit") or parsed.args.get("offset"):
+            rejected_rules[rule_name] = "outer DISTINCT/LIMIT/OFFSET is not supported"
+            return None
+        if parsed.args.get("where"):
+            rejected_rules[rule_name] = "outer WHERE with QUALIFY top-N is not supported"
+            return None
+
+        topn_limit, row_number_window = self._extract_qualify_row_number_bound(qualify_clause.this)
+        if topn_limit is None or row_number_window is None:
+            rejected_rules[rule_name] = "QUALIFY is not a simple row_number upper bound"
+            return None
+
+        source = self._wrapped_semantic_source(parsed, rejected_rules)
+        if source is None:
+            rejected_rules[rule_name] = "QUALIFY source is not a direct semantic wrapper"
+            return None
+
+        try:
+            plan = self._plan_simple_query(source.inner_select.copy())
+        except Exception as e:
+            rejected_rules[rule_name] = f"QUALIFY semantic source cannot be planned: {e}"
+            return None
+
+        output_name_to_ref = self._plan_output_name_to_ref(plan)
+        projection = self._analyze_wrapper_projection(parsed, source, plan, output_name_to_ref, rejected_rules)
+        if projection is None:
+            rejected_rules[rule_name] = rejected_rules.get(
+                "wrapper_flattening", "QUALIFY top-N projection is not supported"
+            )
+            return None
+
+        plan.metrics = projection.metrics
+        plan.dimensions = projection.dimensions
+        plan.aliases = projection.aliases
+
+        order_by = self._translated_window_order_by(
+            row_number_window,
+            projection.visible_name_to_ref,
+            projection.projected_refs,
+            rejected_rules,
+            rule_name=rule_name,
+        )
+        if order_by is None:
+            return None
+        plan.order_by = order_by
+        plan.limit = topn_limit
+
+        return self._finalize_wrapped_optimization(
+            plan=plan,
+            applied_rules=[
+                "wrapper_flattening",
+                rule_name,
+                "safe_order_pushdown",
+                "safe_limit_pushdown",
+                *projection.applied_rules,
+            ],
+            pushed_filters=[],
+            rejected_rules=rejected_rules,
+            extra_candidate=CandidatePlan(
+                name=rule_name,
+                valid=True,
+                reason="global QUALIFY ROW_NUMBER filter is equivalent to ORDER BY plus LIMIT",
+            ),
+        )
+
+    def _extract_qualify_row_number_bound(self, predicate: exp.Expression) -> tuple[int | None, exp.Window | None]:
+        if not isinstance(predicate, (exp.LTE, exp.LT)):
+            return None, None
+
+        left = predicate.this
+        right = predicate.expression
+        if not isinstance(left, exp.Window) or not isinstance(right, exp.Literal) or not right.is_int:
+            return None, None
+        if not isinstance(left.this, exp.RowNumber):
+            return None, None
+        if left.args.get("partition_by"):
+            return None, None
+        if not left.args.get("order"):
+            return None, None
+
+        value = int(right.this)
+        if isinstance(predicate, exp.LT):
+            value -= 1
+        if value <= 0:
+            return None, None
+        return value, left
+
+    def _analyze_ranked_topn_projection(
+        self,
+        select: exp.Select,
+        source: _WrappedSemanticSource,
+        plan: SemanticQueryPlan,
+        row_number_alias: str,
+        rejected_rules: dict[str, str],
+    ) -> _ProjectionAnalysis | None:
+        rule_name = "global_row_number_topn"
+        if (
+            select.args.get("where")
+            or select.args.get("group")
+            or select.args.get("having")
+            or select.args.get("qualify")
+        ):
+            rejected_rules[rule_name] = "ranked query has blocking clauses"
+            return None
+        if select.args.get("distinct") or select.args.get("limit") or select.args.get("offset"):
+            rejected_rules[rule_name] = "ranked query DISTINCT/LIMIT/OFFSET is not supported"
+            return None
+        if select.args.get("joins"):
+            rejected_rules[rule_name] = "ranked query joins another relation"
+            return None
+
+        row_number_count = 0
+        non_window_projections: list[exp.Expression] = []
+        for projection in select.expressions:
+            alias = projection.alias if isinstance(projection, exp.Alias) else None
+            expression = self._projection_expression(projection)
+            if isinstance(expression, exp.Window):
+                if alias != row_number_alias:
+                    rejected_rules[rule_name] = "row_number alias does not match outer filter"
+                    return None
+                if not isinstance(expression.this, exp.RowNumber):
+                    rejected_rules[rule_name] = "only ROW_NUMBER is supported"
+                    return None
+                if expression.args.get("partition_by"):
+                    rejected_rules[rule_name] = "partitioned ROW_NUMBER is not global"
+                    return None
+                if not expression.args.get("order"):
+                    rejected_rules[rule_name] = "ROW_NUMBER has no ORDER BY"
+                    return None
+                row_number_count += 1
+                continue
+            if any(expression.find_all(exp.Window)):
+                rejected_rules[rule_name] = "ranked query contains another window expression"
+                return None
+            non_window_projections.append(projection.copy())
+
+        if row_number_count != 1:
+            rejected_rules[rule_name] = "ranked query must project exactly one ROW_NUMBER"
+            return None
+
+        projection_select = exp.select(*non_window_projections)
+        output_name_to_ref = self._plan_output_name_to_ref(plan)
+        return self._analyze_wrapper_projection(
+            projection_select,
+            source,
+            plan,
+            output_name_to_ref,
+            rejected_rules,
+        )
+
+    def _translated_row_number_order_by(
+        self,
+        ranked_select: exp.Select,
+        row_number_alias: str,
+        visible_name_to_ref: dict[str, str],
+        projected_refs: set[str],
+        rejected_rules: dict[str, str],
+    ) -> list[str] | None:
+        rule_name = "global_row_number_topn"
+        row_number_window = None
+        for projection in ranked_select.expressions:
+            if projection.alias != row_number_alias:
+                continue
+            expression = self._projection_expression(projection)
+            if isinstance(expression, exp.Window):
+                row_number_window = expression
+                break
+        if row_number_window is None:
+            rejected_rules[rule_name] = "ROW_NUMBER projection not found"
+            return None
+
+        return self._translated_window_order_by(
+            row_number_window,
+            visible_name_to_ref,
+            projected_refs,
+            rejected_rules,
+            rule_name=rule_name,
+        )
+
+    def _translated_window_order_by(
+        self,
+        row_number_window: exp.Window,
+        visible_name_to_ref: dict[str, str],
+        projected_refs: set[str],
+        rejected_rules: dict[str, str],
+        rule_name: str,
+    ) -> list[str] | None:
+        order_clause = row_number_window.args.get("order")
+        if not order_clause:
+            rejected_rules[rule_name] = "ROW_NUMBER has no ORDER BY"
+            return None
+
+        order_by: list[str] = []
+        for order_expr in order_clause.expressions:
+            if isinstance(order_expr, exp.Ordered) and order_expr.args.get("nulls_first"):
+                rejected_rules[rule_name] = "ROW_NUMBER ORDER BY uses explicit NULLS ordering"
+                return None
+            expression = order_expr.this if isinstance(order_expr, exp.Ordered) else order_expr
+            if not isinstance(expression, exp.Column):
+                rejected_rules[rule_name] = "ROW_NUMBER ORDER BY computes a new expression"
+                return None
+            ref = visible_name_to_ref.get(expression.name)
+            if ref is None or ref not in projected_refs:
+                rejected_rules[rule_name] = "ROW_NUMBER ORDER BY references a non-projected field"
+                return None
+            order_name = next(
+                (name for name, visible_ref in visible_name_to_ref.items() if visible_ref == ref),
+                expression.name,
+            )
+            if isinstance(order_expr, exp.Ordered) and order_expr.args.get("desc", False):
+                order_name = f"{order_name} DESC"
+            elif isinstance(order_expr, exp.Ordered):
+                order_name = f"{order_name} ASC"
+            order_by.append(order_name)
+
+        return order_by
 
     def _wrapped_semantic_source(
         self, select: exp.Select, rejected_rules: dict[str, str]
@@ -543,6 +1570,463 @@ class QueryRewriter:
 
         rejected_rules["wrapped_semantic_optimizer"] = "outer query is not a single semantic subquery or CTE wrapper"
         return None
+
+    def _outer_has_aggregate_boundary(self, select: exp.Select) -> bool:
+        if select.args.get("group") or select.args.get("having"):
+            return True
+        return any(
+            self._is_supported_outer_rollup_aggregate(self._projection_expression(expr)) for expr in select.expressions
+        )
+
+    def _analyze_same_grain_aggregate_wrapper(
+        self,
+        select: exp.Select,
+        source: _WrappedSemanticSource,
+        plan: SemanticQueryPlan,
+        output_name_to_ref: dict[str, str],
+        rejected_rules: dict[str, str],
+    ) -> _ProjectionAnalysis | None:
+        rule_name = "same_grain_metric_wrapper"
+        group_clause = select.args.get("group")
+        if not group_clause:
+            rejected_rules[rule_name] = "outer_query_has_no_group_by"
+            return None
+        if select.args.get("joins"):
+            rejected_rules[rule_name] = "outer_query_joins_relation"
+            return None
+        if select.args.get("distinct"):
+            rejected_rules[rule_name] = "outer_query_uses_distinct"
+            return None
+        if select.args.get("having"):
+            rejected_rules[rule_name] = "outer_query_uses_having"
+            return None
+        if select.args.get("qualify"):
+            rejected_rules[rule_name] = "outer_query_uses_qualify"
+            return None
+        if any(select.find_all(exp.Window)):
+            rejected_rules[rule_name] = "outer_query_uses_window"
+            return None
+        if sql_has_aggregate(select.sql(dialect=self.dialect)):
+            rejected_rules[rule_name] = "outer_query_contains_aggregate"
+            return None
+
+        selected_refs: list[str] = []
+        aliases = dict(plan.aliases)
+        visible_name_to_ref: dict[str, str] = {}
+        projected_refs: set[str] = set()
+
+        for projection in select.expressions:
+            alias = projection.alias if isinstance(projection, exp.Alias) else None
+            expression = self._projection_expression(projection)
+            if not isinstance(expression, exp.Column):
+                rejected_rules[rule_name] = "outer_projection_computes_expression"
+                return None
+            if expression.table and expression.table != source.source_name:
+                rejected_rules[rule_name] = "outer_projection_references_another_relation"
+                return None
+            ref = output_name_to_ref.get(expression.name)
+            if ref is None:
+                rejected_rules[rule_name] = f"outer_projection_unknown_field_{expression.name}"
+                return None
+            if ref in projected_refs:
+                rejected_rules[rule_name] = "outer_projection_selects_duplicate_field"
+                return None
+
+            selected_refs.append(ref)
+            projected_refs.add(ref)
+            output_name = alias or expression.name
+            visible_name_to_ref[output_name] = ref
+            if alias:
+                aliases[ref] = alias
+
+        group_refs: set[str] = set()
+        for group_expr in group_clause.expressions:
+            if not isinstance(group_expr, exp.Column):
+                rejected_rules[rule_name] = "outer_group_expression_not_supported"
+                return None
+            if group_expr.table and group_expr.table != source.source_name:
+                rejected_rules[rule_name] = "outer_group_references_another_relation"
+                return None
+            ref = output_name_to_ref.get(group_expr.name)
+            if ref is None:
+                rejected_rules[rule_name] = f"outer_group_unknown_field_{group_expr.name}"
+                return None
+            group_refs.add(ref)
+
+        inner_refs = set(plan.dimensions) | set(plan.metrics)
+        if group_refs != inner_refs or projected_refs != inner_refs:
+            rejected_rules[rule_name] = "outer_group_does_not_match_inner_grain"
+            return None
+
+        return _ProjectionAnalysis(
+            metrics=[metric for metric in plan.metrics if metric in projected_refs],
+            dimensions=[dimension for dimension in plan.dimensions if dimension in projected_refs],
+            aliases={ref: alias for ref, alias in aliases.items() if ref in projected_refs},
+            visible_name_to_ref=visible_name_to_ref,
+            projected_refs=projected_refs,
+            applied_rules=[rule_name],
+        )
+
+    def _analyze_wrapper_aggregate_boundary(
+        self,
+        select: exp.Select,
+        source: _WrappedSemanticSource,
+        plan: SemanticQueryPlan,
+        output_name_to_ref: dict[str, str],
+        rejected_rules: dict[str, str],
+    ) -> _AggregateBoundaryAnalysis | None:
+        rule_name = "aggregate_boundary_rollup"
+
+        if select.args.get("joins"):
+            rejected_rules[rule_name] = "outer_query_joins_relation"
+            return None
+        if select.args.get("distinct"):
+            rejected_rules[rule_name] = "outer_query_uses_distinct"
+            return None
+        if select.args.get("qualify"):
+            rejected_rules[rule_name] = "outer_query_uses_qualify"
+            return None
+        if select.args.get("having"):
+            rejected_rules[rule_name] = "aggregate_boundary_having_not_supported"
+            return None
+        if any(select.find_all(exp.Window)):
+            rejected_rules[rule_name] = "outer_query_uses_window"
+            return None
+        if source.inner_select.args.get("limit") or source.inner_select.args.get("offset"):
+            rejected_rules[rule_name] = "inner_query_limits_row_membership"
+            return None
+        if source.inner_select.args.get("distinct"):
+            rejected_rules[rule_name] = "inner_query_uses_distinct"
+            return None
+        if source.inner_select.args.get("having"):
+            rejected_rules[rule_name] = "inner_query_has_metric_having"
+            return None
+
+        group_refs = self._resolve_outer_group_refs(select, source, output_name_to_ref, plan, rejected_rules)
+        if group_refs is None:
+            return None
+
+        selected_dimensions: list[str] = []
+        selected_metrics: list[str] = []
+        aliases: dict[str, str] = {}
+        visible_name_to_ref: dict[str, str] = {}
+        projected_refs: set[str] = set()
+        applied_rules = [rule_name]
+
+        for projection in select.expressions:
+            alias = projection.alias if isinstance(projection, exp.Alias) else None
+            expression = self._projection_expression(projection)
+
+            time_rollup_ref = self._resolve_outer_time_rollup_dimension(
+                expression,
+                source,
+                output_name_to_ref,
+                plan,
+                rejected_rules,
+                rule_name,
+            )
+            if time_rollup_ref is None and isinstance(expression, exp.TimestampTrunc) and rule_name in rejected_rules:
+                return None
+            if time_rollup_ref is not None:
+                if time_rollup_ref not in group_refs:
+                    rejected_rules[rule_name] = "outer_projection_dimension_not_grouped"
+                    return None
+                if time_rollup_ref in selected_dimensions:
+                    rejected_rules[rule_name] = "outer_projection_selects_duplicate_dimension"
+                    return None
+                output_name = alias or time_rollup_ref.split(".", 1)[1]
+                selected_dimensions.append(time_rollup_ref)
+                projected_refs.add(time_rollup_ref)
+                visible_name_to_ref[output_name] = time_rollup_ref
+                if alias:
+                    aliases[time_rollup_ref] = alias
+                applied_rules.append("time_grain_rollup")
+                continue
+
+            if isinstance(expression, exp.Column):
+                if expression.table and expression.table != source.source_name:
+                    rejected_rules[rule_name] = "outer_projection_references_another_relation"
+                    return None
+                ref = output_name_to_ref.get(expression.name)
+                if ref not in group_refs:
+                    rejected_rules[rule_name] = "outer_projection_dimension_not_grouped"
+                    return None
+                if ref in selected_dimensions:
+                    rejected_rules[rule_name] = "outer_projection_selects_duplicate_dimension"
+                    return None
+                output_name = alias or expression.name
+                selected_dimensions.append(ref)
+                projected_refs.add(ref)
+                visible_name_to_ref[output_name] = ref
+                if alias:
+                    aliases[ref] = alias
+                continue
+
+            metric_analysis = self._analyze_outer_rollup_aggregate(
+                expression,
+                alias,
+                source,
+                plan,
+                output_name_to_ref,
+                group_refs,
+                rejected_rules,
+            )
+            if metric_analysis is None:
+                return None
+
+            metric_ref, output_name, metric_rule = metric_analysis
+            if metric_ref in selected_metrics:
+                rejected_rules[rule_name] = "outer_projection_selects_duplicate_metric"
+                return None
+            selected_metrics.append(metric_ref)
+            projected_refs.add(metric_ref)
+            aliases[metric_ref] = output_name
+            visible_name_to_ref[output_name] = metric_ref
+            applied_rules.append(metric_rule)
+
+        if not selected_metrics:
+            rejected_rules[rule_name] = "outer_projection_has_no_rollup_metrics"
+            return None
+
+        if set(selected_dimensions) != group_refs:
+            rejected_rules[rule_name] = "outer_group_dimension_not_projected"
+            return None
+
+        filters = self._translated_outer_filters(select, source, plan, output_name_to_ref, rejected_rules)
+        if filters is None:
+            rejected_rules[rule_name] = rejected_rules.pop(
+                "safe_filter_pushdown",
+                "aggregate_boundary_filter_not_supported",
+            )
+            return None
+        if filters.row_filters:
+            applied_rules.append("aggregate_boundary_dimension_filter_pushdown")
+        if filters.aggregate_filters:
+            applied_rules.append("safe_metric_filter_having_pushdown")
+
+        return _AggregateBoundaryAnalysis(
+            metrics=selected_metrics,
+            dimensions=selected_dimensions,
+            aliases=aliases,
+            visible_name_to_ref=visible_name_to_ref,
+            projected_refs=projected_refs,
+            row_filters=filters.row_filters,
+            aggregate_filters=filters.aggregate_filters,
+            applied_rules=self._dedupe(applied_rules),
+        )
+
+    def _projection_expression(self, projection: exp.Expression) -> exp.Expression:
+        return projection.this if isinstance(projection, exp.Alias) else projection
+
+    def _resolve_outer_group_refs(
+        self,
+        select: exp.Select,
+        source: _WrappedSemanticSource,
+        output_name_to_ref: dict[str, str],
+        plan: SemanticQueryPlan,
+        rejected_rules: dict[str, str],
+    ) -> set[str] | None:
+        rule_name = "aggregate_boundary_rollup"
+        group_clause = select.args.get("group")
+        if not group_clause:
+            return set()
+
+        dimension_refs = set(plan.dimensions)
+        group_refs: set[str] = set()
+        for group_expr in group_clause.expressions:
+            resolved_group_expr = self._resolve_group_expression_position(select, group_expr)
+            if resolved_group_expr is None:
+                rejected_rules[rule_name] = "outer_group_position_not_supported"
+                return None
+            time_rollup_ref = self._resolve_outer_time_rollup_dimension(
+                resolved_group_expr,
+                source,
+                output_name_to_ref,
+                plan,
+                rejected_rules,
+                rule_name,
+            )
+            if (
+                time_rollup_ref is None
+                and isinstance(resolved_group_expr, exp.TimestampTrunc)
+                and rule_name in rejected_rules
+            ):
+                return None
+            if time_rollup_ref is not None:
+                group_refs.add(time_rollup_ref)
+                continue
+            if not isinstance(resolved_group_expr, exp.Column):
+                rejected_rules[rule_name] = "outer_group_expression_not_supported"
+                return None
+            if resolved_group_expr.table and resolved_group_expr.table != source.source_name:
+                rejected_rules[rule_name] = "outer_group_references_another_relation"
+                return None
+            ref = output_name_to_ref.get(resolved_group_expr.name)
+            if ref not in dimension_refs:
+                rejected_rules[rule_name] = "outer_group_field_not_inner_dimension"
+                return None
+            group_refs.add(ref)
+
+        return group_refs
+
+    def _resolve_outer_time_rollup_dimension(
+        self,
+        expression: exp.Expression,
+        source: _WrappedSemanticSource,
+        output_name_to_ref: dict[str, str],
+        plan: SemanticQueryPlan,
+        rejected_rules: dict[str, str],
+        rule_name: str,
+    ) -> str | None:
+        if not isinstance(expression, exp.TimestampTrunc):
+            return None
+
+        column = expression.this
+        if not isinstance(column, exp.Column):
+            rejected_rules[rule_name] = "time_rollup_input_not_dimension"
+            return None
+        if column.table and column.table != source.source_name:
+            rejected_rules[rule_name] = "time_rollup_references_another_relation"
+            return None
+
+        inner_ref = output_name_to_ref.get(column.name)
+        if inner_ref not in set(plan.dimensions):
+            rejected_rules[rule_name] = "time_rollup_input_not_inner_dimension"
+            return None
+        if "__" not in inner_ref:
+            rejected_rules[rule_name] = "time_rollup_input_has_no_grain"
+            return None
+
+        base_ref, inner_grain = inner_ref.rsplit("__", 1)
+        target_grain = self._timestamp_trunc_unit(expression)
+        if target_grain is None:
+            rejected_rules[rule_name] = "time_rollup_grain_not_supported"
+            return None
+        if not self._is_time_grain_rollup_safe(inner_grain, target_grain):
+            rejected_rules[rule_name] = "time_grain_rollup_not_safe"
+            return None
+        return f"{base_ref}__{target_grain}"
+
+    def _timestamp_trunc_unit(self, expression: exp.TimestampTrunc) -> str | None:
+        unit = expression.args.get("unit")
+        if unit is None:
+            return None
+        value = getattr(unit, "this", None)
+        if value is None:
+            value = unit.sql(dialect=self.dialect)
+        return str(value).strip("'\"").lower()
+
+    def _is_time_grain_rollup_safe(self, inner_grain: str, target_grain: str) -> bool:
+        order = ["second", "minute", "hour", "day", "week", "month", "quarter", "year"]
+        if inner_grain not in order or target_grain not in order:
+            return False
+        if inner_grain == target_grain:
+            return True
+        if inner_grain == "week":
+            return False
+        return order.index(inner_grain) < order.index(target_grain)
+
+    def _resolve_group_expression_position(
+        self,
+        select: exp.Select,
+        group_expr: exp.Expression,
+    ) -> exp.Expression | None:
+        if not isinstance(group_expr, exp.Literal) or not group_expr.is_int:
+            return group_expr
+        index = int(group_expr.this) - 1
+        if index < 0 or index >= len(select.expressions):
+            return None
+        return self._projection_expression(select.expressions[index])
+
+    def _analyze_outer_rollup_aggregate(
+        self,
+        expression: exp.Expression,
+        alias: str | None,
+        source: _WrappedSemanticSource,
+        plan: SemanticQueryPlan,
+        output_name_to_ref: dict[str, str],
+        group_refs: set[str],
+        rejected_rules: dict[str, str],
+    ) -> tuple[str, str, str] | None:
+        rule_name = "aggregate_boundary_rollup"
+        outer_agg = self._outer_rollup_aggregate_name(expression)
+        if outer_agg is None:
+            rejected_rules[rule_name] = "outer_projection_computes_expression"
+            return None
+
+        if any(expression.find_all(exp.Distinct)):
+            rejected_rules[rule_name] = "outer_aggregate_distinct_not_supported"
+            return None
+        if any(expression.find_all(exp.Order)):
+            rejected_rules[rule_name] = "outer_aggregate_order_not_supported"
+            return None
+
+        argument = expression.this
+        if not isinstance(argument, exp.Column):
+            rejected_rules[rule_name] = "outer_aggregate_input_not_metric"
+            return None
+        if argument.table and argument.table != source.source_name:
+            rejected_rules[rule_name] = "outer_aggregate_references_another_relation"
+            return None
+
+        metric_ref = output_name_to_ref.get(argument.name)
+        if metric_ref not in set(plan.metrics):
+            rejected_rules[rule_name] = "outer_aggregate_input_not_metric"
+            return None
+
+        metric, _model_context = self._resolve_metric(metric_ref)
+        if not metric:
+            rejected_rules[rule_name] = "outer_metric_not_found"
+            return None
+
+        dropped_dimensions = set(plan.dimensions) - group_refs
+        if metric.non_additive_dimension and self._dimension_is_dropped(
+            metric.non_additive_dimension,
+            dropped_dimensions,
+        ):
+            rejected_rules[rule_name] = "non_additive_dimension_dropped"
+            return None
+
+        metric_agg = metric.agg
+        if outer_agg == "sum" and metric_agg == "sum":
+            metric_rule = "additive_metric_rollup"
+        elif outer_agg == "sum" and metric_agg == "count":
+            metric_rule = "count_metric_rollup"
+        elif outer_agg == "min" and metric_agg == "min":
+            if metric.fill_nulls_with is not None:
+                rejected_rules[rule_name] = "min_max_rollup_with_fill_nulls_not_supported"
+                return None
+            metric_rule = "min_metric_rollup"
+        elif outer_agg == "max" and metric_agg == "max":
+            if metric.fill_nulls_with is not None:
+                rejected_rules[rule_name] = "min_max_rollup_with_fill_nulls_not_supported"
+                return None
+            metric_rule = "max_metric_rollup"
+        else:
+            rejected_rules[rule_name] = "outer_aggregate_not_rollup_safe"
+            return None
+
+        return metric_ref, alias or argument.name, metric_rule
+
+    def _is_supported_outer_rollup_aggregate(self, expression: exp.Expression) -> bool:
+        return self._outer_rollup_aggregate_name(expression) is not None
+
+    def _outer_rollup_aggregate_name(self, expression: exp.Expression) -> str | None:
+        if isinstance(expression, exp.Sum):
+            return "sum"
+        if isinstance(expression, exp.Min):
+            return "min"
+        if isinstance(expression, exp.Max):
+            return "max"
+        return None
+
+    def _dimension_is_dropped(self, dimension_name: str, dropped_dimensions: set[str]) -> bool:
+        for dropped in dropped_dimensions:
+            if dropped == dimension_name:
+                return True
+            if "." in dropped and dropped.split(".", 1)[1] == dimension_name:
+                return True
+        return False
 
     def _wrapper_has_blocking_features(self, select: exp.Select, rejected_rules: dict[str, str]) -> bool:
         if select.args.get("joins"):
@@ -649,7 +2133,7 @@ class QueryRewriter:
             visible_name_to_ref[output_name] = ref
 
         selected = set(selected_refs)
-        selected_dimensions = [dimension for dimension in plan.dimensions if dimension in selected]
+        selected_dimensions = [ref for ref in selected_refs if ref in plan.dimensions]
         if set(selected_dimensions) != set(plan.dimensions):
             rejected_rules["wrapper_flattening"] = (
                 "outer projection drops dimensions and would change semantic grouping"
@@ -657,7 +2141,7 @@ class QueryRewriter:
             return None
 
         return _ProjectionAnalysis(
-            metrics=[metric for metric in plan.metrics if metric in selected],
+            metrics=[ref for ref in selected_refs if ref in plan.metrics],
             dimensions=selected_dimensions,
             aliases={ref: alias for ref, alias in aliases.items() if ref in selected},
             visible_name_to_ref=visible_name_to_ref,
@@ -672,29 +2156,75 @@ class QueryRewriter:
         plan: SemanticQueryPlan,
         output_name_to_ref: dict[str, str],
         rejected_rules: dict[str, str],
-    ) -> list[str] | None:
+    ) -> _FilterTranslation | None:
         where_clause = select.args.get("where")
         if not where_clause:
-            return []
+            return _FilterTranslation(row_filters=[], aggregate_filters=[])
 
         if plan.limit is not None or plan.offset is not None or source.inner_select.args.get("distinct"):
             rejected_rules["safe_filter_pushdown"] = "inner semantic query limits row membership"
             return None
 
-        dimension_refs = set(plan.dimensions)
+        selected_refs = set(plan.dimensions) | set(plan.metrics)
+        row_filters: list[str] = []
+        aggregate_filters: list[str] = []
         try:
-            translated = self._translate_wrapper_expression(
-                where_clause.this,
-                output_name_to_ref,
-                source.source_name,
-                allowed_refs=dimension_refs,
-                rule_name="safe_filter_pushdown",
-            )
+            for filter_part in self._top_level_and_parts(where_clause.this):
+                stage = self._wrapper_filter_stage(
+                    filter_part,
+                    output_name_to_ref,
+                    source.source_name,
+                    selected_refs,
+                    rule_name="safe_filter_pushdown",
+                )
+                translated = self._translate_wrapper_expression(
+                    filter_part,
+                    output_name_to_ref,
+                    source.source_name,
+                    allowed_refs=selected_refs,
+                    rule_name="safe_filter_pushdown",
+                )
+                if stage == "aggregate":
+                    aggregate_filters.extend(self._filters_from_expression(translated))
+                else:
+                    row_filters.extend(self._filters_from_expression(translated))
         except ValueError as e:
             rejected_rules["safe_filter_pushdown"] = str(e)
             return None
 
-        return self._filters_from_expression(translated)
+        return _FilterTranslation(row_filters=row_filters, aggregate_filters=aggregate_filters)
+
+    def _top_level_and_parts(self, expression: exp.Expression) -> list[exp.Expression]:
+        if isinstance(expression, exp.And):
+            return [*self._top_level_and_parts(expression.left), *self._top_level_and_parts(expression.right)]
+        return [expression]
+
+    def _wrapper_filter_stage(
+        self,
+        expression: exp.Expression,
+        name_to_ref: dict[str, str],
+        source_name: str,
+        allowed_refs: set[str],
+        rule_name: str,
+    ) -> str:
+        refs = set()
+        for column in expression.find_all(exp.Column):
+            if column.table and column.table != source_name:
+                raise ValueError(f"{rule_name} references another relation")
+            ref = name_to_ref.get(column.name)
+            if ref is None:
+                raise ValueError(f"{rule_name} references unknown field '{column.name}'")
+            if ref not in allowed_refs:
+                raise ValueError(f"{rule_name} cannot move unprojected or computed field '{column.name}'")
+            if self._metric_needs_window_function(ref):
+                raise ValueError(f"{rule_name} cannot move window metric filter '{column.name}'")
+            refs.add(ref)
+
+        metric_refs = {ref for ref in refs if self._is_metric_ref(ref)}
+        dimension_refs = refs - metric_refs
+        if metric_refs and dimension_refs and any(expression.find_all(exp.Or)):
+            raise ValueError(f"{rule_name} cannot split mixed metric/dimension OR predicate")
+        return "aggregate" if metric_refs else "row"
 
     def _translated_outer_order_by(
         self,
@@ -715,6 +2245,10 @@ class QueryRewriter:
 
         order_by: list[str] = []
         for order_expr in order_clause.expressions:
+            if isinstance(order_expr, exp.Ordered) and order_expr.args.get("nulls_first"):
+                rejected_rules["safe_order_pushdown"] = "outer ORDER BY uses explicit NULLS ordering"
+                return None
+
             expression = order_expr.this if isinstance(order_expr, exp.Ordered) else order_expr
             if not isinstance(expression, exp.Column):
                 rejected_rules["safe_order_pushdown"] = "outer ORDER BY computes a new expression"
@@ -878,6 +2412,8 @@ class QueryRewriter:
             metrics=plan.metrics,
             dimensions=plan.dimensions,
             filters=plan.filters,
+            row_filters=plan.row_filters,
+            aggregate_filters=plan.aggregate_filters,
             order_by=plan.order_by,
             limit=plan.limit,
             offset=plan.offset,
@@ -903,7 +2439,13 @@ class QueryRewriter:
             raise ValueError("Semantic expression queries cannot be represented as a simple rewrite plan")
 
         metrics, dimensions, aliases = self._extract_metrics_and_dimensions(parsed)
+        self._validate_root_group_by(parsed, dimensions, aliases)
         filters = [*self._extract_filters(parsed), *explicit_join_filters]
+        having_clause = parsed.args.get("having")
+        if having_clause:
+            qualified_having = self._qualify_root_filter_expression(having_clause.this.copy())
+            filters.extend(self._filters_from_expression(qualified_having))
+        row_filters, aggregate_filters = self._stage_semantic_filters(filters)
         order_by = self._extract_order_by(parsed)
         limit = self._extract_limit(parsed)
         offset = self._extract_offset(parsed)
@@ -917,6 +2459,8 @@ class QueryRewriter:
             metrics=metrics,
             dimensions=dimensions,
             filters=filters,
+            row_filters=row_filters,
+            aggregate_filters=aggregate_filters,
             order_by=order_by,
             limit=limit,
             offset=offset,
@@ -925,7 +2469,57 @@ class QueryRewriter:
         plan.eligibility = self._plan_eligibility(plan)
         plan.candidate_kind = self._chosen_candidate_kind(plan)
         plan.candidate_plans = self._candidate_plans_for_plan(plan)
+        if plan.candidate_kind == "single_model_preaggregation":
+            plan.applied_rules.append("preaggregation_route_selection")
+        if plan.candidate_kind == "join_key_preaggregation":
+            plan.applied_rules.append("join_key_preaggregation_route_selection")
+        if plan.candidate_kind == "fanout_preaggregation":
+            plan.applied_rules.append("fanout_strategy_selection")
         return plan
+
+    def _validate_root_group_by(
+        self,
+        parsed: exp.Select,
+        dimensions: list[str],
+        aliases: dict[str, str],
+    ) -> None:
+        group_clause = parsed.args.get("group")
+        if not group_clause:
+            return
+
+        dimension_refs = set(dimensions)
+        name_to_ref: dict[str, str] = {}
+        ambiguous_names: set[str] = set()
+        for ref in dimensions:
+            if "." in ref:
+                _model_name, field_name = ref.split(".", 1)
+                if field_name in name_to_ref and name_to_ref[field_name] != ref:
+                    ambiguous_names.add(field_name)
+                else:
+                    name_to_ref[field_name] = ref
+            name_to_ref[ref] = ref
+            alias = aliases.get(ref)
+            if alias:
+                name_to_ref[alias] = ref
+
+        grouped_refs = set()
+        for expression in group_clause.expressions:
+            if not isinstance(expression, exp.Column):
+                raise ValueError("GROUP BY is only supported when it repeats selected semantic dimensions exactly.")
+
+            if expression.table:
+                ref = f"{expression.table}.{expression.name}"
+            elif expression.name in ambiguous_names:
+                raise ValueError(f"GROUP BY field '{expression.name}' is ambiguous; use a qualified semantic field.")
+            else:
+                ref = name_to_ref.get(expression.name)
+
+            if ref not in dimension_refs:
+                raise ValueError("GROUP BY is only supported when it repeats selected semantic dimensions exactly.")
+            grouped_refs.add(ref)
+
+        if grouped_refs != dimension_refs:
+            raise ValueError("GROUP BY must include exactly the selected semantic dimensions.")
 
     def _source_kind_for_table(self, table_name: str | None) -> str:
         if table_name == "metrics":
@@ -939,23 +2533,133 @@ class QueryRewriter:
     def _plan_eligibility(self, plan: SemanticQueryPlan) -> dict[str, dict[str, object]]:
         window_metrics = [metric for metric in plan.metrics if self._metric_needs_window_function(metric)]
         fanout_needed = self.generator._needs_preaggregation_for_fanout(plan.metrics, plan.dimensions)
+        window_details: dict[str, object] = {
+            "eligible": bool(window_metrics),
+            "metrics": window_metrics,
+            "reason": "window_metric_required" if window_metrics else "no_window_metrics",
+        }
+        if window_metrics:
+            window_details["inner_preaggregation"] = self._window_inner_preaggregation_eligibility(
+                plan,
+                window_metrics,
+            )
         return {
-            "window_metric": {
-                "eligible": bool(window_metrics),
-                "metrics": window_metrics,
-                "reason": "window_metric_required" if window_metrics else "no_window_metrics",
-            },
+            "window_metric": window_details,
             "fanout_preaggregation": {
                 "eligible": fanout_needed,
                 "reason": "fanout_protection_required" if fanout_needed else "fanout_protection_not_needed",
             },
+            "join_key_preaggregation": self._join_key_preaggregation_eligibility(plan),
             "single_model_preaggregation": self._single_model_preaggregation_eligibility(plan),
         }
+
+    def _join_key_preaggregation_eligibility(self, plan: SemanticQueryPlan) -> dict[str, object]:
+        details = self.generator.explain_join_key_preaggregation(
+            metrics=plan.metrics,
+            dimensions=plan.dimensions,
+            filters=plan.filters,
+            aliases=plan.aliases,
+        )
+        details["enabled"] = self.use_preaggregations
+        details["requires_enablement"] = True
+        return details
+
+    def _window_inner_preaggregation_eligibility(
+        self,
+        plan: SemanticQueryPlan,
+        window_metrics: list[str],
+    ) -> dict[str, object]:
+        if not self.use_preaggregations:
+            return {
+                "eligible": False,
+                "reason": "preaggregations_not_enabled",
+            }
+
+        base_metrics = self._window_inner_base_metrics(window_metrics)
+        if not base_metrics:
+            return {
+                "eligible": False,
+                "reason": "no_preaggregatable_window_base_metrics",
+            }
+
+        inner_plan = SemanticQueryPlan(
+            source_sql=plan.source_sql,
+            source_kind=plan.source_kind,
+            metrics=base_metrics,
+            dimensions=plan.dimensions,
+            filters=plan.filters,
+            order_by=None,
+            aliases={},
+        )
+        details = self._single_model_preaggregation_eligibility(inner_plan)
+        details["metrics"] = base_metrics
+        return details
+
+    def _window_inner_base_metrics(self, window_metrics: list[str]) -> list[str]:
+        base_metrics: list[str] = []
+
+        def add(metric_ref: str | None, model_context: str | None = None) -> None:
+            if not metric_ref:
+                return
+            if "." not in metric_ref and model_context:
+                metric_ref = f"{model_context}.{metric_ref}"
+            if metric_ref not in base_metrics:
+                base_metrics.append(metric_ref)
+
+        for metric_ref in window_metrics:
+            metric, model_context = self._resolve_metric(metric_ref)
+            if not metric:
+                continue
+
+            if metric.type == "cumulative":
+                add(metric.sql or metric.base_metric, model_context)
+            elif metric.type == "time_comparison":
+                add(metric.base_metric, model_context)
+            elif metric.type == "ratio" and metric.offset_window:
+                add(metric.numerator, model_context)
+                add(metric.denominator, model_context)
+
+        return base_metrics
+
+    def _resolve_metric(self, metric_ref: str):
+        if "." in metric_ref:
+            model_name, metric_name = metric_ref.split(".", 1)
+            try:
+                model = self.graph.get_model(model_name)
+                model_metric = model.get_metric(metric_name) if model else None
+                if model_metric:
+                    return model_metric, model_name
+            except KeyError:
+                pass
+            try:
+                return self.graph.get_metric(metric_ref), None
+            except KeyError:
+                return None, model_name
+
+        try:
+            return self.graph.get_metric(metric_ref), None
+        except KeyError:
+            pass
+
+        matches = []
+        for model_name, model in self.graph.models.items():
+            metric = model.get_metric(metric_ref)
+            if metric:
+                matches.append((metric, model_name))
+        if len(matches) == 1:
+            return matches[0]
+
+        return None, None
+
+    def _is_metric_ref(self, ref: str) -> bool:
+        metric, _model_context = self._resolve_metric(ref)
+        return metric is not None
 
     def _candidate_plans_for_plan(self, plan: SemanticQueryPlan) -> list[CandidatePlan]:
         window_details = plan.eligibility["window_metric"]
         fanout_details = plan.eligibility["fanout_preaggregation"]
         preagg_details = plan.eligibility["single_model_preaggregation"]
+        join_key_details = plan.eligibility["join_key_preaggregation"]
 
         return [
             CandidatePlan(
@@ -973,6 +2677,12 @@ class QueryRewriter:
                 valid=bool(preagg_details["eligible"]),
                 reason=str(preagg_details["reason"]),
                 details=preagg_details,
+            ),
+            CandidatePlan(
+                name="join_key_preaggregation",
+                valid=bool(join_key_details["eligible"]),
+                reason=str(join_key_details["reason"]),
+                details=join_key_details,
             ),
             CandidatePlan(
                 name="fanout_preaggregation",
@@ -998,6 +2708,8 @@ class QueryRewriter:
             return "window_metric"
         if plan.eligibility["fanout_preaggregation"]["eligible"]:
             return "fanout_preaggregation"
+        if self.use_preaggregations and plan.eligibility["join_key_preaggregation"]["eligible"]:
+            return "join_key_preaggregation"
         if self.use_preaggregations and plan.eligibility["single_model_preaggregation"]["eligible"]:
             return "single_model_preaggregation"
         return "direct_semantic"
@@ -1030,6 +2742,28 @@ class QueryRewriter:
 
         try:
             parsed_dims = self.generator._parse_dimension_refs(plan.dimensions)
+            metric_names = [metric.split(".", 1)[1] if "." in metric else metric for metric in plan.metrics]
+            dim_names = []
+            time_granularity = None
+            for dim_ref, gran in parsed_dims:
+                dim_name = dim_ref.split(".", 1)[1] if "." in dim_ref else dim_ref
+                dim_names.append(dim_name)
+                if gran:
+                    time_granularity = gran
+            row_filters = plan.row_filters or [
+                f for f in plan.filters if not self._semantic_filter_references_metric(f)
+            ]
+            filter_exprs = [f.replace(f"{model_name}.", "").replace(f"{model_name}_cte.", "") for f in row_filters]
+
+            from sidemantic.core.preagg_matcher import PreAggregationMatcher
+
+            matcher = PreAggregationMatcher(model)
+            preagg_candidates = matcher.explain_matching(
+                metrics=metric_names,
+                dimensions=dim_names,
+                time_granularity=time_granularity,
+                filters=filter_exprs,
+            )
             preagg_sql = self.generator._try_use_preaggregation(
                 model_name=model_name,
                 metrics=plan.metrics,
@@ -1038,6 +2772,7 @@ class QueryRewriter:
                 order_by=plan.order_by,
                 limit=plan.limit,
                 offset=plan.offset,
+                aliases=plan.aliases,
             )
         except Exception as e:
             return {
@@ -1047,13 +2782,54 @@ class QueryRewriter:
                 "error": str(e),
             }
 
+        candidate_details = [
+            {
+                "name": candidate.name,
+                "matched": candidate.matched,
+                "selected": candidate.selected,
+                "score": candidate.score,
+                "checks": [
+                    {
+                        "name": check.name,
+                        "passed": check.passed,
+                        "detail": check.detail,
+                    }
+                    for check in candidate.checks
+                ],
+            }
+            for candidate in preagg_candidates
+        ]
+        reason = "matching_preaggregation" if preagg_sql else self._preaggregation_rejection_reason(candidate_details)
+
         return {
             "eligible": preagg_sql is not None,
-            "reason": "matching_preaggregation" if preagg_sql else "no_matching_preaggregation",
+            "reason": reason,
             "model": model_name,
             "enabled": self.use_preaggregations,
             "requires_enablement": True,
+            "row_filters": list(plan.row_filters or []),
+            "aggregate_filters": list(plan.aggregate_filters or []),
+            "candidates": candidate_details,
         }
+
+    def _preaggregation_rejection_reason(self, candidates: list[dict[str, object]]) -> str:
+        failed_checks = []
+        for candidate in candidates:
+            for check in candidate.get("checks", []):
+                if not check["passed"]:
+                    if "count_distinct_not_rollup_safe" in str(check.get("detail", "")):
+                        return "count_distinct_not_rollup_safe"
+                    failed_checks.append(check["name"])
+
+        if "filters" in failed_checks:
+            return "filter_not_compatible"
+        if "granularity" in failed_checks:
+            return "time_grain_mismatch"
+        if "dimensions" in failed_checks:
+            return "dimension_not_in_rollup"
+        if "measures" in failed_checks:
+            return "metric_not_in_rollup"
+        return "no_matching_preaggregation"
 
     def _metric_needs_window_function(self, metric_ref: str) -> bool:
         metric = None
@@ -2830,6 +4606,14 @@ class QueryRewriter:
         return isinstance(from_clause.this, exp.Subquery)
 
     def _rewrite_with_ctes_or_subqueries(self, parsed: exp.Select) -> str:
+        rewritten_sql, _semantic_islands, _rejected_rules, _warnings = (
+            self._rewrite_with_ctes_or_subqueries_and_islands(parsed)
+        )
+        return rewritten_sql
+
+    def _rewrite_with_ctes_or_subqueries_and_islands(
+        self, parsed: exp.Select
+    ) -> tuple[str, list[_SemanticIslandRewrite], dict[str, str], list[str]]:
         """Rewrite query that contains CTEs or subqueries.
 
         Recursively walks the query tree bottom-up, rewriting any
@@ -2839,9 +4623,9 @@ class QueryRewriter:
         """
         optimization, _rejected_rules = self._optimize_wrapped_semantic_query(parsed)
         if optimization is not None:
-            return self._generate_from_plan(optimization.plan)
+            return self._generate_from_plan(optimization.plan), [], _rejected_rules, []
 
-        self._rewrite_select_tree(parsed)
+        semantic_islands, rejected_rules, warnings = self._rewrite_select_tree(parsed)
 
         # If the root SELECT itself references a semantic model, it must
         # still go through _rewrite_simple_query (which enforces the
@@ -2876,11 +4660,21 @@ class QueryRewriter:
                         gen_with.set("recursive", True)
                 else:
                     rewritten.set("with", original_with.copy())
-                return rewritten.sql(dialect=self.dialect)
+                return rewritten.sql(dialect=self.dialect), semantic_islands, rejected_rules, warnings
 
-            return rewritten_sql
+            return rewritten_sql, semantic_islands, rejected_rules, warnings
 
-        return parsed.sql(dialect=self.dialect)
+        return parsed.sql(dialect=self.dialect), semantic_islands, rejected_rules, warnings
+
+    def _rewrite_set_operation(self, parsed: exp.SetOperation) -> str:
+        rewritten_sql, _semantic_islands, _rejected_rules, _warnings = self._rewrite_set_operation_with_islands(parsed)
+        return rewritten_sql
+
+    def _rewrite_set_operation_with_islands(
+        self, parsed: exp.SetOperation
+    ) -> tuple[str, list[_SemanticIslandRewrite], dict[str, str], list[str]]:
+        semantic_islands, rejected_rules, warnings = self._rewrite_set_operation_tree(parsed)
+        return parsed.sql(dialect=self.dialect), semantic_islands, rejected_rules, warnings
 
     def _select_tree_references_semantic_model(self, select: exp.Select) -> bool:
         if self._references_semantic_model(select):
@@ -2894,12 +4688,18 @@ class QueryRewriter:
 
         return False
 
-    def _raise_on_user_cte_name_collision(self, select: exp.Select) -> None:
-        with_clause = select.args.get("with")
+    def _expression_tree_references_semantic_model(self, expression: exp.Expression) -> bool:
+        for nested_select in expression.find_all(exp.Select):
+            if self._references_semantic_model(nested_select):
+                return True
+        return False
+
+    def _raise_on_user_cte_name_collision(self, expression: exp.Expression) -> None:
+        with_clause = expression.args.get("with")
         if not with_clause:
             return
 
-        reserved_names = self._generated_cte_names_for_select_tree(select)
+        reserved_names = self._generated_cte_names_for_select_tree(expression)
         for cte in with_clause.expressions:
             if cte.alias in reserved_names:
                 raise ValueError(
@@ -2907,9 +4707,9 @@ class QueryRewriter:
                     f"generated name. Please choose a different CTE name."
                 )
 
-    def _generated_cte_names_for_select_tree(self, select: exp.Select) -> set[str]:
+    def _generated_cte_names_for_select_tree(self, expression: exp.Expression) -> set[str]:
         reserved_names: set[str] = set()
-        for nested_select in select.find_all(exp.Select):
+        for nested_select in expression.find_all(exp.Select):
             if not self._references_semantic_model(nested_select):
                 continue
             reserved_names.update(self._generated_cte_names_for_semantic_select(nested_select))
@@ -2991,43 +4791,433 @@ class QueryRewriter:
         rewritten.set("expressions", rewritten_projections)
         return rewritten.sql(dialect=self.dialect)
 
-    def _rewrite_select_tree(self, select: exp.Select):
+    def _rewrite_select_tree(
+        self, select: exp.Select
+    ) -> tuple[list[_SemanticIslandRewrite], dict[str, str], list[str]]:
         """Recursively rewrite semantic subqueries and CTEs (bottom-up).
 
         At each level: recurse into children first, then rewrite this
         node if it directly references a semantic model.
         """
+        semantic_islands: list[_SemanticIslandRewrite] = []
+        rejected_rules: dict[str, str] = {}
+        warnings: list[str] = []
+
         # Recurse into CTEs
         if select.args.get("with"):
             for cte in select.args["with"].expressions:
                 cte_query = cte.this
-                if isinstance(cte_query, exp.Select):
-                    self._rewrite_select_tree(cte_query)
-                    if self._references_semantic_model(cte_query):
-                        rewritten_sql = self._rewrite_simple_query(cte_query)
-                        cte.set("this", sqlglot.parse_one(rewritten_sql, dialect=self.dialect))
+                if isinstance(cte_query, (exp.Select, exp.SetOperation)):
+                    replacement, child_islands, child_rejected, child_warnings = self._rewrite_query_island(
+                        cte_query,
+                        name=cte.alias or "cte",
+                        source_kind="cte",
+                    )
+                    cte.set("this", replacement)
+                    semantic_islands.extend(child_islands)
+                    rejected_rules.update(child_rejected)
+                    warnings.extend(child_warnings)
 
         # Recurse into FROM subquery
         from_clause = select.args.get("from")
         if from_clause and isinstance(from_clause.this, exp.Subquery):
             subquery = from_clause.this
             subquery_select = subquery.this
-            if isinstance(subquery_select, exp.Select):
-                self._rewrite_select_tree(subquery_select)
-                if self._references_semantic_model(subquery_select):
-                    rewritten_sql = self._rewrite_simple_query(subquery_select)
-                    subquery.set("this", sqlglot.parse_one(rewritten_sql, dialect=self.dialect))
+            if isinstance(subquery_select, (exp.Select, exp.SetOperation)):
+                replacement, child_islands, child_rejected, child_warnings = self._rewrite_query_island(
+                    subquery_select,
+                    name=subquery.alias_or_name or "subquery",
+                    source_kind="subquery",
+                )
+                subquery.set("this", replacement)
+                self._annotate_conditional_aggregate_islands(select, child_islands, child_rejected)
+                semantic_islands.extend(child_islands)
+                rejected_rules.update(child_rejected)
+                warnings.extend(child_warnings)
 
         # Recurse into JOIN subqueries
         for join in select.args.get("joins") or []:
             join_expr = join.this
             if isinstance(join_expr, exp.Subquery):
                 join_select = join_expr.this
-                if isinstance(join_select, exp.Select):
-                    self._rewrite_select_tree(join_select)
-                    if self._references_semantic_model(join_select):
-                        rewritten_sql = self._rewrite_simple_query(join_select)
-                        join_expr.set("this", sqlglot.parse_one(rewritten_sql, dialect=self.dialect))
+                if isinstance(join_select, (exp.Select, exp.SetOperation)):
+                    replacement, child_islands, child_rejected, child_warnings = self._rewrite_query_island(
+                        join_select,
+                        name=join_expr.alias_or_name or "join_subquery",
+                        source_kind="join_subquery",
+                    )
+                    join_expr.set("this", replacement)
+                    self._annotate_conditional_aggregate_islands(select, child_islands, child_rejected)
+                    semantic_islands.extend(child_islands)
+                    rejected_rules.update(child_rejected)
+                    warnings.extend(child_warnings)
+
+        for clause_subquery in self._current_select_clause_subqueries(select):
+            subquery_select = clause_subquery.this
+            if isinstance(subquery_select, (exp.Select, exp.SetOperation)):
+                replacement, child_islands, child_rejected, child_warnings = self._rewrite_query_island(
+                    subquery_select,
+                    name=clause_subquery.alias_or_name or "clause_subquery",
+                    source_kind="clause_subquery",
+                )
+                clause_subquery.set("this", replacement)
+                semantic_islands.extend(child_islands)
+                rejected_rules.update(child_rejected)
+                warnings.extend(child_warnings)
+
+        for exists in self._current_select_clause_exists(select):
+            exists_select = exists.this
+            if isinstance(exists_select, (exp.Select, exp.SetOperation)):
+                replacement, child_islands, child_rejected, child_warnings = self._rewrite_query_island(
+                    exists_select,
+                    name="exists_subquery",
+                    source_kind="clause_subquery",
+                )
+                exists.set("this", replacement)
+                semantic_islands.extend(child_islands)
+                rejected_rules.update(child_rejected)
+                warnings.extend(child_warnings)
+
+        return semantic_islands, rejected_rules, warnings
+
+    def _current_select_clause_expressions(self, select: exp.Select) -> list[exp.Expression]:
+        clauses: list[exp.Expression] = list(select.expressions)
+        for key in ("where", "having", "qualify"):
+            clause = select.args.get(key)
+            if clause is not None:
+                clauses.append(clause.this)
+        for key in ("group", "order"):
+            clause = select.args.get(key)
+            if clause is not None:
+                clauses.extend(list(clause.expressions))
+        return clauses
+
+    def _current_select_clause_subqueries(self, select: exp.Select) -> list[exp.Subquery]:
+        clauses = self._current_select_clause_expressions(select)
+        subqueries: list[exp.Subquery] = []
+        seen: set[int] = set()
+        for clause in clauses:
+            for subquery in clause.find_all(exp.Subquery):
+                identity = id(subquery)
+                if identity not in seen:
+                    subqueries.append(subquery)
+                    seen.add(identity)
+        return subqueries
+
+    def _current_select_clause_exists(self, select: exp.Select) -> list[exp.Exists]:
+        clauses = self._current_select_clause_expressions(select)
+        exists_nodes: list[exp.Exists] = []
+        seen: set[int] = set()
+        for clause in clauses:
+            for exists in clause.find_all(exp.Exists):
+                identity = id(exists)
+                if identity not in seen:
+                    exists_nodes.append(exists)
+                    seen.add(identity)
+        return exists_nodes
+
+    def _annotate_conditional_aggregate_islands(
+        self,
+        select: exp.Select,
+        semantic_islands: list[_SemanticIslandRewrite],
+        rejected_rules: dict[str, str],
+    ) -> None:
+        if not semantic_islands:
+            return
+        valid = False
+        rejection: str | None = None
+        for island in semantic_islands:
+            valid, rejection = self._conditional_aggregate_wrapper_is_safe(select, island.plan)
+            if valid:
+                island.applied_rules = self._dedupe([*island.applied_rules, "conditional_aggregate_wrapper"])
+        if not valid and rejection:
+            rejected_rules["conditional_aggregate_wrapper"] = rejection
+
+    def _conditional_aggregate_wrapper_is_safe(
+        self,
+        select: exp.Select,
+        plan: SemanticQueryPlan,
+    ) -> tuple[bool, str | None]:
+        conditional_sums: list[exp.Sum] = []
+        for projection in select.expressions:
+            expression = self._projection_expression(projection)
+            if isinstance(expression, exp.Sum) and isinstance(expression.this, exp.Case):
+                conditional_sums.append(expression)
+            conditional_sums.extend(
+                sum_expr
+                for sum_expr in expression.find_all(exp.Sum)
+                if isinstance(sum_expr.this, exp.Case) and sum_expr is not expression
+            )
+        if not conditional_sums:
+            return False, None
+
+        output_name_to_ref = self._plan_output_name_to_ref(plan)
+        dimension_refs = set(plan.dimensions)
+        metric_refs = set(plan.metrics)
+
+        for sum_expr in conditional_sums:
+            case_expr = sum_expr.this
+            if not isinstance(case_expr, exp.Case):
+                return False, "conditional aggregate input is not CASE"
+            default = case_expr.args.get("default")
+            if default is not None and not (
+                isinstance(default, exp.Literal) and not default.is_string and str(default.this) in {"0", "0.0"}
+            ):
+                return False, "conditional aggregate CASE default is not zero"
+            if case_expr.args.get("this") is not None:
+                return False, "simple CASE conditional aggregates are not supported"
+
+            ifs = case_expr.args.get("ifs") or []
+            if not ifs:
+                return False, "conditional aggregate CASE has no predicates"
+            for if_expr in ifs:
+                metric_input = if_expr.args.get("true")
+                if not isinstance(metric_input, exp.Column):
+                    return False, "conditional aggregate result is not a metric column"
+                metric_ref = output_name_to_ref.get(metric_input.name)
+                if metric_ref not in metric_refs:
+                    return False, "conditional aggregate result is not an inner metric"
+                metric, _model_context = self._resolve_metric(metric_ref)
+                if metric is None or metric.agg not in {"sum", "count"}:
+                    return False, "conditional aggregate metric is not additive"
+
+                predicate = if_expr.this
+                for column in predicate.find_all(exp.Column):
+                    ref = output_name_to_ref.get(column.name)
+                    if ref not in dimension_refs:
+                        return False, "conditional aggregate predicate references a non-dimension"
+
+        return True, None
+
+    def _rewrite_query_island(
+        self,
+        query: exp.Expression,
+        name: str,
+        source_kind: str,
+        *,
+        as_set_branch: bool = False,
+    ) -> tuple[exp.Expression, list[_SemanticIslandRewrite], dict[str, str], list[str]]:
+        if isinstance(query, exp.SetOperation):
+            semantic_islands, rejected_rules, warnings = self._rewrite_set_operation_tree(query)
+            return query, semantic_islands, rejected_rules, warnings
+
+        if not isinstance(query, exp.Select):
+            return query, [], {}, []
+
+        if not self._select_tree_references_semantic_model(query):
+            return query, [], {}, []
+
+        replacement, island, rejected_rules = self._try_optimize_select_as_island(
+            query,
+            name=name,
+            source_kind=source_kind,
+            as_set_branch=as_set_branch,
+        )
+        if island is not None and replacement is not None:
+            return replacement, [island], rejected_rules, []
+
+        child_islands, child_rejected, child_warnings = self._rewrite_select_tree(query)
+        rejected_rules.update(child_rejected)
+        return query, child_islands, rejected_rules, child_warnings
+
+    def _rewrite_set_operation_tree(
+        self, expression: exp.SetOperation
+    ) -> tuple[list[_SemanticIslandRewrite], dict[str, str], list[str]]:
+        semantic_islands: list[_SemanticIslandRewrite] = []
+        rejected_rules: dict[str, str] = {}
+        warnings: list[str] = []
+
+        set_rejection = self._set_operation_branch_rejection(expression)
+        if set_rejection is not None:
+            rejected_rules["set_operation_branch_optimization"] = set_rejection
+            return semantic_islands, rejected_rules, warnings
+
+        with_clause = expression.args.get("with")
+        if with_clause:
+            for cte in with_clause.expressions:
+                cte_query = cte.this
+                if isinstance(cte_query, (exp.Select, exp.SetOperation)):
+                    replacement, child_islands, child_rejected, child_warnings = self._rewrite_query_island(
+                        cte_query,
+                        name=cte.alias or "cte",
+                        source_kind="cte",
+                    )
+                    cte.set("this", replacement)
+                    semantic_islands.extend(child_islands)
+                    rejected_rules.update(child_rejected)
+                    warnings.extend(child_warnings)
+
+        for arg_name, branch_name in (("this", "left_branch"), ("expression", "right_branch")):
+            branch = expression.args.get(arg_name)
+            if not isinstance(branch, (exp.Select, exp.SetOperation)):
+                continue
+            replacement, child_islands, child_rejected, child_warnings = self._rewrite_query_island(
+                branch,
+                name=branch_name,
+                source_kind="set_operation_branch",
+                as_set_branch=True,
+            )
+            expression.set(arg_name, replacement)
+            semantic_islands.extend(child_islands)
+            rejected_rules.update(child_rejected)
+            warnings.extend(child_warnings)
+
+        return semantic_islands, rejected_rules, warnings
+
+    def _set_operation_branch_rejection(self, expression: exp.SetOperation) -> str | None:
+        branch_selects = [
+            branch
+            for branch in (expression.args.get("this"), expression.args.get("expression"))
+            if isinstance(branch, exp.Select)
+        ]
+        for branch in branch_selects:
+            if branch.args.get("order"):
+                return "branch-level ORDER BY is not safe to optimize inside a set operation"
+
+        known_arities = [
+            len(branch.expressions)
+            for branch in branch_selects
+            if not (len(branch.expressions) == 1 and isinstance(branch.expressions[0], exp.Star))
+        ]
+        if known_arities and any(arity != known_arities[0] for arity in known_arities):
+            return "set operation branch projections do not align"
+        return None
+
+    def _try_optimize_select_as_island(
+        self,
+        select: exp.Select,
+        name: str,
+        source_kind: str,
+        *,
+        as_set_branch: bool,
+    ) -> tuple[exp.Expression | None, _SemanticIslandRewrite | None, dict[str, str]]:
+        rejected_rules: dict[str, str] = {}
+        source_sql = select.sql(dialect=self.dialect)
+
+        if self._current_select_references_outer_scope(select):
+            rejected_rules["semantic_island_optimization"] = "semantic island references outer query scope"
+            return None, None, rejected_rules
+
+        optimization, wrapped_rejected = self._optimize_wrapped_semantic_query(select.copy())
+        rejected_rules.update(wrapped_rejected)
+        if optimization is not None:
+            plan = optimization.plan
+            if as_set_branch and not self._set_branch_output_is_compatible(select, plan):
+                rejected_rules["set_operation_branch_optimization"] = (
+                    "branch output columns would not align after rewrite"
+                )
+                return None, None, rejected_rules
+            rewritten_sql = self._generate_from_plan(plan)
+            replacement = self._parse_island_replacement(rewritten_sql, name=name, as_set_branch=as_set_branch)
+            return (
+                replacement,
+                _SemanticIslandRewrite(
+                    name=name,
+                    source_kind=source_kind,
+                    source_sql=source_sql,
+                    rewritten_sql=rewritten_sql,
+                    plan=plan,
+                    applied_rules=self._dedupe(["semantic_island_optimization", *optimization.applied_rules]),
+                    rejected_rules=rejected_rules,
+                ),
+                rejected_rules,
+            )
+
+        if not self._references_semantic_model(select):
+            return None, None, rejected_rules
+
+        try:
+            plan = self._plan_simple_query(select.copy())
+        except Exception as e:
+            rejected_rules["semantic_island_optimization"] = f"semantic island cannot be planned: {e}"
+            return None, None, rejected_rules
+
+        if as_set_branch and not self._set_branch_output_is_compatible(select, plan):
+            rejected_rules["set_operation_branch_optimization"] = "branch output columns would not align after rewrite"
+            return None, None, rejected_rules
+
+        rewritten_sql = self._generate_from_plan(plan)
+        replacement = self._parse_island_replacement(rewritten_sql, name=name, as_set_branch=as_set_branch)
+        return (
+            replacement,
+            _SemanticIslandRewrite(
+                name=name,
+                source_kind=source_kind,
+                source_sql=source_sql,
+                rewritten_sql=rewritten_sql,
+                plan=plan,
+                applied_rules=self._dedupe(["semantic_island_optimization", *plan.applied_rules]),
+                rejected_rules=rejected_rules,
+            ),
+            rejected_rules,
+        )
+
+    def _parse_island_replacement(self, rewritten_sql: str, name: str, *, as_set_branch: bool) -> exp.Expression:
+        if not as_set_branch:
+            return sqlglot.parse_one(rewritten_sql, dialect=self.dialect)
+
+        alias = self._safe_internal_alias(f"{name}_semantic")
+        return sqlglot.parse_one(
+            f"SELECT * FROM (\n{rewritten_sql}\n) AS {alias}",
+            dialect=self.dialect,
+        )
+
+    def _safe_internal_alias(self, name: str) -> str:
+        return "".join(char if char.isalnum() or char == "_" else "_" for char in name) or "semantic_branch"
+
+    def _set_branch_output_is_compatible(self, select: exp.Select, plan: SemanticQueryPlan) -> bool:
+        if len(select.expressions) == 1 and isinstance(select.expressions[0], exp.Star):
+            return True
+        original_names = list(select.named_selects)
+        planned_names = list(self._plan_output_name_to_ref(plan))
+        return len(original_names) == len(planned_names) and original_names == planned_names
+
+    def _current_select_references_outer_scope(self, select: exp.Select) -> bool:
+        local_names = self._current_select_relation_names(select)
+        clauses: list[exp.Expression] = list(select.expressions)
+        for key in ("where", "having", "qualify"):
+            clause = select.args.get(key)
+            if clause is not None:
+                clauses.append(clause.this)
+        for key in ("group", "order"):
+            clause = select.args.get(key)
+            if clause is not None:
+                clauses.extend(list(clause.expressions))
+
+        for clause in clauses:
+            for column in clause.find_all(exp.Column):
+                if (
+                    column.table
+                    and column.table not in local_names
+                    and column.table not in self.graph.models
+                    and column.table != "metrics"
+                ):
+                    return True
+        return False
+
+    def _current_select_relation_names(self, select: exp.Select) -> set[str]:
+        names: set[str] = set()
+        from_clause = select.args.get("from")
+        if from_clause is not None:
+            self._add_relation_names(from_clause.this, names)
+        for join in select.args.get("joins") or []:
+            self._add_relation_names(join.this, names)
+        with_clause = select.args.get("with")
+        if with_clause:
+            for cte in with_clause.expressions:
+                if cte.alias:
+                    names.add(cte.alias)
+        return names
+
+    def _add_relation_names(self, relation: exp.Expression, names: set[str]) -> None:
+        if isinstance(relation, exp.Table):
+            names.add(relation.name)
+            if relation.alias:
+                names.add(relation.alias)
+            return
+        if isinstance(relation, exp.Subquery):
+            if relation.alias_or_name:
+                names.add(relation.alias_or_name)
 
     def _references_semantic_model(self, select: exp.Select) -> bool:
         """Check if a SELECT statement references any semantic models."""
@@ -3508,7 +5698,8 @@ class QueryRewriter:
         if not select.args.get("where"):
             return []
 
-        where = self._normalize_source_aliases(select.args["where"].this)
+        where = self._normalize_source_aliases(select.args["where"].this.copy())
+        where = self._qualify_root_filter_expression(where)
 
         # Handle compound conditions (AND/OR)
         if isinstance(where, (exp.And, exp.Or)):
@@ -3516,6 +5707,70 @@ class QueryRewriter:
 
         # Single condition
         return [where.sql(dialect=self.dialect)]
+
+    def _qualify_root_filter_expression(self, expression: exp.Expression) -> exp.Expression:
+        default_model = getattr(self, "inferred_table", None)
+        if default_model not in self.graph.models:
+            return expression
+
+        model = self.graph.get_model(default_model)
+
+        def qualify(node: exp.Expression) -> exp.Expression:
+            if isinstance(node, exp.Select):
+                return node
+            if isinstance(node, exp.Subquery):
+                return node
+            if isinstance(node, exp.Column) and not node.table:
+                field_name = node.name
+                base_field_name = field_name.rsplit("__", 1)[0] if "__" in field_name else field_name
+                if model.get_dimension(base_field_name) or model.get_metric(base_field_name):
+                    node.set("table", exp.to_identifier(default_model))
+                return node
+
+            for key, value in list(node.args.items()):
+                if isinstance(value, exp.Expression):
+                    node.set(key, qualify(value))
+                elif isinstance(value, list):
+                    node.set(
+                        key,
+                        [qualify(item) if isinstance(item, exp.Expression) else item for item in value],
+                    )
+            return node
+
+        return qualify(expression)
+
+    def _stage_semantic_filters(self, filters: list[str]) -> tuple[list[str], list[str]]:
+        row_filters: list[str] = []
+        aggregate_filters: list[str] = []
+        for filter_expr in filters:
+            if self._semantic_filter_references_metric(filter_expr):
+                aggregate_filters.append(filter_expr)
+            else:
+                row_filters.append(filter_expr)
+        return row_filters, aggregate_filters
+
+    def _semantic_filter_references_metric(self, filter_expr: str) -> bool:
+        try:
+            parsed = sqlglot.parse_one(filter_expr, dialect=self.dialect)
+        except Exception:
+            return False
+
+        for column in parsed.find_all(exp.Column):
+            table_name = column.table.replace("_cte", "") if column.table else None
+            field_name = column.name.rsplit("__", 1)[0] if "__" in column.name else column.name
+            if table_name and table_name in self.graph.models:
+                model = self.graph.get_model(table_name)
+                if model.get_metric(field_name):
+                    return True
+            elif not table_name:
+                if field_name in self.graph.metrics:
+                    return True
+                inferred_table = getattr(self, "inferred_table", None)
+                if inferred_table in self.graph.models:
+                    model = self.graph.get_model(inferred_table)
+                    if model.get_metric(field_name):
+                        return True
+        return False
 
     def _extract_compound_filters(self, condition: exp.Expression) -> list[str]:
         """Extract filters from compound AND/OR conditions.
@@ -3586,6 +5841,10 @@ class QueryRewriter:
             limit_expr = limit.expression
             if isinstance(limit_expr, exp.Literal):
                 return int(limit_expr.this)
+        if isinstance(limit, exp.Fetch):
+            count_expr = limit.args.get("count")
+            if isinstance(count_expr, exp.Literal):
+                return int(count_expr.this)
 
         return None
 

--- a/sidemantic/sql/query_rewriter.py
+++ b/sidemantic/sql/query_rewriter.py
@@ -14,6 +14,7 @@ from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.rust_bridge import get_rust_module, graph_to_rust_yaml
 from sidemantic.sql.aggregation_detection import sql_has_aggregate
 from sidemantic.sql.generator import SQLGenerator
+from sidemantic.sql.planner import CandidatePlan, RewriteExplanation, SemanticQueryPlan
 
 
 @dataclass
@@ -24,18 +25,45 @@ class _YardstickAggregateCall:
     include_visible_default: bool
 
 
+@dataclass
+class _WrappedSemanticSource:
+    inner_select: exp.Select
+    source_name: str
+    source_kind: str
+
+
+@dataclass
+class _ProjectionAnalysis:
+    metrics: list[str]
+    dimensions: list[str]
+    aliases: dict[str, str]
+    visible_name_to_ref: dict[str, str]
+    projected_refs: set[str]
+    applied_rules: list[str]
+
+
+@dataclass
+class _WrappedOptimization:
+    plan: SemanticQueryPlan
+    pushed_filters: list[str]
+    applied_rules: list[str]
+    rejected_rules: dict[str, str]
+
+
 class QueryRewriter:
     """Rewrites user SQL queries to use the semantic layer."""
 
-    def __init__(self, graph: SemanticGraph, dialect: str = "duckdb"):
+    def __init__(self, graph: SemanticGraph, dialect: str = "duckdb", use_preaggregations: bool = False):
         """Initialize query rewriter.
 
         Args:
             graph: Semantic graph with models and metrics
             dialect: SQL dialect for parsing/generation
+            use_preaggregations: Enable single-model pre-aggregation routing
         """
         self.graph = graph
         self.dialect = dialect
+        self.use_preaggregations = use_preaggregations
         self.generator = SQLGenerator(graph, dialect=dialect)
         self._use_rust_rewriter = os.getenv("SIDEMANTIC_RS_REWRITER", "0") == "1"
         self._rust_no_fallback = os.getenv("SIDEMANTIC_RS_NO_FALLBACK", "0") == "1"
@@ -184,6 +212,903 @@ class QueryRewriter:
             if column.table in aliases:
                 column.set("table", exp.to_identifier(aliases[column.table]))
         return rewritten
+
+    def explain(self, sql: str, strict: bool = True) -> RewriteExplanation:
+        """Explain how a SQL query would be rewritten by the semantic layer.
+
+        The explanation follows the same routing as rewrite() but returns
+        structured planner state and candidate decisions instead of only SQL.
+        """
+        sql = sql.strip()
+
+        if self._looks_like_yardstick_query(sql):
+            try:
+                rewritten_sql = self._rewrite_yardstick_query(sql, strict=strict)
+            except Exception as e:
+                if strict:
+                    raise
+                return self._passthrough_explanation(
+                    sql,
+                    reason="yardstick_rewrite_failed",
+                    warning=f"Yardstick rewrite failed: {e}",
+                )
+
+            return RewriteExplanation(
+                input_sql=sql,
+                rewritten_sql=rewritten_sql,
+                chosen_plan="yardstick_semantic_sql",
+                source_kind="yardstick",
+                candidate_plans=[
+                    CandidatePlan(
+                        name="yardstick_semantic_sql",
+                        valid=True,
+                        reason="query uses Yardstick semantic SQL syntax",
+                    ),
+                    CandidatePlan(
+                        name="direct_semantic",
+                        valid=False,
+                        reason="primary semantic SQL planner does not handle Yardstick syntax",
+                    ),
+                ],
+                warnings=["Yardstick semantic SQL uses a separate rewrite path."],
+            )
+
+        if ";" in sql:
+            try:
+                statements = sqlglot.parse(sql, dialect=self.dialect)
+            except Exception as e:
+                if strict:
+                    raise
+                return self._passthrough_explanation(
+                    sql,
+                    reason="parse_failed",
+                    warning=f"SQL parse failed: {e}",
+                )
+            if len(statements) > 1:
+                if strict:
+                    raise ValueError("Multiple statements are not supported")
+                return self._passthrough_explanation(sql, reason="multiple_statements")
+
+        try:
+            parsed = sqlglot.parse_one(sql, dialect=self.dialect)
+        except Exception as e:
+            if strict:
+                raise ValueError(f"Failed to parse SQL: {e}")
+            return self._passthrough_explanation(
+                sql,
+                reason="parse_failed",
+                warning=f"SQL parse failed: {e}",
+            )
+
+        if not isinstance(parsed, exp.Select):
+            if strict:
+                raise ValueError("Only SELECT queries are supported")
+            return self._passthrough_explanation(sql, reason="not_select")
+
+        if self._contains_implicit_yardstick_measure_query(parsed):
+            try:
+                rewritten_sql = self._rewrite_yardstick_query(sql, strict=strict, allow_plain_measures=True)
+            except Exception as e:
+                if strict:
+                    raise
+                return self._passthrough_explanation(
+                    sql,
+                    reason="yardstick_rewrite_failed",
+                    warning=f"Yardstick rewrite failed: {e}",
+                )
+            return RewriteExplanation(
+                input_sql=sql,
+                rewritten_sql=rewritten_sql,
+                chosen_plan="yardstick_semantic_sql",
+                source_kind="yardstick",
+                candidate_plans=[
+                    CandidatePlan(
+                        name="yardstick_semantic_sql",
+                        valid=True,
+                        reason="query uses implicit Yardstick measure syntax",
+                    )
+                ],
+                warnings=["Yardstick semantic SQL uses a separate rewrite path."],
+            )
+
+        if parsed.args.get("from") is None and parsed.args.get("with") is None:
+            if any(isinstance(expr, exp.Star) for expr in parsed.expressions):
+                if strict:
+                    raise ValueError("SELECT * requires a FROM clause with a single table")
+                return self._passthrough_explanation(sql, reason="select_star_without_from")
+            return self._passthrough_explanation(sql, reason="projection_only")
+
+        references_semantic_model = self._select_tree_references_semantic_model(parsed)
+        if not references_semantic_model:
+            return self._passthrough_explanation(sql, reason="no_semantic_model_reference")
+
+        self._raise_on_user_cte_name_collision(parsed)
+
+        if self._use_rust_rewriter:
+            rust_sql = self._prepare_sql_for_rust(parsed, sql)
+            rust_rewritten = self._rewrite_with_rust(rust_sql, strict=strict)
+            if rust_rewritten is not None:
+                return RewriteExplanation(
+                    input_sql=sql,
+                    rewritten_sql=rust_rewritten,
+                    chosen_plan="rust_semantic_rewriter",
+                    source_kind="rust",
+                    candidate_plans=[
+                        CandidatePlan(
+                            name="rust_semantic_rewriter",
+                            valid=True,
+                            reason="SIDEMANTIC_RS_REWRITER is enabled",
+                        )
+                    ],
+                    warnings=["Rust rewriter handled this query before the Python planner."],
+                )
+
+        has_ctes = parsed.args.get("with") is not None
+        has_subquery_in_from = self._has_subquery_in_from(parsed)
+        has_subquery_in_joins = any(isinstance(join.this, exp.Subquery) for join in (parsed.args.get("joins") or []))
+
+        if has_ctes or has_subquery_in_from or has_subquery_in_joins:
+            return self._explain_ctes_or_subqueries(sql, parsed)
+
+        plan = self._plan_simple_query(parsed)
+        rewritten_sql = self._generate_from_plan(plan)
+        return self._explanation_from_plan(sql, plan, rewritten_sql)
+
+    def _passthrough_explanation(self, sql: str, reason: str, warning: str | None = None) -> RewriteExplanation:
+        warnings = [warning] if warning else []
+        return RewriteExplanation(
+            input_sql=sql,
+            rewritten_sql=sql,
+            chosen_plan="passthrough_plain_sql",
+            source_kind="plain_sql",
+            candidate_plans=[
+                CandidatePlan(
+                    name="passthrough_plain_sql",
+                    valid=True,
+                    reason=reason,
+                ),
+                CandidatePlan(
+                    name="direct_semantic",
+                    valid=False,
+                    reason="query does not reference a semantic model",
+                ),
+            ],
+            warnings=warnings,
+        )
+
+    def _explain_ctes_or_subqueries(self, sql: str, parsed: exp.Select) -> RewriteExplanation:
+        optimization, rejected_rules = self._optimize_wrapped_semantic_query(parsed)
+        if optimization is not None:
+            explanation = self._explanation_from_plan(
+                sql, optimization.plan, self._generate_from_plan(optimization.plan)
+            )
+            explanation.pushed_filters = optimization.pushed_filters
+            explanation.applied_rules = optimization.applied_rules
+            explanation.rejected_rules = optimization.rejected_rules
+            return explanation
+
+        semantic_scopes, warnings = self._collect_semantic_scopes(parsed)
+        root_references_semantic_model = self._references_semantic_model(parsed)
+
+        rewritten_sql = self._rewrite_with_ctes_or_subqueries(parsed.copy())
+
+        if root_references_semantic_model and len(semantic_scopes) == 1:
+            chosen_plan = semantic_scopes[0].candidate_kind
+            source_kind = semantic_scopes[0].source_kind
+        else:
+            chosen_plan = "semantic_plus_postprocess"
+            source_kind = "subquery"
+
+        candidate_plans = self._candidate_plans_for_scopes(semantic_scopes, chosen_plan)
+        return RewriteExplanation(
+            input_sql=sql,
+            rewritten_sql=rewritten_sql,
+            chosen_plan=chosen_plan,
+            source_kind=source_kind,
+            metrics=self._dedupe([metric for scope in semantic_scopes for metric in scope.metrics]),
+            dimensions=self._dedupe([dimension for scope in semantic_scopes for dimension in scope.dimensions]),
+            filters=self._dedupe([filter_expr for scope in semantic_scopes for filter_expr in scope.filters]),
+            candidate_plans=candidate_plans,
+            semantic_scopes=semantic_scopes,
+            post_process=parsed.sql(dialect=self.dialect) if not root_references_semantic_model else None,
+            rejected_rules=rejected_rules,
+            warnings=warnings,
+        )
+
+    def _optimize_wrapped_semantic_query(
+        self, parsed: exp.Select
+    ) -> tuple[_WrappedOptimization | None, dict[str, str]]:
+        rejected_rules: dict[str, str] = {}
+        source = self._wrapped_semantic_source(parsed, rejected_rules)
+        if source is None:
+            return None, rejected_rules
+
+        if self._wrapper_has_blocking_features(parsed, rejected_rules):
+            return None, rejected_rules
+
+        try:
+            plan = self._plan_simple_query(source.inner_select.copy())
+        except Exception as e:
+            rejected_rules["wrapped_semantic_optimizer"] = f"inner semantic query cannot be planned: {e}"
+            return None, rejected_rules
+
+        output_name_to_ref = self._plan_output_name_to_ref(plan)
+        projection = self._analyze_wrapper_projection(parsed, source, plan, output_name_to_ref, rejected_rules)
+        if projection is None:
+            return None, rejected_rules
+
+        plan.metrics = projection.metrics
+        plan.dimensions = projection.dimensions
+        plan.aliases = projection.aliases
+
+        applied_rules = ["wrapper_flattening", *projection.applied_rules]
+        pushed_filters: list[str] = []
+
+        filters = self._translated_outer_filters(parsed, source, plan, output_name_to_ref, rejected_rules)
+        if filters is None:
+            return None, rejected_rules
+        if filters:
+            plan.filters = [*plan.filters, *filters]
+            pushed_filters = filters
+            applied_rules.append("safe_filter_pushdown")
+
+        order_by = self._translated_outer_order_by(
+            parsed,
+            source,
+            projection.visible_name_to_ref,
+            output_name_to_ref,
+            projection.projected_refs,
+            rejected_rules,
+        )
+        if order_by is None:
+            return None, rejected_rules
+        if order_by:
+            plan.order_by = order_by
+            applied_rules.append("safe_order_pushdown")
+
+        if not self._apply_outer_limit_offset(parsed, plan, rejected_rules):
+            return None, rejected_rules
+        if parsed.args.get("limit") is not None or parsed.args.get("offset") is not None:
+            applied_rules.append("safe_limit_pushdown")
+
+        plan.eligibility = self._plan_eligibility(plan)
+        plan.candidate_kind = self._chosen_candidate_kind(plan)
+        plan.candidate_plans = self._candidate_plans_for_plan(plan)
+        if plan.candidate_kind == "single_model_preaggregation":
+            applied_rules.append("preaggregation_route_selection")
+        if plan.candidate_kind == "fanout_preaggregation":
+            applied_rules.append("fanout_strategy_selection")
+        plan.applied_rules = self._dedupe(applied_rules)
+        plan.rejected_rules = rejected_rules
+
+        return (
+            _WrappedOptimization(
+                plan=plan,
+                pushed_filters=pushed_filters,
+                applied_rules=plan.applied_rules,
+                rejected_rules=rejected_rules,
+            ),
+            rejected_rules,
+        )
+
+    def _wrapped_semantic_source(
+        self, select: exp.Select, rejected_rules: dict[str, str]
+    ) -> _WrappedSemanticSource | None:
+        from_clause = select.args.get("from")
+        if not from_clause:
+            rejected_rules["wrapped_semantic_optimizer"] = "outer query has no FROM clause"
+            return None
+
+        with_clause = select.args.get("with")
+        table_expr = from_clause.this
+
+        if isinstance(table_expr, exp.Subquery):
+            if with_clause:
+                rejected_rules["cte_wrapper"] = "outer WITH plus subquery wrapper is not flattened"
+                return None
+            inner_select = table_expr.this
+            if not isinstance(inner_select, exp.Select):
+                rejected_rules["wrapped_semantic_optimizer"] = "subquery is not a SELECT"
+                return None
+            if not self._references_semantic_model(inner_select):
+                rejected_rules["wrapped_semantic_optimizer"] = "subquery does not directly reference a semantic model"
+                return None
+            return _WrappedSemanticSource(
+                inner_select=inner_select,
+                source_name=table_expr.alias_or_name or "",
+                source_kind="subquery",
+            )
+
+        if isinstance(table_expr, exp.Table) and with_clause:
+            ctes = list(with_clause.expressions)
+            if len(ctes) != 1:
+                rejected_rules["cte_wrapper"] = "only single-CTE semantic wrappers can be flattened"
+                return None
+            cte = ctes[0]
+            if table_expr.name != cte.alias:
+                rejected_rules["cte_wrapper"] = "outer query does not read directly from the semantic CTE"
+                return None
+            inner_select = cte.this
+            if not isinstance(inner_select, exp.Select):
+                rejected_rules["cte_wrapper"] = "semantic CTE is not a SELECT"
+                return None
+            if not self._references_semantic_model(inner_select):
+                rejected_rules["cte_wrapper"] = "CTE does not directly reference a semantic model"
+                return None
+            return _WrappedSemanticSource(
+                inner_select=inner_select,
+                source_name=table_expr.name,
+                source_kind="cte",
+            )
+
+        rejected_rules["wrapped_semantic_optimizer"] = "outer query is not a single semantic subquery or CTE wrapper"
+        return None
+
+    def _wrapper_has_blocking_features(self, select: exp.Select, rejected_rules: dict[str, str]) -> bool:
+        if select.args.get("joins"):
+            rejected_rules["wrapper_flattening"] = "outer query joins to another relation"
+            return True
+
+        if select.args.get("distinct"):
+            rejected_rules["wrapper_flattening"] = "outer query uses DISTINCT"
+            return True
+
+        if select.args.get("group") or select.args.get("having"):
+            rejected_rules["wrapper_flattening"] = "outer query changes aggregation"
+            return True
+
+        if select.args.get("qualify"):
+            rejected_rules["wrapper_flattening"] = "outer query uses QUALIFY"
+            return True
+
+        outer_sql = select.sql(dialect=self.dialect)
+        if sql_has_aggregate(outer_sql):
+            rejected_rules["wrapper_flattening"] = "outer query contains aggregate expressions"
+            return True
+
+        if any(select.find_all(exp.Window)):
+            rejected_rules["wrapper_flattening"] = "outer query contains window functions"
+            return True
+
+        return False
+
+    def _plan_output_name_to_ref(self, plan: SemanticQueryPlan) -> dict[str, str]:
+        refs = [*plan.dimensions, *plan.metrics]
+        field_names: dict[str, list[str]] = {}
+        for ref in refs:
+            if "." in ref:
+                model_name, field_name = ref.split(".", 1)
+                field_names.setdefault(field_name, []).append(model_name)
+            else:
+                field_names.setdefault(ref, []).append("")
+
+        output_name_to_ref: dict[str, str] = {}
+        for ref in refs:
+            if ref in plan.aliases:
+                output_name = plan.aliases[ref]
+            elif "." in ref:
+                model_name, field_name = ref.split(".", 1)
+                output_name = f"{model_name}_{field_name}" if len(field_names.get(field_name, [])) > 1 else field_name
+            else:
+                output_name = ref
+            output_name_to_ref[output_name] = ref
+        return output_name_to_ref
+
+    def _analyze_wrapper_projection(
+        self,
+        select: exp.Select,
+        source: _WrappedSemanticSource,
+        plan: SemanticQueryPlan,
+        output_name_to_ref: dict[str, str],
+        rejected_rules: dict[str, str],
+    ) -> _ProjectionAnalysis | None:
+        if not select.expressions:
+            rejected_rules["wrapper_flattening"] = "outer query has no projections"
+            return None
+
+        if len(select.expressions) == 1 and isinstance(select.expressions[0], exp.Star):
+            visible_name_to_ref = dict(output_name_to_ref)
+            return _ProjectionAnalysis(
+                metrics=list(plan.metrics),
+                dimensions=list(plan.dimensions),
+                aliases=dict(plan.aliases),
+                visible_name_to_ref=visible_name_to_ref,
+                projected_refs=set(visible_name_to_ref.values()),
+                applied_rules=["trivial_wrapper_flattening"],
+            )
+
+        selected_refs: list[str] = []
+        aliases = dict(plan.aliases)
+        visible_name_to_ref: dict[str, str] = {}
+        applied_rules = ["wrapper_projection_flattening"]
+
+        for projection in select.expressions:
+            alias = projection.alias if isinstance(projection, exp.Alias) else None
+            expression = projection.this if isinstance(projection, exp.Alias) else projection
+            if not isinstance(expression, exp.Column):
+                rejected_rules["wrapper_flattening"] = "outer projection computes a new expression"
+                return None
+            if expression.table and expression.table != source.source_name:
+                rejected_rules["wrapper_flattening"] = "outer projection references another relation"
+                return None
+            column_name = expression.name
+            ref = output_name_to_ref.get(column_name)
+            if ref is None:
+                rejected_rules["wrapper_flattening"] = (
+                    f"outer projection '{column_name}' is not an inner semantic field"
+                )
+                return None
+            if ref in selected_refs:
+                rejected_rules["wrapper_flattening"] = "outer projection selects the same semantic field more than once"
+                return None
+
+            selected_refs.append(ref)
+            output_name = alias or column_name
+            if alias:
+                aliases[ref] = alias
+            visible_name_to_ref[output_name] = ref
+
+        selected = set(selected_refs)
+        selected_dimensions = [dimension for dimension in plan.dimensions if dimension in selected]
+        if set(selected_dimensions) != set(plan.dimensions):
+            rejected_rules["wrapper_flattening"] = (
+                "outer projection drops dimensions and would change semantic grouping"
+            )
+            return None
+
+        return _ProjectionAnalysis(
+            metrics=[metric for metric in plan.metrics if metric in selected],
+            dimensions=selected_dimensions,
+            aliases={ref: alias for ref, alias in aliases.items() if ref in selected},
+            visible_name_to_ref=visible_name_to_ref,
+            projected_refs=selected,
+            applied_rules=applied_rules,
+        )
+
+    def _translated_outer_filters(
+        self,
+        select: exp.Select,
+        source: _WrappedSemanticSource,
+        plan: SemanticQueryPlan,
+        output_name_to_ref: dict[str, str],
+        rejected_rules: dict[str, str],
+    ) -> list[str] | None:
+        where_clause = select.args.get("where")
+        if not where_clause:
+            return []
+
+        if plan.limit is not None or plan.offset is not None or source.inner_select.args.get("distinct"):
+            rejected_rules["safe_filter_pushdown"] = "inner semantic query limits row membership"
+            return None
+
+        dimension_refs = set(plan.dimensions)
+        try:
+            translated = self._translate_wrapper_expression(
+                where_clause.this,
+                output_name_to_ref,
+                source.source_name,
+                allowed_refs=dimension_refs,
+                rule_name="safe_filter_pushdown",
+            )
+        except ValueError as e:
+            rejected_rules["safe_filter_pushdown"] = str(e)
+            return None
+
+        return self._filters_from_expression(translated)
+
+    def _translated_outer_order_by(
+        self,
+        select: exp.Select,
+        source: _WrappedSemanticSource,
+        visible_name_to_ref: dict[str, str],
+        output_name_to_ref: dict[str, str],
+        projected_refs: set[str],
+        rejected_rules: dict[str, str],
+    ) -> list[str] | None:
+        order_clause = select.args.get("order")
+        if not order_clause:
+            return []
+
+        if select.args.get("limit") is not None and self._extract_limit(source.inner_select) is not None:
+            rejected_rules["safe_order_pushdown"] = "inner semantic query already has LIMIT"
+            return None
+
+        order_by: list[str] = []
+        for order_expr in order_clause.expressions:
+            expression = order_expr.this if isinstance(order_expr, exp.Ordered) else order_expr
+            if not isinstance(expression, exp.Column):
+                rejected_rules["safe_order_pushdown"] = "outer ORDER BY computes a new expression"
+                return None
+            if expression.table and expression.table != source.source_name:
+                rejected_rules["safe_order_pushdown"] = "outer ORDER BY references another relation"
+                return None
+
+            column_name = expression.name
+            ref = visible_name_to_ref.get(column_name) or output_name_to_ref.get(column_name)
+            if ref is None:
+                rejected_rules["safe_order_pushdown"] = f"outer ORDER BY '{column_name}' is not a semantic field"
+                return None
+            if ref not in projected_refs:
+                rejected_rules["safe_order_pushdown"] = "outer ORDER BY references a non-projected field"
+                return None
+
+            order_name = next(
+                (name for name, visible_ref in visible_name_to_ref.items() if visible_ref == ref), column_name
+            )
+            if isinstance(order_expr, exp.Ordered) and order_expr.args.get("desc", False):
+                order_name = f"{order_name} DESC"
+            elif isinstance(order_expr, exp.Ordered):
+                order_name = f"{order_name} ASC"
+            order_by.append(order_name)
+
+        return order_by
+
+    def _apply_outer_limit_offset(
+        self,
+        select: exp.Select,
+        plan: SemanticQueryPlan,
+        rejected_rules: dict[str, str],
+    ) -> bool:
+        outer_limit = self._extract_limit(select)
+        outer_offset = self._extract_offset(select)
+
+        if outer_limit is not None and plan.limit is not None:
+            rejected_rules["safe_limit_pushdown"] = "inner semantic query already has LIMIT"
+            return False
+        if outer_offset is not None and plan.offset is not None:
+            rejected_rules["safe_limit_pushdown"] = "inner semantic query already has OFFSET"
+            return False
+
+        if outer_limit is not None:
+            plan.limit = outer_limit
+        if outer_offset is not None:
+            plan.offset = outer_offset
+        return True
+
+    def _translate_wrapper_expression(
+        self,
+        expression: exp.Expression,
+        name_to_ref: dict[str, str],
+        source_name: str,
+        allowed_refs: set[str],
+        rule_name: str,
+    ) -> exp.Expression:
+        if any(expression.find_all(exp.Select)):
+            raise ValueError("outer expression contains a subquery")
+        if any(expression.find_all(exp.Window)):
+            raise ValueError("outer expression contains a window function")
+        if sql_has_aggregate(expression.sql(dialect=self.dialect)):
+            raise ValueError("outer expression contains an aggregate")
+
+        def replace_column(node):
+            if not isinstance(node, exp.Column):
+                return node
+            if node.table and node.table != source_name:
+                raise ValueError(f"{rule_name} references another relation")
+            ref = name_to_ref.get(node.name)
+            if ref is None:
+                raise ValueError(f"{rule_name} references unknown field '{node.name}'")
+            if ref not in allowed_refs:
+                raise ValueError(f"{rule_name} cannot move metric or computed field '{node.name}'")
+            return self._column_expression_for_ref(ref)
+
+        return expression.copy().transform(replace_column)
+
+    def _column_expression_for_ref(self, ref: str) -> exp.Expression:
+        if "." not in ref:
+            return exp.column(ref)
+        table, name = ref.split(".", 1)
+        return exp.column(name, table=table)
+
+    def _filters_from_expression(self, expression: exp.Expression) -> list[str]:
+        if isinstance(expression, (exp.And, exp.Or)):
+            return self._extract_compound_filters(expression)
+        return [expression.sql(dialect=self.dialect)]
+
+    def _collect_semantic_scopes(self, select: exp.Select) -> tuple[list[SemanticQueryPlan], list[str]]:
+        scopes: list[SemanticQueryPlan] = []
+        warnings: list[str] = []
+        had_inferred_table = hasattr(self, "inferred_table")
+        previous_inferred_table = getattr(self, "inferred_table", None)
+
+        try:
+            for nested_select in select.find_all(exp.Select):
+                if not self._references_semantic_model(nested_select):
+                    continue
+                try:
+                    scopes.append(self._plan_simple_query(nested_select.copy()))
+                except Exception as e:
+                    warnings.append(f"Could not plan semantic scope {nested_select.sql(dialect=self.dialect)}: {e}")
+        finally:
+            if had_inferred_table:
+                self.inferred_table = previous_inferred_table
+            elif hasattr(self, "inferred_table"):
+                del self.inferred_table
+
+        return scopes, warnings
+
+    def _candidate_plans_for_scopes(self, scopes: list[SemanticQueryPlan], chosen_plan: str) -> list[CandidatePlan]:
+        if not scopes:
+            return [
+                CandidatePlan(
+                    name="semantic_plus_postprocess",
+                    valid=False,
+                    reason="no semantic scopes found",
+                )
+            ]
+
+        candidates_by_name: dict[str, CandidatePlan] = {}
+        for scope in scopes:
+            for candidate in scope.candidate_plans:
+                existing = candidates_by_name.get(candidate.name)
+                if existing is None or (candidate.valid and not existing.valid):
+                    candidates_by_name[candidate.name] = candidate
+
+        candidates_by_name["semantic_plus_postprocess"] = CandidatePlan(
+            name="semantic_plus_postprocess",
+            valid=chosen_plan == "semantic_plus_postprocess",
+            reason=(
+                "outer SQL performs post-processing around semantic scopes"
+                if chosen_plan == "semantic_plus_postprocess"
+                else "root semantic query can be planned directly"
+            ),
+        )
+        candidates_by_name.setdefault(
+            "passthrough_plain_sql",
+            CandidatePlan(
+                name="passthrough_plain_sql",
+                valid=False,
+                reason="query contains semantic scopes",
+            ),
+        )
+
+        return list(candidates_by_name.values())
+
+    def _explanation_from_plan(
+        self,
+        sql: str,
+        plan: SemanticQueryPlan,
+        rewritten_sql: str | None,
+    ) -> RewriteExplanation:
+        return RewriteExplanation(
+            input_sql=sql,
+            rewritten_sql=rewritten_sql,
+            chosen_plan=plan.candidate_kind,
+            source_kind=plan.source_kind,
+            metrics=plan.metrics,
+            dimensions=plan.dimensions,
+            filters=plan.filters,
+            order_by=plan.order_by,
+            limit=plan.limit,
+            offset=plan.offset,
+            aliases=plan.aliases,
+            candidate_plans=plan.candidate_plans,
+            semantic_scopes=[plan],
+            preaggregation=plan.eligibility.get("single_model_preaggregation", {}),
+            fanout=plan.eligibility.get("fanout_preaggregation", {}),
+            applied_rules=plan.applied_rules,
+            rejected_rules=plan.rejected_rules,
+        )
+
+    def _plan_simple_query(self, parsed: exp.Select) -> SemanticQueryPlan:
+        """Build a behavior-preserving semantic query plan for a simple SELECT."""
+        explicit_join_filters = []
+        if parsed.args.get("joins"):
+            explicit_join_filters = self._validate_explicit_semantic_joins(parsed)
+
+        self.inferred_table = self._extract_from_table(parsed)
+        self.table_aliases = self._source_aliases(parsed)
+
+        if self._needs_expression_postprocess(parsed):
+            raise ValueError("Semantic expression queries cannot be represented as a simple rewrite plan")
+
+        metrics, dimensions, aliases = self._extract_metrics_and_dimensions(parsed)
+        filters = [*self._extract_filters(parsed), *explicit_join_filters]
+        order_by = self._extract_order_by(parsed)
+        limit = self._extract_limit(parsed)
+        offset = self._extract_offset(parsed)
+
+        if not metrics and not dimensions:
+            raise ValueError("Query must select at least one metric or dimension")
+
+        plan = SemanticQueryPlan(
+            source_sql=parsed.sql(dialect=self.dialect),
+            source_kind=self._source_kind_for_table(self.inferred_table),
+            metrics=metrics,
+            dimensions=dimensions,
+            filters=filters,
+            order_by=order_by,
+            limit=limit,
+            offset=offset,
+            aliases=aliases,
+        )
+        plan.eligibility = self._plan_eligibility(plan)
+        plan.candidate_kind = self._chosen_candidate_kind(plan)
+        plan.candidate_plans = self._candidate_plans_for_plan(plan)
+        return plan
+
+    def _source_kind_for_table(self, table_name: str | None) -> str:
+        if table_name == "metrics":
+            return "metrics"
+        if table_name in self.graph.models:
+            return "model"
+        if table_name:
+            return "table"
+        return "unknown"
+
+    def _plan_eligibility(self, plan: SemanticQueryPlan) -> dict[str, dict[str, object]]:
+        window_metrics = [metric for metric in plan.metrics if self._metric_needs_window_function(metric)]
+        fanout_needed = self.generator._needs_preaggregation_for_fanout(plan.metrics, plan.dimensions)
+        return {
+            "window_metric": {
+                "eligible": bool(window_metrics),
+                "metrics": window_metrics,
+                "reason": "window_metric_required" if window_metrics else "no_window_metrics",
+            },
+            "fanout_preaggregation": {
+                "eligible": fanout_needed,
+                "reason": "fanout_protection_required" if fanout_needed else "fanout_protection_not_needed",
+            },
+            "single_model_preaggregation": self._single_model_preaggregation_eligibility(plan),
+        }
+
+    def _candidate_plans_for_plan(self, plan: SemanticQueryPlan) -> list[CandidatePlan]:
+        window_details = plan.eligibility["window_metric"]
+        fanout_details = plan.eligibility["fanout_preaggregation"]
+        preagg_details = plan.eligibility["single_model_preaggregation"]
+
+        return [
+            CandidatePlan(
+                name="direct_semantic",
+                valid=True,
+                reason="simple SELECT references semantic model fields",
+            ),
+            CandidatePlan(
+                name="semantic_plus_postprocess",
+                valid=False,
+                reason="no outer SQL post-processing required",
+            ),
+            CandidatePlan(
+                name="single_model_preaggregation",
+                valid=bool(preagg_details["eligible"]),
+                reason=str(preagg_details["reason"]),
+                details=preagg_details,
+            ),
+            CandidatePlan(
+                name="fanout_preaggregation",
+                valid=bool(fanout_details["eligible"]),
+                reason=str(fanout_details["reason"]),
+                details=fanout_details,
+            ),
+            CandidatePlan(
+                name="window_metric",
+                valid=bool(window_details["eligible"]),
+                reason=str(window_details["reason"]),
+                details=window_details,
+            ),
+            CandidatePlan(
+                name="passthrough_plain_sql",
+                valid=False,
+                reason="query references semantic model fields",
+            ),
+        ]
+
+    def _chosen_candidate_kind(self, plan: SemanticQueryPlan) -> str:
+        if plan.eligibility["window_metric"]["eligible"]:
+            return "window_metric"
+        if plan.eligibility["fanout_preaggregation"]["eligible"]:
+            return "fanout_preaggregation"
+        if self.use_preaggregations and plan.eligibility["single_model_preaggregation"]["eligible"]:
+            return "single_model_preaggregation"
+        return "direct_semantic"
+
+    def _single_model_preaggregation_eligibility(self, plan: SemanticQueryPlan) -> dict[str, object]:
+        try:
+            model_names = self.generator._find_required_models(plan.metrics, plan.dimensions, plan.filters)
+        except Exception as e:
+            return {
+                "eligible": False,
+                "reason": "model_resolution_failed",
+                "error": str(e),
+            }
+
+        if len(model_names) != 1:
+            return {
+                "eligible": False,
+                "reason": "not_single_model_query",
+                "models": model_names,
+            }
+
+        model_name = model_names[0]
+        model = self.graph.get_model(model_name)
+        if not model.pre_aggregations:
+            return {
+                "eligible": False,
+                "reason": "model_has_no_preaggregations",
+                "model": model_name,
+            }
+
+        try:
+            parsed_dims = self.generator._parse_dimension_refs(plan.dimensions)
+            preagg_sql = self.generator._try_use_preaggregation(
+                model_name=model_name,
+                metrics=plan.metrics,
+                parsed_dims=parsed_dims,
+                filters=plan.filters,
+                order_by=plan.order_by,
+                limit=plan.limit,
+                offset=plan.offset,
+            )
+        except Exception as e:
+            return {
+                "eligible": False,
+                "reason": "preaggregation_check_failed",
+                "model": model_name,
+                "error": str(e),
+            }
+
+        return {
+            "eligible": preagg_sql is not None,
+            "reason": "matching_preaggregation" if preagg_sql else "no_matching_preaggregation",
+            "model": model_name,
+            "enabled": self.use_preaggregations,
+            "requires_enablement": True,
+        }
+
+    def _metric_needs_window_function(self, metric_ref: str) -> bool:
+        metric = None
+        if "." in metric_ref:
+            model_name, metric_name = metric_ref.split(".", 1)
+            try:
+                model = self.graph.get_model(model_name)
+                metric = model.get_metric(metric_name) if model else None
+            except KeyError:
+                pass
+            if not metric:
+                try:
+                    metric = self.graph.get_metric(metric_ref)
+                except KeyError:
+                    pass
+        else:
+            try:
+                metric = self.graph.get_metric(metric_ref)
+            except KeyError:
+                pass
+            if not metric:
+                for model in self.graph.models.values():
+                    found = model.get_metric(metric_ref)
+                    if found:
+                        metric = found
+                        break
+
+        if not metric:
+            return False
+
+        if metric.type in ("cumulative", "time_comparison", "conversion", "retention", "cohort"):
+            return True
+        return metric.type == "ratio" and bool(metric.offset_window)
+
+    def _generate_from_plan(self, plan: SemanticQueryPlan) -> str:
+        return self.generator.generate(
+            metrics=plan.metrics,
+            dimensions=plan.dimensions,
+            filters=plan.filters,
+            order_by=plan.order_by,
+            limit=plan.limit,
+            offset=plan.offset,
+            use_preaggregations=self.use_preaggregations,
+            aliases=plan.aliases,
+        )
+
+    def _dedupe(self, values: list[str]) -> list[str]:
+        deduped = []
+        seen = set()
+        for value in values:
+            if value in seen:
+                continue
+            deduped.append(value)
+            seen.add(value)
+        return deduped
 
     def _looks_like_yardstick_query(self, sql: str) -> bool:
         """Return True if query appears to use Yardstick query syntax."""
@@ -1912,6 +2837,10 @@ class QueryRewriter:
         Outer queries are left as plain SQL, so post-processing
         (CASE, window functions, arithmetic, etc.) works naturally.
         """
+        optimization, _rejected_rules = self._optimize_wrapped_semantic_query(parsed)
+        if optimization is not None:
+            return self._generate_from_plan(optimization.plan)
+
         self._rewrite_select_tree(parsed)
 
         # If the root SELECT itself references a semantic model, it must
@@ -2130,34 +3059,14 @@ class QueryRewriter:
         if parsed.args.get("joins"):
             explicit_join_filters = self._validate_explicit_semantic_joins(parsed)
 
-        # Extract FROM table for inference
         self.inferred_table = self._extract_from_table(parsed)
         self.table_aliases = self._source_aliases(parsed)
 
         if self._needs_expression_postprocess(parsed):
             return self._rewrite_expression_query(parsed, extra_filters=explicit_join_filters)
 
-        # Extract components
-        metrics, dimensions, aliases = self._extract_metrics_and_dimensions(parsed)
-        filters = [*self._extract_filters(parsed), *explicit_join_filters]
-        order_by = self._extract_order_by(parsed)
-        limit = self._extract_limit(parsed)
-        offset = self._extract_offset(parsed)
-
-        # Validate we have something to select
-        if not metrics and not dimensions:
-            raise ValueError("Query must select at least one metric or dimension")
-
-        # Generate semantic layer SQL
-        return self.generator.generate(
-            metrics=metrics,
-            dimensions=dimensions,
-            filters=filters,
-            order_by=order_by,
-            limit=limit,
-            offset=offset,
-            aliases=aliases,
-        )
+        plan = self._plan_simple_query(parsed)
+        return self._generate_from_plan(plan)
 
     def _validate_explicit_semantic_joins(self, select: exp.Select) -> list[str]:
         """Allow explicit joins only when they point at modeled semantic relationships."""

--- a/tests/adapters/test_added_fixture_coverage.py
+++ b/tests/adapters/test_added_fixture_coverage.py
@@ -651,7 +651,7 @@ def _pick_execution_query(graph):
                 else:
                     dimension_type = "VARCHAR"
                 for column in dimension_columns or {"id"}:
-                    column_types.setdefault(column, dimension_type)
+                    column_types[column] = dimension_type
                 return {
                     "model_name": model.name,
                     "execution_model_name": execution_model_name,

--- a/tests/optimizations/test_pre_aggregations.py
+++ b/tests/optimizations/test_pre_aggregations.py
@@ -222,6 +222,44 @@ def test_preagg_matcher_granularity_rollup():
     assert preagg is None
 
 
+def test_preagg_matcher_prefers_total_rollup_over_time_rollup_for_total_query():
+    """Test total queries choose the smallest compatible rollup."""
+    model = Model(
+        name="orders",
+        table="orders",
+        dimensions=[
+            Dimension(name="created_at", type="time"),
+        ],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+        ],
+        pre_aggregations=[
+            PreAggregation(
+                name="daily",
+                measures=["revenue"],
+                dimensions=[],
+                time_dimension="created_at",
+                granularity="day",
+            ),
+            PreAggregation(
+                name="total",
+                measures=["revenue"],
+                dimensions=[],
+            ),
+        ],
+    )
+
+    matcher = PreAggregationMatcher(model)
+
+    preagg = matcher.find_matching_preagg(
+        metrics=["revenue"],
+        dimensions=[],
+    )
+
+    assert preagg is not None
+    assert preagg.name == "total"
+
+
 def test_preagg_matcher_measure_not_available():
     """Test pre-aggregation matching fails when measure not available."""
     model = Model(
@@ -408,6 +446,75 @@ def test_preagg_with_filters(layer):
     # Should use pre-aggregation with filter applied
     assert "orders_preagg_by_status_region" in sql
     assert "region = 'US'" in sql or "region='US'" in sql
+
+
+@pytest.mark.parametrize(
+    "filter_expr",
+    [
+        "orders.region IN ('US', 'EU')",
+        "orders.created_at BETWEEN DATE '2024-01-01' AND DATE '2024-01-31'",
+        "orders.region IS NOT NULL",
+        "LOWER(orders.region) LIKE 'u%'",
+        "\"Order Region\" = 'US'",
+    ],
+)
+def test_preagg_filter_column_extraction_uses_sqlglot(filter_expr):
+    model = Model(
+        name="orders",
+        table="public.orders",
+        primary_key="order_id",
+        dimensions=[
+            Dimension(name="status", type="categorical", sql="status"),
+            Dimension(name="region", type="categorical", sql="region"),
+            Dimension(name="created_at", type="time", sql="created_at"),
+            Dimension(name="Order Region", type="categorical", sql='"Order Region"'),
+        ],
+        metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        pre_aggregations=[
+            PreAggregation(
+                name="wide",
+                measures=["revenue"],
+                dimensions=["status", "region", "created_at", "Order Region"],
+            )
+        ],
+    )
+    matcher = PreAggregationMatcher(model)
+
+    preagg = matcher.find_matching_preagg(
+        metrics=["revenue"],
+        dimensions=["status"],
+        filters=[filter_expr],
+    )
+
+    assert preagg is not None
+    assert preagg.name == "wide"
+
+
+def test_preagg_filter_column_extraction_ignores_subquery_columns():
+    model = Model(
+        name="orders",
+        table="public.orders",
+        primary_key="order_id",
+        dimensions=[Dimension(name="status", type="categorical", sql="status")],
+        metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        pre_aggregations=[
+            PreAggregation(
+                name="by_status",
+                measures=["revenue"],
+                dimensions=["status"],
+            )
+        ],
+    )
+    matcher = PreAggregationMatcher(model)
+
+    preagg = matcher.find_matching_preagg(
+        metrics=["revenue"],
+        dimensions=["status"],
+        filters=["status IN (SELECT status FROM allowed_statuses)"],
+    )
+
+    assert preagg is not None
+    assert preagg.name == "by_status"
 
 
 def test_preagg_granularity_conversion(layer):
@@ -883,7 +990,249 @@ def test_generate_materialization_sql_no_time_dimension():
     # Should have dimensions and measures
     assert "category as category" in sql
     assert "brand as brand" in sql
-    assert "AVG(price) as avg_price_raw" in sql
+    assert "SUM(price) as avg_price_raw" in sql
+
+
+def test_avg_preaggregation_rolls_up_with_sum_count_state(layer):
+    layer.use_preaggregations = True
+    layer.conn.execute("""
+        CREATE TABLE products (
+            id INTEGER,
+            category VARCHAR,
+            price DECIMAL(10, 2)
+        )
+    """)
+    layer.conn.execute("""
+        INSERT INTO products VALUES
+            (1, 'hardware', 10.00),
+            (2, 'hardware', 20.00),
+            (3, 'software', 50.00)
+    """)
+    layer.conn.execute("""
+        CREATE TABLE products_preagg_by_category AS
+        SELECT
+            category,
+            SUM(price) AS avg_price_raw,
+            COUNT(*) AS count_raw
+        FROM products
+        GROUP BY category
+    """)
+    model = Model(
+        name="products",
+        table="products",
+        primary_key="id",
+        dimensions=[Dimension(name="category", type="categorical", sql="category")],
+        metrics=[
+            Metric(name="avg_price", agg="avg", sql="price"),
+            Metric(name="count", agg="count"),
+        ],
+        pre_aggregations=[
+            PreAggregation(
+                name="by_category",
+                measures=["avg_price", "count"],
+                dimensions=["category"],
+            )
+        ],
+    )
+    layer.add_model(model)
+
+    preagg_sql = layer.compile(
+        metrics=["products.avg_price"],
+        dimensions=["products.category"],
+        order_by=["category"],
+    )
+    baseline_rows = layer.query(
+        metrics=["products.avg_price"],
+        dimensions=["products.category"],
+        order_by=["category"],
+        use_preaggregations=False,
+    ).fetchall()
+    preagg_rows = layer.adapter.execute(preagg_sql).fetchall()
+
+    assert "products_preagg_by_category" in preagg_sql
+    assert "SUM(avg_price_raw) / NULLIF(SUM(count_raw), 0)" in preagg_sql
+    assert preagg_rows == baseline_rows
+
+
+def test_avg_preaggregation_rejects_missing_count_state(layer):
+    layer.use_preaggregations = True
+    model = Model(
+        name="products",
+        table="products",
+        primary_key="id",
+        dimensions=[Dimension(name="category", type="categorical", sql="category")],
+        metrics=[Metric(name="avg_price", agg="avg", sql="price")],
+        pre_aggregations=[
+            PreAggregation(
+                name="by_category",
+                measures=["avg_price"],
+                dimensions=["category"],
+            )
+        ],
+    )
+    layer.add_model(model)
+
+    sql = layer.compile(
+        metrics=["products.avg_price"],
+        dimensions=["products.category"],
+    )
+
+    assert "products_preagg_by_category" not in sql
+
+
+def test_ratio_metric_preaggregation_rebuilds_from_additive_leaves(layer):
+    layer.use_preaggregations = True
+    layer.conn.execute("""
+        CREATE TABLE orders (
+            id INTEGER,
+            status VARCHAR,
+            amount DECIMAL(10, 2)
+        )
+    """)
+    layer.conn.execute("""
+        INSERT INTO orders VALUES
+            (1, 'completed', 100.00),
+            (2, 'completed', 300.00),
+            (3, 'pending', 50.00)
+    """)
+    layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw,
+            COUNT(*) AS count_raw
+        FROM orders
+        GROUP BY status
+    """)
+    model = Model(
+        name="orders",
+        table="orders",
+        primary_key="id",
+        dimensions=[Dimension(name="status", type="categorical", sql="status")],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+            Metric(name="count", agg="count"),
+            Metric(name="revenue_per_order", type="ratio", numerator="revenue", denominator="count"),
+        ],
+        pre_aggregations=[
+            PreAggregation(
+                name="by_status",
+                measures=["revenue", "count"],
+                dimensions=["status"],
+            )
+        ],
+    )
+    layer.add_model(model)
+
+    preagg_sql = layer.compile(
+        metrics=["orders.revenue_per_order"],
+        dimensions=["orders.status"],
+        order_by=["status"],
+    )
+    baseline_rows = layer.query(
+        metrics=["orders.revenue_per_order"],
+        dimensions=["orders.status"],
+        order_by=["status"],
+        use_preaggregations=False,
+    ).fetchall()
+    preagg_rows = layer.adapter.execute(preagg_sql).fetchall()
+
+    assert "orders_preagg_by_status" in preagg_sql
+    assert "SUM(revenue_raw) / NULLIF(SUM(count_raw), 0)" in preagg_sql
+    assert preagg_rows == baseline_rows
+
+
+def test_derived_metric_preaggregation_rebuilds_from_additive_leaves(layer):
+    layer.use_preaggregations = True
+    layer.conn.execute("""
+        CREATE TABLE orders (
+            id INTEGER,
+            status VARCHAR,
+            amount DECIMAL(10, 2),
+            discount DECIMAL(10, 2)
+        )
+    """)
+    layer.conn.execute("""
+        INSERT INTO orders VALUES
+            (1, 'completed', 100.00, 5.00),
+            (2, 'completed', 300.00, 10.00),
+            (3, 'pending', 50.00, 0.00)
+    """)
+    layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw,
+            SUM(discount) AS discounts_raw
+        FROM orders
+        GROUP BY status
+    """)
+    model = Model(
+        name="orders",
+        table="orders",
+        primary_key="id",
+        dimensions=[Dimension(name="status", type="categorical", sql="status")],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+            Metric(name="discounts", agg="sum", sql="discount"),
+            Metric(name="net_revenue", type="derived", sql="revenue - discounts"),
+        ],
+        pre_aggregations=[
+            PreAggregation(
+                name="by_status",
+                measures=["revenue", "discounts"],
+                dimensions=["status"],
+            )
+        ],
+    )
+    layer.add_model(model)
+
+    preagg_sql = layer.compile(
+        metrics=["orders.net_revenue"],
+        dimensions=["orders.status"],
+        order_by=["status"],
+    )
+    baseline_rows = layer.query(
+        metrics=["orders.net_revenue"],
+        dimensions=["orders.status"],
+        order_by=["status"],
+        use_preaggregations=False,
+    ).fetchall()
+    preagg_rows = layer.adapter.execute(preagg_sql).fetchall()
+
+    assert "orders_preagg_by_status" in preagg_sql
+    assert "SUM(revenue_raw) - SUM(discounts_raw)" in preagg_sql
+    assert preagg_rows == baseline_rows
+
+
+def test_ratio_metric_preaggregation_rejects_count_distinct_leaf(layer):
+    layer.use_preaggregations = True
+    model = Model(
+        name="orders",
+        table="orders",
+        primary_key="id",
+        dimensions=[Dimension(name="status", type="categorical", sql="status")],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+            Metric(name="unique_customers", agg="count_distinct", sql="customer_id"),
+            Metric(name="revenue_per_customer", type="ratio", numerator="revenue", denominator="unique_customers"),
+        ],
+        pre_aggregations=[
+            PreAggregation(
+                name="by_status",
+                measures=["revenue", "unique_customers"],
+                dimensions=["status"],
+            )
+        ],
+    )
+    layer.add_model(model)
+
+    sql = layer.compile(
+        metrics=["orders.revenue_per_customer"],
+        dimensions=["orders.status"],
+    )
+
+    assert "orders_preagg_by_status" not in sql
 
 
 def test_generate_materialization_sql_with_duckdb():

--- a/tests/queries/test_semantic_sql_planner.py
+++ b/tests/queries/test_semantic_sql_planner.py
@@ -1,0 +1,560 @@
+"""Tests for semantic SQL rewrite planning and explanations."""
+
+import pytest
+
+from sidemantic.core.dimension import Dimension
+from sidemantic.core.metric import Metric
+from sidemantic.core.model import Model
+from sidemantic.core.pre_aggregation import PreAggregation
+from sidemantic.core.relationship import Relationship
+from sidemantic.core.semantic_layer import SemanticLayer
+from sidemantic.sql.query_rewriter import QueryRewriter
+from tests.utils import fetch_dicts
+
+
+@pytest.fixture
+def semantic_layer():
+    layer = SemanticLayer(auto_register=False)
+
+    orders = Model(
+        name="orders",
+        table="orders",
+        primary_key="id",
+        dimensions=[
+            Dimension(name="status", type="categorical", sql="status"),
+            Dimension(name="order_date", type="time", sql="order_date", granularity="day"),
+        ],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+            Metric(name="count", agg="count"),
+        ],
+        relationships=[Relationship(name="customers", type="many_to_one", foreign_key="customer_id")],
+    )
+    customers = Model(
+        name="customers",
+        table="customers",
+        primary_key="id",
+        dimensions=[
+            Dimension(name="region", type="categorical", sql="region"),
+            Dimension(name="tier", type="categorical", sql="tier"),
+        ],
+        metrics=[Metric(name="count", agg="count")],
+        relationships=[Relationship(name="orders", type="one_to_many", foreign_key="customer_id")],
+    )
+
+    layer.add_model(orders)
+    layer.add_model(customers)
+    layer.conn.execute("""
+        CREATE TABLE orders (
+            id INTEGER,
+            customer_id INTEGER,
+            status VARCHAR,
+            order_date DATE,
+            amount DECIMAL(10, 2)
+        )
+    """)
+    layer.conn.execute("""
+        INSERT INTO orders VALUES
+            (1, 1, 'completed', '2024-01-01', 100.00),
+            (2, 1, 'completed', '2024-01-02', 150.00),
+            (3, 2, 'pending', '2024-01-03', 200.00)
+    """)
+    layer.conn.execute("""
+        CREATE TABLE customers (
+            id INTEGER,
+            region VARCHAR,
+            tier VARCHAR
+        )
+    """)
+    layer.conn.execute("""
+        INSERT INTO customers VALUES
+            (1, 'US', 'premium'),
+            (2, 'EU', 'standard')
+    """)
+    return layer
+
+
+def _candidate_by_name(explanation):
+    return {candidate.name: candidate for candidate in explanation.candidate_plans}
+
+
+def _rows(result):
+    return fetch_dicts(result)
+
+
+def test_explain_direct_semantic_query_is_machine_testable(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    explanation = rewriter.explain("SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'completed'")
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.source_kind == "model"
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.dimensions == ["orders.status"]
+    assert explanation.filters == ["orders.status = 'completed'"]
+    assert explanation.rewritten_sql == rewriter.rewrite(
+        "SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'completed'"
+    )
+
+
+def test_explain_from_metrics_query_records_metrics_source(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    explanation = rewriter.explain("SELECT orders.revenue, customers.region FROM metrics")
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.source_kind == "metrics"
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.dimensions == ["customers.region"]
+
+
+def test_explain_lists_deterministic_candidate_plans(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    explanation = rewriter.explain("SELECT orders.revenue, customers.region FROM orders")
+    candidates = _candidate_by_name(explanation)
+
+    assert set(candidates) == {
+        "direct_semantic",
+        "semantic_plus_postprocess",
+        "single_model_preaggregation",
+        "fanout_preaggregation",
+        "window_metric",
+        "passthrough_plain_sql",
+    }
+    assert candidates["direct_semantic"].valid is True
+    assert candidates["passthrough_plain_sql"].valid is False
+    assert candidates["single_model_preaggregation"].details["reason"] in {
+        "model_has_no_preaggregations",
+        "not_single_model_query",
+        "no_matching_preaggregation",
+        "matching_preaggregation",
+    }
+
+
+def test_safe_outer_filter_pushdown_rewrites_to_direct_semantic(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    wrapped_sql = "SELECT * FROM (SELECT orders.revenue, customers.region FROM orders) sq WHERE region = 'US'"
+    direct_sql = "SELECT orders.revenue, customers.region FROM orders WHERE customers.region = 'US'"
+
+    explanation = rewriter.explain(wrapped_sql)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.post_process is None
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.dimensions == ["customers.region"]
+    assert explanation.filters == ["customers.region = 'US'"]
+    assert explanation.pushed_filters == ["customers.region = 'US'"]
+    assert "safe_filter_pushdown" in explanation.applied_rules
+    assert candidates["direct_semantic"].valid is True
+    assert " AS sq WHERE" not in explanation.rewritten_sql
+    assert explanation.rewritten_sql == rewriter.rewrite(wrapped_sql)
+    assert _rows(semantic_layer.sql(wrapped_sql)) == _rows(semantic_layer.sql(direct_sql))
+
+
+def test_safe_outer_filter_pushdown_from_cte_wrapper(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    wrapped_sql = """
+        WITH orders_agg AS (
+            SELECT orders.revenue, orders.status FROM orders
+        )
+        SELECT * FROM orders_agg WHERE status = 'completed'
+    """
+    direct_sql = "SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'completed'"
+
+    explanation = rewriter.explain(wrapped_sql)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.post_process is None
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.dimensions == ["orders.status"]
+    assert explanation.filters == ["orders.status = 'completed'"]
+    assert explanation.pushed_filters == ["orders.status = 'completed'"]
+    assert "safe_filter_pushdown" in explanation.applied_rules
+    assert candidates["direct_semantic"].valid is True
+    assert "orders_agg" not in explanation.rewritten_sql
+    assert explanation.rewritten_sql == rewriter.rewrite(wrapped_sql)
+    assert _rows(semantic_layer.sql(wrapped_sql)) == _rows(semantic_layer.sql(direct_sql))
+
+
+def test_explain_cte_semantic_query_rejects_metric_filter_pushdown(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        WITH orders_agg AS (
+            SELECT orders.revenue, orders.status FROM orders
+        )
+        SELECT * FROM orders_agg WHERE revenue > 100
+    """
+
+    explanation = rewriter.explain(sql)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.dimensions == ["orders.status"]
+    assert len(explanation.semantic_scopes) == 1
+    assert "metric or computed field" in explanation.rejected_rules["safe_filter_pushdown"]
+    assert candidates["semantic_plus_postprocess"].valid is True
+    assert explanation.rewritten_sql == rewriter.rewrite(sql)
+
+
+def test_explain_multiple_semantic_ctes_reports_all_scopes(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        WITH
+        orders_agg AS (
+            SELECT orders.revenue, orders.status FROM orders
+        ),
+        customers_agg AS (
+            SELECT customers.count, customers.region FROM customers
+        )
+        SELECT *
+        FROM orders_agg
+        JOIN customers_agg ON orders_agg.status IS NOT NULL
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.metrics == ["orders.revenue", "customers.count"]
+    assert explanation.dimensions == ["orders.status", "customers.region"]
+    assert len(explanation.semantic_scopes) == 2
+    assert [scope.source_kind for scope in explanation.semantic_scopes] == ["model", "model"]
+    assert explanation.rewritten_sql == rewriter.rewrite(sql)
+
+
+def test_explain_root_semantic_query_preserves_user_cte(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        WITH statuses AS (
+            SELECT 'completed' AS status
+        )
+        SELECT orders.revenue
+        FROM orders
+        WHERE orders.status IN (SELECT status FROM statuses)
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.filters == ["orders.status IN (SELECT status FROM statuses)"]
+    assert "WITH statuses AS" in explanation.rewritten_sql
+    assert explanation.rewritten_sql == rewriter.rewrite(sql)
+
+
+def test_explain_fanout_preaggregation_candidate(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    explanation = rewriter.explain("SELECT orders.revenue, customers.count FROM orders")
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "fanout_preaggregation"
+    assert explanation.fanout["eligible"] is True
+    assert explanation.fanout["reason"] == "fanout_protection_required"
+    assert candidates["fanout_preaggregation"].valid is True
+
+
+def test_explain_window_metric_candidate(semantic_layer):
+    semantic_layer.add_metric(
+        Metric(
+            name="running_total_revenue",
+            type="cumulative",
+            sql="orders.revenue",
+        )
+    )
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    explanation = rewriter.explain("SELECT running_total_revenue, orders.order_date FROM metrics")
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "window_metric"
+    assert candidates["window_metric"].valid is True
+    assert candidates["window_metric"].details["metrics"] == ["running_total_revenue"]
+
+
+def test_explain_single_model_preaggregation_candidate(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    explanation = rewriter.explain("SELECT orders.revenue, orders.status FROM orders")
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.preaggregation["eligible"] is True
+    assert explanation.preaggregation["reason"] == "matching_preaggregation"
+    assert explanation.preaggregation["requires_enablement"] is True
+    assert candidates["single_model_preaggregation"].valid is True
+
+
+def test_explain_yardstick_route(monkeypatch, semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    monkeypatch.setattr(
+        rewriter,
+        "_rewrite_yardstick_query",
+        lambda _sql, strict=True, allow_plain_measures=False: "SELECT 1 AS yardstick",
+    )
+
+    explanation = rewriter.explain("SEMANTIC SELECT AGGREGATE(revenue) AS revenue FROM sales_v")
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "yardstick_semantic_sql"
+    assert explanation.source_kind == "yardstick"
+    assert explanation.rewritten_sql == "SELECT 1 AS yardstick"
+    assert candidates["yardstick_semantic_sql"].valid is True
+    assert explanation.warnings == ["Yardstick semantic SQL uses a separate rewrite path."]
+
+
+def test_explain_rust_rewriter_route(monkeypatch, semantic_layer):
+    class FakeRustModule:
+        def __init__(self):
+            self.calls = []
+
+        def rewrite_with_yaml(self, yaml_text: str, sql_text: str) -> str:
+            self.calls.append((yaml_text, sql_text))
+            return "SELECT 1 AS from_rust"
+
+    fake = FakeRustModule()
+    monkeypatch.setenv("SIDEMANTIC_RS_REWRITER", "1")
+    monkeypatch.delenv("SIDEMANTIC_RS_NO_FALLBACK", raising=False)
+    monkeypatch.setattr("sidemantic.sql.query_rewriter.get_rust_module", lambda: fake)
+    monkeypatch.setattr("sidemantic.sql.query_rewriter.graph_to_rust_yaml", lambda _graph: "models: []")
+
+    explanation = QueryRewriter(semantic_layer.graph, dialect="duckdb").explain("SELECT orders.revenue FROM orders")
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "rust_semantic_rewriter"
+    assert explanation.source_kind == "rust"
+    assert explanation.rewritten_sql == "SELECT 1 AS from_rust"
+    assert candidates["rust_semantic_rewriter"].valid is True
+    assert fake.calls == [("models: []", "SELECT orders.revenue FROM orders")]
+
+
+def test_trivial_wrapper_uses_direct_semantic_plan(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    wrapped_sql = "SELECT * FROM (SELECT orders.revenue, orders.status FROM orders) sq"
+    direct_sql = "SELECT orders.revenue, orders.status FROM orders"
+
+    explanation = rewriter.explain(wrapped_sql)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.post_process is None
+    assert explanation.rewritten_sql == rewriter.rewrite(direct_sql)
+    assert rewriter.rewrite(wrapped_sql) == rewriter.rewrite(direct_sql)
+    assert "trivial_wrapper_flattening" in explanation.applied_rules
+    assert "wrapper_flattening" in explanation.applied_rules
+
+
+def test_safe_outer_order_limit_offset_pushdown(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    wrapped_sql = """
+        SELECT *
+        FROM (SELECT orders.revenue, orders.status FROM orders) sq
+        ORDER BY status DESC
+        LIMIT 1
+        OFFSET 1
+    """
+    direct_sql = """
+        SELECT orders.revenue, orders.status
+        FROM orders
+        ORDER BY orders.status DESC
+        LIMIT 1
+        OFFSET 1
+    """
+
+    explanation = rewriter.explain(wrapped_sql)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.post_process is None
+    assert explanation.order_by == ["status DESC"]
+    assert explanation.limit == 1
+    assert explanation.offset == 1
+    assert "safe_order_pushdown" in explanation.applied_rules
+    assert "safe_limit_pushdown" in explanation.applied_rules
+    assert " AS sq" not in explanation.rewritten_sql
+    assert explanation.rewritten_sql == rewriter.rewrite(wrapped_sql)
+    assert _rows(semantic_layer.sql(wrapped_sql)) == _rows(semantic_layer.sql(direct_sql))
+
+
+def test_wrapper_projection_flattening_aliases_without_changing_grouping(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    wrapped_sql = """
+        SELECT status, revenue AS total_revenue
+        FROM (SELECT orders.revenue, orders.count, orders.status FROM orders) sq
+        ORDER BY status
+    """
+    direct_sql = """
+        SELECT orders.status, orders.revenue AS total_revenue
+        FROM orders
+        ORDER BY orders.status
+    """
+
+    explanation = rewriter.explain(wrapped_sql)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.post_process is None
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.dimensions == ["orders.status"]
+    assert explanation.aliases == {"orders.revenue": "total_revenue"}
+    assert "wrapper_projection_flattening" in explanation.applied_rules
+    assert "safe_order_pushdown" in explanation.applied_rules
+    assert "total_revenue" in explanation.rewritten_sql
+    assert "count" not in explanation.rewritten_sql
+    assert " AS sq" not in explanation.rewritten_sql
+    assert explanation.rewritten_sql == rewriter.rewrite(wrapped_sql)
+    assert _rows(semantic_layer.sql(wrapped_sql)) == _rows(semantic_layer.sql(direct_sql))
+
+
+def test_wrapped_preaggregation_route_selection(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb", use_preaggregations=True)
+    wrapped_sql = "SELECT * FROM (SELECT orders.revenue, orders.status FROM orders) sq"
+
+    explanation = rewriter.explain(wrapped_sql)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "single_model_preaggregation"
+    assert explanation.preaggregation["eligible"] is True
+    assert explanation.preaggregation["enabled"] is True
+    assert "preaggregation_route_selection" in explanation.applied_rules
+    assert candidates["single_model_preaggregation"].valid is True
+    assert "orders_preagg_by_status" in explanation.rewritten_sql
+    assert " AS sq" not in explanation.rewritten_sql
+
+
+def test_wrapped_preaggregation_executes_against_materialized_table(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    wrapped_sql = """
+        SELECT *
+        FROM (SELECT orders.revenue, orders.status FROM orders) sq
+        ORDER BY status
+    """
+
+    explanation = semantic_layer.explain_sql(wrapped_sql)
+    preagg_rows = _rows(semantic_layer.sql(wrapped_sql))
+    base_rows = _rows(
+        semantic_layer.query(
+            metrics=["orders.revenue"],
+            dimensions=["orders.status"],
+            order_by=["status"],
+            use_preaggregations=False,
+        )
+    )
+
+    assert explanation.chosen_plan == "single_model_preaggregation"
+    assert "orders_preagg_by_status" in explanation.rewritten_sql
+    assert " AS sq" not in explanation.rewritten_sql
+    assert preagg_rows == base_rows
+
+
+def test_wrapped_fanout_strategy_selection(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    wrapped_sql = "SELECT * FROM (SELECT orders.revenue, customers.count FROM orders) sq"
+
+    explanation = rewriter.explain(wrapped_sql)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "fanout_preaggregation"
+    assert explanation.post_process is None
+    assert explanation.fanout["eligible"] is True
+    assert explanation.fanout["reason"] == "fanout_protection_required"
+    assert "fanout_strategy_selection" in explanation.applied_rules
+    assert candidates["fanout_preaggregation"].valid is True
+    assert " AS sq" not in explanation.rewritten_sql
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT * FROM (SELECT orders.revenue, orders.status FROM orders) sq WHERE revenue > 100",
+        "SELECT revenue * 2 AS doubled FROM (SELECT orders.revenue, orders.status FROM orders) sq",
+        "SELECT revenue, ROW_NUMBER() OVER () AS rn FROM (SELECT orders.revenue, orders.status FROM orders) sq",
+        "SELECT SUM(revenue) AS total FROM (SELECT orders.revenue, orders.status FROM orders) sq",
+        "SELECT DISTINCT status FROM (SELECT orders.revenue, orders.status FROM orders) sq",
+        "SELECT revenue FROM (SELECT orders.revenue, orders.status FROM orders) sq",
+        "SELECT * FROM (SELECT orders.revenue, orders.status FROM orders LIMIT 1) sq WHERE status = 'completed'",
+        "SELECT * FROM (SELECT orders.revenue, orders.status FROM orders) sq JOIN other_table ot ON TRUE",
+        """
+        WITH passthrough AS (
+            SELECT 1 AS marker
+        )
+        SELECT * FROM (SELECT orders.revenue, orders.status FROM orders) sq
+        """,
+    ],
+)
+def test_wrapped_optimizer_negative_cases(semantic_layer, sql):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.post_process is not None
+    assert explanation.rejected_rules
+    assert explanation.rewritten_sql == rewriter.rewrite(sql)
+
+
+def test_explain_passthrough_plain_sql_non_strict(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    explanation = rewriter.explain("SHOW TABLES", strict=False)
+
+    assert explanation.chosen_plan == "passthrough_plain_sql"
+    assert explanation.source_kind == "plain_sql"
+    assert explanation.rewritten_sql == "SHOW TABLES"
+
+
+def test_semantic_layer_explain_sql(semantic_layer):
+    explanation = semantic_layer.explain_sql("SELECT orders.revenue FROM orders")
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.metrics == ["orders.revenue"]
+    assert "orders_cte" in explanation.rewritten_sql
+
+
+def test_rewrite_simple_query_still_generates_same_sql(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = "SELECT orders.revenue, orders.status FROM orders ORDER BY orders.status DESC LIMIT 10"
+
+    assert rewriter.explain(sql).rewritten_sql == rewriter.rewrite(sql)
+
+
+def test_explanation_can_be_serialized_to_dict(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    explanation_dict = rewriter.explain("SELECT orders.revenue FROM orders").to_dict()
+
+    assert explanation_dict["chosen_plan"] == "direct_semantic"
+    assert explanation_dict["semantic_scopes"][0]["metrics"] == ["orders.revenue"]
+    assert explanation_dict["candidate_plans"][0]["name"] == "direct_semantic"

--- a/tests/queries/test_semantic_sql_planner.py
+++ b/tests/queries/test_semantic_sql_planner.py
@@ -9,7 +9,7 @@ from sidemantic.core.pre_aggregation import PreAggregation
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_layer import SemanticLayer
 from sidemantic.sql.query_rewriter import QueryRewriter
-from tests.utils import fetch_dicts
+from tests.utils import fetch_columns, fetch_dicts, fetch_rows
 
 
 @pytest.fixture
@@ -82,6 +82,45 @@ def _rows(result):
     return fetch_dicts(result)
 
 
+def _subquery(sql: str) -> str:
+    return "(\n" + sql.rstrip() + "\n)"
+
+
+def _compiled_semantic_sql(layer: SemanticLayer, sql: str, use_preaggregations: bool = False) -> str:
+    return QueryRewriter(
+        layer.graph,
+        dialect="duckdb",
+        use_preaggregations=use_preaggregations,
+    ).rewrite(sql)
+
+
+def _sorted_rows(rows):
+    return sorted(rows, key=repr)
+
+
+def _assert_query_matches_baseline(
+    layer: SemanticLayer,
+    sql: str,
+    baseline_sql: str,
+    ordered: bool = False,
+):
+    explanation = layer.explain_sql(sql)
+    optimized_result = layer.sql(sql)
+    optimized_columns = fetch_columns(optimized_result)
+    optimized_rows = fetch_rows(optimized_result)
+    baseline_result = layer.conn.execute(baseline_sql)
+    baseline_columns = fetch_columns(baseline_result)
+    baseline_rows = fetch_rows(baseline_result)
+
+    assert optimized_columns == baseline_columns
+    if ordered:
+        assert optimized_rows == baseline_rows
+    else:
+        assert _sorted_rows(optimized_rows) == _sorted_rows(baseline_rows)
+
+    return explanation
+
+
 def test_explain_direct_semantic_query_is_machine_testable(semantic_layer):
     rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
 
@@ -118,6 +157,7 @@ def test_explain_lists_deterministic_candidate_plans(semantic_layer):
         "direct_semantic",
         "semantic_plus_postprocess",
         "single_model_preaggregation",
+        "join_key_preaggregation",
         "fanout_preaggregation",
         "window_metric",
         "passthrough_plain_sql",
@@ -179,25 +219,570 @@ def test_safe_outer_filter_pushdown_from_cte_wrapper(semantic_layer):
     assert _rows(semantic_layer.sql(wrapped_sql)) == _rows(semantic_layer.sql(direct_sql))
 
 
-def test_explain_cte_semantic_query_rejects_metric_filter_pushdown(semantic_layer):
+def test_positive_wrapper_rewrites_match_unoptimized_baselines(semantic_layer):
+    orders_revenue_status = _compiled_semantic_sql(
+        semantic_layer,
+        "SELECT orders.revenue, orders.status FROM orders",
+    )
+    orders_revenue_region = _compiled_semantic_sql(
+        semantic_layer,
+        "SELECT orders.revenue, customers.region FROM orders",
+    )
+
+    cases = [
+        {
+            "sql": "SELECT * FROM (SELECT orders.revenue, customers.region FROM orders) sq WHERE region = 'US'",
+            "baseline": "SELECT * FROM " + _subquery(orders_revenue_region) + " sq WHERE region = 'US'",
+            "ordered": False,
+            "rule": "safe_filter_pushdown",
+        },
+        {
+            "sql": """
+                WITH orders_agg AS (
+                    SELECT orders.revenue, orders.status FROM orders
+                )
+                SELECT * FROM orders_agg WHERE status = 'completed'
+            """,
+            "baseline": "WITH orders_agg AS "
+            + _subquery(orders_revenue_status)
+            + " SELECT * FROM orders_agg WHERE status = 'completed'",
+            "ordered": False,
+            "rule": "safe_filter_pushdown",
+        },
+        {
+            "sql": """
+                SELECT *
+                FROM (SELECT orders.revenue, orders.status FROM orders) sq
+                ORDER BY status DESC
+                LIMIT 1
+                OFFSET 1
+            """,
+            "baseline": "SELECT * FROM "
+            + _subquery(orders_revenue_status)
+            + " sq ORDER BY status DESC LIMIT 1 OFFSET 1",
+            "ordered": True,
+            "rule": "safe_order_pushdown",
+        },
+        {
+            "sql": """
+                SELECT status, revenue AS total_revenue
+                FROM (SELECT orders.revenue, orders.status FROM orders) sq
+                ORDER BY status
+            """,
+            "baseline": "SELECT status, revenue AS total_revenue FROM "
+            + _subquery(orders_revenue_status)
+            + " sq ORDER BY status",
+            "ordered": True,
+            "rule": "wrapper_projection_flattening",
+        },
+    ]
+
+    for case in cases:
+        explanation = _assert_query_matches_baseline(
+            semantic_layer,
+            case["sql"],
+            case["baseline"],
+            ordered=case["ordered"],
+        )
+        assert case["rule"] in explanation.applied_rules
+        assert explanation.post_process is None
+
+
+def test_external_bi_wrapper_corpus_positive_cases(semantic_layer):
+    orders_revenue_status_aliases = _compiled_semantic_sql(
+        semantic_layer,
+        'SELECT orders.revenue AS "Total Revenue", orders.status AS "Order Status" FROM orders',
+    )
+    orders_revenue_status = _compiled_semantic_sql(
+        semantic_layer,
+        "SELECT orders.revenue, orders.status FROM orders",
+    )
+    from_metrics = _compiled_semantic_sql(
+        semantic_layer,
+        "SELECT orders.revenue, customers.region FROM metrics",
+    )
+
+    cases = [
+        {
+            "name": "tableau_custom_sql",
+            "sql": """
+                SELECT "Order Status" AS status, "Total Revenue" AS total_revenue
+                FROM (
+                    SELECT orders.revenue AS "Total Revenue", orders.status AS "Order Status" FROM orders
+                ) "Custom SQL Query"
+                WHERE "Order Status" = 'completed'
+                ORDER BY "Total Revenue" DESC
+            """,
+            "baseline": 'SELECT "Order Status" AS status, "Total Revenue" AS total_revenue FROM '
+            + _subquery(orders_revenue_status_aliases)
+            + ' "Custom SQL Query" WHERE "Order Status" = \'completed\' ORDER BY "Total Revenue" DESC',
+            "ordered": True,
+        },
+        {
+            "name": "power_query_native_query",
+            "sql": """
+                SELECT "_"."status", "_"."revenue"
+                FROM (SELECT orders.revenue, orders.status FROM orders) AS "_"
+                WHERE "_"."status" = 'completed'
+            """,
+            "baseline": 'SELECT "_"."status", "_"."revenue" FROM '
+            + _subquery(orders_revenue_status)
+            + ' AS "_" WHERE "_"."status" = \'completed\'',
+            "ordered": False,
+        },
+        {
+            "name": "superset_virtual_dataset",
+            "sql": """
+                SELECT status, revenue
+                FROM (SELECT orders.revenue, orders.status FROM orders) AS virtual_table
+                WHERE status = 'completed'
+            """,
+            "baseline": "SELECT status, revenue FROM "
+            + _subquery(orders_revenue_status)
+            + " AS virtual_table WHERE status = 'completed'",
+            "ordered": False,
+        },
+        {
+            "name": "metabase_saved_question_cte",
+            "sql": """
+                WITH question_42 AS (
+                    SELECT orders.revenue, orders.status FROM orders
+                )
+                SELECT status, revenue FROM question_42 WHERE status = 'completed'
+            """,
+            "baseline": "WITH question_42 AS "
+            + _subquery(orders_revenue_status)
+            + " SELECT status, revenue FROM question_42 WHERE status = 'completed'",
+            "ordered": False,
+        },
+        {
+            "name": "from_metrics_wrapper",
+            "sql": """
+                SELECT region AS market, revenue AS total_revenue
+                FROM (SELECT orders.revenue, customers.region FROM metrics) metric_source
+                WHERE region = 'US'
+                ORDER BY total_revenue DESC
+            """,
+            "baseline": "SELECT region AS market, revenue AS total_revenue FROM "
+            + _subquery(from_metrics)
+            + " metric_source WHERE region = 'US' ORDER BY total_revenue DESC",
+            "ordered": True,
+        },
+    ]
+
+    for case in cases:
+        explanation = _assert_query_matches_baseline(
+            semantic_layer,
+            case["sql"],
+            case["baseline"],
+            ordered=case["ordered"],
+        )
+        assert explanation.chosen_plan in {"direct_semantic", "fanout_preaggregation"}
+        assert explanation.post_process is None
+        assert "wrapper_flattening" in explanation.applied_rules
+
+
+def test_bi_corpus_acceptance_matrix_records_expected_routes(semantic_layer):
+    cases = [
+        {
+            "name": "tableau_joined_custom_sql",
+            "sql": """
+                SELECT custom_sql.status, labels.label
+                FROM (SELECT orders.revenue, orders.status FROM orders) custom_sql
+                JOIN (SELECT 'completed' AS status, 'Closed' AS label) labels
+                  ON labels.status = custom_sql.status
+            """,
+            "baseline": "SELECT custom_sql.status, labels.label FROM "
+            + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+            + " custom_sql JOIN (SELECT 'completed' AS status, 'Closed' AS label) labels"
+            + " ON labels.status = custom_sql.status",
+            "route": "semantic_plus_postprocess",
+            "rule": "semantic_island_optimization",
+        },
+        {
+            "name": "power_query_projection_pruning",
+            "sql": """
+                SELECT "_"."status"
+                FROM (SELECT orders.revenue, orders.status FROM orders) AS "_"
+                WHERE "_"."status" = 'completed'
+            """,
+            "baseline": 'SELECT "_"."status" FROM '
+            + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+            + ' AS "_" WHERE "_"."status" = \'completed\'',
+            "route": "direct_semantic",
+            "rule": "wrapper_projection_flattening",
+        },
+        {
+            "name": "metabase_field_filter_in",
+            "sql": """
+                WITH question_42 AS (
+                    SELECT orders.revenue, orders.status FROM orders
+                )
+                SELECT status, revenue
+                FROM question_42
+                WHERE status IN ('completed', 'pending')
+            """,
+            "baseline": "WITH question_42 AS "
+            + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+            + " SELECT status, revenue FROM question_42 WHERE status IN ('completed', 'pending')",
+            "route": "direct_semantic",
+            "rule": "safe_filter_pushdown",
+        },
+        {
+            "name": "hex_chained_semantic_and_raw_branch",
+            "sql": """
+                SELECT status, revenue
+                FROM (SELECT orders.revenue, orders.status FROM orders) semantic_branch
+                UNION ALL
+                SELECT 'raw' AS status, 0 AS revenue
+            """,
+            "baseline": "SELECT status, revenue FROM "
+            + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+            + " semantic_branch UNION ALL SELECT 'raw' AS status, 0 AS revenue",
+            "route": "semantic_plus_postprocess",
+            "rule": "set_operation_branch_optimization",
+        },
+        {
+            "name": "sigma_custom_sql_workbook_filter",
+            "sql": """
+                SELECT status, revenue
+                FROM (SELECT orders.revenue, orders.status FROM orders) workbook_sql
+                WHERE status = 'completed'
+                ORDER BY revenue DESC
+            """,
+            "baseline": "SELECT status, revenue FROM "
+            + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+            + " workbook_sql WHERE status = 'completed' ORDER BY revenue DESC",
+            "route": "direct_semantic",
+            "rule": "safe_filter_pushdown",
+            "ordered": True,
+        },
+        {
+            "name": "superset_time_and_rls_filter",
+            "sql": """
+                SELECT order_date__day, status, revenue
+                FROM (
+                    SELECT orders.revenue, orders.status, orders.order_date__day FROM orders
+                ) virtual_table
+                WHERE order_date__day >= DATE '2024-01-01'
+                  AND order_date__day < DATE '2024-02-01'
+                  AND status = 'completed'
+            """,
+            "baseline": "SELECT order_date__day, status, revenue FROM "
+            + _subquery(
+                _compiled_semantic_sql(
+                    semantic_layer,
+                    "SELECT orders.revenue, orders.status, orders.order_date__day FROM orders",
+                )
+            )
+            + " virtual_table WHERE order_date__day >= DATE '2024-01-01'"
+            + " AND order_date__day < DATE '2024-02-01'"
+            + " AND status = 'completed'",
+            "route": "direct_semantic",
+            "rule": "safe_filter_pushdown",
+        },
+    ]
+
+    for case in cases:
+        explanation = _assert_query_matches_baseline(
+            semantic_layer,
+            case["sql"],
+            case["baseline"],
+            ordered=case.get("ordered", False),
+        )
+
+        assert explanation.chosen_plan == case["route"], case["name"]
+        assert case["rule"] in explanation.applied_rules, case["name"]
+
+
+@pytest.mark.parametrize(
+    ("name", "sql", "rejected_rule"),
+    [
+        (
+            "tableau_computed_projection",
+            "SELECT status || 'x' AS status_x FROM (SELECT orders.status FROM orders) sq",
+            "wrapper_flattening",
+        ),
+        (
+            "power_query_non_foldable_transform",
+            """
+                SELECT COALESCE(status, 'unknown') AS status_bucket, SUM(revenue) AS revenue
+                FROM (SELECT orders.status, orders.revenue FROM orders) sq
+                GROUP BY 1
+            """,
+            "aggregate_boundary_rollup",
+        ),
+        (
+            "power_bi_distinct_count_subtotal",
+            """
+                SELECT status, SUM(unique_customers) AS unique_customers
+                FROM (
+                    SELECT orders.unique_customers, orders.status, orders.order_date FROM orders
+                ) sq
+                GROUP BY status
+            """,
+            "aggregate_boundary_rollup",
+        ),
+        (
+            "superset_mixed_or_filter",
+            """
+                SELECT *
+                FROM (SELECT orders.revenue, orders.status FROM orders) sq
+                WHERE status = 'completed' OR revenue > 100
+            """,
+            "safe_filter_pushdown",
+        ),
+    ],
+)
+def test_bi_corpus_rejection_matrix_records_expected_reasons(semantic_layer, name, sql, rejected_rule):
+    if name == "power_bi_distinct_count_subtotal":
+        orders = semantic_layer.get_model("orders")
+        orders.metrics.append(Metric(name="unique_customers", agg="count_distinct", sql="customer_id"))
+
+    explanation = semantic_layer.explain_sql(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert rejected_rule in explanation.rejected_rules
+    assert explanation.semantic_islands or explanation.post_process is not None
+
+
+def test_external_cte_chain_corpus_flattens_linear_steps(semantic_layer):
+    sql = """
+        WITH base AS (
+            SELECT orders.revenue, orders.status FROM orders
+        ),
+        filtered AS (
+            SELECT * FROM base WHERE status = 'completed'
+        ),
+        projected AS (
+            SELECT status, revenue FROM filtered
+        )
+        SELECT status, revenue FROM projected ORDER BY revenue DESC LIMIT 1
+    """
+    baseline_sql = (
+        "WITH base AS "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+        + ", filtered AS (SELECT * FROM base WHERE status = 'completed'), "
+        + "projected AS (SELECT status, revenue FROM filtered) "
+        + "SELECT status, revenue FROM projected ORDER BY revenue DESC LIMIT 1"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.post_process is None
+    assert explanation.filters == ["orders.status = 'completed'"]
+    assert explanation.order_by == ["revenue DESC"]
+    assert explanation.limit == 1
+    assert "linear_cte_chain_flattening" in explanation.applied_rules
+    assert "safe_filter_pushdown" in explanation.applied_rules
+    assert "safe_order_pushdown" in explanation.applied_rules
+    assert "safe_limit_pushdown" in explanation.applied_rules
+    assert candidates["linear_cte_chain_flattening"].valid is True
+    assert "WITH base" not in explanation.rewritten_sql
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        """
+        WITH base AS (
+            SELECT orders.revenue, orders.status FROM orders
+        ),
+        filtered AS (
+            SELECT * FROM base
+        )
+        SELECT a.status FROM filtered a JOIN filtered b ON a.status = b.status
+        """,
+        """
+        WITH base AS (
+            SELECT orders.revenue, orders.status FROM orders
+        ),
+        projected AS (
+            SELECT status, revenue * 2 AS doubled FROM base
+        )
+        SELECT * FROM projected
+        """,
+        """
+        WITH base AS (
+            SELECT orders.revenue, orders.status FROM orders
+        ),
+        ranked AS (
+            SELECT status, revenue, ROW_NUMBER() OVER (ORDER BY revenue DESC) AS rn FROM base
+        )
+        SELECT status, revenue FROM ranked
+        """,
+        """
+        WITH base AS (
+            SELECT orders.revenue, orders.status FROM orders
+        ),
+        distinct_statuses AS (
+            SELECT DISTINCT status FROM base
+        )
+        SELECT * FROM distinct_statuses
+        """,
+        """
+        WITH base AS (
+            SELECT orders.revenue, orders.status FROM orders
+        ),
+        rolled AS (
+            SELECT status, SUM(revenue) AS revenue FROM base GROUP BY status
+        )
+        SELECT * FROM rolled
+        """,
+    ],
+)
+def test_linear_cte_chain_rejects_unsafe_steps(semantic_layer, sql):
+    explanation = semantic_layer.explain_sql(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.post_process is not None
+    assert "linear_cte_chain_flattening" in explanation.rejected_rules
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        "status IN ('completed', 'pending')",
+        "status NOT IN ('pending')",
+        "order_date BETWEEN DATE '2024-01-01' AND DATE '2024-01-02'",
+        "status IS NOT NULL",
+        "status LIKE 'comp%'",
+        "NOT (status = 'pending')",
+        "status = 'completed' OR status = 'pending'",
+        "sq.status = 'completed'",
+    ],
+)
+def test_outer_dimension_filter_pushdown_predicate_matrix(semantic_layer, predicate):
+    inner_sql = "SELECT orders.revenue, orders.status, orders.order_date FROM orders"
+    wrapped_sql = f"SELECT * FROM ({inner_sql}) sq WHERE {predicate}"
+    baseline_sql = (
+        "SELECT * FROM " + _subquery(_compiled_semantic_sql(semantic_layer, inner_sql)) + f" sq WHERE {predicate}"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert "safe_filter_pushdown" in explanation.applied_rules
+
+
+@pytest.mark.parametrize(
+    ("outer_order", "ordered"),
+    [
+        ("status ASC", True),
+        ("total_revenue DESC", True),
+        ("sq.status DESC", True),
+        ("sq.total_revenue DESC", True),
+    ],
+)
+def test_outer_order_limit_pushdown_matrix(semantic_layer, outer_order, ordered):
+    inner_sql = "SELECT orders.revenue AS total_revenue, orders.status FROM orders"
+    wrapped_sql = f"""
+        SELECT status, total_revenue
+        FROM ({inner_sql}) sq
+        ORDER BY {outer_order}
+        LIMIT 2
+    """
+    baseline_sql = (
+        "SELECT status, total_revenue FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, inner_sql))
+        + f" sq ORDER BY {outer_order} LIMIT 2"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql, ordered=ordered)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert "safe_order_pushdown" in explanation.applied_rules
+    assert "safe_limit_pushdown" in explanation.applied_rules
+
+
+def test_explain_cte_semantic_query_pushes_metric_filter_to_having(semantic_layer):
     rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
     sql = """
         WITH orders_agg AS (
             SELECT orders.revenue, orders.status FROM orders
         )
-        SELECT * FROM orders_agg WHERE revenue > 100
+        SELECT * FROM orders_agg WHERE revenue > 225
+    """
+    baseline_sql = (
+        "SELECT * FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+        + " orders_agg WHERE revenue > 225"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.dimensions == ["orders.status"]
+    assert explanation.filters == ["orders.revenue > 225"]
+    assert explanation.row_filters == []
+    assert explanation.aggregate_filters == ["orders.revenue > 225"]
+    assert len(explanation.semantic_scopes) == 1
+    assert "safe_metric_filter_having_pushdown" in explanation.applied_rules
+    assert candidates["direct_semantic"].valid is True
+    assert "HAVING" in explanation.rewritten_sql
+    assert "orders_agg" not in explanation.rewritten_sql
+    assert explanation.rewritten_sql == rewriter.rewrite(sql)
+
+
+def test_wrapper_mixed_and_filter_splits_row_and_metric_stages(semantic_layer):
+    sql = """
+        SELECT *
+        FROM (SELECT orders.revenue, orders.status FROM orders) sq
+        WHERE status = 'completed' AND revenue > 225
+    """
+    baseline_sql = (
+        "SELECT * FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+        + " sq WHERE status = 'completed' AND revenue > 225"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.row_filters == ["orders.status = 'completed'"]
+    assert explanation.aggregate_filters == ["orders.revenue > 225"]
+    assert "safe_filter_pushdown" in explanation.applied_rules
+    assert "safe_metric_filter_having_pushdown" in explanation.applied_rules
+    assert "WHERE status = 'completed'" in explanation.rewritten_sql
+    assert "HAVING" in explanation.rewritten_sql
+
+
+def test_wrapper_mixed_or_filter_stays_postprocess(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        SELECT *
+        FROM (SELECT orders.revenue, orders.status FROM orders) sq
+        WHERE status = 'completed' OR revenue > 225
     """
 
     explanation = rewriter.explain(sql)
-    candidates = _candidate_by_name(explanation)
 
     assert explanation.chosen_plan == "semantic_plus_postprocess"
-    assert explanation.metrics == ["orders.revenue"]
-    assert explanation.dimensions == ["orders.status"]
-    assert len(explanation.semantic_scopes) == 1
-    assert "metric or computed field" in explanation.rejected_rules["safe_filter_pushdown"]
-    assert candidates["semantic_plus_postprocess"].valid is True
-    assert explanation.rewritten_sql == rewriter.rewrite(sql)
+    assert explanation.post_process is not None
+    assert explanation.rejected_rules["safe_filter_pushdown"] == (
+        "safe_filter_pushdown cannot split mixed metric/dimension OR predicate"
+    )
+
+
+def test_wrapper_metric_filter_over_hidden_metric_stays_postprocess(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        SELECT status
+        FROM (SELECT orders.revenue, orders.status FROM orders) sq
+        WHERE revenue > 225
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.post_process is not None
+    assert explanation.rejected_rules["safe_filter_pushdown"] == (
+        "safe_filter_pushdown cannot move unprojected or computed field 'revenue'"
+    )
 
 
 def test_explain_multiple_semantic_ctes_reports_all_scopes(semantic_layer):
@@ -225,6 +810,200 @@ def test_explain_multiple_semantic_ctes_reports_all_scopes(semantic_layer):
     assert explanation.rewritten_sql == rewriter.rewrite(sql)
 
 
+def test_multiple_semantic_cte_islands_use_preaggregations(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    customers = semantic_layer.get_model("customers")
+    customers.pre_aggregations = [
+        PreAggregation(
+            name="by_region",
+            measures=["count"],
+            dimensions=["region"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    semantic_layer.conn.execute("""
+        CREATE TABLE customers_preagg_by_region AS
+        SELECT
+            region,
+            COUNT(*) AS count_raw
+        FROM customers
+        GROUP BY region
+    """)
+    sql = """
+        WITH
+        orders_agg AS (
+            SELECT orders.revenue, orders.status FROM orders
+        ),
+        customers_agg AS (
+            SELECT customers.count, customers.region FROM customers
+        )
+        SELECT o.status, c.region, o.revenue, c.count
+        FROM orders_agg o
+        JOIN customers_agg c ON o.status IS NOT NULL
+        ORDER BY o.status, c.region
+    """
+    baseline_sql = (
+        "WITH orders_agg AS "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status FROM orders",
+                use_preaggregations=False,
+            )
+        )
+        + ", customers_agg AS "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT customers.count, customers.region FROM customers",
+                use_preaggregations=False,
+            )
+        )
+        + " SELECT o.status, c.region, o.revenue, c.count"
+        + " FROM orders_agg o JOIN customers_agg c ON o.status IS NOT NULL"
+        + " ORDER BY o.status, c.region"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.post_process is not None
+    assert len(explanation.semantic_islands) == 2
+    assert {island["name"] for island in explanation.semantic_islands} == {"orders_agg", "customers_agg"}
+    assert {island["chosen_plan"] for island in explanation.semantic_islands} == {"single_model_preaggregation"}
+    assert "semantic_island_optimization" in explanation.applied_rules
+    assert explanation.rewritten_sql.count("orders_preagg_by_status") == 1
+    assert explanation.rewritten_sql.count("customers_preagg_by_region") == 1
+    assert "JOIN customers_agg AS c" in explanation.rewritten_sql
+
+
+def test_one_semantic_cte_island_preserves_plain_cte(semantic_layer):
+    sql = """
+        WITH
+        orders_agg AS (
+            SELECT orders.revenue, orders.status FROM orders
+        ),
+        labels AS (
+            SELECT 'completed' AS status, 'Closed' AS label
+        )
+        SELECT labels.label, orders_agg.revenue
+        FROM orders_agg
+        JOIN labels ON labels.status = orders_agg.status
+        ORDER BY labels.label
+    """
+    baseline_sql = (
+        "WITH orders_agg AS "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+        + ", labels AS (SELECT 'completed' AS status, 'Closed' AS label)"
+        + " SELECT labels.label, orders_agg.revenue"
+        + " FROM orders_agg JOIN labels ON labels.status = orders_agg.status"
+        + " ORDER BY labels.label"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert len(explanation.semantic_islands) == 1
+    assert explanation.semantic_islands[0]["name"] == "orders_agg"
+    assert "labels AS (SELECT 'completed' AS status, 'Closed' AS label)" in explanation.rewritten_sql
+
+
+def test_derived_table_semantic_island_under_outer_join_uses_preaggregation(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    sql = """
+        SELECT orders_agg.status, labels.label, orders_agg.revenue
+        FROM (
+            SELECT orders.revenue, orders.status FROM orders
+        ) orders_agg
+        JOIN (
+            SELECT 'completed' AS status, 'Closed' AS label
+            UNION ALL
+            SELECT 'pending' AS status, 'Open' AS label
+        ) labels
+          ON labels.status = orders_agg.status
+        ORDER BY orders_agg.status
+    """
+    baseline_sql = (
+        "SELECT orders_agg.status, labels.label, orders_agg.revenue FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status FROM orders",
+                use_preaggregations=False,
+            )
+        )
+        + " orders_agg JOIN "
+        + _subquery(
+            """
+            SELECT 'completed' AS status, 'Closed' AS label
+            UNION ALL
+            SELECT 'pending' AS status, 'Open' AS label
+            """
+        )
+        + " labels ON labels.status = orders_agg.status ORDER BY orders_agg.status"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert len(explanation.semantic_islands) == 1
+    assert explanation.semantic_islands[0]["source_kind"] == "subquery"
+    assert explanation.semantic_islands[0]["chosen_plan"] == "single_model_preaggregation"
+    assert "semantic_island_optimization" in explanation.applied_rules
+    assert "preaggregation_route_selection" in explanation.applied_rules
+    assert "orders_preagg_by_status" in explanation.rewritten_sql
+    assert "JOIN (SELECT 'completed' AS status, 'Closed' AS label" in explanation.rewritten_sql
+
+
+def test_semantic_island_with_outer_dependency_is_rejected(semantic_layer):
+    sql = """
+        SELECT *
+        FROM (SELECT 1 AS id) c
+        WHERE EXISTS (
+            SELECT 1
+            FROM orders
+            WHERE orders.customer_id = c.id
+        )
+    """
+
+    explanation = semantic_layer.explain_sql(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.semantic_islands == []
+    assert explanation.rejected_rules["semantic_island_optimization"] == "semantic island references outer query scope"
+
+
 def test_explain_root_semantic_query_preserves_user_cte(semantic_layer):
     rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
     sql = """
@@ -243,6 +1022,727 @@ def test_explain_root_semantic_query_preserves_user_cte(semantic_layer):
     assert explanation.filters == ["orders.status IN (SELECT status FROM statuses)"]
     assert "WITH statuses AS" in explanation.rewritten_sql
     assert explanation.rewritten_sql == rewriter.rewrite(sql)
+
+
+@pytest.mark.parametrize(
+    ("sql", "reason"),
+    [
+        ("SELECT orders.revenue FROM orders GROUP BY orders.status", "GROUP BY"),
+    ],
+)
+def test_root_semantic_query_rejects_unsupported_aggregate_clauses(semantic_layer, sql, reason):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    with pytest.raises(ValueError, match=reason):
+        rewriter.explain(sql)
+
+    with pytest.raises(ValueError, match=reason):
+        rewriter.rewrite(sql)
+
+
+def test_root_semantic_query_allows_redundant_group_by_dimensions(semantic_layer):
+    sql = """
+        SELECT orders.revenue, orders.status
+        FROM orders
+        GROUP BY orders.status
+    """
+    direct_sql = "SELECT orders.revenue, orders.status FROM orders"
+
+    explanation = semantic_layer.explain_sql(sql)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.dimensions == ["orders.status"]
+    assert _sorted_rows(_rows(semantic_layer.sql(sql))) == _sorted_rows(_rows(semantic_layer.sql(direct_sql)))
+
+
+def test_root_semantic_query_preserves_having_metric_filter(semantic_layer):
+    sql = """
+        SELECT orders.revenue, orders.status
+        FROM orders
+        HAVING orders.revenue > 225
+    """
+
+    explanation = semantic_layer.explain_sql(sql)
+    rows = _rows(semantic_layer.sql(sql))
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.filters == ["orders.revenue > 225"]
+    assert "HAVING" in explanation.rewritten_sql
+    assert "revenue > 225" in explanation.rewritten_sql
+    assert rows == [{"status": "completed", "revenue": 250.0}]
+
+
+def test_root_unqualified_dimension_filter_is_qualified_for_pushdown(semantic_layer):
+    qualified_sql = """
+        SELECT orders.revenue, orders.status
+        FROM orders
+        WHERE orders.status = 'completed'
+    """
+    unqualified_sql = """
+        SELECT revenue, status
+        FROM orders
+        WHERE status = 'completed'
+    """
+
+    explanation = semantic_layer.explain_sql(unqualified_sql)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.filters == ["orders.status = 'completed'"]
+    assert explanation.row_filters == ["orders.status = 'completed'"]
+    assert explanation.aggregate_filters == []
+    assert "WHERE status = 'completed'" in explanation.rewritten_sql
+    assert _rows(semantic_layer.sql(unqualified_sql)) == _rows(semantic_layer.sql(qualified_sql))
+
+
+def test_aggregate_boundary_sum_rollup_drops_finer_dimension(semantic_layer):
+    wrapped_sql = """
+        SELECT status, SUM(revenue) AS revenue
+        FROM (
+            SELECT orders.revenue, orders.status, orders.order_date FROM orders
+        ) sq
+        GROUP BY status
+        ORDER BY status
+    """
+    baseline_sql = (
+        "SELECT status, SUM(revenue) AS revenue FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status, orders.order_date FROM orders",
+            )
+        )
+        + " sq GROUP BY status ORDER BY status"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.dimensions == ["orders.status"]
+    assert explanation.aliases == {"orders.revenue": "revenue"}
+    assert "aggregate_boundary_rollup" in explanation.applied_rules
+    assert "additive_metric_rollup" in explanation.applied_rules
+    assert " AS sq" not in explanation.rewritten_sql
+
+
+def test_same_grain_aggregate_wrapper_flattens_without_changing_grouping(semantic_layer):
+    wrapped_sql = """
+        SELECT status, revenue
+        FROM (
+            SELECT orders.revenue, orders.status FROM orders
+        ) sq
+        GROUP BY status, revenue
+        ORDER BY status
+    """
+    baseline_sql = (
+        "SELECT status, revenue FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+        + " sq GROUP BY status, revenue ORDER BY status"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql, ordered=True)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.dimensions == ["orders.status"]
+    assert "same_grain_metric_wrapper" in explanation.applied_rules
+    assert candidates["same_grain_metric_wrapper"].valid is True
+    assert " AS sq" not in explanation.rewritten_sql
+
+
+def test_same_grain_aggregate_wrapper_rejects_computed_projection(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        SELECT status, revenue * 2 AS doubled_revenue
+        FROM (
+            SELECT orders.revenue, orders.status FROM orders
+        ) sq
+        GROUP BY status, revenue
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.rejected_rules["same_grain_metric_wrapper"] == "outer_projection_computes_expression"
+
+
+def test_aggregate_boundary_sum_rollup_uses_preaggregation(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    wrapped_sql = """
+        SELECT status, SUM(revenue) AS revenue
+        FROM (
+            SELECT orders.revenue, orders.status, orders.order_date__day FROM orders
+        ) sq
+        GROUP BY status
+        ORDER BY status
+    """
+    baseline_sql = (
+        "SELECT status, SUM(revenue) AS revenue FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status, orders.order_date__day FROM orders",
+                use_preaggregations=False,
+            )
+        )
+        + " sq GROUP BY status ORDER BY status"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql, ordered=True)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "single_model_preaggregation"
+    assert candidates["aggregate_boundary_rollup"].valid is True
+    assert "aggregate_boundary_rollup" in explanation.applied_rules
+    assert "preaggregation_route_selection" in explanation.applied_rules
+    assert "orders_preagg_by_status" in explanation.rewritten_sql
+
+
+def test_aggregate_boundary_count_metric_rollup(semantic_layer):
+    wrapped_sql = """
+        SELECT status, SUM(count) AS count
+        FROM (
+            SELECT orders.count, orders.status, orders.order_date FROM orders
+        ) sq
+        GROUP BY status
+        ORDER BY status
+    """
+    baseline_sql = (
+        "SELECT status, SUM(count) AS count FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.count, orders.status, orders.order_date FROM orders",
+            )
+        )
+        + " sq GROUP BY status ORDER BY status"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.metrics == ["orders.count"]
+    assert explanation.dimensions == ["orders.status"]
+    assert "aggregate_boundary_rollup" in explanation.applied_rules
+    assert "count_metric_rollup" in explanation.applied_rules
+
+
+def test_aggregate_boundary_min_max_metric_rollup(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.metrics.extend(
+        [
+            Metric(name="min_amount", agg="min", sql="amount"),
+            Metric(name="max_amount", agg="max", sql="amount"),
+        ]
+    )
+    min_sql = """
+        SELECT status, MIN(min_amount) AS min_amount
+        FROM (
+            SELECT orders.min_amount, orders.status, orders.order_date FROM orders
+        ) sq
+        GROUP BY status
+        ORDER BY status
+    """
+    max_sql = """
+        SELECT status, MAX(max_amount) AS max_amount
+        FROM (
+            SELECT orders.max_amount, orders.status, orders.order_date FROM orders
+        ) sq
+        GROUP BY status
+        ORDER BY status
+    """
+    min_baseline = (
+        "SELECT status, MIN(min_amount) AS min_amount FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.min_amount, orders.status, orders.order_date FROM orders",
+            )
+        )
+        + " sq GROUP BY status ORDER BY status"
+    )
+    max_baseline = (
+        "SELECT status, MAX(max_amount) AS max_amount FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.max_amount, orders.status, orders.order_date FROM orders",
+            )
+        )
+        + " sq GROUP BY status ORDER BY status"
+    )
+
+    min_explanation = _assert_query_matches_baseline(semantic_layer, min_sql, min_baseline, ordered=True)
+    max_explanation = _assert_query_matches_baseline(semantic_layer, max_sql, max_baseline, ordered=True)
+
+    assert "aggregate_boundary_rollup" in min_explanation.applied_rules
+    assert "min_metric_rollup" in min_explanation.applied_rules
+    assert "aggregate_boundary_rollup" in max_explanation.applied_rules
+    assert "max_metric_rollup" in max_explanation.applied_rules
+
+
+def test_aggregate_boundary_rejects_mismatched_min_rollup(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.metrics.append(Metric(name="min_amount", agg="min", sql="amount"))
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        SELECT status, SUM(min_amount) AS min_amount
+        FROM (
+            SELECT orders.min_amount, orders.status, orders.order_date FROM orders
+        ) sq
+        GROUP BY status
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.rejected_rules["aggregate_boundary_rollup"] == "outer_aggregate_not_rollup_safe"
+
+
+def test_aggregate_boundary_scalar_sum_rollup(semantic_layer):
+    wrapped_sql = """
+        SELECT SUM(revenue) AS total_revenue
+        FROM (
+            SELECT orders.revenue, orders.status FROM orders
+        ) sq
+    """
+    baseline_sql = (
+        "SELECT SUM(revenue) AS total_revenue FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+        + " sq"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.dimensions == []
+    assert explanation.aliases == {"orders.revenue": "total_revenue"}
+    assert "aggregate_boundary_rollup" in explanation.applied_rules
+
+
+def test_additive_total_union_uses_branch_preaggregations(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    sql = """
+        SELECT status, revenue
+        FROM (SELECT orders.revenue, orders.status FROM orders) detail
+        UNION ALL
+        SELECT NULL AS status, SUM(revenue) AS revenue
+        FROM (SELECT orders.revenue, orders.status FROM orders) detail_total
+        ORDER BY status
+    """
+    baseline_sql = (
+        "SELECT status, revenue FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status FROM orders",
+                use_preaggregations=False,
+            )
+        )
+        + " detail UNION ALL SELECT NULL AS status, SUM(revenue) AS revenue FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status FROM orders",
+                use_preaggregations=False,
+            )
+        )
+        + " detail_total ORDER BY status"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert "set_operation_branch_optimization" in explanation.applied_rules
+    assert "semantic_island_optimization" in explanation.applied_rules
+    assert "preaggregation_route_selection" in explanation.applied_rules
+    assert explanation.rewritten_sql.count("orders_preagg_by_status") == 2
+    assert "UNION ALL SELECT NULL AS status, SUM(revenue) AS revenue" in explanation.rewritten_sql
+
+
+def test_grouping_sets_subtotal_preserves_outer_shape_and_uses_preaggregation(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    sql = """
+        SELECT status, SUM(revenue) AS revenue
+        FROM (SELECT orders.revenue, orders.status FROM orders) sq
+        GROUP BY GROUPING SETS ((status), ())
+        ORDER BY status
+    """
+    baseline_sql = (
+        "SELECT status, SUM(revenue) AS revenue FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status FROM orders",
+                use_preaggregations=False,
+            )
+        )
+        + " sq GROUP BY GROUPING SETS ((status), ()) ORDER BY status"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert "semantic_island_optimization" in explanation.applied_rules
+    assert "preaggregation_route_selection" in explanation.applied_rules
+    assert "GROUP BY GROUPING SETS ((status), ())" in explanation.rewritten_sql
+    assert "orders_preagg_by_status" in explanation.rewritten_sql
+
+
+def test_aggregate_boundary_rejects_non_additive_subtotals(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.metrics.append(Metric(name="median_amount", agg="median", sql="amount"))
+    ratio_sql = """
+        SELECT status, SUM(revenue) / SUM(count) AS revenue_per_order
+        FROM (
+            SELECT orders.revenue, orders.count, orders.status, orders.order_date FROM orders
+        ) sq
+        GROUP BY status
+    """
+    median_sql = """
+        SELECT status, MEDIAN(median_amount) AS median_amount
+        FROM (
+            SELECT orders.median_amount, orders.status, orders.order_date FROM orders
+        ) sq
+        GROUP BY status
+    """
+
+    ratio_explanation = semantic_layer.explain_sql(ratio_sql)
+    median_explanation = semantic_layer.explain_sql(median_sql)
+
+    assert ratio_explanation.chosen_plan == "semantic_plus_postprocess"
+    assert ratio_explanation.rejected_rules["aggregate_boundary_rollup"] == "outer_projection_computes_expression"
+    assert median_explanation.chosen_plan == "semantic_plus_postprocess"
+    assert median_explanation.rejected_rules["aggregate_boundary_rollup"] == "outer_projection_computes_expression"
+
+
+def test_aggregate_boundary_time_grain_rollup_day_to_month(semantic_layer):
+    wrapped_sql = """
+        SELECT DATE_TRUNC('month', order_date__day) AS order_month, SUM(revenue) AS revenue
+        FROM (
+            SELECT orders.order_date__day, orders.revenue FROM orders
+        ) sq
+        GROUP BY 1
+        ORDER BY order_month
+    """
+    baseline_sql = (
+        "SELECT DATE_TRUNC('month', order_date__day) AS order_month, SUM(revenue) AS revenue FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.order_date__day, orders.revenue FROM orders"))
+        + " sq GROUP BY 1 ORDER BY order_month"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.metrics == ["orders.revenue"]
+    assert explanation.dimensions == ["orders.order_date__month"]
+    assert explanation.aliases == {
+        "orders.order_date__month": "order_month",
+        "orders.revenue": "revenue",
+    }
+    assert "aggregate_boundary_rollup" in explanation.applied_rules
+    assert "time_grain_rollup" in explanation.applied_rules
+    assert "DATE_TRUNC('MONTH', order_date) AS order_date__month" in explanation.rewritten_sql
+
+
+def test_aggregate_boundary_time_grain_rollup_uses_daily_preaggregation(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="daily_revenue",
+            measures=["revenue"],
+            time_dimension="order_date",
+            granularity="day",
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_daily_revenue AS
+        SELECT
+            DATE_TRUNC('day', order_date) AS order_date_day,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY 1
+    """)
+    wrapped_sql = """
+        SELECT DATE_TRUNC('month', order_date__day) AS order_month, SUM(revenue) AS revenue
+        FROM (
+            SELECT orders.order_date__day, orders.revenue FROM orders
+        ) sq
+        GROUP BY 1
+        ORDER BY order_month
+    """
+    baseline_sql = (
+        "SELECT DATE_TRUNC('month', order_date__day) AS order_month, SUM(revenue) AS revenue FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.order_date__day, orders.revenue FROM orders",
+                use_preaggregations=False,
+            )
+        )
+        + " sq GROUP BY 1 ORDER BY order_month"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "single_model_preaggregation"
+    assert "aggregate_boundary_rollup" in explanation.applied_rules
+    assert "time_grain_rollup" in explanation.applied_rules
+    assert "preaggregation_route_selection" in explanation.applied_rules
+    assert "orders_preagg_daily_revenue" in explanation.rewritten_sql
+    assert "DATE_TRUNC('MONTH', order_date_day)" in explanation.rewritten_sql
+
+
+def test_aggregate_boundary_time_grain_rollup_rejects_week_to_month(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        SELECT DATE_TRUNC('month', order_date__week) AS order_month, SUM(revenue) AS revenue
+        FROM (
+            SELECT orders.order_date__week, orders.revenue FROM orders
+        ) sq
+        GROUP BY 1
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.rejected_rules["aggregate_boundary_rollup"] == "time_grain_rollup_not_safe"
+
+
+@pytest.mark.parametrize(
+    ("sql", "reason"),
+    [
+        (
+            """
+            SELECT COALESCE(status, 'unknown') AS status_bucket, SUM(revenue) AS revenue
+            FROM (
+                SELECT orders.status, orders.revenue FROM orders
+            ) sq
+            GROUP BY 1
+            """,
+            "outer_group_expression_not_supported",
+        ),
+        (
+            """
+            SELECT CURRENT_DATE AS today, SUM(revenue) AS revenue
+            FROM (
+                SELECT orders.status, orders.revenue FROM orders
+            ) sq
+            GROUP BY 1
+            """,
+            "outer_group_expression_not_supported",
+        ),
+    ],
+)
+def test_aggregate_boundary_time_grain_rollup_rejects_unsafe_dimension_expressions(semantic_layer, sql, reason):
+    explanation = semantic_layer.explain_sql(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.rejected_rules["aggregate_boundary_rollup"] == reason
+    assert "semantic_island_optimization" in explanation.applied_rules
+
+
+def test_conditional_aggregate_pivot_uses_inner_preaggregation(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    sql = """
+        SELECT
+            SUM(CASE WHEN status = 'completed' THEN revenue ELSE 0 END) AS completed_revenue,
+            SUM(CASE WHEN status = 'pending' THEN revenue ELSE 0 END) AS pending_revenue
+        FROM (
+            SELECT orders.revenue, orders.status FROM orders
+        ) sq
+    """
+    baseline_sql = (
+        "SELECT "
+        + "SUM(CASE WHEN status = 'completed' THEN revenue ELSE 0 END) AS completed_revenue, "
+        + "SUM(CASE WHEN status = 'pending' THEN revenue ELSE 0 END) AS pending_revenue FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status FROM orders",
+                use_preaggregations=False,
+            )
+        )
+        + " sq"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert len(explanation.semantic_islands) == 1
+    assert explanation.semantic_islands[0]["chosen_plan"] == "single_model_preaggregation"
+    assert "conditional_aggregate_wrapper" in explanation.applied_rules
+    assert "orders_preagg_by_status" in explanation.rewritten_sql
+    assert "completed_revenue" in explanation.rewritten_sql
+
+
+def test_conditional_aggregate_pivot_rejects_count_distinct_metric(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.metrics.append(Metric(name="unique_customers", agg="count_distinct", sql="customer_id"))
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        SELECT
+            SUM(CASE WHEN status = 'completed' THEN unique_customers ELSE 0 END) AS completed_customers
+        FROM (
+            SELECT orders.unique_customers, orders.status FROM orders
+        ) sq
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert "conditional_aggregate_wrapper" not in explanation.applied_rules
+    assert explanation.rejected_rules["conditional_aggregate_wrapper"] == (
+        "conditional aggregate metric is not additive"
+    )
+
+
+def test_conditional_aggregate_pivot_with_outer_row_filter_uses_preaggregation(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    sql = """
+        SELECT
+            SUM(CASE WHEN status = 'completed' THEN revenue ELSE 0 END) AS completed_revenue
+        FROM (
+            SELECT orders.revenue, orders.status FROM orders
+        ) sq
+        WHERE status IS NOT NULL
+    """
+    baseline_sql = (
+        "SELECT SUM(CASE WHEN status = 'completed' THEN revenue ELSE 0 END) AS completed_revenue FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status FROM orders",
+                use_preaggregations=False,
+            )
+        )
+        + " sq WHERE status IS NOT NULL"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert "conditional_aggregate_wrapper" in explanation.applied_rules
+    assert "preaggregation_route_selection" in explanation.applied_rules
+    assert "orders_preagg_by_status" in explanation.rewritten_sql
+    assert "WHERE NOT status IS NULL" in explanation.rewritten_sql
+
+
+@pytest.mark.parametrize(
+    ("sql", "reason"),
+    [
+        (
+            """
+            SELECT
+                SUM(CASE WHEN tier = 'premium' THEN revenue ELSE 0 END) AS premium_revenue
+            FROM (
+                SELECT orders.revenue, orders.status FROM orders
+            ) sq
+            """,
+            "conditional aggregate predicate references a non-dimension",
+        ),
+        (
+            """
+            SELECT
+                SUM(CASE WHEN status = 'completed' THEN revenue * 2 ELSE 0 END) AS completed_revenue
+            FROM (
+                SELECT orders.revenue, orders.status FROM orders
+            ) sq
+            """,
+            "conditional aggregate result is not a metric column",
+        ),
+    ],
+)
+def test_conditional_aggregate_pivot_rejects_unsafe_shapes(semantic_layer, sql, reason):
+    explanation = semantic_layer.explain_sql(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert "conditional_aggregate_wrapper" not in explanation.applied_rules
+    assert explanation.rejected_rules["conditional_aggregate_wrapper"] == reason
 
 
 def test_explain_fanout_preaggregation_candidate(semantic_layer):
@@ -294,6 +1794,142 @@ def test_explain_single_model_preaggregation_candidate(semantic_layer):
     assert explanation.preaggregation["reason"] == "matching_preaggregation"
     assert explanation.preaggregation["requires_enablement"] is True
     assert candidates["single_model_preaggregation"].valid is True
+
+
+@pytest.mark.parametrize(
+    ("preaggregation", "sql", "reason", "failed_check"),
+    [
+        (
+            PreAggregation(
+                name="by_status",
+                measures=["revenue"],
+                dimensions=["status"],
+            ),
+            "SELECT orders.revenue, orders.order_date FROM orders",
+            "dimension_not_in_rollup",
+            "dimensions",
+        ),
+        (
+            PreAggregation(
+                name="total_revenue",
+                measures=["revenue"],
+                dimensions=[],
+            ),
+            "SELECT orders.revenue FROM orders WHERE orders.status = 'completed'",
+            "filter_not_compatible",
+            "filters",
+        ),
+        (
+            PreAggregation(
+                name="by_status_count",
+                measures=["count"],
+                dimensions=["status"],
+            ),
+            "SELECT orders.revenue, orders.status FROM orders",
+            "metric_not_in_rollup",
+            "measures",
+        ),
+        (
+            PreAggregation(
+                name="monthly_revenue",
+                measures=["revenue"],
+                dimensions=[],
+                time_dimension="order_date",
+                granularity="month",
+            ),
+            "SELECT orders.revenue, orders.order_date__day FROM orders",
+            "time_grain_mismatch",
+            "granularity",
+        ),
+    ],
+)
+def test_explain_preaggregation_negative_eligibility_reasons(
+    semantic_layer,
+    preaggregation,
+    sql,
+    reason,
+    failed_check,
+):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [preaggregation]
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    explanation = rewriter.explain(sql)
+    candidate = explanation.preaggregation["candidates"][0]
+    failed_checks = {check["name"] for check in candidate["checks"] if not check["passed"]}
+
+    assert explanation.preaggregation["eligible"] is False
+    assert explanation.preaggregation["reason"] == reason
+    assert failed_check in failed_checks
+
+
+def test_count_distinct_exact_grain_preaggregation_candidate(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.metrics.append(Metric(name="unique_customers", agg="count_distinct", sql="customer_id"))
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="unique_customers_by_status",
+            measures=["unique_customers"],
+            dimensions=["status"],
+        )
+    ]
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    explanation = rewriter.explain("SELECT orders.unique_customers, orders.status FROM orders")
+
+    assert explanation.preaggregation["eligible"] is True
+    assert explanation.preaggregation["reason"] == "matching_preaggregation"
+
+
+def test_count_distinct_exact_grain_preaggregation_executes(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.metrics.append(Metric(name="unique_customers", agg="count_distinct", sql="customer_id"))
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="unique_customers_by_status",
+            measures=["unique_customers"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_unique_customers_by_status AS
+        SELECT
+            status,
+            COUNT(DISTINCT customer_id) AS unique_customers_raw
+        FROM orders
+        GROUP BY status
+    """)
+    sql = "SELECT orders.unique_customers, orders.status FROM orders ORDER BY orders.status"
+    baseline_sql = _compiled_semantic_sql(semantic_layer, sql, use_preaggregations=False)
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "single_model_preaggregation"
+    assert "orders_preagg_unique_customers_by_status" in explanation.rewritten_sql
+    assert "SUM(unique_customers_raw) AS unique_customers" in explanation.rewritten_sql
+
+
+def test_count_distinct_rollup_preaggregation_rejected(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.metrics.append(Metric(name="unique_customers", agg="count_distinct", sql="customer_id"))
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="unique_customers_by_status_day",
+            measures=["unique_customers"],
+            dimensions=["status", "order_date"],
+        )
+    ]
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+
+    explanation = rewriter.explain("SELECT orders.unique_customers, orders.status FROM orders")
+    measure_check = next(
+        check for check in explanation.preaggregation["candidates"][0]["checks"] if check["name"] == "measures"
+    )
+
+    assert explanation.preaggregation["eligible"] is False
+    assert explanation.preaggregation["reason"] == "count_distinct_not_rollup_safe"
+    assert "count_distinct_not_rollup_safe" in measure_check["detail"]
 
 
 def test_explain_yardstick_route(monkeypatch, semantic_layer):
@@ -479,6 +2115,125 @@ def test_wrapped_preaggregation_executes_against_materialized_table(semantic_lay
     assert preagg_rows == base_rows
 
 
+def test_root_having_metric_filter_uses_preaggregation(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    sql = """
+        SELECT orders.revenue, orders.status
+        FROM orders
+        HAVING orders.revenue > 225
+    """
+    baseline_sql = _compiled_semantic_sql(semantic_layer, sql, use_preaggregations=False)
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql)
+
+    assert explanation.chosen_plan == "single_model_preaggregation"
+    assert explanation.row_filters == []
+    assert explanation.aggregate_filters == ["orders.revenue > 225"]
+    assert explanation.preaggregation["aggregate_filters"] == ["orders.revenue > 225"]
+    assert "orders_preagg_by_status" in explanation.rewritten_sql
+    assert "HAVING SUM(revenue_raw) > 225" in explanation.rewritten_sql
+
+
+def test_wrapped_metric_filter_uses_preaggregation_having(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    wrapped_sql = """
+        SELECT *
+        FROM (SELECT orders.revenue, orders.status FROM orders) sq
+        WHERE revenue > 225
+    """
+    baseline_sql = (
+        "SELECT * FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status FROM orders",
+                use_preaggregations=False,
+            )
+        )
+        + " sq WHERE revenue > 225"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql)
+
+    assert explanation.chosen_plan == "single_model_preaggregation"
+    assert "safe_metric_filter_having_pushdown" in explanation.applied_rules
+    assert "preaggregation_route_selection" in explanation.applied_rules
+    assert explanation.aggregate_filters == ["orders.revenue > 225"]
+    assert explanation.preaggregation["aggregate_filters"] == ["orders.revenue > 225"]
+    assert "orders_preagg_by_status" in explanation.rewritten_sql
+    assert "HAVING SUM(revenue_raw) > 225" in explanation.rewritten_sql
+    assert " AS sq" not in explanation.rewritten_sql
+
+
+def test_wrapped_preaggregation_preserves_projection_alias_and_order(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    wrapped_sql = """
+        SELECT status, revenue AS total_revenue
+        FROM (SELECT orders.revenue, orders.status FROM orders) sq
+        ORDER BY total_revenue DESC
+    """
+    baseline_sql = (
+        "SELECT status, revenue AS total_revenue FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+        + " sq ORDER BY total_revenue DESC"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "single_model_preaggregation"
+    assert explanation.aliases == {"orders.revenue": "total_revenue"}
+    assert "SUM(revenue_raw) AS total_revenue" in explanation.rewritten_sql
+    assert "ORDER BY total_revenue DESC" in explanation.rewritten_sql
+
+
 def test_wrapped_fanout_strategy_selection(semantic_layer):
     rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
     wrapped_sql = "SELECT * FROM (SELECT orders.revenue, customers.count FROM orders) sq"
@@ -495,16 +2250,819 @@ def test_wrapped_fanout_strategy_selection(semantic_layer):
     assert " AS sq" not in explanation.rewritten_sql
 
 
+def test_wrapped_fanout_preserves_aliases_and_executes(semantic_layer):
+    wrapped_sql = """
+        SELECT *
+        FROM (
+            SELECT orders.revenue AS total_revenue, customers.count AS customer_count FROM orders
+        ) sq
+        ORDER BY total_revenue DESC
+    """
+    baseline_sql = (
+        "SELECT * FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue AS total_revenue, customers.count AS customer_count FROM orders",
+            )
+        )
+        + " sq ORDER BY total_revenue DESC"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "fanout_preaggregation"
+    assert explanation.aliases == {
+        "orders.revenue": "total_revenue",
+        "customers.count": "customer_count",
+    }
+    assert "orders_preagg.total_revenue AS total_revenue" in explanation.rewritten_sql
+    assert "customers_preagg.customer_count AS customer_count" in explanation.rewritten_sql
+
+
+def test_wrapped_fanout_uses_child_preaggregations(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="total_revenue",
+            measures=["revenue"],
+            dimensions=[],
+        )
+    ]
+    customers = semantic_layer.get_model("customers")
+    customers.pre_aggregations = [
+        PreAggregation(
+            name="total_count",
+            measures=["count"],
+            dimensions=[],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_total_revenue AS
+        SELECT SUM(amount) AS revenue_raw
+        FROM orders
+    """)
+    semantic_layer.conn.execute("""
+        CREATE TABLE customers_preagg_total_count AS
+        SELECT COUNT(*) AS count_raw
+        FROM customers
+    """)
+    wrapped_sql = """
+        SELECT *
+        FROM (
+            SELECT orders.revenue AS total_revenue, customers.count AS customer_count FROM orders
+        ) sq
+    """
+    baseline_sql = (
+        "SELECT * FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue AS total_revenue, customers.count AS customer_count FROM orders",
+                use_preaggregations=False,
+            )
+        )
+        + " sq"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql)
+
+    assert explanation.chosen_plan == "fanout_preaggregation"
+    assert "orders_preagg_total_revenue" in explanation.rewritten_sql
+    assert "customers_preagg_total_count" in explanation.rewritten_sql
+    assert "fanout_strategy_selection" in explanation.applied_rules
+
+
+def test_fanout_join_key_preaggregation_rolls_orders_to_customer_region(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_customer",
+            measures=["revenue"],
+            dimensions=["customer_id"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_customer AS
+        SELECT
+            customer_id,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY customer_id
+    """)
+    sql = """
+        SELECT orders.revenue, customers.region
+        FROM orders
+        ORDER BY customers.region
+    """
+    baseline_sql = _compiled_semantic_sql(semantic_layer, sql, use_preaggregations=False)
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "join_key_preaggregation"
+    assert "join_key_preaggregation_route_selection" in explanation.applied_rules
+    assert candidates["join_key_preaggregation"].valid is True
+    assert candidates["join_key_preaggregation"].details["preaggregation"] == "by_customer"
+    assert candidates["join_key_preaggregation"].details["preaggregation_dimensions"] == ["customer_id"]
+    assert candidates["join_key_preaggregation"].details["join_keys"][0]["relationship"] == "many_to_one"
+    assert "orders_preagg_by_customer" in explanation.rewritten_sql
+    assert "LEFT JOIN customers AS customers" in explanation.rewritten_sql
+    assert "FROM orders\n" not in explanation.rewritten_sql
+
+
+def test_fanout_join_key_preaggregation_rejects_missing_join_key_rollup(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    sql = "SELECT orders.revenue, customers.region FROM orders"
+
+    explanation = semantic_layer.explain_sql(sql)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert candidates["join_key_preaggregation"].valid is False
+    assert candidates["join_key_preaggregation"].reason == "missing_join_key_preaggregation"
+
+
+def test_fanout_join_key_preaggregation_rejects_one_to_many_remote_dimension(semantic_layer):
+    customers = semantic_layer.get_model("customers")
+    customers.pre_aggregations = [
+        PreAggregation(
+            name="by_customer",
+            measures=["count"],
+            dimensions=["id"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    sql = "SELECT customers.count, orders.status FROM customers"
+
+    explanation = semantic_layer.explain_sql(sql)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert candidates["join_key_preaggregation"].valid is False
+    assert candidates["join_key_preaggregation"].reason == "remote_dimension_not_many_to_one"
+
+
+def test_wrapped_window_metric_executes_against_baseline(semantic_layer):
+    semantic_layer.add_metric(
+        Metric(
+            name="running_total_revenue",
+            type="cumulative",
+            sql="orders.revenue",
+        )
+    )
+    wrapped_sql = """
+        SELECT *
+        FROM (SELECT running_total_revenue, orders.order_date FROM metrics) sq
+        ORDER BY order_date
+    """
+    baseline_sql = (
+        "SELECT * FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT running_total_revenue, orders.order_date FROM metrics",
+            )
+        )
+        + " sq ORDER BY order_date"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "window_metric"
+    assert "safe_order_pushdown" in explanation.applied_rules
+
+
+def test_wrapped_window_metric_uses_inner_preaggregation(semantic_layer):
+    semantic_layer.add_metric(
+        Metric(
+            name="running_total_revenue",
+            type="cumulative",
+            sql="orders.revenue",
+        )
+    )
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="daily_revenue",
+            measures=["revenue"],
+            time_dimension="order_date",
+            granularity="day",
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_daily_revenue AS
+        SELECT
+            DATE_TRUNC('day', order_date) AS order_date_day,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY 1
+    """)
+    wrapped_sql = """
+        SELECT *
+        FROM (SELECT running_total_revenue, orders.order_date__day FROM metrics) sq
+        ORDER BY order_date__day
+    """
+    baseline_sql = (
+        "SELECT * FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT running_total_revenue, orders.order_date__day FROM metrics",
+                use_preaggregations=False,
+            )
+        )
+        + " sq ORDER BY order_date__day"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, wrapped_sql, baseline_sql, ordered=True)
+    window_candidate = _candidate_by_name(explanation)["window_metric"]
+
+    assert explanation.chosen_plan == "window_metric"
+    assert window_candidate.details["inner_preaggregation"]["eligible"] is True
+    assert window_candidate.details["inner_preaggregation"]["reason"] == "matching_preaggregation"
+    assert window_candidate.details["inner_preaggregation"]["metrics"] == ["orders.revenue"]
+    assert "orders_preagg_daily_revenue" in explanation.rewritten_sql
+    assert "used_preagg=true" in explanation.rewritten_sql
+    assert "safe_order_pushdown" in explanation.applied_rules
+
+
+def test_wrapper_window_metric_filter_stays_postprocess(semantic_layer):
+    semantic_layer.add_metric(
+        Metric(
+            name="running_total_revenue",
+            type="cumulative",
+            sql="orders.revenue",
+        )
+    )
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        SELECT *
+        FROM (SELECT running_total_revenue, orders.order_date FROM metrics) sq
+        WHERE running_total_revenue > 100
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.post_process is not None
+    assert explanation.rejected_rules["safe_filter_pushdown"] == (
+        "safe_filter_pushdown cannot move window metric filter 'running_total_revenue'"
+    )
+
+
+def test_dimension_only_distinct_wrapper_flattens(semantic_layer):
+    sql = """
+        SELECT DISTINCT status
+        FROM (SELECT orders.status FROM orders) sq
+        ORDER BY status
+    """
+    baseline_sql = (
+        "SELECT DISTINCT status FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.status FROM orders"))
+        + " sq ORDER BY status"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.metrics == []
+    assert explanation.dimensions == ["orders.status"]
+    assert "dimension_distinct_wrapper" in explanation.applied_rules
+    assert candidates["dimension_distinct_wrapper"].valid is True
+    assert "DISTINCT" not in explanation.rewritten_sql
+    assert " AS sq" not in explanation.rewritten_sql
+
+
+def test_dimension_distinct_slicer_preserves_null_filter_order_and_limit(semantic_layer):
+    sql = """
+        SELECT DISTINCT status
+        FROM (SELECT orders.status FROM orders) sq
+        WHERE status IS NOT NULL
+        ORDER BY status
+        LIMIT 1000
+    """
+    baseline_sql = (
+        "SELECT DISTINCT status FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.status FROM orders"))
+        + " sq WHERE status IS NOT NULL ORDER BY status LIMIT 1000"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.filters == ["NOT orders.status IS NULL"]
+    assert explanation.limit == 1000
+    assert "dimension_distinct_wrapper" in explanation.applied_rules
+    assert "safe_filter_pushdown" in explanation.applied_rules
+    assert "safe_order_pushdown" in explanation.applied_rules
+    assert "safe_limit_pushdown" in explanation.applied_rules
+    assert "DISTINCT" not in explanation.rewritten_sql
+    assert "FROM (" not in explanation.rewritten_sql
+
+
+def test_dimension_distinct_slicer_supports_lower_like_search(semantic_layer):
+    sql = """
+        SELECT DISTINCT status
+        FROM (SELECT orders.status FROM orders) sq
+        WHERE LOWER(status) LIKE 'comp%'
+        ORDER BY status
+    """
+    baseline_sql = (
+        "SELECT DISTINCT status FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.status FROM orders"))
+        + " sq WHERE LOWER(status) LIKE 'comp%' ORDER BY status"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.filters == ["LOWER(orders.status) LIKE 'comp%'"]
+    assert "dimension_distinct_wrapper" in explanation.applied_rules
+    assert "safe_filter_pushdown" in explanation.applied_rules
+    assert "LOWER(status) LIKE 'comp%'" in explanation.rewritten_sql
+
+
+def test_dimension_distinct_remote_dimension_probe_flattens(semantic_layer):
+    sql = """
+        SELECT DISTINCT region
+        FROM (SELECT customers.region FROM orders) sq
+        WHERE region IN ('US', 'EU')
+        ORDER BY region
+        LIMIT 10
+    """
+    baseline_sql = (
+        "SELECT DISTINCT region FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT customers.region FROM orders"))
+        + " sq WHERE region IN ('US', 'EU') ORDER BY region LIMIT 10"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.dimensions == ["customers.region"]
+    assert "dimension_distinct_wrapper" in explanation.applied_rules
+    assert "FROM customers" in explanation.rewritten_sql
+    assert "DISTINCT" not in explanation.rewritten_sql
+
+
+def test_dimension_distinct_wrapper_rejects_metrics(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        SELECT DISTINCT status
+        FROM (SELECT orders.revenue, orders.status FROM orders) sq
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.rejected_rules["dimension_distinct_wrapper"] == "inner semantic query projects metrics"
+
+
+def test_dimension_distinct_wrapper_rejects_computed_projection(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        SELECT DISTINCT SUBSTR(status, 1, 1) AS status_prefix
+        FROM (SELECT orders.status FROM orders) sq
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.rejected_rules["dimension_distinct_wrapper"] == "outer projection computes a new expression"
+
+
+def test_dimension_distinct_wrapper_rejects_hidden_filter(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        SELECT DISTINCT status
+        FROM (SELECT orders.status FROM orders) sq
+        WHERE order_date__day >= DATE '2024-01-01'
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.rejected_rules["dimension_distinct_wrapper"] == (
+        "safe_filter_pushdown references unknown field 'order_date__day'"
+    )
+    assert explanation.rejected_rules["safe_filter_pushdown"] == (
+        "safe_filter_pushdown references unknown field 'order_date__day'"
+    )
+
+
+def test_global_row_number_topn_rewrites_to_order_limit(semantic_layer):
+    sql = """
+        SELECT status, revenue
+        FROM (
+            SELECT
+                status,
+                revenue,
+                ROW_NUMBER() OVER (ORDER BY revenue DESC) AS rn
+            FROM (SELECT orders.revenue, orders.status FROM orders) semantic_result
+        ) ranked
+        WHERE rn <= 1
+        ORDER BY revenue DESC
+    """
+    baseline_sql = (
+        "SELECT status, revenue FROM ("
+        "SELECT status, revenue, ROW_NUMBER() OVER (ORDER BY revenue DESC) AS rn FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+        + " semantic_result) ranked WHERE rn <= 1 ORDER BY revenue DESC"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.order_by == ["revenue DESC"]
+    assert explanation.limit == 1
+    assert "global_row_number_topn" in explanation.applied_rules
+    assert "safe_order_pushdown" in explanation.applied_rules
+    assert "safe_limit_pushdown" in explanation.applied_rules
+    assert candidates["global_row_number_topn"].valid is True
+    assert "ROW_NUMBER" not in explanation.rewritten_sql
+    assert "LIMIT 1" in explanation.rewritten_sql
+
+
+def test_global_row_number_between_rewrites_to_limit_offset(semantic_layer):
+    sql = """
+        SELECT status, revenue
+        FROM (
+            SELECT
+                status,
+                revenue,
+                ROW_NUMBER() OVER (ORDER BY revenue DESC) AS rn
+            FROM (SELECT orders.revenue, orders.status FROM orders) semantic_result
+        ) ranked
+        WHERE rn BETWEEN 2 AND 2
+        ORDER BY revenue DESC
+    """
+    baseline_sql = (
+        "SELECT status, revenue FROM ("
+        "SELECT status, revenue, ROW_NUMBER() OVER (ORDER BY revenue DESC) AS rn FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+        + " semantic_result) ranked WHERE rn BETWEEN 2 AND 2 ORDER BY revenue DESC"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.limit == 1
+    assert explanation.offset == 1
+    assert "global_row_number_topn" in explanation.applied_rules
+    assert "ROW_NUMBER" not in explanation.rewritten_sql
+    assert "LIMIT 1" in explanation.rewritten_sql
+    assert "OFFSET 1" in explanation.rewritten_sql
+
+
+def test_qualify_row_number_topn_rewrites_to_order_limit(semantic_layer):
+    sql = """
+        SELECT status, revenue
+        FROM (SELECT orders.revenue, orders.status FROM orders) sq
+        QUALIFY ROW_NUMBER() OVER (ORDER BY revenue DESC) <= 1
+    """
+    baseline_sql = (
+        "SELECT status, revenue FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+        + " sq QUALIFY ROW_NUMBER() OVER (ORDER BY revenue DESC) <= 1"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.limit == 1
+    assert explanation.order_by == ["revenue DESC"]
+    assert "qualify_row_number_topn" in explanation.applied_rules
+    assert candidates["qualify_row_number_topn"].valid is True
+    assert "QUALIFY" not in explanation.rewritten_sql
+    assert "ROW_NUMBER" not in explanation.rewritten_sql
+    assert "LIMIT 1" in explanation.rewritten_sql
+
+
+def test_fetch_first_topn_rewrites_through_limit_pushdown(semantic_layer):
+    sql = """
+        SELECT status, revenue
+        FROM (SELECT orders.revenue, orders.status FROM orders) sq
+        ORDER BY revenue DESC
+        FETCH FIRST 1 ROWS ONLY
+    """
+    baseline_sql = (
+        "SELECT status, revenue FROM "
+        + _subquery(_compiled_semantic_sql(semantic_layer, "SELECT orders.revenue, orders.status FROM orders"))
+        + " sq ORDER BY revenue DESC FETCH FIRST 1 ROWS ONLY"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert explanation.limit == 1
+    assert "safe_order_pushdown" in explanation.applied_rules
+    assert "safe_limit_pushdown" in explanation.applied_rules
+    assert "FETCH" not in explanation.rewritten_sql
+    assert "LIMIT 1" in explanation.rewritten_sql
+
+
+def test_sql_server_top_n_rewrites_through_limit_pushdown(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="tsql")
+    sql = """
+        SELECT TOP 1 status, revenue
+        FROM (SELECT orders.revenue, orders.status FROM orders) sq
+        ORDER BY revenue DESC
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert "safe_limit_pushdown" in explanation.applied_rules
+    assert "safe_order_pushdown" in explanation.applied_rules
+    assert "TOP 1" in explanation.rewritten_sql
+    assert " AS sq" not in explanation.rewritten_sql
+
+
+@pytest.mark.parametrize(
+    ("window_fn", "expected_reason"),
+    [
+        ("RANK", "only ROW_NUMBER is supported"),
+        ("DENSE_RANK", "only ROW_NUMBER is supported"),
+    ],
+)
+def test_global_topn_rejects_rank_tie_semantics(semantic_layer, window_fn, expected_reason):
+    sql = f"""
+        SELECT status, revenue
+        FROM (
+            SELECT status, revenue, {window_fn}() OVER (ORDER BY revenue DESC) AS rank_value
+            FROM (SELECT orders.revenue, orders.status FROM orders) semantic_result
+        ) ranked
+        WHERE rank_value <= 1
+        ORDER BY revenue DESC
+    """
+
+    explanation = semantic_layer.explain_sql(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.rejected_rules["global_row_number_topn"] == expected_reason
+    assert "semantic_island_optimization" in explanation.applied_rules
+
+
+def test_global_topn_rejects_outer_projection_of_rank_column(semantic_layer):
+    sql = """
+        SELECT status, revenue, rn
+        FROM (
+            SELECT status, revenue, ROW_NUMBER() OVER (ORDER BY revenue DESC) AS rn
+            FROM (SELECT orders.revenue, orders.status FROM orders) semantic_result
+        ) ranked
+        WHERE rn <= 1
+        ORDER BY revenue DESC
+    """
+
+    explanation = semantic_layer.explain_sql(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert (
+        explanation.rejected_rules["global_row_number_topn"] == "outer projection 'rn' is not an inner semantic field"
+    )
+    assert "semantic_island_optimization" in explanation.applied_rules
+
+
+def test_union_all_semantic_branches_use_preaggregations(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_status",
+            measures=["revenue"],
+            dimensions=["status"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_status AS
+        SELECT
+            status,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY status
+    """)
+    sql = """
+        SELECT status, revenue
+        FROM (SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'completed') completed
+        UNION ALL
+        SELECT status, revenue
+        FROM (SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'pending') pending
+    """
+    baseline_sql = (
+        "SELECT status, revenue FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'completed'",
+                use_preaggregations=False,
+            )
+        )
+        + " completed UNION ALL SELECT status, revenue FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'pending'",
+                use_preaggregations=False,
+            )
+        )
+        + " pending"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert candidates["set_operation_branch_optimization"].valid is True
+    assert len(explanation.semantic_islands) == 2
+    assert {island["chosen_plan"] for island in explanation.semantic_islands} == {"single_model_preaggregation"}
+    assert "set_operation_branch_optimization" in explanation.applied_rules
+    assert explanation.rewritten_sql.count("orders_preagg_by_status") == 2
+    assert "UNION ALL" in explanation.rewritten_sql
+
+
+def test_hex_style_union_preview_cte_preserves_outer_limit(semantic_layer):
+    sql = """
+        WITH query AS (
+            SELECT status
+            FROM (SELECT orders.status FROM orders WHERE orders.status = 'completed') completed
+            UNION ALL
+            SELECT status
+            FROM (SELECT orders.status FROM orders WHERE orders.status = 'pending') pending
+        )
+        SELECT * FROM query LIMIT 2
+    """
+    completed_status = _compiled_semantic_sql(
+        semantic_layer,
+        "SELECT orders.status FROM orders WHERE orders.status = 'completed'",
+    )
+    pending_status = _compiled_semantic_sql(
+        semantic_layer,
+        "SELECT orders.status FROM orders WHERE orders.status = 'pending'",
+    )
+    baseline_sql = (
+        "WITH query AS (SELECT status FROM "
+        + _subquery(completed_status)
+        + " completed UNION ALL SELECT status FROM "
+        + _subquery(pending_status)
+        + " pending) SELECT * FROM query LIMIT 2"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert len(explanation.semantic_islands) == 2
+    assert "set_operation_branch_optimization" in explanation.applied_rules
+    assert "SELECT * FROM query LIMIT 2" in explanation.rewritten_sql
+
+
+def test_set_operation_preserves_raw_branch(semantic_layer):
+    sql = """
+        SELECT status, revenue
+        FROM (SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'completed') completed
+        UNION ALL
+        SELECT 'manual' AS status, 0 AS revenue
+    """
+    baseline_sql = (
+        "SELECT status, revenue FROM "
+        + _subquery(
+            _compiled_semantic_sql(
+                semantic_layer,
+                "SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'completed'",
+            )
+        )
+        + " completed UNION ALL SELECT 'manual' AS status, 0 AS revenue"
+    )
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert len(explanation.semantic_islands) == 1
+    assert "SELECT 'manual' AS status, 0 AS revenue" in explanation.rewritten_sql
+
+
+def test_set_operation_mismatched_branch_projection_is_rejected(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        SELECT status
+        FROM (SELECT orders.status FROM orders) left_branch
+        UNION ALL
+        SELECT status, revenue
+        FROM (SELECT orders.revenue, orders.status FROM orders) right_branch
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "passthrough_plain_sql"
+    assert explanation.semantic_islands == []
+    assert explanation.rejected_rules["set_operation_branch_optimization"] == (
+        "set operation branch projections do not align"
+    )
+
+
+def test_set_operation_branch_order_by_is_rejected(semantic_layer):
+    sql = """
+        SELECT orders.revenue, orders.status FROM orders ORDER BY orders.status
+        UNION ALL
+        SELECT orders.revenue, orders.status FROM orders
+    """
+
+    explanation = semantic_layer.explain_sql(sql)
+
+    assert explanation.chosen_plan == "passthrough_plain_sql"
+    assert explanation.semantic_islands == []
+    assert explanation.rejected_rules["set_operation_branch_optimization"] == (
+        "branch-level ORDER BY is not safe to optimize inside a set operation"
+    )
+
+
+def test_global_row_number_topn_rejects_partitioned_rank(semantic_layer):
+    rewriter = QueryRewriter(semantic_layer.graph, dialect="duckdb")
+    sql = """
+        SELECT status, revenue
+        FROM (
+            SELECT
+                status,
+                revenue,
+                ROW_NUMBER() OVER (PARTITION BY status ORDER BY revenue DESC) AS rn
+            FROM (SELECT orders.revenue, orders.status FROM orders) semantic_result
+        ) ranked
+        WHERE rn <= 1
+    """
+
+    explanation = rewriter.explain(sql)
+
+    assert explanation.chosen_plan == "semantic_plus_postprocess"
+    assert explanation.rejected_rules["global_row_number_topn"] == "partitioned ROW_NUMBER is not global"
+
+
+def test_projection_width_reduction_omits_unused_primary_key(semantic_layer):
+    sql = "SELECT orders.revenue, orders.status FROM orders"
+
+    explanation = semantic_layer.explain_sql(sql)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert "id AS id" not in explanation.rewritten_sql
+    assert "customer_id AS customer_id" not in explanation.rewritten_sql
+    assert "status AS status" in explanation.rewritten_sql
+    assert "amount AS revenue_raw" in explanation.rewritten_sql
+
+
+def test_projection_width_reduction_keeps_join_keys_for_joined_dimensions(semantic_layer):
+    sql = "SELECT orders.revenue, customers.region FROM orders"
+
+    explanation = semantic_layer.explain_sql(sql)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert "customer_id AS customer_id" in explanation.rewritten_sql
+    assert "id AS id" in explanation.rewritten_sql
+    assert _sorted_rows(_rows(semantic_layer.sql(sql))) == _sorted_rows(
+        _rows(semantic_layer.query(metrics=["orders.revenue"], dimensions=["customers.region"]))
+    )
+
+
+def test_projection_width_reduction_keeps_count_distinct_key_state(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.metrics.append(Metric(name="unique_orders", agg="count_distinct"))
+    sql = "SELECT orders.unique_orders, orders.status FROM orders ORDER BY orders.status"
+
+    explanation = semantic_layer.explain_sql(sql)
+    rows = _rows(semantic_layer.sql(sql))
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert "id AS unique_orders_raw" in explanation.rewritten_sql
+    assert "id AS id" not in explanation.rewritten_sql
+    assert rows == [
+        {"status": "completed", "unique_orders": 2},
+        {"status": "pending", "unique_orders": 1},
+    ]
+
+
 @pytest.mark.parametrize(
     "sql",
     [
-        "SELECT * FROM (SELECT orders.revenue, orders.status FROM orders) sq WHERE revenue > 100",
         "SELECT revenue * 2 AS doubled FROM (SELECT orders.revenue, orders.status FROM orders) sq",
         "SELECT revenue, ROW_NUMBER() OVER () AS rn FROM (SELECT orders.revenue, orders.status FROM orders) sq",
-        "SELECT SUM(revenue) AS total FROM (SELECT orders.revenue, orders.status FROM orders) sq",
         "SELECT DISTINCT status FROM (SELECT orders.revenue, orders.status FROM orders) sq",
         "SELECT revenue FROM (SELECT orders.revenue, orders.status FROM orders) sq",
         "SELECT * FROM (SELECT orders.revenue, orders.status FROM orders LIMIT 1) sq WHERE status = 'completed'",
+        "SELECT * FROM (SELECT orders.revenue, orders.status FROM orders) sq ORDER BY 1",
+        "SELECT * FROM (SELECT orders.revenue, orders.status FROM orders) sq ORDER BY status || ''",
+        "SELECT * FROM (SELECT orders.revenue, orders.status FROM orders) sq ORDER BY status DESC NULLS FIRST",
         "SELECT * FROM (SELECT orders.revenue, orders.status FROM orders) sq JOIN other_table ot ON TRUE",
         """
         WITH passthrough AS (

--- a/tests/queries/test_semantic_sql_planner.py
+++ b/tests/queries/test_semantic_sql_planner.py
@@ -2373,6 +2373,42 @@ def test_fanout_join_key_preaggregation_rolls_orders_to_customer_region(semantic
     assert "FROM orders\n" not in explanation.rewritten_sql
 
 
+def test_join_key_preaggregation_reads_local_time_dimension_from_grain_column(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_customer_day",
+            measures=["revenue"],
+            dimensions=["customer_id"],
+            time_dimension="order_date",
+            granularity="day",
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_customer_day AS
+        SELECT
+            DATE_TRUNC('day', order_date) AS order_date_day,
+            customer_id,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY 1, 2
+    """)
+    sql = """
+        SELECT orders.revenue, orders.order_date__month, customers.region
+        FROM orders
+        ORDER BY orders.order_date__month, customers.region
+    """
+    baseline_sql = _compiled_semantic_sql(semantic_layer, sql, use_preaggregations=False)
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "join_key_preaggregation"
+    assert "orders_preagg_by_customer_day" in explanation.rewritten_sql
+    assert "DATE_TRUNC('MONTH', orders_rollup.order_date_day)" in explanation.rewritten_sql
+    assert "orders_rollup.order_date)" not in explanation.rewritten_sql
+
+
 def test_fanout_join_key_preaggregation_rejects_missing_join_key_rollup(semantic_layer):
     orders = semantic_layer.get_model("orders")
     orders.pre_aggregations = [

--- a/tests/queries/test_semantic_sql_planner.py
+++ b/tests/queries/test_semantic_sql_planner.py
@@ -2369,7 +2369,8 @@ def test_fanout_join_key_preaggregation_rolls_orders_to_customer_region(semantic
     assert candidates["join_key_preaggregation"].details["preaggregation_dimensions"] == ["customer_id"]
     assert candidates["join_key_preaggregation"].details["join_keys"][0]["relationship"] == "many_to_one"
     assert "orders_preagg_by_customer" in explanation.rewritten_sql
-    assert "LEFT JOIN customers AS customers" in explanation.rewritten_sql
+    assert "FROM customers AS customers" in explanation.rewritten_sql
+    assert "LEFT JOIN orders_preagg_by_customer AS orders_rollup" in explanation.rewritten_sql
     assert "FROM orders\n" not in explanation.rewritten_sql
 
 
@@ -2407,6 +2408,79 @@ def test_join_key_preaggregation_reads_local_time_dimension_from_grain_column(se
     assert "orders_preagg_by_customer_day" in explanation.rewritten_sql
     assert "DATE_TRUNC('MONTH', orders_rollup.order_date_day)" in explanation.rewritten_sql
     assert "orders_rollup.order_date)" not in explanation.rewritten_sql
+
+
+def test_join_key_preaggregation_reads_ungrained_local_time_dimension_from_grain_column(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_customer_day",
+            measures=["revenue"],
+            dimensions=["customer_id"],
+            time_dimension="order_date",
+            granularity="day",
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_customer_day AS
+        SELECT
+            DATE_TRUNC('day', order_date) AS order_date_day,
+            customer_id,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY 1, 2
+    """)
+    sql = """
+        SELECT orders.revenue, orders.order_date, customers.region
+        FROM orders
+        ORDER BY orders.order_date, customers.region
+    """
+    baseline_sql = _compiled_semantic_sql(semantic_layer, sql, use_preaggregations=False)
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "join_key_preaggregation"
+    assert "orders_preagg_by_customer_day" in explanation.rewritten_sql
+    assert "orders_rollup.order_date_day AS order_date" in explanation.rewritten_sql
+    assert "orders_rollup.order_date AS order_date" not in explanation.rewritten_sql
+
+
+def test_join_key_preaggregation_joins_remote_sql_source(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    customers = semantic_layer.get_model("customers")
+    customers.sql = "SELECT id, region, tier FROM customers WHERE tier = 'premium'"
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_customer",
+            measures=["revenue"],
+            dimensions=["customer_id"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+    semantic_layer.conn.execute("""
+        CREATE TABLE orders_preagg_by_customer AS
+        SELECT
+            customer_id,
+            SUM(amount) AS revenue_raw
+        FROM orders
+        GROUP BY customer_id
+    """)
+    sql = """
+        SELECT orders.revenue, customers.region
+        FROM orders
+        ORDER BY customers.region
+    """
+    baseline_sql = _compiled_semantic_sql(semantic_layer, sql, use_preaggregations=False)
+
+    explanation = _assert_query_matches_baseline(semantic_layer, sql, baseline_sql, ordered=True)
+
+    assert explanation.chosen_plan == "join_key_preaggregation"
+    assert "FROM (SELECT id, region, tier FROM customers WHERE tier = 'premium') AS customers" in (
+        explanation.rewritten_sql
+    )
+    assert "LEFT JOIN customers AS customers" not in explanation.rewritten_sql
+    assert "LEFT JOIN orders_preagg_by_customer AS orders_rollup" in explanation.rewritten_sql
 
 
 def test_fanout_join_key_preaggregation_rejects_missing_join_key_rollup(semantic_layer):

--- a/tests/queries/test_semantic_sql_planner_benchmark.py
+++ b/tests/queries/test_semantic_sql_planner_benchmark.py
@@ -1,0 +1,40 @@
+from scripts.benchmark_semantic_sql_planner import run_benchmarks
+
+
+def test_semantic_sql_planner_benchmark_proof_fields():
+    results = run_benchmarks(row_count=10_000, iterations=1)
+
+    assert results
+    assert {result["name"] for result in results} >= {
+        "wrapped_preaggregation",
+        "aggregate_boundary_sum_rollup_preagg",
+        "window_inner_preaggregation",
+        "fanout_child_preaggregation",
+        "linear_cte_chain_preaggregation",
+        "multi_semantic_cte_island_preaggregation",
+        "dimension_distinct_wrapper",
+        "dimension_slicer_null_search_limit",
+        "global_row_number_topn",
+        "topn_pagination_preaggregation",
+        "additive_total_union_preaggregation",
+        "virtual_dataset_time_rls_preaggregation",
+        "conditional_pivot_preaggregation",
+        "time_expression_grain_rollup_preaggregation",
+        "union_branch_semantic_islands_preaggregation",
+        "projection_width_reduction_wide_key",
+    }
+
+    for result in results:
+        assert result["rows_equal"] is True
+        assert result["chosen_plan_matches"] is not False
+        assert result["expected_rules_present"] is True
+        assert result["expected_fragments_present"] is not False
+        assert result["forbidden_fragments_absent"] is not False
+        assert isinstance(result["sql_changed"], bool)
+        assert result["baseline_ms"] >= 0
+        assert result["optimized_ms"] >= 0
+
+    performance_cases = [result for result in results if result["case_type"] == "performance"]
+    assert performance_cases
+    assert all(result["min_speedup"] is not None for result in performance_cases)
+    assert all("speedup_floor_met" in result for result in performance_cases)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,5 +1,6 @@
 """Tests for CLI command wiring."""
 
+import json
 import os
 from pathlib import Path
 
@@ -85,6 +86,27 @@ def test_query_dry_run_emits_sql(tmp_path):
     assert result.exit_code == 0
     assert "select" in result.stdout.lower()
     assert "count" in result.stdout.lower()
+
+
+def test_explain_sql_outputs_planner_json(tmp_path):
+    _write_min_model(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "explain-sql",
+            "SELECT * FROM (SELECT order_count, status FROM orders) sq WHERE status = 'completed'",
+            "--models",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["chosen_plan"] == "direct_semantic"
+    assert payload["pushed_filters"] == ["orders.status = 'completed'"]
+    assert "safe_filter_pushdown" in payload["applied_rules"]
+    assert "rewritten_sql" in payload
 
 
 def test_query_engine_rust_sets_rewriter_env(monkeypatch, tmp_path):


### PR DESCRIPTION
Implements the semantic SQL rewrite planner and optimizer coverage in this PR: explainable rewrite plans, semantic island optimization, slicer/dropdown rewrites, additive totals/subtotals, Top-N variants, Superset-style wrapper pushdown, conditional aggregate pivots, safe time-grain expression recovery, set-operation branch optimization, and preaggregation route selection support.

Adds BI corpus accepted/rejected coverage, benchmark proof cases, and expanded explain/SQL-shape/execution-equivalence assertions. Also fixes related projection-order and cross-model subquery behavior found during validation.

Validated locally with ruff check, ruff format --check, and pytest -v.