### PR TITLE
Add Rust ADBC execution via dbc

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -219,16 +219,21 @@ jobs:
 
       - name: Install ADBC driver through dbc
         run: |
+          DRIVER_DIR="$HOME/.config/adbc/drivers"
+          echo "ADBC_DRIVER_PATH=$DRIVER_DIR" >> "$GITHUB_ENV"
+
           DB="${{ matrix.db }}"
           DRIVER="$DB"
           if [ "$DB" = "postgres" ]; then
             DRIVER="postgresql"
           fi
           if [ "$DB" = "clickhouse" ]; then
-            uv run --with dbc dbc install --pre clickhouse
+            uv run --with dbc dbc install --level user --pre clickhouse
+            uv run --with dbc dbc list --level user
             exit 0
           fi
-          uv run --with dbc dbc install "$DRIVER"
+          uv run --with dbc dbc install --level user "$DRIVER"
+          uv run --with dbc dbc list --level user
 
       - name: Run Python ADBC smoke tests
         if: matrix.db != 'sqlite' && matrix.db != 'duckdb'
@@ -278,7 +283,6 @@ jobs:
             echo "Skipping Rust BigQuery ADBC probe; BIGQUERY_ADBC_CREDENTIALS_JSON secret plus BIGQUERY_ADBC_PROJECT/BIGQUERY_ADBC_DATASET vars are required."
             exit 0
           fi
-          uvx dbc install bigquery
           CREDENTIALS_FILE="$(mktemp)"
           printf '%s' "$BIGQUERY_ADBC_CREDENTIALS_JSON" > "$CREDENTIALS_FILE"
           echo "::add-mask::$BIGQUERY_ADBC_CREDENTIALS_JSON"
@@ -295,7 +299,6 @@ jobs:
             echo "Skipping Rust Snowflake ADBC probe; SNOWFLAKE_ADBC_URI secret is required."
             exit 0
           fi
-          uvx dbc install snowflake
           echo "::add-mask::$SNOWFLAKE_ADBC_URI"
           echo "SIDEMANTIC_TEST_ADBC_SNOWFLAKE_DRIVER=snowflake" >> "$GITHUB_ENV"
           echo "SIDEMANTIC_TEST_ADBC_SNOWFLAKE_URI=$SNOWFLAKE_ADBC_URI" >> "$GITHUB_ENV"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -164,7 +164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        db: [postgres, bigquery, snowflake, clickhouse]
+        db: [sqlite, duckdb, postgres, bigquery, snowflake, clickhouse]
 
     services:
       postgres:
@@ -217,20 +217,21 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev --extra adbc
 
-      - name: Install ADBC driver (best effort)
+      - name: Install ADBC driver through dbc
         run: |
           DB="${{ matrix.db }}"
+          DRIVER="$DB"
+          if [ "$DB" = "postgres" ]; then
+            DRIVER="postgresql"
+          fi
           if [ "$DB" = "clickhouse" ]; then
-            uvx dbc install --pre clickhouse
+            uv run --with dbc dbc install --pre clickhouse
             exit 0
           fi
-          PKG_DB="$DB"
-          if [ "$DB" = "postgres" ]; then
-            PKG_DB="postgresql"
-          fi
-          uv pip install "adbc_driver_${PKG_DB}" || uv pip install "adbc-driver-${PKG_DB}" || true
+          uv run --with dbc dbc install "$DRIVER"
 
-      - name: Run ADBC smoke tests
+      - name: Run Python ADBC smoke tests
+        if: matrix.db != 'sqlite' && matrix.db != 'duckdb'
         env:
           ADBC_TEST: "1"
           ADBC_DB: ${{ matrix.db }}
@@ -246,15 +247,23 @@ jobs:
       - name: Install Rust for Rust ADBC probe
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Export SQLite ADBC driver for Rust
+        if: matrix.db == 'sqlite'
+        run: |
+          echo "SIDEMANTIC_TEST_ADBC_SQLITE_DRIVER=sqlite" >> "$GITHUB_ENV"
+          echo "SIDEMANTIC_TEST_ADBC_SQLITE_URI=:memory:" >> "$GITHUB_ENV"
+          echo "SIDEMANTIC_TEST_ADBC_REQUIRE=sqlite" >> "$GITHUB_ENV"
+
+      - name: Export DuckDB ADBC driver for Rust
+        if: matrix.db == 'duckdb'
+        run: |
+          echo "SIDEMANTIC_TEST_ADBC_DUCKDB_DRIVER=duckdb" >> "$GITHUB_ENV"
+          echo "SIDEMANTIC_TEST_ADBC_REQUIRE=duckdb" >> "$GITHUB_ENV"
+
       - name: Export Postgres ADBC driver for Rust
         if: matrix.db == 'postgres'
         run: |
-          uv pip install adbc-driver-postgresql
-          uv run python - <<'PY' >> "$GITHUB_ENV"
-          import adbc_driver_postgresql
-
-          print(f"SIDEMANTIC_TEST_ADBC_POSTGRES_DRIVER={adbc_driver_postgresql._driver_path()}")
-          PY
+          echo "SIDEMANTIC_TEST_ADBC_POSTGRES_DRIVER=postgresql" >> "$GITHUB_ENV"
           echo "SIDEMANTIC_TEST_ADBC_POSTGRES_URI=postgresql://test:test@localhost:5432/sidemantic_test" >> "$GITHUB_ENV"
           echo "SIDEMANTIC_TEST_ADBC_REQUIRE=postgres" >> "$GITHUB_ENV"
 
@@ -298,6 +307,20 @@ jobs:
           echo "SIDEMANTIC_TEST_ADBC_CLICKHOUSE_DRIVER=clickhouse" >> "$GITHUB_ENV"
           echo "SIDEMANTIC_TEST_ADBC_CLICKHOUSE_URI=http://localhost:8123/" >> "$GITHUB_ENV"
           echo "SIDEMANTIC_TEST_ADBC_REQUIRE=clickhouse" >> "$GITHUB_ENV"
+
+      - name: Run Rust ADBC semantic smoke
+        env:
+          SIDEMANTIC_ADBC_TESTS: "1"
+          SIDEMANTIC_ADBC_DB: ${{ matrix.db }}
+          SIDEMANTIC_ADBC_REQUIRED: ${{ contains(fromJSON('["sqlite","duckdb","postgres","clickhouse"]'), matrix.db) }}
+          POSTGRES_URL: "postgres://test:test@localhost:5432/sidemantic_test"
+          BIGQUERY_EMULATOR_HOST: "localhost:9050"
+          BIGQUERY_PROJECT: "test-project"
+          BIGQUERY_DATASET: "test_dataset"
+          CLICKHOUSE_URL: "adbc://clickhouse?uri=http://localhost:8123/"
+          SNOWFLAKE_TEST: "1"
+          RUST_MIN_STACK: 16777216
+        run: cargo test --manifest-path sidemantic-rs/Cargo.toml --features adbc-exec --test adbc_engines -- --nocapture
 
       - name: Run Rust ADBC probe
         run: cargo test --manifest-path sidemantic-rs/Cargo.toml --features adbc-exec --test adbc_driver_matrix

