### PR TITLE
Use polyglot-sql in Rust query generation

### DIFF
--- a/sidemantic-rs/src/config/sql_parser.rs
+++ b/sidemantic-rs/src/config/sql_parser.rs
@@ -561,6 +561,14 @@ fn parse_metric_expression(name: &str, expr: &str) -> HashMap<String, String> {
     let mut props = HashMap::new();
     props.insert("name".to_string(), name.to_string());
 
+    if let Some((agg, inner_expr)) = parse_top_level_function_metric(expr) {
+        props.insert("agg".to_string(), agg);
+        if !inner_expr.is_empty() {
+            props.insert("sql".to_string(), inner_expr);
+        }
+        return props;
+    }
+
     if let Some((agg, inner_expr)) = extract_aggregation_with_polyglot(expr) {
         props.insert("agg".to_string(), agg);
         if !inner_expr.is_empty() {
@@ -583,6 +591,99 @@ fn extract_aggregation_with_polyglot(expr: &str) -> Option<(String, String)> {
     let select = statement.as_select()?;
     let parsed_expr = select.expressions.first()?;
     extract_aggregation_polyglot_expr(parsed_expr)
+}
+
+fn parse_top_level_function_metric(expr: &str) -> Option<(String, String)> {
+    let trimmed = expr.trim();
+    let (rest, function_name) = identifier(trimmed).ok()?;
+    let rest = rest.trim_start().strip_prefix('(')?;
+    let (inner_expr, rest) = parse_balanced_parens(rest)?;
+
+    if !rest.trim().is_empty() {
+        return None;
+    }
+
+    let function_name = function_name.to_lowercase();
+    let mut inner_expr = inner_expr.trim().to_string();
+
+    let agg = match function_name.as_str() {
+        "sum" => "sum",
+        "avg" | "average" => "avg",
+        "min" => "min",
+        "max" => "max",
+        "median" => "median",
+        "count_distinct" | "countdistinct" => "count_distinct",
+        "count" => {
+            if inner_expr == "*" {
+                inner_expr.clear();
+                "count"
+            } else if let Some(distinct_inner) = strip_distinct_prefix(&inner_expr) {
+                inner_expr = distinct_inner.to_string();
+                "count_distinct"
+            } else {
+                "count"
+            }
+        }
+        _ => return Some(("expression".to_string(), trimmed.to_string())),
+    };
+
+    Some((agg.to_string(), inner_expr))
+}
+
+fn parse_balanced_parens(input: &str) -> Option<(&str, &str)> {
+    let mut depth = 0usize;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut chars = input.char_indices().peekable();
+
+    while let Some((idx, ch)) = chars.next() {
+        if in_single_quote {
+            if ch == '\'' {
+                if matches!(chars.peek(), Some((_, '\''))) {
+                    chars.next();
+                } else {
+                    in_single_quote = false;
+                }
+            }
+            continue;
+        }
+
+        if in_double_quote {
+            if ch == '"' {
+                in_double_quote = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' => in_single_quote = true,
+            '"' => in_double_quote = true,
+            '(' => depth += 1,
+            ')' if depth == 0 => return Some((&input[..idx], &input[idx + ch.len_utf8()..])),
+            ')' => depth -= 1,
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn strip_distinct_prefix(expr: &str) -> Option<&str> {
+    let trimmed = expr.trim_start();
+    let prefix = trimmed.get(..8)?;
+
+    if prefix.eq_ignore_ascii_case("distinct") {
+        let rest = trimmed.get(8..)?;
+        if !rest.chars().next()?.is_whitespace() {
+            return None;
+        }
+        let rest = rest.trim_start();
+        if !rest.is_empty() {
+            return Some(rest);
+        }
+    }
+
+    None
 }
 
 fn parse_polyglot_with_large_stack(sql: String) -> Option<Vec<Expression>> {
@@ -659,6 +760,7 @@ fn extract_aggregation_from_function_name_polyglot(
         "avg" | "average" => "avg",
         "min" => "min",
         "max" => "max",
+        "median" => "median",
         "count_distinct" => "count_distinct",
         _ => return None,
     };
@@ -682,7 +784,19 @@ fn extract_inner_expression_polyglot(expr: &Expression) -> String {
         }
         Expression::Identifier(ident) => ident.name.clone(),
         Expression::Star(_) => String::new(),
-        _ => String::new(),
+        _ => generate_expr_str(expr),
+    }
+}
+
+fn generate_expr_str(expr: &Expression) -> String {
+    match expr {
+        Expression::Column(_)
+        | Expression::Identifier(_)
+        | Expression::Star(_)
+        | Expression::Literal(_) => expr.to_string(),
+        _ => {
+            polyglot_sql::generate(expr, DialectType::Generic).unwrap_or_else(|_| expr.to_string())
+        }
     }
 }
 
@@ -1584,6 +1698,38 @@ mod tests {
 
         let count = model.get_metric("order_count").unwrap();
         assert_eq!(count.agg, Some(Aggregation::Count));
+    }
+
+    #[test]
+    fn test_simple_metric_function_coverage() {
+        let sql = r#"
+            MODEL (name orders, table orders);
+            METRIC revenue AS SUM(COALESCE(amount, 0));
+            METRIC unique_customers AS COUNT(DISTINCT customer_id);
+            METRIC median_amount AS MEDIAN(amount);
+            METRIC approximate_customers AS APPROX_COUNT_DISTINCT(customer_id);
+        "#;
+
+        let model = parse_sql_model(sql).unwrap();
+
+        let revenue = model.get_metric("revenue").unwrap();
+        assert_eq!(revenue.agg, Some(Aggregation::Sum));
+        assert_eq!(revenue.sql, Some("COALESCE(amount, 0)".to_string()));
+
+        let unique_customers = model.get_metric("unique_customers").unwrap();
+        assert_eq!(unique_customers.agg, Some(Aggregation::CountDistinct));
+        assert_eq!(unique_customers.sql, Some("customer_id".to_string()));
+
+        let median_amount = model.get_metric("median_amount").unwrap();
+        assert_eq!(median_amount.agg, Some(Aggregation::Median));
+        assert_eq!(median_amount.sql, Some("amount".to_string()));
+
+        let approximate_customers = model.get_metric("approximate_customers").unwrap();
+        assert_eq!(approximate_customers.agg, Some(Aggregation::Expression));
+        assert_eq!(
+            approximate_customers.sql,
+            Some("APPROX_COUNT_DISTINCT(customer_id)".to_string())
+        );
     }
 
     #[test]

--- a/sidemantic-rs/src/config/sql_parser.rs
+++ b/sidemantic-rs/src/config/sql_parser.rs
@@ -27,9 +27,9 @@ use nom::{
     IResult,
 };
 
-use polyglot_sql::Expression;
 #[cfg(not(target_arch = "wasm32"))]
-use polyglot_sql::{parse as polyglot_parse, DialectType};
+use polyglot_sql::parse as polyglot_parse;
+use polyglot_sql::{DialectType, Expression};
 
 use crate::core::{
     Aggregation, CohortInnerMetric, ComparisonCalculation, ComparisonType, Dimension,

--- a/sidemantic-rs/src/core/relative_date.rs
+++ b/sidemantic-rs/src/core/relative_date.rs
@@ -24,7 +24,7 @@ impl RelativeDate {
     /// ```
     /// use sidemantic::RelativeDate;
     /// assert_eq!(RelativeDate::parse("today"), Some("CURRENT_DATE".to_string()));
-    /// assert_eq!(RelativeDate::parse("last 7 days"), Some("CURRENT_DATE - 7".to_string()));
+    /// assert_eq!(RelativeDate::parse("last 7 days"), Some("CURRENT_DATE - INTERVAL '7 days'".to_string()));
     /// ```
     pub fn parse(expr: &str) -> Option<String> {
         let expr = expr.to_lowercase();
@@ -33,8 +33,8 @@ impl RelativeDate {
         // Simple keywords
         match expr {
             "today" => return Some("CURRENT_DATE".to_string()),
-            "yesterday" => return Some("CURRENT_DATE - 1".to_string()),
-            "tomorrow" => return Some("CURRENT_DATE + 1".to_string()),
+            "yesterday" => return Some("CURRENT_DATE - INTERVAL '1 day'".to_string()),
+            "tomorrow" => return Some("CURRENT_DATE + INTERVAL '1 day'".to_string()),
             "this week" => return Some("DATE_TRUNC('week', CURRENT_DATE)".to_string()),
             "last week" => {
                 return Some("DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '1 week'".to_string())
@@ -73,12 +73,12 @@ impl RelativeDate {
         // Last N days/weeks/months/years
         if let Some(caps) = LAST_N_DAYS.captures(expr) {
             let n: i32 = caps[1].parse().ok()?;
-            return Some(format!("CURRENT_DATE - {n}"));
+            return Some(format!("CURRENT_DATE - INTERVAL '{n} days'"));
         }
 
         if let Some(caps) = LAST_N_WEEKS.captures(expr) {
             let n: i32 = caps[1].parse().ok()?;
-            return Some(format!("CURRENT_DATE - {}", n * 7));
+            return Some(format!("CURRENT_DATE - INTERVAL '{} days'", n * 7));
         }
 
         if let Some(caps) = LAST_N_MONTHS.captures(expr) {
@@ -105,7 +105,7 @@ impl RelativeDate {
     /// use sidemantic::RelativeDate;
     /// assert_eq!(
     ///     RelativeDate::to_range("last 7 days", "created_at"),
-    ///     Some("created_at >= CURRENT_DATE - 7".to_string())
+    ///     Some("created_at >= CURRENT_DATE - INTERVAL '7 days'".to_string())
     /// );
     /// ```
     pub fn to_range(expr: &str, column: &str) -> Option<String> {
@@ -180,7 +180,7 @@ mod tests {
         assert_eq!(RelativeDate::parse("today"), Some("CURRENT_DATE".into()));
         assert_eq!(
             RelativeDate::parse("yesterday"),
-            Some("CURRENT_DATE - 1".into())
+            Some("CURRENT_DATE - INTERVAL '1 day'".into())
         );
         assert_eq!(
             RelativeDate::parse("this month"),
@@ -192,15 +192,15 @@ mod tests {
     fn test_parse_last_n() {
         assert_eq!(
             RelativeDate::parse("last 7 days"),
-            Some("CURRENT_DATE - 7".into())
+            Some("CURRENT_DATE - INTERVAL '7 days'".into())
         );
         assert_eq!(
             RelativeDate::parse("last 30 days"),
-            Some("CURRENT_DATE - 30".into())
+            Some("CURRENT_DATE - INTERVAL '30 days'".into())
         );
         assert_eq!(
             RelativeDate::parse("last 2 weeks"),
-            Some("CURRENT_DATE - 14".into())
+            Some("CURRENT_DATE - INTERVAL '14 days'".into())
         );
     }
 
@@ -208,7 +208,7 @@ mod tests {
     fn test_to_range() {
         assert_eq!(
             RelativeDate::to_range("last 7 days", "created_at"),
-            Some("created_at >= CURRENT_DATE - 7".into())
+            Some("created_at >= CURRENT_DATE - INTERVAL '7 days'".into())
         );
         assert!(RelativeDate::to_range("this month", "order_date")
             .unwrap()

--- a/sidemantic-rs/src/core/symmetric_agg.rs
+++ b/sidemantic-rs/src/core/symmetric_agg.rs
@@ -125,8 +125,8 @@ pub fn build_symmetric_aggregate_sql_with_key_expr(
             "1000000000000".to_string(),
         ),
         SqlDialect::DuckDB => (
-            format!("HASH({pk_col})::HUGEINT"),
-            "(1::HUGEINT << 40)".to_string(),
+            format!("CAST(HASH({pk_col}) AS HUGEINT)"),
+            "1048576".to_string(),
         ),
     };
 
@@ -194,9 +194,9 @@ mod tests {
             SqlDialect::DuckDB,
         );
         assert!(sql.contains("SUM(DISTINCT"));
-        assert!(sql.contains("HASH(order_id)::HUGEINT"));
+        assert!(sql.contains("CAST(HASH(order_id) AS HUGEINT)"));
         assert!(sql.contains("+ CAST(amount AS DECIMAL(38, 6))"));
-        assert!(sql.contains("CAST((HASH(order_id)::HUGEINT * (1::HUGEINT << 40))"));
+        assert!(sql.contains("CAST((CAST(HASH(order_id) AS HUGEINT) * 1048576)"));
     }
 
     #[test]
@@ -282,7 +282,7 @@ mod tests {
             Some("o"),
             SqlDialect::DuckDB,
         );
-        assert!(sql.contains("HASH(CONCAT("));
+        assert!(sql.contains("CAST(HASH(CONCAT("));
         assert!(sql.contains("CAST(o.amount AS DECIMAL(38, 6))"));
     }
 }

--- a/sidemantic-rs/src/core/table_calc.rs
+++ b/sidemantic-rs/src/core/table_calc.rs
@@ -153,7 +153,7 @@ impl TableCalculation {
         let partition = self.partition_clause();
         let over = self.combine_partition_order(&partition, &order);
         Ok(format!(
-            "SUM({field}) OVER ({over} ROWS UNBOUNDED PRECEDING)"
+            "SUM({field}) OVER ({over} ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"
         ))
     }
 
@@ -276,7 +276,7 @@ mod tests {
         let sql = calc.to_sql().unwrap();
         assert!(sql.contains("SUM(revenue) OVER"));
         assert!(sql.contains("ORDER BY order_date"));
-        assert!(sql.contains("ROWS UNBOUNDED PRECEDING"));
+        assert!(sql.contains("ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"));
     }
 
     #[test]

--- a/sidemantic-rs/src/sql/generator.rs
+++ b/sidemantic-rs/src/sql/generator.rs
@@ -2,6 +2,9 @@
 
 use std::collections::{HashMap, HashSet};
 
+use polyglot_sql::expressions::{Expression, Literal, Raw};
+use polyglot_sql::DialectType;
+
 use crate::core::{
     build_symmetric_aggregate_sql_with_key_expr, Aggregation, CohortInnerMetric, JoinPath, Metric,
     MetricType, Model, RelationshipType, RelativeDate, SemanticGraph, SqlDialect, SymmetricAggType,
@@ -10,6 +13,7 @@ use crate::core::{
 use crate::error::{Result, SidemanticError};
 
 type CtePushdownClassification = (HashMap<String, Vec<String>>, Vec<String>);
+const SOURCE_DIALECT: DialectType = DialectType::DuckDB;
 
 /// A semantic query definition
 #[derive(Debug, Clone, Default)]
@@ -122,11 +126,24 @@ struct MetricRef {
 /// SQL generator for semantic queries
 pub struct SqlGenerator<'a> {
     graph: &'a SemanticGraph,
+    dialect: DialectType,
 }
 
 impl<'a> SqlGenerator<'a> {
     pub fn new(graph: &'a SemanticGraph) -> Self {
-        Self { graph }
+        Self {
+            graph,
+            dialect: SOURCE_DIALECT,
+        }
+    }
+
+    pub fn with_dialect(mut self, dialect: DialectType) -> Self {
+        self.dialect = dialect;
+        self
+    }
+
+    pub fn dialect(&self) -> DialectType {
+        self.dialect
     }
 
     /// Generate SQL from a semantic query
@@ -449,21 +466,21 @@ impl<'a> SqlGenerator<'a> {
                             &primary_key_expr,
                             SymmetricAggType::Sum,
                             Some(&alias),
-                            SqlDialect::DuckDB,
+                            self.symmetric_agg_dialect(),
                         ),
                         Some(Aggregation::Avg) => build_symmetric_aggregate_sql_with_key_expr(
                             &raw_alias,
                             &primary_key_expr,
                             SymmetricAggType::Avg,
                             Some(&alias),
-                            SqlDialect::DuckDB,
+                            self.symmetric_agg_dialect(),
                         ),
                         Some(Aggregation::Count) => build_symmetric_aggregate_sql_with_key_expr(
                             &raw_alias,
                             &primary_key_expr,
                             SymmetricAggType::Count,
                             Some(&alias),
-                            SqlDialect::DuckDB,
+                            self.symmetric_agg_dialect(),
                         ),
                         Some(Aggregation::CountDistinct) => {
                             build_symmetric_aggregate_sql_with_key_expr(
@@ -471,7 +488,7 @@ impl<'a> SqlGenerator<'a> {
                                 &primary_key_expr,
                                 SymmetricAggType::CountDistinct,
                                 Some(&alias),
-                                SqlDialect::DuckDB,
+                                self.symmetric_agg_dialect(),
                             )
                         }
                         // Min/Max/None don't need symmetric aggregates
@@ -4083,13 +4100,100 @@ impl<'a> SqlGenerator<'a> {
         Ok(result)
     }
 
+    fn symmetric_agg_dialect(&self) -> SqlDialect {
+        match self.dialect {
+            DialectType::BigQuery => SqlDialect::BigQuery,
+            DialectType::PostgreSQL
+            | DialectType::Redshift
+            | DialectType::CockroachDB
+            | DialectType::Materialize
+            | DialectType::RisingWave => SqlDialect::Postgres,
+            DialectType::Snowflake => SqlDialect::Snowflake,
+            DialectType::ClickHouse => SqlDialect::ClickHouse,
+            DialectType::Databricks => SqlDialect::Databricks,
+            DialectType::Spark => SqlDialect::Spark,
+            _ => SqlDialect::DuckDB,
+        }
+    }
+
+    fn emit_expression(&self, expression: &Expression) -> Result<String> {
+        polyglot_sql::generate(expression, self.dialect)
+            .map(|sql| sql.trim_end().to_string())
+            .map_err(|e| {
+                SidemanticError::SqlGeneration(format!(
+                    "polyglot-sql failed to generate {} SQL: {e}",
+                    self.dialect
+                ))
+            })
+    }
+
+    fn parse_where_expr(&self, expr_sql: &str) -> Result<Expression> {
+        let sql = format!("SELECT 1 WHERE {expr_sql}");
+        let expression = polyglot_sql::parse_one(&sql, SOURCE_DIALECT)
+            .map_err(|e| SidemanticError::SqlParse(e.to_string()))?;
+
+        match expression {
+            Expression::Select(select) => select
+                .where_clause
+                .map(|where_clause| where_clause.this)
+                .ok_or_else(|| {
+                    SidemanticError::SqlParse(format!(
+                        "Expected WHERE expression in SQL fragment: {expr_sql}"
+                    ))
+                }),
+            _ => Err(SidemanticError::SqlParse(format!(
+                "Expected SELECT when parsing WHERE fragment: {expr_sql}"
+            ))),
+        }
+    }
+
+    fn expand_filter_with_polyglot(&self, filter: &str) -> Result<String> {
+        let parsed = self.parse_where_expr(filter)?;
+        let graph = self.graph;
+
+        let rewritten = polyglot_sql::transform_map(parsed, &|node| {
+            if let Expression::Literal(Literal::String(value)) = &node {
+                if let Some(sql_date) = RelativeDate::parse(value) {
+                    return Ok(Expression::Raw(Raw { sql: sql_date }));
+                }
+            }
+
+            if let Expression::Column(col) = &node {
+                if let Some(table) = &col.table {
+                    if let Some(model) = graph.get_model(&table.name) {
+                        if let Some(dimension) = model.get_dimension(&col.name.name) {
+                            return Ok(Expression::Raw(Raw {
+                                sql: format!(
+                                    "{}.{}",
+                                    self.model_alias(&model.name),
+                                    dimension.sql_expr()
+                                ),
+                            }));
+                        }
+                    }
+                }
+            }
+
+            Ok(node)
+        })
+        .map_err(|e| SidemanticError::SqlGeneration(e.to_string()))?;
+
+        self.emit_expression(&rewritten)
+    }
+
     /// Expand filter expressions, replacing model.field references and relative dates
     fn expand_filters(&self, filters: &[String]) -> Result<Vec<String>> {
         let mut expanded = Vec::new();
 
         for filter in filters {
+            let relative_expanded = self.expand_relative_dates(filter);
+            if let Ok(expanded_filter) = self.expand_filter_with_polyglot(&relative_expanded) {
+                expanded.push(expanded_filter);
+                continue;
+            }
+
             // Simple expansion: replace model.field with alias.field
-            let mut expanded_filter = filter.clone();
+            let mut expanded_filter = relative_expanded;
 
             for model in self.graph.models() {
                 let alias = self.model_alias(&model.name);
@@ -4738,6 +4842,52 @@ mod tests {
     }
 
     #[test]
+    fn test_symmetric_aggregate_uses_target_dialect() {
+        let mut graph = SemanticGraph::new();
+
+        let orders = Model::new("orders", "order_id")
+            .with_table("orders")
+            .with_dimension(Dimension::categorical("status"))
+            .with_relationship(Relationship::many_to_one("customers"));
+
+        let customers = Model::new("customers", "id")
+            .with_table("customers")
+            .with_dimension(Dimension::categorical("country"))
+            .with_metric(Metric::sum("total_credit", "credit_limit"));
+
+        graph.add_model(orders).unwrap();
+        graph.add_model(customers).unwrap();
+
+        let generator = SqlGenerator::new(&graph).with_dialect(DialectType::PostgreSQL);
+        let query = SemanticQuery::new()
+            .with_metrics(vec!["customers.total_credit".into()])
+            .with_dimensions(vec!["orders.status".into()]);
+
+        let sql = generator.generate(&query).unwrap();
+
+        assert!(
+            sql.contains("hashtext(customers_cte.id::text)::numeric"),
+            "Expected PostgreSQL symmetric aggregate hash: {sql}"
+        );
+        assert!(
+            !sql.contains("CAST(HASH(customers_cte.id) AS HUGEINT)"),
+            "Should not hardcode DuckDB symmetric aggregate SQL: {sql}"
+        );
+    }
+
+    #[test]
+    fn test_filter_rewrite_uses_polyglot_sql() {
+        let graph = create_test_graph();
+        let generator = SqlGenerator::new(&graph);
+
+        let rewritten = generator
+            .expand_filter_with_polyglot("orders.order_date >= 'today'")
+            .unwrap();
+
+        assert_eq!(rewritten, "orders_cte.created_at >= CURRENT_DATE");
+    }
+
+    #[test]
     fn test_simple_metric_sql_column_does_not_pull_same_named_metric_model() {
         let mut graph = SemanticGraph::new();
 
@@ -4778,6 +4928,33 @@ mod tests {
         assert!(
             !sql.contains("expenses_cte"),
             "simple column SQL was misread as expenses.total_amount metric dependency: {sql}"
+        );
+    }
+
+    #[test]
+    fn test_derived_metric_expansion_is_token_aware() {
+        let mut graph = SemanticGraph::new();
+
+        let orders = Model::new("orders", "order_id")
+            .with_table("orders")
+            .with_metric(Metric::sum("revenue", "amount"))
+            .with_metric(Metric::sum("revenue_net", "net_amount"))
+            .with_metric(Metric::derived("net_ratio", "revenue / revenue_net"));
+
+        graph.add_model(orders).unwrap();
+
+        let generator = SqlGenerator::new(&graph);
+        let query = SemanticQuery::new().with_metrics(vec!["orders.net_ratio".into()]);
+
+        let sql = generator.generate(&query).unwrap();
+
+        assert!(
+            sql.contains("revenue_net"),
+            "Expected longer metric reference to survive derived expansion: {sql}"
+        );
+        assert!(
+            !sql.contains("revenue_raw)_net"),
+            "Derived expansion must not replace metric-name substrings: {sql}"
         );
     }
 
@@ -4838,7 +5015,7 @@ mod tests {
             "Expected running total: {sql}"
         );
         assert!(
-            sql.contains("ROWS UNBOUNDED PRECEDING"),
+            sql.contains("ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"),
             "Expected unbounded preceding: {sql}"
         );
 
@@ -4884,7 +5061,7 @@ mod tests {
 
         // Relative date should be expanded to SQL
         assert!(
-            sql.contains("CURRENT_DATE - 7"),
+            sql.contains("CURRENT_DATE - INTERVAL '7 days'"),
             "Expected relative date expansion: {sql}"
         );
         // Should NOT contain the quoted string anymore

--- a/tests/native-fixtures/manifest.yml
+++ b/tests/native-fixtures/manifest.yml
@@ -134,7 +134,7 @@ fixtures:
         rust_only_reason: Python native query API does not accept table_calculations yet.
         result_columns: [status, total_revenue, running_revenue, revenue_pct_of_total]
         sql_contains: [total_revenue, status]
-        rust_sql_contains: [running_revenue, revenue_pct_of_total, "ROWS UNBOUNDED PRECEDING", NULLIF]
+        rust_sql_contains: [running_revenue, revenue_pct_of_total, "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW", NULLIF]
 
   - name: preaggregation_routing
     valid: true


### PR DESCRIPTION
## Summary
- Adds a target dialect to the pure Rust SQL generator and uses it for symmetric aggregate SQL instead of hardcoding DuckDB.
- Routes Rust filter expression rewriting through polyglot-sql when parsing succeeds, with the existing string rewrite as fallback for legacy filter forms.
- Broadens Rust SQL metric parsing so known top-level aggregates preserve complex arguments, `MEDIAN()` maps correctly, `COUNT(DISTINCT ...)` normalizes, and unknown function calls stay expression metrics.
- Keeps the related SQL correctness fixes for relative-date intervals, DuckDB symmetric hash casting, and running-total window frames.