--- a/sidemantic-rs/Cargo.lock
+++ b/sidemantic-rs/Cargo.lock
@@ -1670,6 +1670,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tower-lsp",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/sidemantic-rs/Cargo.toml
+++ b/sidemantic-rs/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 default = []
 python = ["dep:pyo3"]
 python-adbc = ["python", "adbc-exec"]
-adbc-exec = ["dep:adbc_driver_manager", "dep:adbc_core", "dep:arrow-array", "dep:arrow-schema", "dep:arrow-ipc"]
+adbc-exec = ["dep:adbc_driver_manager", "dep:adbc_core", "dep:arrow-array", "dep:arrow-schema", "dep:arrow-ipc", "dep:url"]
 wasm = ["dep:wasm-bindgen"]
 mcp-server = ["dep:rmcp", "dep:tokio"]
 mcp-adbc = ["mcp-server", "adbc-exec"]
@@ -40,6 +40,7 @@ adbc_core = { version = "0.22.0", optional = true }
 arrow-array = { version = ">=53.1.0, <58", default-features = false, optional = true }
 arrow-schema = { version = ">=53.1.0, <58", default-features = false, optional = true }
 arrow-ipc = { version = ">=53.1.0, <58", default-features = false, optional = true }
+url = { version = "2.5", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 minijinja = { version = "2.5", features = ["builtins", "serde"] }
 wasm-bindgen = { version = "0.2", optional = true }

--- a/sidemantic-rs/src/db/adbc.rs
+++ b/sidemantic-rs/src/db/adbc.rs
@@ -14,6 +14,7 @@ use arrow_array::{
 use arrow_ipc::writer::StreamWriter;
 use arrow_schema::{DataType, Schema, TimeUnit};
 use std::io::Write;
+use std::path::PathBuf;
 
 use crate::core::SemanticGraph;
 use crate::error::{Result, SidemanticError};
@@ -69,9 +70,9 @@ pub struct AdbcExecutor {
 impl AdbcExecutor {
     pub fn connect(spec: ConnectionSpec) -> Result<Self> {
         let entrypoint = spec.entrypoint.clone();
-        let mut driver = ManagedDriver::load_from_name(
+        let mut driver = load_managed_driver(
             &spec.driver,
-            entrypoint.as_deref().map(str::as_bytes),
+            entrypoint.as_deref(),
             spec.adbc_version,
             spec.load_flags,
             spec.additional_search_paths.clone(),
@@ -171,6 +172,35 @@ impl AdbcExecutor {
     pub fn database(&self) -> &ManagedDatabase {
         &self.database
     }
+}
+
+fn load_managed_driver(
+    driver: &str,
+    entrypoint: Option<&str>,
+    adbc_version: AdbcVersion,
+    load_flags: adbc_core::LoadFlags,
+    additional_search_paths: Option<Vec<PathBuf>>,
+) -> std::result::Result<ManagedDriver, adbc_core::error::Error> {
+    let entrypoint_bytes = entrypoint.map(str::as_bytes);
+    ManagedDriver::load_from_name(
+        driver,
+        entrypoint_bytes,
+        adbc_version,
+        load_flags,
+        additional_search_paths.clone(),
+    )
+    .or_else(|err| {
+        if matches!(adbc_version, AdbcVersion::V100) {
+            return Err(err);
+        }
+        ManagedDriver::load_from_name(
+            driver,
+            entrypoint_bytes,
+            AdbcVersion::V100,
+            load_flags,
+            additional_search_paths,
+        )
+    })
 }
 
 fn adbc_error(context: &str, err: impl std::fmt::Display) -> SidemanticError {

--- a/sidemantic-rs/src/db/adbc.rs
+++ b/sidemantic-rs/src/db/adbc.rs
@@ -2,7 +2,7 @@ use adbc_core::{
     options::{AdbcVersion, OptionConnection, OptionDatabase, OptionValue},
     Connection, Database, Driver, Statement, LOAD_FLAG_DEFAULT,
 };
-use adbc_driver_manager::ManagedDriver;
+use adbc_driver_manager::{ManagedConnection, ManagedDatabase, ManagedDriver};
 use arrow_array::{
     Array, BinaryArray, BooleanArray, Date32Array, Date64Array, Decimal128Array, Float16Array,
     Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, LargeBinaryArray,
@@ -12,10 +12,15 @@ use arrow_array::{
     UInt32Array, UInt64Array, UInt8Array,
 };
 use arrow_ipc::writer::StreamWriter;
-use arrow_schema::{DataType, TimeUnit};
+use arrow_schema::{DataType, Schema, TimeUnit};
 use std::io::Write;
 
+use crate::core::SemanticGraph;
 use crate::error::{Result, SidemanticError};
+use crate::sql::{QueryRewriter, SemanticQuery, SqlGenerator};
+
+use super::result::ExecutionResult;
+use super::url::ConnectionSpec;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AdbcValue {
@@ -48,6 +53,124 @@ pub struct AdbcExecutionRequest {
     pub entrypoint: Option<String>,
     pub database_options: Vec<(OptionDatabase, OptionValue)>,
     pub connection_options: Vec<(OptionConnection, OptionValue)>,
+}
+
+/// Pure Rust ADBC executor for semantic queries.
+///
+/// Drivers are loaded by the ADBC driver manager. Drivers installed with
+/// `dbc install <driver>` are found through the manager's normal manifest
+/// search paths.
+pub struct AdbcExecutor {
+    pub spec: ConnectionSpec,
+    database: ManagedDatabase,
+    connection: ManagedConnection,
+}
+
+impl AdbcExecutor {
+    pub fn connect(spec: ConnectionSpec) -> Result<Self> {
+        let entrypoint = spec.entrypoint.clone();
+        let mut driver = ManagedDriver::load_from_name(
+            &spec.driver,
+            entrypoint.as_deref().map(str::as_bytes),
+            spec.adbc_version,
+            spec.load_flags,
+            spec.additional_search_paths.clone(),
+        )
+        .map_err(|err| {
+            SidemanticError::Database(format!(
+                "failed to load ADBC driver '{}' through the dbc/ADBC registry. \
+                 Install the driver with `dbc install {}` and make sure the ADBC driver \
+                 manager search path can see it. Underlying error: {err}",
+                spec.driver, spec.driver
+            ))
+        })?;
+
+        let options = connection_spec_database_options(&spec);
+        let database = if options.is_empty() {
+            driver.new_database()
+        } else {
+            driver.new_database_with_opts(options)
+        }?;
+        let connection = database.new_connection()?;
+
+        Ok(Self {
+            spec,
+            database,
+            connection,
+        })
+    }
+
+    pub fn connect_url(url: &str) -> Result<Self> {
+        Self::connect(ConnectionSpec::from_url(url)?)
+    }
+
+    /// Execute SQL and return an Arrow record batch reader.
+    pub fn execute_sql(&mut self, sql: &str) -> Result<ExecutionResult> {
+        let mut statement = self.connection.new_statement()?;
+        statement.set_sql_query(sql)?;
+        let mut reader = statement.execute()?;
+        let schema = reader.schema();
+        let mut batches = Vec::new();
+        for batch in &mut reader {
+            batches.push(batch?);
+        }
+        Ok(ExecutionResult::new(sql.to_string(), schema, batches))
+    }
+
+    /// Execute a SQL statement that does not return a result set.
+    pub fn execute_update(&mut self, sql: &str) -> Result<Option<i64>> {
+        let mut statement = self.connection.new_statement()?;
+        statement.set_sql_query(sql)?;
+        Ok(statement.execute_update()?)
+    }
+
+    /// Generate SQL from a semantic query and execute it through ADBC.
+    pub fn execute_semantic_query(
+        &mut self,
+        graph: &SemanticGraph,
+        query: &SemanticQuery,
+    ) -> Result<ExecutionResult> {
+        let sql = SqlGenerator::new(graph).generate(query)?;
+        self.execute_sql(&sql)
+    }
+
+    /// Rewrite SQL through the semantic graph, then execute the rewritten SQL.
+    pub fn rewrite_and_execute(
+        &mut self,
+        graph: &SemanticGraph,
+        sql: &str,
+    ) -> Result<ExecutionResult> {
+        let rewritten = QueryRewriter::new(graph).rewrite(sql)?;
+        self.execute_sql(&rewritten)
+    }
+
+    /// Return an ADBC metadata stream for catalogs, schemas, tables, and columns.
+    pub fn get_objects(
+        &self,
+        depth: adbc_core::options::ObjectDepth,
+    ) -> Result<Box<dyn RecordBatchReader + Send + '_>> {
+        Ok(Box::new(
+            self.connection
+                .get_objects(depth, None, None, None, None, None)?,
+        ))
+    }
+
+    /// Get the Arrow schema for a table.
+    pub fn get_table_schema(
+        &self,
+        catalog: Option<&str>,
+        db_schema: Option<&str>,
+        table_name: &str,
+    ) -> Result<Schema> {
+        Ok(self
+            .connection
+            .get_table_schema(catalog, db_schema, table_name)?)
+    }
+
+    /// Keep a reference to the ADBC database handle for advanced callers.
+    pub fn database(&self) -> &ManagedDatabase {
+        &self.database
+    }
 }
 
 fn adbc_error(context: &str, err: impl std::fmt::Display) -> SidemanticError {
@@ -87,6 +210,29 @@ fn database_options_with_uri(
     }
 
     database_options
+}
+
+fn connection_spec_database_options(spec: &ConnectionSpec) -> Vec<(OptionDatabase, OptionValue)> {
+    let options = spec
+        .database_options
+        .iter()
+        .map(|(key, value)| (database_option_key(key), OptionValue::String(value.clone())))
+        .collect();
+    database_options_with_uri(
+        &spec.driver,
+        spec.entrypoint.as_deref(),
+        spec.uri.clone(),
+        options,
+    )
+}
+
+fn database_option_key(key: &str) -> OptionDatabase {
+    match key {
+        "uri" | "adbc.uri" => OptionDatabase::Uri,
+        "username" | "user" | "adbc.username" => OptionDatabase::Username,
+        "password" | "adbc.password" => OptionDatabase::Password,
+        other => OptionDatabase::Other(other.to_string()),
+    }
 }
 
 pub fn execute_with_adbc(request: AdbcExecutionRequest) -> Result<AdbcExecutionResult> {

--- a/sidemantic-rs/src/db/mod.rs
+++ b/sidemantic-rs/src/db/mod.rs
@@ -1,8 +1,16 @@
 #[cfg(feature = "adbc-exec")]
 mod adbc;
+#[cfg(feature = "adbc-exec")]
+mod result;
+#[cfg(feature = "adbc-exec")]
+mod url;
 
 #[cfg(feature = "adbc-exec")]
 pub use adbc::{
     execute_with_adbc, execute_with_adbc_arrow_ipc, write_adbc_arrow_ipc, AdbcArrowIpcResult,
-    AdbcExecutionRequest, AdbcExecutionResult, AdbcValue,
+    AdbcExecutionRequest, AdbcExecutionResult, AdbcExecutor, AdbcValue,
 };
+#[cfg(feature = "adbc-exec")]
+pub use result::ExecutionResult;
+#[cfg(feature = "adbc-exec")]
+pub use url::{ConnectionSpec, DBC_DRIVER_HINTS};

--- a/sidemantic-rs/src/db/result.rs
+++ b/sidemantic-rs/src/db/result.rs
@@ -1,0 +1,33 @@
+//! Result wrappers for ADBC execution.
+
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
+
+use crate::error::Result;
+
+/// Arrow-backed result of a database query.
+pub struct ExecutionResult {
+    pub sql: String,
+    schema: SchemaRef,
+    batches: Vec<RecordBatch>,
+}
+
+impl ExecutionResult {
+    pub(crate) fn new(sql: String, schema: SchemaRef, batches: Vec<RecordBatch>) -> Self {
+        Self {
+            sql,
+            schema,
+            batches,
+        }
+    }
+
+    /// Return the Arrow schema for this result.
+    pub fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    /// Collect all record batches from the result stream.
+    pub fn collect(self) -> Result<Vec<RecordBatch>> {
+        Ok(self.batches)
+    }
+}

--- a/sidemantic-rs/src/db/url.rs
+++ b/sidemantic-rs/src/db/url.rs
@@ -177,11 +177,8 @@ fn parse_adbc_url(parsed: &Url) -> Result<ConnectionSpec> {
 
     if let Some(uri) = params.remove("uri") {
         spec.uri = Some(uri);
-    } else {
-        let path_uri = parsed.path().trim_start_matches('/');
-        if !path_uri.is_empty() && path_uri != driver {
-            spec.uri = Some(path_uri.to_string());
-        }
+    } else if let Some(path_uri) = adbc_path_uri(parsed, driver) {
+        spec.uri = Some(path_uri);
     }
 
     if spec.uri.is_none() && matches!(spec.driver.as_str(), "sqlite" | "duckdb") {
@@ -190,6 +187,32 @@ fn parse_adbc_url(parsed: &Url) -> Result<ConnectionSpec> {
 
     spec.database_options = params;
     Ok(spec)
+}
+
+fn adbc_path_uri(parsed: &Url, driver: &str) -> Option<String> {
+    let path = parsed.path();
+    if parsed.host_str().is_none() {
+        let driver_prefix = format!("/{driver}");
+        if let Some(rest) = path.strip_prefix(&driver_prefix) {
+            return normalize_adbc_path_uri(rest);
+        }
+    }
+    normalize_adbc_path_uri(path)
+}
+
+fn normalize_adbc_path_uri(path: &str) -> Option<String> {
+    if path.is_empty() || path == "/" {
+        return None;
+    }
+    if let Some(absolute) = path.strip_prefix("//") {
+        return Some(format!("/{absolute}"));
+    }
+    path.strip_prefix('/')
+        .map_or_else(
+            || Some(path.to_string()),
+            |relative| Some(relative.to_string()),
+        )
+        .filter(|value| !value.is_empty())
 }
 
 fn parse_adbc_plus_url(raw: &str, scheme: &str, driver: &str) -> Result<ConnectionSpec> {
@@ -511,6 +534,26 @@ mod tests {
         let sqlite = spec("adbc://sqlite");
         assert_eq!(sqlite.driver, "sqlite");
         assert_eq!(sqlite.uri.as_deref(), Some(":memory:"));
+    }
+
+    #[test]
+    fn preserves_absolute_paths_in_explicit_adbc_urls() {
+        assert_eq!(
+            spec("adbc://sqlite//tmp/test.db").uri.as_deref(),
+            Some("/tmp/test.db")
+        );
+        assert_eq!(
+            spec("adbc://duckdb//tmp/test.duckdb").uri.as_deref(),
+            Some("/tmp/test.duckdb")
+        );
+        assert_eq!(
+            spec("adbc:///sqlite//tmp/test.db").uri.as_deref(),
+            Some("/tmp/test.db")
+        );
+        assert_eq!(
+            spec("adbc://sqlite/relative.db").uri.as_deref(),
+            Some("relative.db")
+        );
     }
 
     #[test]

--- a/sidemantic-rs/src/db/url.rs
+++ b/sidemantic-rs/src/db/url.rs
@@ -1,0 +1,543 @@
+//! Connection URL parsing for ADBC/dbc-backed execution.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use adbc_core::options::AdbcVersion;
+use adbc_core::{LoadFlags, LOAD_FLAG_DEFAULT};
+use url::form_urlencoded;
+use url::Url;
+
+use crate::core::SqlDialect;
+use crate::error::{Result, SidemanticError};
+
+/// Drivers exposed by the Columnar dbc registry that Sidemantic knows how to map.
+pub const DBC_DRIVER_HINTS: &[&str] = &[
+    "bigquery",
+    "clickhouse",
+    "databricks",
+    "duckdb",
+    "exasol",
+    "flightsql",
+    "mssql",
+    "mysql",
+    "postgresql",
+    "redshift",
+    "snowflake",
+    "sqlite",
+    "trino",
+    "oracle",
+    "teradata",
+];
+
+/// Parsed database connection configuration for Rust ADBC execution.
+#[derive(Debug, Clone)]
+pub struct ConnectionSpec {
+    pub driver: String,
+    pub uri: Option<String>,
+    pub database_options: BTreeMap<String, String>,
+    pub entrypoint: Option<String>,
+    pub adbc_version: AdbcVersion,
+    pub load_flags: LoadFlags,
+    pub additional_search_paths: Option<Vec<PathBuf>>,
+}
+
+impl ConnectionSpec {
+    pub fn with_driver(driver: impl Into<String>) -> Self {
+        Self {
+            driver: driver.into(),
+            uri: None,
+            database_options: BTreeMap::new(),
+            entrypoint: None,
+            adbc_version: AdbcVersion::V110,
+            load_flags: LOAD_FLAG_DEFAULT,
+            additional_search_paths: None,
+        }
+    }
+
+    pub fn from_url(raw: &str) -> Result<Self> {
+        if raw.trim().is_empty() {
+            return Err(SidemanticError::ConnectionUrl(
+                "connection URL cannot be empty".into(),
+            ));
+        }
+
+        if let Some(spec) = parse_direct_file_uri(raw, "sqlite") {
+            return Ok(spec);
+        }
+        if let Some(spec) = parse_direct_file_uri(raw, "duckdb") {
+            return Ok(spec);
+        }
+        if let Some(spec) = parse_duckdb_motherduck_uri(raw) {
+            return Ok(spec);
+        }
+
+        let parsed = Url::parse(raw)?;
+        let scheme = parsed.scheme().to_ascii_lowercase();
+
+        if scheme == "adbc" {
+            return parse_adbc_url(&parsed);
+        }
+        if let Some(driver) = scheme.strip_prefix("adbc+") {
+            return parse_adbc_plus_url(raw, &scheme, driver);
+        }
+
+        parse_standard_url(raw, &parsed)
+    }
+
+    pub fn with_uri(mut self, uri: impl Into<String>) -> Self {
+        self.uri = Some(uri.into());
+        self
+    }
+
+    pub fn with_database_option(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        self.database_options.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn with_entrypoint(mut self, entrypoint: impl Into<String>) -> Self {
+        self.entrypoint = Some(entrypoint.into());
+        self
+    }
+
+    pub fn with_load_flags(mut self, load_flags: LoadFlags) -> Self {
+        self.load_flags = load_flags;
+        self
+    }
+
+    pub fn with_additional_search_paths(mut self, paths: Vec<PathBuf>) -> Self {
+        self.additional_search_paths = Some(paths);
+        self
+    }
+
+    pub fn driver_basename(&self) -> String {
+        driver_basename(&self.driver)
+    }
+
+    pub fn sql_dialect(&self) -> Option<SqlDialect> {
+        match self.driver_basename().as_str() {
+            "bigquery" => Some(SqlDialect::BigQuery),
+            "clickhouse" => Some(SqlDialect::ClickHouse),
+            "databricks" => Some(SqlDialect::Databricks),
+            "duckdb" => Some(SqlDialect::DuckDB),
+            "postgres" | "postgresql" => Some(SqlDialect::Postgres),
+            "snowflake" => Some(SqlDialect::Snowflake),
+            "spark" => Some(SqlDialect::Spark),
+            _ => None,
+        }
+    }
+}
+
+fn parse_direct_file_uri(raw: &str, driver: &str) -> Option<ConnectionSpec> {
+    let prefix = format!("{driver}:");
+    let slashed_prefix = format!("{driver}://");
+    if !raw.starts_with(&prefix) || raw.starts_with(&slashed_prefix) {
+        return None;
+    }
+
+    let value = raw[prefix.len()..].trim();
+    let uri = if value.is_empty() || value == "memory:" || value == ":memory:" {
+        ":memory:".to_string()
+    } else {
+        value.to_string()
+    };
+
+    Some(ConnectionSpec::with_driver(driver).with_uri(uri))
+}
+
+fn parse_duckdb_motherduck_uri(raw: &str) -> Option<ConnectionSpec> {
+    let prefix = "duckdb://";
+    let rest = raw.strip_prefix(prefix)?;
+    if !rest.starts_with("md:") {
+        return None;
+    }
+    Some(ConnectionSpec::with_driver("duckdb").with_uri(rest.to_string()))
+}
+
+fn parse_adbc_url(parsed: &Url) -> Result<ConnectionSpec> {
+    let driver = parsed
+        .host_str()
+        .or_else(|| parsed.path_segments().and_then(|mut parts| parts.next()))
+        .filter(|driver| !driver.is_empty())
+        .ok_or_else(|| {
+            SidemanticError::ConnectionUrl(
+                "adbc:// URL must specify a driver, e.g. adbc://postgresql?uri=postgresql://host/db"
+                    .into(),
+            )
+        })?;
+
+    let mut params = query_options(parsed);
+    let entrypoint = params.remove("entrypoint");
+    let mut spec = ConnectionSpec::with_driver(driver);
+    spec.entrypoint = entrypoint;
+
+    if let Some(uri) = params.remove("uri") {
+        spec.uri = Some(uri);
+    } else {
+        let path_uri = parsed.path().trim_start_matches('/');
+        if !path_uri.is_empty() && path_uri != driver {
+            spec.uri = Some(path_uri.to_string());
+        }
+    }
+
+    if spec.uri.is_none() && matches!(spec.driver.as_str(), "sqlite" | "duckdb") {
+        spec.uri = Some(":memory:".to_string());
+    }
+
+    spec.database_options = params;
+    Ok(spec)
+}
+
+fn parse_adbc_plus_url(raw: &str, scheme: &str, driver: &str) -> Result<ConnectionSpec> {
+    if driver.is_empty() {
+        return Err(SidemanticError::ConnectionUrl(
+            "adbc+ URLs must include a driver name, e.g. adbc+postgresql://host/db".into(),
+        ));
+    }
+
+    let uri = replace_scheme(raw, scheme, driver);
+    let parsed = Url::parse(&uri)?;
+    let mut spec = ConnectionSpec::with_driver(driver);
+    spec.database_options = query_options(&parsed);
+    spec.uri = if matches!(driver, "sqlite" | "duckdb") {
+        Some(file_uri_from_url(driver, &parsed))
+    } else {
+        Some(uri)
+    };
+    Ok(spec)
+}
+
+fn parse_standard_url(raw: &str, parsed: &Url) -> Result<ConnectionSpec> {
+    let scheme = parsed.scheme().to_ascii_lowercase();
+    let (driver, uri) = match scheme.as_str() {
+        "bigquery" => ("bigquery", bigquery_uri_from_url(parsed)?),
+        "clickhouse" => ("clickhouse", raw.to_string()),
+        "databricks" => ("databricks", databricks_uri_from_url(parsed)?),
+        "duckdb" => ("duckdb", file_uri_from_url("duckdb", parsed)),
+        "exasol" => ("exasol", raw.to_string()),
+        "flightsql" => ("flightsql", raw.to_string()),
+        "mssql" => ("mssql", raw.to_string()),
+        "mysql" => ("mysql", raw.to_string()),
+        "oracle" => ("oracle", raw.to_string()),
+        "postgres" => ("postgresql", replace_scheme(raw, "postgres", "postgresql")),
+        "postgresql" => ("postgresql", raw.to_string()),
+        "redshift" => ("redshift", raw.to_string()),
+        "snowflake" => ("snowflake", raw.to_string()),
+        "sqlserver" => ("mssql", replace_scheme(raw, "sqlserver", "mssql")),
+        "sqlite" => ("sqlite", file_uri_from_url("sqlite", parsed)),
+        "teradata" => ("teradata", raw.to_string()),
+        "trino" => ("trino", raw.to_string()),
+        other => {
+            return Err(SidemanticError::ConnectionUrl(format!(
+                "unsupported database URL scheme '{other}'. Supported dbc drivers: {}",
+                DBC_DRIVER_HINTS.join(", ")
+            )));
+        }
+    };
+
+    Ok(ConnectionSpec::with_driver(driver).with_uri(uri))
+}
+
+fn query_options(parsed: &Url) -> BTreeMap<String, String> {
+    parsed
+        .query_pairs()
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect()
+}
+
+fn file_uri_from_url(driver: &str, parsed: &Url) -> String {
+    if driver == "duckdb" {
+        if let Some(host) = parsed.host_str() {
+            if let Some(motherduck) = host.strip_prefix("md:") {
+                return format!("md:{motherduck}");
+            }
+        }
+    }
+
+    let path = parsed.path();
+    if path.is_empty() || path == "/" || path == "/:memory:" {
+        return ":memory:".to_string();
+    }
+    if path.starts_with("//") {
+        return path[1..].to_string();
+    }
+    path.to_string()
+}
+
+fn bigquery_project_dataset(parsed: &Url) -> (Option<String>, Option<String>) {
+    let path_parts: Vec<_> = parsed
+        .path_segments()
+        .map(|parts| parts.filter(|part| !part.is_empty()).collect())
+        .unwrap_or_default();
+    let query = query_options(parsed);
+    let query_dataset = query
+        .get("DatasetId")
+        .or_else(|| query.get("datasetId"))
+        .or_else(|| query.get("dataset_id"))
+        .cloned();
+
+    if let Some(host) = parsed.host_str() {
+        if !host.contains('.') {
+            return (
+                Some(host.to_string()),
+                path_parts
+                    .first()
+                    .map(|value| (*value).to_string())
+                    .or(query_dataset),
+            );
+        }
+    }
+
+    (
+        path_parts.first().map(|value| (*value).to_string()),
+        query_dataset.or_else(|| path_parts.get(1).map(|value| (*value).to_string())),
+    )
+}
+
+fn bigquery_uri_from_url(parsed: &Url) -> Result<String> {
+    let (project, dataset) = bigquery_project_dataset(parsed);
+    let project = project.ok_or_else(|| {
+        SidemanticError::ConnectionUrl("BigQuery URL must include a project id".into())
+    })?;
+
+    let mut query_items = Vec::new();
+    for (key, value) in parsed.query_pairs() {
+        let lowered = key.to_ascii_lowercase();
+        if matches!(
+            lowered.as_str(),
+            "location" | "region" | "datasetid" | "dataset_id"
+        ) {
+            continue;
+        }
+        query_items.push((key.into_owned(), value.into_owned()));
+    }
+
+    if let Some(dataset) = dataset {
+        query_items.push(("DatasetId".into(), dataset));
+    }
+
+    let query = query_options(parsed);
+    if let Some(location) = query
+        .get("Location")
+        .or_else(|| query.get("location"))
+        .or_else(|| query.get("region"))
+    {
+        query_items.push(("Location".into(), location.clone()));
+    }
+
+    let endpoint = parsed
+        .host_str()
+        .filter(|host| host.contains('.'))
+        .unwrap_or("");
+    let encoded_query = form_urlencoded::Serializer::new(String::new())
+        .extend_pairs(query_items)
+        .finish();
+    let uri = format!("bigquery://{endpoint}/{project}");
+    Ok(if encoded_query.is_empty() {
+        uri
+    } else {
+        format!("{uri}?{encoded_query}")
+    })
+}
+
+fn databricks_uri_from_url(parsed: &Url) -> Result<String> {
+    let host = parsed.host_str().ok_or_else(|| {
+        SidemanticError::ConnectionUrl("Databricks URL must include a server hostname".into())
+    })?;
+    let host = if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+
+    let username = parsed.username();
+    let password = parsed.password();
+    let userinfo = if username == "token" {
+        password.map(|password| format!("token:{password}"))
+    } else if !username.is_empty() && password.is_none() {
+        Some(format!("token:{username}"))
+    } else if !username.is_empty() {
+        Some(format!("{}:{}", username, password.unwrap_or_default()))
+    } else {
+        None
+    };
+
+    let mut uri = String::from("databricks://");
+    if let Some(userinfo) = userinfo {
+        uri.push_str(&userinfo);
+        uri.push('@');
+    }
+    uri.push_str(&host);
+    uri.push(':');
+    uri.push_str(&parsed.port().unwrap_or(443).to_string());
+    uri.push_str(parsed.path());
+    if let Some(query) = parsed.query() {
+        uri.push('?');
+        uri.push_str(query);
+    }
+    Ok(uri)
+}
+
+fn replace_scheme(raw: &str, old_scheme: &str, new_scheme: &str) -> String {
+    format!("{new_scheme}{}", &raw[old_scheme.len()..])
+}
+
+fn driver_basename(driver: &str) -> String {
+    let driver = driver.to_ascii_lowercase();
+    driver
+        .strip_prefix("adbc_driver_")
+        .unwrap_or(&driver)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(url: &str) -> ConnectionSpec {
+        ConnectionSpec::from_url(url).unwrap()
+    }
+
+    #[test]
+    fn maps_network_schemes_to_dbc_driver_names() {
+        let cases = [
+            ("postgres://u:p@host:5432/db", "postgresql"),
+            ("postgresql://host/db", "postgresql"),
+            ("mysql://host/db", "mysql"),
+            ("mssql://host/db", "mssql"),
+            ("sqlserver://host/db", "mssql"),
+            ("redshift://host/db", "redshift"),
+            ("snowflake://acct/db/schema", "snowflake"),
+            ("bigquery://project/dataset", "bigquery"),
+            ("clickhouse://host/default", "clickhouse"),
+            ("trino://host/catalog/schema", "trino"),
+            ("flightsql://host:31337", "flightsql"),
+            (
+                "databricks://token@host/sql/1.0/warehouses/abc",
+                "databricks",
+            ),
+            ("exasol://host/db", "exasol"),
+            ("oracle://host/service", "oracle"),
+            ("teradata://host/db", "teradata"),
+        ];
+
+        for (url, expected_driver) in cases {
+            assert_eq!(spec(url).driver, expected_driver);
+        }
+    }
+
+    #[test]
+    fn normalizes_postgres_and_sqlserver_aliases() {
+        assert_eq!(
+            spec("postgres://u:p@host:5432/db").uri.as_deref(),
+            Some("postgresql://u:p@host:5432/db")
+        );
+        assert_eq!(
+            spec("sqlserver://host:1433/db").uri.as_deref(),
+            Some("mssql://host:1433/db")
+        );
+    }
+
+    #[test]
+    fn normalizes_file_database_urls() {
+        assert_eq!(spec("sqlite:///:memory:").uri.as_deref(), Some(":memory:"));
+        assert_eq!(spec("sqlite::memory:").uri.as_deref(), Some(":memory:"));
+        assert_eq!(
+            spec("sqlite:///tmp/test.db").uri.as_deref(),
+            Some("/tmp/test.db")
+        );
+        assert_eq!(spec("duckdb:///:memory:").uri.as_deref(), Some(":memory:"));
+        assert_eq!(
+            spec("duckdb:///tmp/test.duckdb").uri.as_deref(),
+            Some("/tmp/test.duckdb")
+        );
+        assert_eq!(
+            spec("duckdb://md:warehouse").uri.as_deref(),
+            Some("md:warehouse")
+        );
+    }
+
+    #[test]
+    fn translates_bigquery_user_url_to_dbc_uri_shape() {
+        let parsed = spec("bigquery://proj/dataset?location=EU");
+        assert_eq!(parsed.driver, "bigquery");
+        assert_eq!(
+            parsed.uri.as_deref(),
+            Some("bigquery:///proj?DatasetId=dataset&Location=EU")
+        );
+    }
+
+    #[test]
+    fn translates_databricks_token_url_to_dbc_uri_shape() {
+        let parsed = spec("databricks://dapi123@workspace.cloud.databricks.com/sql/1.0/warehouses/abc?catalog=main");
+        assert_eq!(parsed.driver, "databricks");
+        assert_eq!(
+            parsed.uri.as_deref(),
+            Some("databricks://token:dapi123@workspace.cloud.databricks.com:443/sql/1.0/warehouses/abc?catalog=main")
+        );
+    }
+
+    #[test]
+    fn standard_urls_keep_query_parameters_in_uri_only() {
+        let snowflake = spec("snowflake://acct/db/schema?warehouse=compute_wh");
+        assert_eq!(
+            snowflake.uri.as_deref(),
+            Some("snowflake://acct/db/schema?warehouse=compute_wh")
+        );
+        assert!(snowflake.database_options.is_empty());
+
+        let bigquery = spec("bigquery://proj/dataset?location=EU");
+        assert_eq!(
+            bigquery.uri.as_deref(),
+            Some("bigquery:///proj?DatasetId=dataset&Location=EU")
+        );
+        assert!(bigquery.database_options.is_empty());
+    }
+
+    #[test]
+    fn parses_explicit_adbc_url() {
+        let parsed = spec("adbc://postgresql?uri=postgresql://host/db&sslmode=require");
+        assert_eq!(parsed.driver, "postgresql");
+        assert_eq!(parsed.uri.as_deref(), Some("postgresql://host/db"));
+        assert_eq!(
+            parsed.database_options.get("sslmode").map(String::as_str),
+            Some("require")
+        );
+
+        let sqlite = spec("adbc://sqlite");
+        assert_eq!(sqlite.driver, "sqlite");
+        assert_eq!(sqlite.uri.as_deref(), Some(":memory:"));
+    }
+
+    #[test]
+    fn parses_adbc_plus_escape_hatch() {
+        let parsed = spec("adbc+postgresql://host/db");
+        assert_eq!(parsed.driver, "postgresql");
+        assert_eq!(parsed.uri.as_deref(), Some("postgresql://host/db"));
+    }
+
+    #[test]
+    fn reports_unknown_scheme_with_dbc_hint() {
+        let err = ConnectionSpec::from_url("unknown://host/db").unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("unsupported database URL scheme"));
+        assert!(message.contains("postgresql"));
+    }
+
+    #[test]
+    fn maps_driver_to_sql_dialect() {
+        assert_eq!(
+            spec("postgres://host/db").sql_dialect(),
+            Some(SqlDialect::Postgres)
+        );
+        assert_eq!(
+            spec("snowflake://acct/db").sql_dialect(),
+            Some(SqlDialect::Snowflake)
+        );
+        assert_eq!(spec("trino://host/catalog/schema").sql_dialect(), None);
+    }
+}

--- a/sidemantic-rs/src/error.rs
+++ b/sidemantic-rs/src/error.rs
@@ -50,6 +50,13 @@ pub enum SidemanticError {
     #[error("SQL generation error: {0}")]
     SqlGeneration(String),
 
+    // Database execution errors
+    #[error("Database error: {0}")]
+    Database(String),
+
+    #[error("Connection URL error: {0}")]
+    ConnectionUrl(String),
+
     // Reference errors
     #[error("Invalid reference: '{reference}'. Expected format: model.field or model.field__granularity")]
     InvalidReference { reference: String },
@@ -158,6 +165,27 @@ impl From<std::io::Error> for SidemanticError {
 impl From<serde_yaml::Error> for SidemanticError {
     fn from(err: serde_yaml::Error) -> Self {
         SidemanticError::YamlParse(err.to_string())
+    }
+}
+
+#[cfg(feature = "adbc-exec")]
+impl From<adbc_core::error::Error> for SidemanticError {
+    fn from(err: adbc_core::error::Error) -> Self {
+        SidemanticError::Database(err.to_string())
+    }
+}
+
+#[cfg(feature = "adbc-exec")]
+impl From<arrow_schema::ArrowError> for SidemanticError {
+    fn from(err: arrow_schema::ArrowError) -> Self {
+        SidemanticError::Database(err.to_string())
+    }
+}
+
+#[cfg(feature = "adbc-exec")]
+impl From<url::ParseError> for SidemanticError {
+    fn from(err: url::ParseError) -> Self {
+        SidemanticError::ConnectionUrl(err.to_string())
     }
 }
 

--- a/sidemantic-rs/src/lib.rs
+++ b/sidemantic-rs/src/lib.rs
@@ -130,5 +130,6 @@ pub use wasm::{
 #[cfg(feature = "adbc-exec")]
 pub use db::{
     execute_with_adbc, execute_with_adbc_arrow_ipc, write_adbc_arrow_ipc, AdbcArrowIpcResult,
-    AdbcExecutionRequest, AdbcExecutionResult, AdbcValue,
+    AdbcExecutionRequest, AdbcExecutionResult, AdbcExecutor, AdbcValue, ConnectionSpec,
+    ExecutionResult, DBC_DRIVER_HINTS,
 };

--- a/sidemantic-rs/tests/adbc_engines.rs
+++ b/sidemantic-rs/tests/adbc_engines.rs
@@ -1,0 +1,201 @@
+#![cfg(feature = "adbc-exec")]
+
+use std::env;
+
+use sidemantic::{AdbcExecutor, Dimension, Metric, Model, SemanticGraph, SemanticQuery};
+
+#[test]
+fn adbc_engine_semantic_query_smoke() {
+    if env::var("SIDEMANTIC_ADBC_TESTS").ok().as_deref() != Some("1") {
+        return;
+    }
+
+    let target = EngineTarget::from_env();
+    match run_target(&target) {
+        Ok(()) => {}
+        Err(err) if !target.required => {
+            eprintln!(
+                "skipping best-effort Rust ADBC smoke for {}: {err}",
+                target.db
+            );
+        }
+        Err(err) => panic!("Rust ADBC smoke failed for {}: {err}", target.db),
+    }
+}
+
+struct EngineTarget {
+    db: String,
+    url: String,
+    table: String,
+    required: bool,
+}
+
+impl EngineTarget {
+    fn from_env() -> Self {
+        let db = env::var("SIDEMANTIC_ADBC_DB")
+            .unwrap_or_else(|_| "sqlite".to_string())
+            .to_ascii_lowercase();
+
+        let required = required_from_env(&db);
+        match db.as_str() {
+            "sqlite" => Self {
+                db,
+                url: "sqlite:///:memory:".to_string(),
+                table: "sidemantic_adbc_smoke".to_string(),
+                required,
+            },
+            "duckdb" => Self {
+                db,
+                url: "duckdb:///:memory:".to_string(),
+                table: "sidemantic_adbc_smoke".to_string(),
+                required,
+            },
+            "postgres" | "postgresql" => Self {
+                db,
+                url: env::var("POSTGRES_URL").unwrap_or_else(|_| {
+                    "postgres://test:test@localhost:5432/sidemantic_test".into()
+                }),
+                table: "sidemantic_adbc_smoke".to_string(),
+                required,
+            },
+            "clickhouse" => Self {
+                db,
+                url: env::var("CLICKHOUSE_URL")
+                    .unwrap_or_else(|_| "adbc://clickhouse?uri=http://localhost:8123/".into()),
+                table: "sidemantic_adbc_smoke".to_string(),
+                required,
+            },
+            "bigquery" => {
+                let project =
+                    env::var("BIGQUERY_PROJECT").unwrap_or_else(|_| "test-project".into());
+                let dataset =
+                    env::var("BIGQUERY_DATASET").unwrap_or_else(|_| "test_dataset".into());
+                env::set_var("GOOGLE_CLOUD_PROJECT", &project);
+                Self {
+                    db,
+                    url: format!("bigquery://{project}/{dataset}"),
+                    table: format!("{dataset}.sidemantic_adbc_smoke"),
+                    required,
+                }
+            }
+            "snowflake" => Self {
+                db,
+                url: env::var("SNOWFLAKE_URL").unwrap_or_else(|_| {
+                    "snowflake://test:test@test/testdb/public?warehouse=test_warehouse".into()
+                }),
+                table: "sidemantic_adbc_smoke".to_string(),
+                required,
+            },
+            other => panic!("unsupported SIDEMANTIC_ADBC_DB={other:?}"),
+        }
+    }
+
+    fn drop_sql(&self) -> String {
+        format!("DROP TABLE IF EXISTS {}", self.table)
+    }
+
+    fn create_sql(&self) -> String {
+        match self.db.as_str() {
+            "bigquery" => format!(
+                "CREATE TABLE {} (order_id INT64, status STRING, amount INT64)",
+                self.table
+            ),
+            "clickhouse" => format!(
+                "CREATE TABLE {} (order_id Int32, status String, amount Int32) ENGINE = Memory",
+                self.table
+            ),
+            "snowflake" => format!(
+                "CREATE OR REPLACE TEMPORARY TABLE {} \
+                 (order_id INTEGER, status VARCHAR, amount INTEGER)",
+                self.table
+            ),
+            _ => format!(
+                "CREATE TABLE {} (order_id INTEGER, status VARCHAR(16), amount INTEGER)",
+                self.table
+            ),
+        }
+    }
+
+    fn insert_sql(&self) -> String {
+        format!(
+            "INSERT INTO {} VALUES (1, 'paid', 10), (2, 'paid', 20), (3, 'open', 5)",
+            self.table
+        )
+    }
+}
+
+fn required_from_env(db: &str) -> bool {
+    match env::var("SIDEMANTIC_ADBC_REQUIRED") {
+        Ok(value) if matches!(value.as_str(), "1" | "true" | "yes" | "required") => true,
+        Ok(value) if matches!(value.as_str(), "0" | "false" | "no" | "best-effort") => false,
+        _ => matches!(
+            db,
+            "sqlite" | "duckdb" | "postgres" | "postgresql" | "clickhouse"
+        ),
+    }
+}
+
+fn run_target(target: &EngineTarget) -> Result<(), String> {
+    let mut executor = AdbcExecutor::connect_url(&target.url).map_err(|err| {
+        format!(
+            "failed to connect with URL {:?} through dbc/ADBC: {err}",
+            target.url
+        )
+    })?;
+
+    let drop_sql = target.drop_sql();
+    let _ = executor.execute_update(&drop_sql);
+
+    let result = run_semantic_flow(target, &mut executor);
+    let _ = executor.execute_update(&drop_sql);
+    result
+}
+
+fn run_semantic_flow(target: &EngineTarget, executor: &mut AdbcExecutor) -> Result<(), String> {
+    execute_update(executor, &target.create_sql())?;
+    execute_update(executor, &target.insert_sql())?;
+
+    let mut graph = SemanticGraph::new();
+    graph
+        .add_model(
+            Model::new("orders", "order_id")
+                .with_table(&target.table)
+                .with_dimension(Dimension::categorical("status"))
+                .with_metric(Metric::sum("revenue", "amount")),
+        )
+        .map_err(|err| format!("failed to build semantic graph: {err}"))?;
+
+    let query = SemanticQuery::new()
+        .with_metrics(vec!["orders.revenue".into()])
+        .with_dimensions(vec!["orders.status".into()]);
+
+    let result = executor
+        .execute_semantic_query(&graph, &query)
+        .map_err(|err| format!("failed to execute semantic query: {err}"))?;
+    let field_names: Vec<_> = result
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect();
+    if field_names != ["status".to_string(), "revenue".to_string()] {
+        return Err(format!("unexpected result schema fields: {field_names:?}"));
+    }
+
+    let batches = result
+        .collect()
+        .map_err(|err| format!("failed to collect semantic query results: {err}"))?;
+    let row_count: usize = batches.iter().map(|batch| batch.num_rows()).sum();
+    if row_count != 2 {
+        return Err(format!("expected two grouped result rows, got {row_count}"));
+    }
+
+    Ok(())
+}
+
+fn execute_update(executor: &mut AdbcExecutor, sql: &str) -> Result<(), String> {
+    executor
+        .execute_update(sql)
+        .map(|_| ())
+        .map_err(|err| format!("failed SQL {sql:?}: {err}"))
+}

--- a/sidemantic/db/adbc.py
+++ b/sidemantic/db/adbc.py
@@ -162,7 +162,7 @@ class ADBCAdapter(BaseDatabaseAdapter):
     def execute(self, sql: str) -> ADBCResult:
         """Execute SQL and return wrapped cursor."""
         cursor = self.conn.cursor()
-        cursor.execute(sql)
+        cursor.execute(_ensure_trailing_newline(sql))
         return ADBCResult(cursor)
 
     def executemany(self, sql: str, params: list) -> ADBCResult:
@@ -422,3 +422,10 @@ class ADBCAdapter(BaseDatabaseAdapter):
             return cls(driver=driver, uri=uri)
 
         return cls(driver=driver, uri=url)
+
+
+def _ensure_trailing_newline(sql: str) -> str:
+    # Some ADBC drivers wrap query SQL in another statement. If a generated
+    # query ends with a line comment, a trailing newline keeps wrapper SQL out
+    # of that comment.
+    return sql if sql.endswith("\n") else f"{sql}\n"

--- a/tests/db/test_adbc_adapter.py
+++ b/tests/db/test_adbc_adapter.py
@@ -467,6 +467,26 @@ def test_adbc_result_fetch_helpers_close_cursor():
     assert cursor3.closed is True
 
 
+def test_adbc_adapter_execute_appends_newline_after_trailing_comment():
+    from sidemantic.db.adbc import ADBCAdapter
+
+    captured = {}
+
+    class FakeCursor:
+        description = [("x",)]
+
+        def execute(self, sql):
+            captured["sql"] = sql
+
+    adapter = ADBCAdapter.__new__(ADBCAdapter)
+    adapter.conn = SimpleNamespace(cursor=FakeCursor)
+
+    adapter.execute("SELECT 1\n-- sidemantic: models=orders")
+
+    assert captured["sql"].endswith("\n")
+    assert captured["sql"].splitlines()[-1] == "-- sidemantic: models=orders"
+
+
 def test_adbc_adapter_get_tables_uses_native_metadata():
     from sidemantic.db.adbc import ADBCAdapter
 


### PR DESCRIPTION
## Summary

Adds a pure Rust ADBC execution layer for `sidemantic-rs`, with connection URL normalization for dbc-backed driver names and Arrow result handling.

Wires the existing ADBC integration workflow to install native drivers through Columnar `dbc`, then runs a Rust semantic-query smoke test across the engine matrix. SQLite, DuckDB, PostgreSQL, and ClickHouse are strict CI targets; BigQuery and Snowflake are present but best-effort because the current CI endpoints are emulator/fakesnow-style rather than guaranteed native Rust ADBC endpoints.

## Impact

Rust can now execute generated semantic SQL through ADBC drivers registered by `dbc`, without adding Python adapter dependencies or Rust-backed Python paths.

## Validation

Validated with the repo-required Python lint, format, and full test suite, plus Rust fmt, clippy, full Rust tests, local SQLite/DuckDB ADBC smoke tests, workflow YAML parsing, and diff whitespace checks.