### PR TITLE
Add pure Rust Python test parity harness

### DIFF
--- a/sidemantic-rs/examples/parity_adapter.rs
+++ b/sidemantic-rs/examples/parity_adapter.rs
@@ -1,0 +1,689 @@
+use std::io::{self, Read};
+
+use polyglot_sql::DialectType;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sidemantic::{
+    build_symmetric_aggregate_sql, config::SidemanticConfig, load_from_string, Aggregation,
+    DimensionType, Metric, Model, QueryRewriter, RelationshipType, SemanticGraph, SemanticQuery,
+    SqlDialect, SqlGenerator, SymmetricAggType, TableCalculation,
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+enum Request {
+    Validate {
+        models_yaml: String,
+    },
+    Compile {
+        models_yaml: String,
+        #[serde(default)]
+        metrics: Vec<String>,
+        #[serde(default)]
+        dimensions: Vec<String>,
+        #[serde(default)]
+        filters: Vec<String>,
+        #[serde(default)]
+        segments: Vec<String>,
+        #[serde(default)]
+        order_by: Vec<String>,
+        limit: Option<usize>,
+        #[serde(default)]
+        ungrouped: bool,
+        #[serde(default)]
+        skip_default_time_dimensions: bool,
+        dialect: Option<String>,
+    },
+    JoinPath {
+        models_yaml: String,
+        from_model: String,
+        to_model: String,
+    },
+    RewriteSql {
+        models_yaml: String,
+        sql: String,
+    },
+    CatalogMetadata {
+        models_yaml: String,
+        schema: Option<String>,
+    },
+    GraphAddModel {
+        models_yaml: String,
+        model_yaml: String,
+    },
+    GraphAddMetric {
+        models_yaml: String,
+        metric_yaml: String,
+    },
+    GraphAddTableCalculation {
+        models_yaml: String,
+        #[serde(default)]
+        table_calculations_json: Vec<Value>,
+        table_calculation_json: Value,
+    },
+    GraphGetModel {
+        models_yaml: String,
+        name: String,
+    },
+    GraphGetMetric {
+        models_yaml: String,
+        name: String,
+    },
+    GraphGetTableCalculation {
+        models_yaml: String,
+        #[serde(default)]
+        table_calculations_json: Vec<Value>,
+        name: String,
+    },
+    GraphBuildAdjacency {
+        models_yaml: String,
+    },
+    SymmetricAggregateSql {
+        measure_expr: String,
+        primary_key: String,
+        agg_type: String,
+        model_alias: Option<String>,
+        dialect: Option<String>,
+    },
+    NeedsSymmetricAggregate {
+        relationship: String,
+        is_base_model: bool,
+    },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum Response {
+    Ok {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sql: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        path: Option<Vec<PathStep>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        catalog: Option<Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        value: Option<Value>,
+    },
+    Error {
+        error: String,
+    },
+}
+
+#[derive(Debug, Serialize)]
+struct PathStep {
+    from_model: String,
+    to_model: String,
+    from_columns: Vec<String>,
+    to_columns: Vec<String>,
+    relationship: &'static str,
+}
+
+fn handle(request: Request) -> sidemantic::Result<Response> {
+    match request {
+        Request::Validate { models_yaml } => {
+            load_from_string(&models_yaml)?;
+            Ok(Response::Ok {
+                sql: None,
+                path: None,
+                catalog: None,
+                value: None,
+            })
+        }
+        Request::Compile {
+            models_yaml,
+            metrics,
+            dimensions,
+            filters,
+            segments,
+            order_by,
+            limit,
+            ungrouped,
+            skip_default_time_dimensions,
+            dialect,
+        } => {
+            let graph = load_from_string(&models_yaml)?;
+            let mut query = SemanticQuery::new()
+                .with_metrics(metrics)
+                .with_dimensions(dimensions)
+                .with_filters(filters)
+                .with_segments(segments)
+                .with_order_by(order_by)
+                .with_ungrouped(ungrouped)
+                .with_skip_default_time_dimensions(skip_default_time_dimensions);
+            if let Some(limit) = limit {
+                query = query.with_limit(limit);
+            }
+            let mut generator = SqlGenerator::new(&graph);
+            if let Some(dialect) = dialect {
+                generator = generator.with_dialect(parse_dialect(&dialect)?);
+            }
+            let sql = generator.generate(&query)?;
+            Ok(Response::Ok {
+                sql: Some(sql),
+                path: None,
+                catalog: None,
+                value: None,
+            })
+        }
+        Request::JoinPath {
+            models_yaml,
+            from_model,
+            to_model,
+        } => {
+            let graph = load_from_string(&models_yaml)?;
+            let path = graph.find_join_path(&from_model, &to_model)?;
+            let steps = path
+                .steps
+                .into_iter()
+                .map(|step| PathStep {
+                    from_model: step.from_model,
+                    to_model: step.to_model,
+                    from_columns: step.from_keys,
+                    to_columns: step.to_keys,
+                    relationship: relationship_type_name(&step.relationship_type),
+                })
+                .collect();
+            Ok(Response::Ok {
+                sql: None,
+                path: Some(steps),
+                catalog: None,
+                value: None,
+            })
+        }
+        Request::RewriteSql { models_yaml, sql } => {
+            let graph = load_from_string(&models_yaml)?;
+            let rewritten = QueryRewriter::new(&graph).rewrite(&sql)?;
+            Ok(Response::Ok {
+                sql: Some(rewritten),
+                path: None,
+                catalog: None,
+                value: None,
+            })
+        }
+        Request::CatalogMetadata {
+            models_yaml,
+            schema,
+        } => {
+            let graph = load_from_string(&models_yaml)?;
+            Ok(Response::Ok {
+                sql: None,
+                path: None,
+                catalog: Some(catalog_metadata(
+                    &graph,
+                    schema.as_deref().unwrap_or("public"),
+                )),
+                value: None,
+            })
+        }
+        Request::GraphAddModel {
+            models_yaml,
+            model_yaml,
+        } => {
+            let mut graph = load_from_string(&models_yaml)?;
+            graph.add_model(parse_single_model(&model_yaml)?)?;
+            Ok(Response::Ok {
+                sql: None,
+                path: None,
+                catalog: None,
+                value: None,
+            })
+        }
+        Request::GraphAddMetric {
+            models_yaml,
+            metric_yaml,
+        } => {
+            let mut graph = load_from_string(&models_yaml)?;
+            graph.add_metric(parse_single_metric(&metric_yaml)?)?;
+            Ok(Response::Ok {
+                sql: None,
+                path: None,
+                catalog: None,
+                value: None,
+            })
+        }
+        Request::GraphAddTableCalculation {
+            models_yaml,
+            table_calculations_json,
+            table_calculation_json,
+        } => {
+            let mut graph =
+                load_graph_with_table_calculations(&models_yaml, table_calculations_json)?;
+            graph.add_table_calculation(parse_table_calculation_value(table_calculation_json)?)?;
+            Ok(Response::Ok {
+                sql: None,
+                path: None,
+                catalog: None,
+                value: None,
+            })
+        }
+        Request::GraphGetModel { models_yaml, name } => {
+            let graph = load_from_string(&models_yaml)?;
+            if graph.get_model(&name).is_none() {
+                return Err(sidemantic::SidemanticError::Validation(format!(
+                    "Model {name} not found"
+                )));
+            }
+            Ok(Response::Ok {
+                sql: None,
+                path: None,
+                catalog: None,
+                value: None,
+            })
+        }
+        Request::GraphGetMetric { models_yaml, name } => {
+            let graph = load_from_string(&models_yaml)?;
+            if graph.get_metric(&name).is_none() {
+                return Err(sidemantic::SidemanticError::Validation(format!(
+                    "Measure {name} not found"
+                )));
+            }
+            Ok(Response::Ok {
+                sql: None,
+                path: None,
+                catalog: None,
+                value: None,
+            })
+        }
+        Request::GraphGetTableCalculation {
+            models_yaml,
+            table_calculations_json,
+            name,
+        } => {
+            let graph = load_graph_with_table_calculations(&models_yaml, table_calculations_json)?;
+            if graph.get_table_calculation(&name).is_none() {
+                return Err(sidemantic::SidemanticError::Validation(format!(
+                    "Table calculation {name} not found"
+                )));
+            }
+            Ok(Response::Ok {
+                sql: None,
+                path: None,
+                catalog: None,
+                value: None,
+            })
+        }
+        Request::GraphBuildAdjacency { models_yaml } => {
+            load_from_string(&models_yaml)?;
+            Ok(Response::Ok {
+                sql: None,
+                path: None,
+                catalog: None,
+                value: None,
+            })
+        }
+        Request::SymmetricAggregateSql {
+            measure_expr,
+            primary_key,
+            agg_type,
+            model_alias,
+            dialect,
+        } => {
+            let agg_type = parse_symmetric_agg_type(&agg_type)?;
+            let dialect = dialect
+                .as_deref()
+                .and_then(SqlDialect::parse)
+                .unwrap_or(SqlDialect::DuckDB);
+            let sql = build_symmetric_aggregate_sql(
+                &measure_expr,
+                &primary_key,
+                agg_type,
+                model_alias.as_deref(),
+                dialect,
+            );
+            Ok(Response::Ok {
+                sql: Some(sql),
+                path: None,
+                catalog: None,
+                value: None,
+            })
+        }
+        Request::NeedsSymmetricAggregate {
+            relationship,
+            is_base_model,
+        } => Ok(Response::Ok {
+            sql: None,
+            path: None,
+            catalog: None,
+            value: Some(json!(
+                sidemantic::core::symmetric_agg::needs_symmetric_aggregate(
+                    &relationship,
+                    is_base_model
+                )
+            )),
+        }),
+    }
+}
+
+fn parse_symmetric_agg_type(agg_type: &str) -> sidemantic::Result<SymmetricAggType> {
+    match agg_type {
+        "sum" => Ok(SymmetricAggType::Sum),
+        "avg" => Ok(SymmetricAggType::Avg),
+        "count" => Ok(SymmetricAggType::Count),
+        "count_distinct" => Ok(SymmetricAggType::CountDistinct),
+        "min" => Ok(SymmetricAggType::Min),
+        "max" => Ok(SymmetricAggType::Max),
+        "median" => Err(sidemantic::SidemanticError::Validation(
+            "Symmetric aggregates do not support MEDIAN. Use pre-aggregation or restructure the query to avoid fan-out joins.".to_string(),
+        )),
+        value => Err(sidemantic::SidemanticError::Validation(format!(
+            "Unsupported aggregation type for symmetric aggregates: {value}"
+        ))),
+    }
+}
+
+fn parse_dialect(dialect: &str) -> sidemantic::Result<DialectType> {
+    match dialect.to_ascii_lowercase().as_str() {
+        "duckdb" => Ok(DialectType::DuckDB),
+        "bigquery" => Ok(DialectType::BigQuery),
+        "postgres" | "postgresql" => Ok(DialectType::PostgreSQL),
+        value => Err(sidemantic::SidemanticError::Validation(format!(
+            "Unsupported SQL dialect for pure Rust Python test parity adapter: {value}"
+        ))),
+    }
+}
+
+fn parse_single_model(model_yaml: &str) -> sidemantic::Result<Model> {
+    let config: SidemanticConfig = serde_yaml::from_str(model_yaml)?;
+    let (models, _, _) = config.into_parts()?;
+    let mut models = models.into_iter();
+    let Some(model) = models.next() else {
+        return Err(sidemantic::SidemanticError::Validation(
+            "Expected exactly one model".to_string(),
+        ));
+    };
+    if models.next().is_some() {
+        return Err(sidemantic::SidemanticError::Validation(
+            "Expected exactly one model".to_string(),
+        ));
+    }
+    Ok(model)
+}
+
+fn parse_single_metric(metric_yaml: &str) -> sidemantic::Result<Metric> {
+    let config: SidemanticConfig = serde_yaml::from_str(metric_yaml)?;
+    let (_, metrics, _) = config.into_parts()?;
+    let mut metrics = metrics.into_iter();
+    let Some(metric) = metrics.next() else {
+        return Err(sidemantic::SidemanticError::Validation(
+            "Expected exactly one metric".to_string(),
+        ));
+    };
+    if metrics.next().is_some() {
+        return Err(sidemantic::SidemanticError::Validation(
+            "Expected exactly one metric".to_string(),
+        ));
+    }
+    Ok(metric)
+}
+
+fn load_graph_with_table_calculations(
+    models_yaml: &str,
+    table_calculations_json: Vec<Value>,
+) -> sidemantic::Result<SemanticGraph> {
+    let mut graph = load_from_string(models_yaml)?;
+    for value in table_calculations_json {
+        graph.add_table_calculation(parse_table_calculation_value(value)?)?;
+    }
+    Ok(graph)
+}
+
+fn parse_table_calculation_value(value: Value) -> sidemantic::Result<TableCalculation> {
+    serde_json::from_value(value).map_err(|err| {
+        sidemantic::SidemanticError::Validation(format!("Invalid table calculation: {err}"))
+    })
+}
+
+fn catalog_metadata(graph: &SemanticGraph, schema: &str) -> Value {
+    let mut tables = Vec::new();
+    let mut columns = Vec::new();
+    let mut constraints = Vec::new();
+    let mut key_column_usage = Vec::new();
+
+    for model in graph.models() {
+        tables.push(json!({
+            "table_catalog": "sidemantic",
+            "table_schema": schema,
+            "table_name": model.name,
+            "table_type": "BASE TABLE",
+            "is_insertable_into": "NO",
+            "is_typed": "NO",
+        }));
+
+        let mut ordinal = 1;
+        for primary_key in model.primary_keys() {
+            columns.push(json!({
+                "table_catalog": "sidemantic",
+                "table_schema": schema,
+                "table_name": model.name,
+                "column_name": primary_key,
+                "ordinal_position": ordinal,
+                "column_default": null,
+                "is_nullable": "NO",
+                "data_type": "BIGINT",
+                "character_maximum_length": null,
+                "numeric_precision": 64,
+                "numeric_scale": 0,
+                "is_primary_key": true,
+                "is_foreign_key": false,
+                "is_metric": false,
+            }));
+            ordinal += 1;
+        }
+
+        if !model.primary_keys().is_empty() {
+            constraints.push(json!({
+                "constraint_catalog": "sidemantic",
+                "constraint_schema": schema,
+                "constraint_name": format!("{}_pkey", model.name),
+                "table_catalog": "sidemantic",
+                "table_schema": schema,
+                "table_name": model.name,
+                "constraint_type": "PRIMARY KEY",
+                "is_deferrable": "NO",
+                "initially_deferred": "NO",
+            }));
+
+            for (key_index, primary_key) in model.primary_keys().into_iter().enumerate() {
+                key_column_usage.push(json!({
+                    "constraint_catalog": "sidemantic",
+                    "constraint_schema": schema,
+                    "constraint_name": format!("{}_pkey", model.name),
+                    "table_catalog": "sidemantic",
+                    "table_schema": schema,
+                    "table_name": model.name,
+                    "column_name": primary_key,
+                    "ordinal_position": key_index + 1,
+                }));
+            }
+        }
+
+        for dimension in &model.dimensions {
+            if model.primary_keys().contains(&dimension.name) {
+                continue;
+            }
+
+            let data_type =
+                postgres_type_for_dimension(&dimension.r#type, dimension.granularity.as_deref());
+            let mut column = json!({
+                "table_catalog": "sidemantic",
+                "table_schema": schema,
+                "table_name": model.name,
+                "column_name": dimension.name,
+                "ordinal_position": ordinal,
+                "column_default": null,
+                "is_nullable": "YES",
+                "data_type": data_type,
+                "character_maximum_length": if data_type == "VARCHAR" { Some(255) } else { None },
+                "numeric_precision": if data_type == "NUMERIC" { Some(38) } else { None },
+                "numeric_scale": if data_type == "NUMERIC" { Some(10) } else { None },
+                "is_primary_key": false,
+                "is_foreign_key": false,
+                "is_metric": false,
+            });
+            if let Some(description) = &dimension.description {
+                column["description"] = json!(description);
+            }
+            if let Some(label) = &dimension.label {
+                column["label"] = json!(label);
+            }
+            columns.push(column);
+            ordinal += 1;
+        }
+
+        for metric in &model.metrics {
+            let data_type = postgres_type_for_metric(metric.agg.as_ref());
+            let mut column = json!({
+                "table_catalog": "sidemantic",
+                "table_schema": schema,
+                "table_name": model.name,
+                "column_name": metric.name,
+                "ordinal_position": ordinal,
+                "column_default": null,
+                "is_nullable": "YES",
+                "data_type": data_type,
+                "character_maximum_length": null,
+                "numeric_precision": if data_type == "NUMERIC" { 38 } else { 64 },
+                "numeric_scale": if data_type == "NUMERIC" { 10 } else { 0 },
+                "is_primary_key": false,
+                "is_foreign_key": false,
+                "is_metric": true,
+                "aggregation": metric_aggregation_name(metric.agg.as_ref()),
+            });
+            if let Some(description) = &metric.description {
+                column["description"] = json!(description);
+            }
+            if let Some(label) = &metric.label {
+                column["label"] = json!(label);
+            }
+            columns.push(column);
+            ordinal += 1;
+        }
+
+        for relationship in &model.relationships {
+            if matches!(
+                relationship.r#type,
+                RelationshipType::ManyToOne | RelationshipType::OneToOne
+            ) {
+                let fk_column = relationship.fk();
+                let referenced_table = &relationship.name;
+                let referenced_column = graph
+                    .get_model(referenced_table)
+                    .map(|target| {
+                        target
+                            .primary_keys()
+                            .into_iter()
+                            .next()
+                            .unwrap_or_else(|| "id".to_string())
+                    })
+                    .unwrap_or_else(|| relationship.pk());
+                let constraint_name = format!("{}_{}_fkey", model.name, fk_column);
+
+                constraints.push(json!({
+                    "constraint_catalog": "sidemantic",
+                    "constraint_schema": schema,
+                    "constraint_name": constraint_name,
+                    "table_catalog": "sidemantic",
+                    "table_schema": schema,
+                    "table_name": model.name,
+                    "constraint_type": "FOREIGN KEY",
+                    "is_deferrable": "NO",
+                    "initially_deferred": "NO",
+                }));
+
+                key_column_usage.push(json!({
+                    "constraint_catalog": "sidemantic",
+                    "constraint_schema": schema,
+                    "constraint_name": constraint_name,
+                    "table_catalog": "sidemantic",
+                    "table_schema": schema,
+                    "table_name": model.name,
+                    "column_name": fk_column,
+                    "ordinal_position": 1,
+                    "position_in_unique_constraint": 1,
+                    "referenced_table_schema": schema,
+                    "referenced_table_name": referenced_table,
+                    "referenced_column_name": referenced_column,
+                }));
+
+                for column in &mut columns {
+                    if column["table_name"] == model.name && column["column_name"] == fk_column {
+                        column["is_foreign_key"] = json!(true);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    json!({
+        "tables": tables,
+        "columns": columns,
+        "constraints": constraints,
+        "key_column_usage": key_column_usage,
+    })
+}
+
+fn postgres_type_for_dimension(
+    dimension_type: &DimensionType,
+    granularity: Option<&str>,
+) -> &'static str {
+    match dimension_type {
+        DimensionType::Categorical => "VARCHAR",
+        DimensionType::Numeric => "NUMERIC",
+        DimensionType::Boolean => "BOOLEAN",
+        DimensionType::Time => match granularity {
+            Some("day" | "week" | "month" | "quarter" | "year") => "DATE",
+            _ => "TIMESTAMP",
+        },
+    }
+}
+
+fn postgres_type_for_metric(aggregation: Option<&Aggregation>) -> &'static str {
+    match aggregation {
+        Some(Aggregation::Count | Aggregation::CountDistinct) => "BIGINT",
+        _ => "NUMERIC",
+    }
+}
+
+fn metric_aggregation_name(aggregation: Option<&Aggregation>) -> &'static str {
+    match aggregation {
+        Some(Aggregation::Sum) => "sum",
+        Some(Aggregation::Count) => "count",
+        Some(Aggregation::CountDistinct) => "count_distinct",
+        Some(Aggregation::Avg) => "avg",
+        Some(Aggregation::Min) => "min",
+        Some(Aggregation::Max) => "max",
+        Some(Aggregation::Median) => "median",
+        Some(Aggregation::Expression) | None => "sum",
+    }
+}
+
+fn relationship_type_name(relationship_type: &RelationshipType) -> &'static str {
+    match relationship_type {
+        RelationshipType::ManyToOne => "many_to_one",
+        RelationshipType::OneToOne => "one_to_one",
+        RelationshipType::OneToMany => "one_to_many",
+        RelationshipType::ManyToMany => "many_to_many",
+    }
+}
+
+fn main() {
+    let mut input = String::new();
+    if let Err(err) = io::stdin().read_to_string(&mut input) {
+        println!(
+            "{}",
+            serde_json::to_string(&Response::Error {
+                error: format!("failed to read stdin: {err}")
+            })
+            .unwrap()
+        );
+        std::process::exit(1);
+    }
+
+    let response = serde_json::from_str::<Request>(&input)
+        .map_err(|err| err.to_string())
+        .and_then(|request| handle(request).map_err(|err| err.to_string()))
+        .unwrap_or_else(|error| Response::Error { error });
+
+    println!("{}", serde_json::to_string(&response).unwrap());
+}

--- a/sidemantic-rs/src/config/loader.rs
+++ b/sidemantic-rs/src/config/loader.rs
@@ -114,6 +114,11 @@ pub fn load_from_string_with_metadata(content: &str) -> Result<LoadedGraphMetada
 
     let mut graph = SemanticGraph::new();
     add_resolved_models_in_order(&mut graph, resolved_models, &model_order)?;
+    for metric in top_level_metrics.iter().cloned() {
+        if graph.get_metric(&metric.name).is_none() {
+            graph.add_metric(metric)?;
+        }
+    }
     for parameter in top_level_parameters {
         graph.add_parameter(parameter)?;
     }
@@ -315,6 +320,11 @@ pub fn load_from_sql_string_with_metadata(content: &str) -> Result<LoadedGraphMe
 
     let mut graph = SemanticGraph::new();
     add_resolved_models_in_order(&mut graph, resolved_models, &model_order)?;
+    for metric in top_level_metrics.iter().cloned() {
+        if graph.get_metric(&metric.name).is_none() {
+            graph.add_metric(metric)?;
+        }
+    }
     for parameter in top_level_parameters {
         graph.add_parameter(parameter)?;
     }
@@ -488,6 +498,11 @@ pub fn load_from_directory_with_metadata(dir: impl AsRef<Path>) -> Result<Loaded
     // Build the graph
     let mut graph = SemanticGraph::new();
     add_resolved_models_in_order(&mut graph, resolved_models, &model_order)?;
+    for metric in all_top_level_metrics.iter().cloned() {
+        if graph.get_metric(&metric.name).is_none() {
+            graph.add_metric(metric)?;
+        }
+    }
     for parameter in all_top_level_parameters {
         graph.add_parameter(parameter)?;
     }

--- a/sidemantic-rs/src/core/graph.rs
+++ b/sidemantic-rs/src/core/graph.rs
@@ -2,8 +2,10 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::core::model::{DimensionType, Model, RelationshipType};
+use crate::core::extract_dependencies;
+use crate::core::model::{DimensionType, Metric, MetricType, Model, RelationshipType};
 use crate::core::Parameter;
+use crate::core::TableCalculation;
 use crate::error::{Result, SidemanticError};
 
 /// A step in a join path
@@ -79,6 +81,9 @@ type AdjacencyEdge = (
 #[derive(Debug, Default)]
 pub struct SemanticGraph {
     models: HashMap<String, Model>,
+    metrics: HashMap<String, Metric>,
+    model_metrics: HashMap<String, Metric>,
+    table_calculations: HashMap<String, TableCalculation>,
     parameters: HashMap<String, Parameter>,
     /// Adjacency list: model -> edges
     adjacency: HashMap<String, Vec<AdjacencyEdge>>,
@@ -221,6 +226,8 @@ impl SemanticGraph {
             )));
         }
 
+        self.index_model_metrics(&model);
+
         self.models.insert(name, model);
         self.rebuild_adjacency();
         Ok(())
@@ -232,8 +239,37 @@ impl SemanticGraph {
 
         Self::validate_model(&model)?;
         self.models.insert(name, model);
+        self.rebuild_model_metric_index();
         self.rebuild_adjacency();
         Ok(())
+    }
+
+    fn is_indexed_model_metric(metric: &Metric) -> bool {
+        matches!(
+            metric.r#type,
+            MetricType::TimeComparison | MetricType::Conversion
+        )
+    }
+
+    fn index_model_metrics(&mut self, model: &Model) {
+        for metric in &model.metrics {
+            if Self::is_indexed_model_metric(metric) && self.get_metric(&metric.name).is_none() {
+                self.model_metrics
+                    .insert(metric.name.clone(), metric.clone());
+            }
+        }
+    }
+
+    fn rebuild_model_metric_index(&mut self) {
+        self.model_metrics.clear();
+
+        let mut model_names: Vec<String> = self.models.keys().cloned().collect();
+        model_names.sort();
+        for model_name in model_names {
+            if let Some(model) = self.models.get(&model_name).cloned() {
+                self.index_model_metrics(&model);
+            }
+        }
     }
 
     /// Get a model by name
@@ -244,6 +280,97 @@ impl SemanticGraph {
     /// Get all models
     pub fn models(&self) -> impl Iterator<Item = &Model> {
         self.models.values()
+    }
+
+    /// Add a graph-level metric.
+    pub fn add_metric(&mut self, metric: Metric) -> Result<()> {
+        if self.get_metric(&metric.name).is_some() {
+            return Err(SidemanticError::Validation(format!(
+                "Measure '{}' already exists",
+                metric.name
+            )));
+        }
+        self.validate_metric_dependencies(&metric)?;
+        self.metrics.insert(metric.name.clone(), metric);
+        Ok(())
+    }
+
+    fn validate_metric_dependencies(&self, metric: &Metric) -> Result<()> {
+        for dependency in extract_dependencies(metric, Some(self)) {
+            let dependency_name = dependency
+                .rsplit_once('.')
+                .map(|(_, name)| name)
+                .unwrap_or(dependency.as_str());
+            if dependency == metric.name || dependency_name == metric.name {
+                return Err(SidemanticError::Validation(format!(
+                    "Metric '{}' cannot reference itself",
+                    metric.name
+                )));
+            }
+
+            if self.metric_dependency_exists(&dependency)? {
+                continue;
+            }
+
+            return Err(SidemanticError::Validation(format!(
+                "measure '{}' not found",
+                dependency_name
+            )));
+        }
+        Ok(())
+    }
+
+    fn metric_dependency_exists(&self, dependency: &str) -> Result<bool> {
+        if let Some((model_name, metric_name)) = dependency.rsplit_once('.') {
+            let Some(model) = self.models.get(model_name) else {
+                let available: Vec<&str> = self.models.keys().map(|s| s.as_str()).collect();
+                return Err(SidemanticError::model_not_found(model_name, &available));
+            };
+            return Ok(model.get_metric(metric_name).is_some());
+        }
+
+        if self.get_metric(dependency).is_some() {
+            return Ok(true);
+        }
+
+        Ok(self
+            .models
+            .values()
+            .any(|model| model.get_metric(dependency).is_some()))
+    }
+
+    /// Get a graph-level metric by name.
+    pub fn get_metric(&self, name: &str) -> Option<&Metric> {
+        self.metrics
+            .get(name)
+            .or_else(|| self.model_metrics.get(name))
+    }
+
+    /// Get all graph-level metrics.
+    pub fn metrics(&self) -> impl Iterator<Item = &Metric> {
+        self.metrics.values().chain(self.model_metrics.values())
+    }
+
+    /// Add a graph-level table calculation.
+    pub fn add_table_calculation(&mut self, calc: TableCalculation) -> Result<()> {
+        if self.table_calculations.contains_key(&calc.name) {
+            return Err(SidemanticError::Validation(format!(
+                "Table calculation '{}' already exists",
+                calc.name
+            )));
+        }
+        self.table_calculations.insert(calc.name.clone(), calc);
+        Ok(())
+    }
+
+    /// Get a graph-level table calculation by name.
+    pub fn get_table_calculation(&self, name: &str) -> Option<&TableCalculation> {
+        self.table_calculations.get(name)
+    }
+
+    /// Get all graph-level table calculations.
+    pub fn table_calculations(&self) -> impl Iterator<Item = &TableCalculation> {
+        self.table_calculations.values()
     }
 
     /// Add a parameter to the graph
@@ -512,12 +639,17 @@ impl SemanticGraph {
         let field_with_granularity = parts[1];
 
         // Check for granularity suffix (e.g., order_date__month)
-        let (field_name, granularity) = if let Some(pos) = field_with_granularity.find("__") {
-            let (field, gran) = field_with_granularity.split_at(pos);
-            (field.to_string(), Some(gran[2..].to_string()))
-        } else {
-            (field_with_granularity.to_string(), None)
-        };
+        let (field_name, granularity) =
+            if let Some((field, gran)) = field_with_granularity.rsplit_once("__") {
+                if field.is_empty() || gran.is_empty() {
+                    return Err(SidemanticError::InvalidReference {
+                        reference: reference.to_string(),
+                    });
+                }
+                (field.to_string(), Some(gran.to_string()))
+            } else {
+                (field_with_granularity.to_string(), None)
+            };
 
         // Verify model exists
         if !self.models.contains_key(model_name) {
@@ -532,7 +664,9 @@ impl SemanticGraph {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::model::{Dimension, Metric, PreAggregation, PreAggregationType, Relationship};
+    use crate::core::model::{
+        ComparisonType, Dimension, Metric, PreAggregation, PreAggregationType, Relationship,
+    };
     use crate::core::parameter::{Parameter, ParameterType};
 
     fn create_test_graph() -> SemanticGraph {
@@ -588,6 +722,44 @@ mod tests {
         assert_eq!(model.table.as_deref(), Some("orders_v2"));
         assert!(model.get_dimension("status").is_none());
         assert!(model.get_metric("order_count").is_some());
+    }
+
+    #[test]
+    fn test_replace_model_updates_indexed_model_metrics() {
+        let mut graph = SemanticGraph::new();
+
+        graph
+            .add_model(
+                Model::new("orders", "order_id")
+                    .with_table("orders")
+                    .with_metric(Metric::sum("revenue", "amount"))
+                    .with_metric(Metric::time_comparison(
+                        "revenue_yoy",
+                        "revenue",
+                        ComparisonType::Yoy,
+                    )),
+            )
+            .unwrap();
+        assert!(graph.get_metric("revenue_yoy").is_some());
+
+        graph
+            .replace_model(
+                Model::new("orders", "order_id")
+                    .with_table("orders")
+                    .with_metric(Metric::sum("revenue", "amount"))
+                    .with_metric(Metric::time_comparison(
+                        "revenue_mom",
+                        "revenue",
+                        ComparisonType::Mom,
+                    )),
+            )
+            .unwrap();
+
+        assert!(graph.get_metric("revenue_yoy").is_none());
+        assert!(graph.get_metric("revenue_mom").is_some());
+        graph
+            .add_metric(Metric::sum("revenue_yoy", "amount"))
+            .unwrap();
     }
 
     #[test]

--- a/sidemantic-rs/src/core/relative_date.rs
+++ b/sidemantic-rs/src/core/relative_date.rs
@@ -24,7 +24,7 @@ impl RelativeDate {
     /// ```
     /// use sidemantic::RelativeDate;
     /// assert_eq!(RelativeDate::parse("today"), Some("CURRENT_DATE".to_string()));
-    /// assert_eq!(RelativeDate::parse("last 7 days"), Some("CURRENT_DATE - INTERVAL '7 days'".to_string()));
+    /// assert_eq!(RelativeDate::parse("last 7 days"), Some("CURRENT_DATE - 7".to_string()));
     /// ```
     pub fn parse(expr: &str) -> Option<String> {
         let expr = expr.to_lowercase();
@@ -33,8 +33,8 @@ impl RelativeDate {
         // Simple keywords
         match expr {
             "today" => return Some("CURRENT_DATE".to_string()),
-            "yesterday" => return Some("CURRENT_DATE - INTERVAL '1 day'".to_string()),
-            "tomorrow" => return Some("CURRENT_DATE + INTERVAL '1 day'".to_string()),
+            "yesterday" => return Some("CURRENT_DATE - 1".to_string()),
+            "tomorrow" => return Some("CURRENT_DATE + 1".to_string()),
             "this week" => return Some("DATE_TRUNC('week', CURRENT_DATE)".to_string()),
             "last week" => {
                 return Some("DATE_TRUNC('week', CURRENT_DATE) - INTERVAL '1 week'".to_string())
@@ -73,12 +73,12 @@ impl RelativeDate {
         // Last N days/weeks/months/years
         if let Some(caps) = LAST_N_DAYS.captures(expr) {
             let n: i32 = caps[1].parse().ok()?;
-            return Some(format!("CURRENT_DATE - INTERVAL '{n} days'"));
+            return Some(format!("CURRENT_DATE - {n}"));
         }
 
         if let Some(caps) = LAST_N_WEEKS.captures(expr) {
             let n: i32 = caps[1].parse().ok()?;
-            return Some(format!("CURRENT_DATE - INTERVAL '{} days'", n * 7));
+            return Some(format!("CURRENT_DATE - {}", n * 7));
         }
 
         if let Some(caps) = LAST_N_MONTHS.captures(expr) {
@@ -105,7 +105,7 @@ impl RelativeDate {
     /// use sidemantic::RelativeDate;
     /// assert_eq!(
     ///     RelativeDate::to_range("last 7 days", "created_at"),
-    ///     Some("created_at >= CURRENT_DATE - INTERVAL '7 days'".to_string())
+    ///     Some("created_at >= CURRENT_DATE - 7".to_string())
     /// );
     /// ```
     pub fn to_range(expr: &str, column: &str) -> Option<String> {
@@ -180,7 +180,7 @@ mod tests {
         assert_eq!(RelativeDate::parse("today"), Some("CURRENT_DATE".into()));
         assert_eq!(
             RelativeDate::parse("yesterday"),
-            Some("CURRENT_DATE - INTERVAL '1 day'".into())
+            Some("CURRENT_DATE - 1".into())
         );
         assert_eq!(
             RelativeDate::parse("this month"),
@@ -192,15 +192,15 @@ mod tests {
     fn test_parse_last_n() {
         assert_eq!(
             RelativeDate::parse("last 7 days"),
-            Some("CURRENT_DATE - INTERVAL '7 days'".into())
+            Some("CURRENT_DATE - 7".into())
         );
         assert_eq!(
             RelativeDate::parse("last 30 days"),
-            Some("CURRENT_DATE - INTERVAL '30 days'".into())
+            Some("CURRENT_DATE - 30".into())
         );
         assert_eq!(
             RelativeDate::parse("last 2 weeks"),
-            Some("CURRENT_DATE - INTERVAL '14 days'".into())
+            Some("CURRENT_DATE - 14".into())
         );
     }
 
@@ -208,7 +208,7 @@ mod tests {
     fn test_to_range() {
         assert_eq!(
             RelativeDate::to_range("last 7 days", "created_at"),
-            Some("created_at >= CURRENT_DATE - INTERVAL '7 days'".into())
+            Some("created_at >= CURRENT_DATE - 7".into())
         );
         assert!(RelativeDate::to_range("this month", "order_date")
             .unwrap()

--- a/sidemantic-rs/src/core/symmetric_agg.rs
+++ b/sidemantic-rs/src/core/symmetric_agg.rs
@@ -105,7 +105,7 @@ pub fn build_symmetric_aggregate_sql_with_key_expr(
     // Dialect-specific hash function and multiplier
     let (hash_expr, multiplier) = match dialect {
         SqlDialect::BigQuery => (
-            format!("FARM_FINGERPRINT(CAST({pk_col} AS STRING))"),
+            format!("CAST(FARM_FINGERPRINT(CAST({pk_col} AS STRING)) AS BIGNUMERIC)"),
             "1000000000000".to_string(),
         ),
         SqlDialect::Postgres => (
@@ -125,21 +125,13 @@ pub fn build_symmetric_aggregate_sql_with_key_expr(
             "1000000000000".to_string(),
         ),
         SqlDialect::DuckDB => (
-            format!("CAST(HASH({pk_col}) AS HUGEINT)"),
-            "1048576".to_string(),
+            format!("HASH({pk_col})::HUGEINT"),
+            "(1::HUGEINT << 40)".to_string(),
         ),
     };
 
-    let symmetric_base_expr = match dialect {
-        SqlDialect::DuckDB => {
-            format!("CAST(({hash_expr} * {multiplier}) AS DECIMAL(38, 6))")
-        }
-        _ => format!("({hash_expr} * {multiplier})"),
-    };
-    let symmetric_measure_expr = match dialect {
-        SqlDialect::DuckDB => format!("CAST({measure_col} AS DECIMAL(38, 6))"),
-        _ => measure_col.clone(),
-    };
+    let symmetric_base_expr = format!("({hash_expr} * {multiplier})");
+    let symmetric_measure_expr = measure_col.clone();
 
     match agg_type {
         SymmetricAggType::Sum => {
@@ -194,9 +186,9 @@ mod tests {
             SqlDialect::DuckDB,
         );
         assert!(sql.contains("SUM(DISTINCT"));
-        assert!(sql.contains("CAST(HASH(order_id) AS HUGEINT)"));
-        assert!(sql.contains("+ CAST(amount AS DECIMAL(38, 6))"));
-        assert!(sql.contains("CAST((CAST(HASH(order_id) AS HUGEINT) * 1048576)"));
+        assert!(sql.contains("HASH(order_id)::HUGEINT"));
+        assert!(sql.contains("+ amount"));
+        assert!(sql.contains("(1::HUGEINT << 40)"));
     }
 
     #[test]
@@ -282,7 +274,7 @@ mod tests {
             Some("o"),
             SqlDialect::DuckDB,
         );
-        assert!(sql.contains("CAST(HASH(CONCAT("));
-        assert!(sql.contains("CAST(o.amount AS DECIMAL(38, 6))"));
+        assert!(sql.contains("HASH(CONCAT("));
+        assert!(sql.contains("+ o.amount"));
     }
 }

--- a/sidemantic-rs/src/error.rs
+++ b/sidemantic-rs/src/error.rs
@@ -9,7 +9,7 @@ pub enum SidemanticError {
     ModelNotFound(String, String),
 
     #[error(
-        "Dimension not found: '{dimension}' in model '{model}'. Available dimensions: {available}"
+        "Dimension '{dimension}' not found in model '{model}'. Available dimensions: {available}"
     )]
     DimensionNotFound {
         model: String,
@@ -17,14 +17,14 @@ pub enum SidemanticError {
         available: String,
     },
 
-    #[error("Metric not found: '{metric}' in model '{model}'. Available metrics: {available}")]
+    #[error("Metric '{metric}' not found in model '{model}'. Available metrics: {available}")]
     MetricNotFound {
         model: String,
         metric: String,
         available: String,
     },
 
-    #[error("Segment not found: '{segment}' in model '{model}'. Available segments: {available}")]
+    #[error("Segment '{segment}' not found in model '{model}'. Available segments: {available}")]
     SegmentNotFound {
         model: String,
         segment: String,
@@ -33,7 +33,7 @@ pub enum SidemanticError {
 
     // Join/relationship errors
     #[error(
-        "No join path found between '{from}' and '{to}'. Check that a relationship is defined."
+        "No join path found between models '{from}' and '{to}'. Check that a relationship is defined."
     )]
     NoJoinPath { from: String, to: String },
 

--- a/sidemantic-rs/src/sql/generator.rs
+++ b/sidemantic-rs/src/sql/generator.rs
@@ -415,22 +415,32 @@ impl<'a> SqlGenerator<'a> {
                 let available: Vec<&str> = self.graph.models().map(|m| m.name.as_str()).collect();
                 SidemanticError::model_not_found(&dim_ref.model, &available)
             })?;
-            let dimension = model.get_dimension(&dim_ref.name).ok_or_else(|| {
+            let alias = self.model_alias(&dim_ref.model);
+            let sql_expr = if let Some(dimension) = model.get_dimension(&dim_ref.name) {
+                if let Some(granularity) = dim_ref
+                    .granularity
+                    .as_deref()
+                    .or(dimension.granularity.as_deref())
+                {
+                    self.normalize_select_expression(
+                        &self.date_trunc_sql(granularity, dimension.sql_expr()),
+                        &alias,
+                    )
+                } else if dimension.window.is_some() {
+                    format!("{}.{}", alias, self.quote_identifier(&dimension.name))
+                } else {
+                    self.dimension_select_expression(dimension, &alias)
+                }
+            } else if Self::is_relationship_foreign_key_dimension(model, &dim_ref.name) {
+                format!("{}.{}", alias, self.quote_identifier(&dim_ref.name))
+            } else {
                 let available: Vec<&str> =
                     model.dimensions.iter().map(|d| d.name.as_str()).collect();
-                SidemanticError::dimension_not_found(&dim_ref.model, &dim_ref.name, &available)
-            })?;
-
-            let alias = self.model_alias(&dim_ref.model);
-            let sql_expr = if dim_ref.granularity.is_some() || dimension.granularity.is_some() {
-                self.normalize_select_expression(
-                    &dimension.sql_with_granularity(dim_ref.granularity.as_deref()),
-                    &alias,
-                )
-            } else if dimension.window.is_some() {
-                format!("{}.{}", alias, self.quote_identifier(&dimension.name))
-            } else {
-                self.dimension_select_expression(dimension, &alias)
+                return Err(SidemanticError::dimension_not_found(
+                    &dim_ref.model,
+                    &dim_ref.name,
+                    &available,
+                ));
             };
             let output_alias = self.output_alias(&dim_ref.model, &dim_ref.alias, &alias_collisions);
 
@@ -667,6 +677,9 @@ impl<'a> SqlGenerator<'a> {
 
         for dim in dimensions {
             let (model, name, granularity) = self.graph.parse_reference(dim)?;
+            if let Some(granularity) = granularity.as_deref() {
+                self.validate_time_granularity(&model, &name, granularity)?;
+            }
 
             // Create alias: model_field or model_field__granularity
             let alias = if let Some(ref g) = granularity {
@@ -704,9 +717,9 @@ impl<'a> SqlGenerator<'a> {
                 if owners.len() == 1 {
                     (owners[0].clone(), metric.clone())
                 } else {
-                    return Err(SidemanticError::InvalidReference {
-                        reference: metric.clone(),
-                    });
+                    return Err(SidemanticError::Validation(format!(
+                        "Metric '{metric}' not found"
+                    )));
                 }
             };
 
@@ -718,6 +731,47 @@ impl<'a> SqlGenerator<'a> {
         }
 
         Ok(refs)
+    }
+
+    fn validate_time_granularity(
+        &self,
+        model_name: &str,
+        dimension_name: &str,
+        granularity: &str,
+    ) -> Result<()> {
+        const VALID_GRANULARITIES: &[&str] = &[
+            "second", "minute", "hour", "day", "week", "month", "quarter", "year",
+        ];
+        if !VALID_GRANULARITIES.contains(&granularity) {
+            return Err(SidemanticError::Validation(format!(
+                "Invalid time granularity '{granularity}'"
+            )));
+        }
+
+        let Some(model) = self.graph.get_model(model_name) else {
+            return Ok(());
+        };
+        let Some(dimension) = model.get_dimension(dimension_name) else {
+            if Self::is_relationship_foreign_key_dimension(model, dimension_name) {
+                return Err(SidemanticError::Validation(format!(
+                    "Cannot apply granularity to non-time dimension '{dimension_name}'"
+                )));
+            }
+            return Ok(());
+        };
+        if dimension.r#type != crate::core::DimensionType::Time {
+            return Err(SidemanticError::Validation(format!(
+                "Cannot apply granularity to non-time dimension '{dimension_name}'"
+            )));
+        }
+        if let Some(supported) = &dimension.supported_granularities {
+            if !supported.iter().any(|item| item == granularity) {
+                return Err(SidemanticError::Validation(format!(
+                    "Invalid time granularity '{granularity}' for dimension '{dimension_name}'"
+                )));
+            }
+        }
+        Ok(())
     }
 
     /// Find all models required by the query
@@ -1240,23 +1294,21 @@ impl<'a> SqlGenerator<'a> {
                 .unwrap_or_else(|| model.primary_key.clone());
         }
 
-        primary_keys
+        let parts = primary_keys
             .iter()
-            .enumerate()
-            .map(|(index, column)| {
+            .flat_map(|column| {
                 let qualified = match alias {
                     Some(alias) => format!("{alias}.{column}"),
                     None => column.clone(),
                 };
-                let casted = format!("COALESCE(CAST({qualified} AS VARCHAR), '')");
-                if index == 0 {
-                    casted
-                } else {
-                    format!("'|' || {casted}")
-                }
+                [
+                    format!("COALESCE(CAST({qualified} AS VARCHAR), '')"),
+                    "'|'".to_string(),
+                ]
             })
-            .collect::<Vec<_>>()
-            .join(" || ")
+            .collect::<Vec<_>>();
+        let parts = &parts[..parts.len().saturating_sub(1)];
+        format!("CONCAT({})", parts.join(", "))
     }
 
     /// Generate alias for a model (first letter lowercase)
@@ -2978,7 +3030,24 @@ impl<'a> SqlGenerator<'a> {
     }
 
     fn date_trunc_sql(&self, granularity: &str, column_expr: &str) -> String {
-        format!("DATE_TRUNC('{granularity}', {column_expr})")
+        if self.dialect == DialectType::BigQuery {
+            format!(
+                "DATE_TRUNC({}, {})",
+                column_expr,
+                granularity.to_ascii_uppercase()
+            )
+        } else {
+            format!("DATE_TRUNC('{granularity}', {column_expr})")
+        }
+    }
+
+    fn is_relationship_foreign_key_dimension(model: &Model, dimension_name: &str) -> bool {
+        model.relationships.iter().any(|relationship| {
+            relationship
+                .foreign_key_columns()
+                .iter()
+                .any(|column| column == dimension_name)
+        })
     }
 
     fn interval_sql(&self, num: &str, unit: &str) -> String {
@@ -4756,6 +4825,34 @@ mod tests {
     }
 
     #[test]
+    fn test_relationship_foreign_key_dimension_rejects_granularity_suffix() {
+        let mut graph = SemanticGraph::new();
+
+        let orders = Model::new("orders", "order_id")
+            .with_table("orders")
+            .with_metric(Metric::count("order_count"))
+            .with_relationship(
+                Relationship::many_to_one("customers").with_keys("customer_id", "id"),
+            );
+        let customers = Model::new("customers", "id").with_table("customers");
+
+        graph.add_model(orders).unwrap();
+        graph.add_model(customers).unwrap();
+
+        let generator = SqlGenerator::new(&graph);
+        let query = SemanticQuery::new()
+            .with_metrics(vec!["orders.order_count".into()])
+            .with_dimensions(vec!["orders.customer_id__month".into()]);
+
+        let err = generator.generate(&query).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Cannot apply granularity to non-time dimension 'customer_id'"),
+            "{err}"
+        );
+    }
+
+    #[test]
     fn test_query_with_composite_join() {
         let mut graph = SemanticGraph::new();
 
@@ -4985,7 +5082,7 @@ mod tests {
             .with_dimensions(vec!["shipments.status".into()]);
 
         let sql = generator.generate(&query).unwrap();
-        assert!(sql.contains("HASH(COALESCE(CAST(order_items_cte.order_id AS VARCHAR), '')"));
+        assert!(sql.contains("HASH(CONCAT(COALESCE(CAST(order_items_cte.order_id AS VARCHAR), '')"));
         assert!(sql.contains("CAST(order_items_cte.item_id AS VARCHAR)"));
     }
 
@@ -5061,7 +5158,7 @@ mod tests {
 
         // Relative date should be expanded to SQL
         assert!(
-            sql.contains("CURRENT_DATE - INTERVAL '7 days'"),
+            sql.contains("CURRENT_DATE - 7"),
             "Expected relative date expansion: {sql}"
         );
         // Should NOT contain the quoted string anymore

--- a/tests/core/test_pure_rust_python_test_parity.py
+++ b/tests/core/test_pure_rust_python_test_parity.py
@@ -1,0 +1,501 @@
+"""Run existing Python tests against the pure Rust test adapter."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass
+from types import ModuleType
+
+import duckdb
+import pytest
+
+import sidemantic
+import sidemantic.core.semantic_graph as semantic_graph_module
+import sidemantic.core.semantic_layer as semantic_layer_module
+import sidemantic.sql.generator as sql_generator_module
+import sidemantic.sql.query_rewriter as query_rewriter_module
+import tests.core.test_auto_dimensions as auto_dimension_tests
+import tests.core.test_symmetric_aggregates as symmetric_aggregate_tests
+import tests.dates.test_integration as date_integration_tests
+import tests.joins.test_composite_key_joins as composite_join_tests
+import tests.joins.test_many_to_many_joins as many_to_many_join_tests
+import tests.joins.test_multi_hop_joins as multi_hop_join_tests
+import tests.joins.test_rails_joins as rails_join_tests
+import tests.metrics.test_cumulative as cumulative_metric_tests
+import tests.metrics.test_default_time_dimension as default_time_dimension_tests
+import tests.metrics.test_derived as derived_metric_tests
+import tests.metrics.test_filters as metric_filter_tests
+import tests.optimizations.test_pre_aggregations as pre_aggregation_tests
+import tests.optimizations.test_preagg_recommender as preagg_recommender_tests
+import tests.optimizations.test_predicate_pushdown as predicate_pushdown_tests
+import tests.queries.test_basic as basic_query_tests
+import tests.queries.test_count_distinct_and_segments as count_distinct_segment_tests
+import tests.queries.test_sql_rewriter as sql_rewriter_tests
+import tests.queries.test_ungrouped_queries as ungrouped_query_tests
+import tests.queries.test_view_generation as view_generation_tests
+import tests.templates.test_jinja_integration as jinja_integration_tests
+import tests.test_catalog as catalog_tests
+import tests.test_foreign_key_dimensions as foreign_key_dimension_tests
+import tests.test_hierarchies as hierarchy_tests
+import tests.test_metadata_fields as metadata_field_tests
+import tests.test_preaggregation_bugs as preaggregation_bug_tests
+import tests.test_segments as segment_tests
+import tests.test_semantic_graph_errors as semantic_graph_error_tests
+import tests.test_sql_generation_security as sql_security_tests
+import tests.test_validation as validation_tests
+import tests.test_with_data as data_query_tests
+import tests.widget.test_widget_examples as widget_example_tests
+from tests.rust_layer_adapter import (
+    RustQueryRewriterAdapter,
+    RustSemanticGraphDirectAdapter,
+    RustSemanticLayerAdapter,
+    RustSQLGeneratorAdapter,
+    rust_build_symmetric_aggregate_sql,
+    rust_needs_symmetric_aggregate,
+)
+
+
+@dataclass(frozen=True)
+class PythonTestParityCase:
+    module: ModuleType
+    func: Callable[..., object]
+    nodeid: str
+    fixture_names: tuple[str, ...]
+    owner: type[object] | None = None
+
+
+PYTHON_TEST_PARITY_MODULES = [
+    validation_tests,
+    symmetric_aggregate_tests,
+    segment_tests,
+    basic_query_tests,
+    data_query_tests,
+    auto_dimension_tests,
+    date_integration_tests,
+    composite_join_tests,
+    many_to_many_join_tests,
+    multi_hop_join_tests,
+    rails_join_tests,
+    cumulative_metric_tests,
+    derived_metric_tests,
+    default_time_dimension_tests,
+    metric_filter_tests,
+    pre_aggregation_tests,
+    preagg_recommender_tests,
+    predicate_pushdown_tests,
+    count_distinct_segment_tests,
+    sql_rewriter_tests,
+    view_generation_tests,
+    ungrouped_query_tests,
+    jinja_integration_tests,
+    foreign_key_dimension_tests,
+    catalog_tests,
+    preaggregation_bug_tests,
+    sql_security_tests,
+    hierarchy_tests,
+    metadata_field_tests,
+    semantic_graph_error_tests,
+    widget_example_tests,
+]
+
+
+PRE_RUN_XFAILS = {
+    "tests.optimizations.test_pre_aggregations::test_sql_generation_without_preagg": (
+        "Pre-aggregation metadata is not serialized to Rust yet, so this would be a false pass"
+    ),
+    "tests.optimizations.test_predicate_pushdown::test_segment_filter_skips_subquery_columns": (
+        "Test body asserts a private Python SQLGenerator segment-resolution helper, not Rust SQL behavior"
+    ),
+}
+
+
+EXPECTED_GAPS = {
+    "tests.core.test_auto_dimensions::test_auto_dimensions_from_table": (
+        "Rust adapter does not yet support Python auto-dimension DB introspection"
+    ),
+    "tests.core.test_auto_dimensions::test_auto_dimensions_type_mapping": (
+        "Rust adapter does not yet support Python auto-dimension DB introspection"
+    ),
+    "tests.core.test_auto_dimensions::test_explicit_dimensions_take_precedence": (
+        "Rust adapter does not yet support Python auto-dimension DB introspection"
+    ),
+    "tests.core.test_auto_dimensions::test_auto_dimensions_sql_model": (
+        "Rust adapter does not yet support Python auto-dimension DB introspection"
+    ),
+    "tests.core.test_auto_dimensions::test_auto_dimensions_composite_pk": (
+        "Rust adapter does not yet support Python auto-dimension DB introspection"
+    ),
+    "tests.core.test_auto_dimensions::test_auto_dimensions_query_works": (
+        "Rust adapter does not yet support query execution for auto-introspected dimensions"
+    ),
+    "tests.core.test_auto_dimensions::test_auto_dimensions_time_granularity_query": (
+        "Rust adapter does not yet support query execution for auto-introspected dimensions"
+    ),
+    "tests.core.test_auto_dimensions::test_auto_dimensions_non_string_type_metadata": (
+        "Rust adapter does not yet support Python auto-dimension DB introspection"
+    ),
+    "tests.optimizations.test_pre_aggregations::test_sql_generation_with_preagg": (
+        "Rust adapter does not yet support Python pre-aggregation routing"
+    ),
+    "tests.optimizations.test_pre_aggregations::test_sql_generation_without_preagg": (
+        "Pre-aggregation metadata is not serialized to Rust yet, so this would be a false pass"
+    ),
+    "tests.optimizations.test_pre_aggregations::test_preagg_with_filters": (
+        "Rust adapter does not yet support Python pre-aggregation routing"
+    ),
+    "tests.optimizations.test_pre_aggregations::test_preagg_granularity_conversion": (
+        "Rust adapter does not yet support Python pre-aggregation routing"
+    ),
+    "tests.optimizations.test_pre_aggregations::test_preagg_per_query_override": (
+        "Rust adapter does not yet support Python pre-aggregation routing"
+    ),
+    "tests.optimizations.test_pre_aggregations::test_avg_preaggregation_rolls_up_with_sum_count_state": (
+        "Rust adapter does not yet support Python pre-aggregation routing"
+    ),
+    "tests.optimizations.test_pre_aggregations::test_avg_preaggregation_rejects_missing_count_state": (
+        "Rust adapter does not yet support Python pre-aggregation routing"
+    ),
+    "tests.optimizations.test_pre_aggregations::test_ratio_metric_preaggregation_rebuilds_from_additive_leaves": (
+        "Rust adapter does not yet support Python pre-aggregation routing"
+    ),
+    "tests.optimizations.test_pre_aggregations::test_derived_metric_preaggregation_rebuilds_from_additive_leaves": (
+        "Rust adapter does not yet support Python pre-aggregation routing"
+    ),
+    "tests.optimizations.test_pre_aggregations::test_ratio_metric_preaggregation_rejects_count_distinct_leaf": (
+        "Rust adapter does not yet support Python pre-aggregation routing"
+    ),
+    "tests.optimizations.test_preagg_recommender::test_query_instrumentation": (
+        "Rust SQL generator does not yet emit Python query instrumentation contracts"
+    ),
+    "tests.optimizations.test_preagg_recommender::test_end_to_end_with_semantic_layer": (
+        "Rust SQL generator does not yet emit Python query instrumentation contracts"
+    ),
+    "tests.metrics.test_cumulative::test_cumulative_with_time_comparison": (
+        "Rust strict model validation rejects this Python fixture's time dimension without granularity"
+    ),
+    "tests.templates.test_jinja_integration::test_simple_parameter_substitution": (
+        "Rust adapter does not yet support Python template parameter interpolation"
+    ),
+    "tests.templates.test_jinja_integration::test_jinja_conditional_with_parameters": (
+        "Rust adapter does not yet support Python template parameter interpolation"
+    ),
+    "tests.queries.test_sql_rewriter::test_ad_hoc_count_aggregation": (
+        "Rust SQL rewriter does not yet support Python ad-hoc aggregate rewrite contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_explicit_join_matching_relationship_supported": (
+        "Rust SQL rewriter does not yet support Python explicit JOIN rewrite contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_explicit_join_with_aliases_supported": (
+        "Rust SQL rewriter does not yet support Python explicit JOIN rewrite contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_explicit_join_accepts_parenthesized_on_clause": (
+        "Rust SQL rewriter does not yet support Python explicit JOIN rewrite contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_explicit_inner_join_preserves_existence_filter": (
+        "Rust SQL rewriter does not yet support Python explicit JOIN rewrite contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_explicit_left_join_preserves_base_rows": (
+        "Rust SQL rewriter does not yet support Python explicit JOIN rewrite contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_explicit_join_rejects_unsupported_join_type": (
+        "Rust SQL rewriter does not yet support Python explicit JOIN rewrite contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_semantic_scalar_expression_over_measures": (
+        "Rust SQL rewriter does not yet support Python semantic scalar expression contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_semantic_expression_order_by_projection_alias": (
+        "Rust SQL rewriter does not yet support Python semantic scalar expression contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_semantic_scalar_function_over_measure": (
+        "Rust SQL rewriter does not yet support Python semantic scalar expression contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_semantic_ad_hoc_aggregate_expression": (
+        "Rust SQL rewriter does not yet support Python ad-hoc aggregate rewrite contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_semantic_ad_hoc_aggregate_expression_with_dimension": (
+        "Rust SQL rewriter does not yet support Python ad-hoc aggregate rewrite contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_semantic_ad_hoc_aggregate_rejects_joined_model_column": (
+        "Rust SQL rewriter does not yet support Python ad-hoc aggregate rewrite contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_graph_level_metrics": (
+        "Rust SQL rewriter does not yet support Python graph-level metric rewrite contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_from_metrics_allows_graph_level_metrics": (
+        "Rust SQL rewriter does not yet support Python graph-level metric rewrite contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_compile_post_process": (
+        "Rust adapter does not yet support Python post_process SQL contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_query_post_process": (
+        "Rust adapter does not yet support Python post_process SQL contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_post_process_missing_placeholder": (
+        "Rust adapter does not yet support Python post_process SQL contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_semantic_root_with_join_subquery_rejected": (
+        "Rust SQL rewriter does not yet support Python semantic-root validation contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_post_process_with_own_ctes": (
+        "Rust adapter does not yet support Python post_process SQL contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_post_process_cte_name_collision": (
+        "Rust adapter does not yet support Python post_process SQL contracts"
+    ),
+    "tests.queries.test_sql_rewriter::test_root_semantic_cte_name_collision": (
+        "Rust SQL rewriter does not yet support Python semantic-root validation contracts"
+    ),
+    "tests.test_preaggregation_bugs::test_avg_metric_with_filtered_count_fails": (
+        "Rust adapter does not yet support Python pre-aggregation routing bug contracts"
+    ),
+    "tests.test_preaggregation_bugs::test_filter_on_unmaterialized_dimension": (
+        "Rust adapter does not yet support Python pre-aggregation routing bug contracts"
+    ),
+    "tests.test_preaggregation_bugs::test_filter_on_unmaterialized_time_grain": (
+        "Rust adapter does not yet support Python pre-aggregation routing bug contracts"
+    ),
+    "tests.test_preaggregation_bugs::test_week_to_month_granularity_wrong_results": (
+        "Rust adapter does not yet support Python pre-aggregation routing bug contracts"
+    ),
+    "tests.test_preaggregation_bugs::test_avg_metric_needs_correct_count": (
+        "Rust adapter does not yet support Python pre-aggregation routing bug contracts"
+    ),
+    "tests.test_sql_generation_security::test_model_ref_rewrite_matches_cte_identifier_quoting": (
+        "Rust adapter does not yet support non-DuckDB dialect parity"
+    ),
+}
+
+
+DIRECT_RUST_GRAPH_PARITY_NODEIDS = {
+    "tests.joins.test_composite_key_joins::test_semantic_graph_composite_pk_adjacency",
+    "tests.joins.test_composite_key_joins::test_semantic_graph_single_pk_still_works",
+    "tests.test_semantic_graph_errors::test_add_duplicate_model",
+    "tests.test_semantic_graph_errors::test_add_duplicate_metric",
+    "tests.test_semantic_graph_errors::test_add_duplicate_table_calculation",
+    "tests.test_semantic_graph_errors::test_get_nonexistent_model",
+    "tests.test_semantic_graph_errors::test_get_nonexistent_metric",
+    "tests.test_semantic_graph_errors::test_get_nonexistent_table_calculation",
+    "tests.test_semantic_graph_errors::test_find_path_nonexistent_from_model",
+    "tests.test_semantic_graph_errors::test_find_path_nonexistent_to_model",
+    "tests.test_semantic_graph_errors::test_find_path_same_model",
+    "tests.test_semantic_graph_errors::test_find_path_no_relationship",
+    "tests.test_semantic_graph_errors::test_auto_register_time_comparison_metric",
+    "tests.test_semantic_graph_errors::test_no_auto_register_regular_metrics",
+    "tests.test_semantic_graph_errors::test_adjacency_not_built_on_add",
+    "tests.test_semantic_graph_errors::test_adjacency_built_on_find_path",
+}
+
+
+DIRECT_RUST_FUNCTION_PARITY_MODULES = {
+    "tests.core.test_symmetric_aggregates",
+}
+
+
+DIRECT_RUST_SQL_GENERATOR_PARITY_NODEIDS = {
+    "tests.queries.test_view_generation::test_generate_view_creates_valid_sql",
+    "tests.queries.test_view_generation::test_view_can_be_queried",
+    "tests.queries.test_view_generation::test_view_name_sql_injection_rejected",
+    "tests.queries.test_view_generation::test_view_name_with_spaces_rejected",
+    "tests.queries.test_view_generation::test_join_view_against_other_tables",
+    "tests.test_foreign_key_dimensions::test_foreign_key_as_dimension_no_join",
+    "tests.test_foreign_key_dimensions::test_foreign_key_dimension_with_join",
+    "tests.test_sql_generation_security::test_count_fanout_uses_column_reference",
+    "tests.widget.test_widget_examples::test_notebook_metric_sql_generates",
+    "tests.widget.test_widget_examples::test_auto_model_metrics_generate_without_dependency_errors",
+}
+
+
+SUPPORTED_SIGNATURES = {
+    ("con",),
+    ("layer",),
+    ("layer", "orders_db"),
+    ("layer", "three_table_chain"),
+    ("orders_db", "layer"),
+    ("semantic_layer",),
+    ("test_db", "semantic_layer"),
+    ("three_table_chain", "layer"),
+    ("timeseries_db", "layer"),
+}
+
+
+def _python_test_parity_functions(module: ModuleType) -> list[pytest.ParameterSet]:
+    tests: list[pytest.ParameterSet] = []
+    for name, value in vars(module).items():
+        if name.startswith("test_") and callable(value):
+            signature = inspect.signature(value)
+            fixture_names = tuple(signature.parameters)
+            nodeid = f"{module.__name__}::{name}"
+            if (
+                fixture_names in SUPPORTED_SIGNATURES
+                or _is_direct_rust_graph_test(nodeid, fixture_names)
+                or _is_direct_rust_function_test(nodeid, fixture_names)
+                or _is_direct_rust_sql_generator_test(nodeid, fixture_names)
+            ):
+                tests.append(
+                    pytest.param(
+                        PythonTestParityCase(module=module, func=value, nodeid=nodeid, fixture_names=fixture_names),
+                        id=nodeid,
+                    )
+                )
+        elif inspect.isclass(value) and name.startswith("Test"):
+            tests.extend(_python_test_parity_methods(module, value))
+    return tests
+
+
+def _python_test_parity_methods(module: ModuleType, owner: type[object]) -> list[pytest.ParameterSet]:
+    tests: list[pytest.ParameterSet] = []
+    for method_name, method in vars(owner).items():
+        if not method_name.startswith("test_") or not callable(method):
+            continue
+        signature = inspect.signature(method)
+        fixture_names = tuple(name for name in signature.parameters if name != "self")
+        nodeid = f"{module.__name__}::{owner.__name__}::{method_name}"
+        if (
+            fixture_names in SUPPORTED_SIGNATURES
+            or _is_direct_rust_graph_test(nodeid, fixture_names)
+            or _is_direct_rust_function_test(nodeid, fixture_names)
+            or _is_direct_rust_sql_generator_test(nodeid, fixture_names)
+        ):
+            tests.append(
+                pytest.param(
+                    PythonTestParityCase(
+                        module=module,
+                        func=method,
+                        nodeid=nodeid,
+                        fixture_names=fixture_names,
+                        owner=owner,
+                    ),
+                    id=nodeid,
+                )
+            )
+    return tests
+
+
+def _is_direct_rust_graph_test(nodeid: str, fixture_names: tuple[str, ...]) -> bool:
+    return fixture_names == () and nodeid in DIRECT_RUST_GRAPH_PARITY_NODEIDS
+
+
+def _is_direct_rust_function_test(nodeid: str, fixture_names: tuple[str, ...]) -> bool:
+    module_name = nodeid.split("::", 1)[0]
+    return module_name in DIRECT_RUST_FUNCTION_PARITY_MODULES and fixture_names in {(), ("conn",)}
+
+
+def _is_direct_rust_sql_generator_test(nodeid: str, fixture_names: tuple[str, ...]) -> bool:
+    return fixture_names == () and nodeid in DIRECT_RUST_SQL_GENERATOR_PARITY_NODEIDS
+
+
+PYTHON_LAYER_PARITY_CASES = [
+    *[test for module in PYTHON_TEST_PARITY_MODULES for test in _python_test_parity_functions(module)],
+]
+
+
+@pytest.mark.parametrize("case", PYTHON_LAYER_PARITY_CASES)
+def test_existing_python_layer_contract_matches_pure_rust(case: PythonTestParityCase, monkeypatch):
+    """Run the Python test function itself with a Rust-backed test layer."""
+    if reason := PRE_RUN_XFAILS.get(case.nodeid):
+        pytest.xfail(reason)
+
+    _patch_semantic_layer_constructors(monkeypatch, case.module)
+    fixtures: dict[str, object] = {}
+    try:
+        fixtures = _fixture_values(case)
+        _call_python_test_case(case, fixtures)
+    except NotImplementedError as exc:
+        if reason := _expected_gap_reason(case.nodeid):
+            pytest.xfail(f"{reason}: {exc}")
+        raise
+    except (Exception, pytest.fail.Exception) as exc:
+        if reason := _expected_gap_reason(case.nodeid):
+            pytest.xfail(f"{reason}: {exc}")
+        raise
+    finally:
+        _close_fixture_values(fixtures)
+
+
+def _patch_semantic_layer_constructors(monkeypatch, module: ModuleType) -> None:
+    monkeypatch.setattr(sidemantic, "SemanticLayer", RustSemanticLayerAdapter)
+    monkeypatch.setattr(semantic_graph_module, "SemanticGraph", RustSemanticGraphDirectAdapter)
+    monkeypatch.setattr(semantic_layer_module, "SemanticLayer", RustSemanticLayerAdapter, raising=False)
+    monkeypatch.setattr(sql_generator_module, "SQLGenerator", RustSQLGeneratorAdapter)
+    monkeypatch.setattr(query_rewriter_module, "QueryRewriter", RustQueryRewriterAdapter)
+    if hasattr(module, "SemanticLayer"):
+        monkeypatch.setattr(module, "SemanticLayer", RustSemanticLayerAdapter)
+    if hasattr(module, "SemanticGraph"):
+        monkeypatch.setattr(module, "SemanticGraph", RustSemanticGraphDirectAdapter)
+    if hasattr(module, "SQLGenerator"):
+        monkeypatch.setattr(module, "SQLGenerator", RustSQLGeneratorAdapter)
+    if hasattr(module, "QueryRewriter"):
+        monkeypatch.setattr(module, "QueryRewriter", RustQueryRewriterAdapter)
+    if hasattr(module, "build_symmetric_aggregate_sql"):
+        monkeypatch.setattr(module, "build_symmetric_aggregate_sql", rust_build_symmetric_aggregate_sql)
+    if hasattr(module, "needs_symmetric_aggregate"):
+        monkeypatch.setattr(module, "needs_symmetric_aggregate", rust_needs_symmetric_aggregate)
+
+
+def _fixture_values(case: PythonTestParityCase) -> dict[str, object]:
+    values: dict[str, object] = {}
+    for fixture_name in case.fixture_names:
+        if fixture_name == "layer":
+            values[fixture_name] = RustSemanticLayerAdapter()
+        elif fixture_name == "test_db":
+            values[fixture_name] = _call_fixture(case.module, "test_db")
+        elif fixture_name == "semantic_layer":
+            values[fixture_name] = _semantic_layer_fixture(case.module, values)
+        elif fixture_name == "orders_db":
+            values[fixture_name] = _call_fixture(case.module, "orders_db")
+        elif fixture_name == "con":
+            values[fixture_name] = _call_fixture(case.module, "con")
+        elif fixture_name == "conn":
+            values[fixture_name] = duckdb.connect(":memory:")
+        elif fixture_name == "three_table_chain":
+            values[fixture_name] = _call_fixture(case.module, "three_table_chain")
+        elif fixture_name == "timeseries_db":
+            values[fixture_name] = _call_fixture(case.module, "timeseries_db")
+        else:
+            raise AssertionError(f"unsupported Python test parity fixture: {fixture_name}")
+    return values
+
+
+def _call_python_test_case(case: PythonTestParityCase, fixtures: dict[str, object]) -> None:
+    if case.owner is None:
+        case.func(**fixtures)
+        return
+
+    instance = case.owner()
+    case.func(instance, **fixtures)
+
+
+def _call_fixture(module: ModuleType, name: str, *args: object) -> object:
+    fixture = getattr(module, name)
+    factory = getattr(fixture, "__wrapped__", fixture)
+    return factory(*args)
+
+
+def _semantic_layer_fixture(module: ModuleType, values: dict[str, object]) -> object:
+    fixture = getattr(module, "semantic_layer")
+    factory = getattr(fixture, "__wrapped__", fixture)
+    fixture_params = tuple(inspect.signature(factory).parameters)
+    args = []
+    for fixture_name in fixture_params:
+        if fixture_name == "test_db":
+            args.append(values.setdefault("test_db", _call_fixture(module, "test_db")))
+        else:
+            raise AssertionError(f"unsupported semantic_layer fixture dependency: {fixture_name}")
+    return factory(*args)
+
+
+def _close_fixture_values(values: dict[str, object]) -> None:
+    seen: set[int] = set()
+    for value in values.values():
+        value_id = id(value)
+        if value_id in seen:
+            continue
+        seen.add(value_id)
+        close = getattr(value, "close", None)
+        if callable(close):
+            close()
+
+
+def _expected_gap_reason(nodeid: str) -> str | None:
+    return PRE_RUN_XFAILS.get(nodeid) or EXPECTED_GAPS.get(nodeid)

--- a/tests/rust_layer_adapter.py
+++ b/tests/rust_layer_adapter.py
@@ -1,0 +1,854 @@
+"""Test-only adapter that drives pure Rust from existing Python test bodies."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import yaml
+
+from sidemantic.core.metric import Metric
+from sidemantic.core.model import Model
+from sidemantic.core.semantic_graph import SemanticGraph
+from sidemantic.validation import MetricValidationError, ModelValidationError, QueryValidationError
+
+ROOT = Path(__file__).resolve().parents[1]
+RUST_MANIFEST = ROOT / "sidemantic-rs" / "Cargo.toml"
+RUST_TARGET_DIR = Path("/tmp/sidemantic-rs-parity-target")
+RUST_ADAPTER_BIN = RUST_TARGET_DIR / "debug" / "examples" / f"parity_adapter{'.exe' if os.name == 'nt' else ''}"
+
+
+class RustSemanticLayerAdapter:
+    """Minimal SemanticLayer-compatible test adapter backed by sidemantic-rs.
+
+    This is intentionally test-only. It lets selected Python tests execute their
+    original bodies against pure Rust load/compile behavior without introducing
+    a product-level Rust-backed Python runtime path.
+    """
+
+    def __init__(
+        self,
+        connection: Any = "duckdb:///:memory:",
+        dialect: str | None = None,
+        auto_register: bool = False,
+        use_preaggregations: bool = False,
+        preagg_database: str | None = None,
+        preagg_schema: str | None = None,
+        init_sql: list[str] | None = None,
+    ):
+        self._graph = SemanticGraph()
+        self.graph = RustSemanticGraphFacade(self)
+        self.connection_string = connection if isinstance(connection, str) else "duckdb://custom"
+        self.dialect = dialect or "duckdb"
+        self.use_preaggregations = use_preaggregations
+        self.preagg_database = preagg_database
+        self.preagg_schema = preagg_schema
+        self.init_sql = init_sql
+        self._owns_conn = False
+        self._conn = self._initial_connection(connection)
+        self.auto_register = auto_register
+
+    @property
+    def conn(self):
+        return self._conn
+
+    @conn.setter
+    def conn(self, value):
+        self._conn = value
+
+    def add_model(self, model: Model) -> None:
+        existing = self._graph.models.get(model.name)
+        if existing is not None:
+            if existing is model or existing.model_dump() == model.model_dump():
+                return
+            existing_dump = existing.model_dump()
+            new_dump = model.model_dump()
+            if existing.auto_dimensions and model.auto_dimensions:
+                existing_dump.pop("dimensions", None)
+                new_dump.pop("dimensions", None)
+                if existing_dump == new_dump:
+                    return
+
+        snapshot = dict(self._graph.models)
+        self._graph.add_model(model)
+        try:
+            self._rust_validate()
+        except Exception as exc:
+            self._graph.models = snapshot
+            if isinstance(exc, ModelValidationError):
+                raise
+            raise ModelValidationError(str(exc)) from exc
+
+    def add_metric(self, measure: Metric) -> None:
+        snapshot = dict(self._graph.metrics)
+        self._graph.add_metric(measure)
+        response = self._rust_request({"action": "validate", "models_yaml": self._models_yaml()})
+        if response["status"] == "error":
+            self._graph.metrics = snapshot
+            raise MetricValidationError(response["error"])
+
+    def compile(
+        self,
+        metrics: list[str] | None = None,
+        dimensions: list[str] | None = None,
+        filters: list[str] | None = None,
+        segments: list[str] | None = None,
+        order_by: list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        dialect: str | None = None,
+        ungrouped: bool = False,
+        parameters: dict[str, Any] | None = None,
+        use_preaggregations: bool | None = None,
+        skip_default_time_dimensions: bool = False,
+        **_kwargs: Any,
+    ) -> str:
+        if _kwargs:
+            unsupported = ", ".join(sorted(_kwargs))
+            raise NotImplementedError(f"pure Rust test adapter does not support compile kwargs: {unsupported}")
+
+        active_dialect = dialect or self.dialect
+        if active_dialect not in {"duckdb", "bigquery"}:
+            raise NotImplementedError(f"pure Rust test adapter does not support dialect '{active_dialect}' yet")
+        if offset is not None:
+            raise NotImplementedError("pure Rust test adapter does not support offset yet")
+        if parameters:
+            raise NotImplementedError("pure Rust test adapter does not support template parameters yet")
+        effective_preaggregations = self.use_preaggregations if use_preaggregations is None else use_preaggregations
+        if effective_preaggregations:
+            raise NotImplementedError("pure Rust test adapter does not support pre-aggregation routing yet")
+
+        response = self._rust_request(
+            {
+                "action": "compile",
+                "models_yaml": self._models_yaml(),
+                "metrics": metrics or [],
+                "dimensions": dimensions or [],
+                "filters": filters or [],
+                "segments": segments or [],
+                "order_by": order_by or [],
+                "limit": limit,
+                "ungrouped": ungrouped,
+                "skip_default_time_dimensions": skip_default_time_dimensions,
+                "dialect": active_dialect,
+            }
+        )
+        if response["status"] == "error":
+            if "unsupported_source_uri_query" in response["error"]:
+                raise ValueError(response["error"].replace("Rust SQL generation", "Python SQL generation"))
+            raise QueryValidationError(response["error"])
+        return response["sql"]
+
+    def query(
+        self,
+        metrics: list[str] | None = None,
+        dimensions: list[str] | None = None,
+        filters: list[str] | None = None,
+        segments: list[str] | None = None,
+        order_by: list[str] | None = None,
+        limit: int | None = None,
+        **kwargs: Any,
+    ):
+        if self._conn is None:
+            raise NotImplementedError("pure Rust test adapter query execution requires layer.conn to be set")
+
+        sql = self.compile(
+            metrics=metrics,
+            dimensions=dimensions,
+            filters=filters,
+            segments=segments,
+            order_by=order_by,
+            limit=limit,
+            **kwargs,
+        )
+        return self._conn.execute(sql)
+
+    def sql(self, sql: str, strict: bool = True, **_kwargs: Any):
+        if _kwargs:
+            unsupported = ", ".join(sorted(_kwargs))
+            raise NotImplementedError(f"pure Rust test adapter does not support sql kwargs: {unsupported}")
+        if not strict:
+            raise NotImplementedError("pure Rust test adapter does not support non-strict SQL rewriting yet")
+        if self._conn is None:
+            raise NotImplementedError("pure Rust test adapter SQL rewriting requires layer.conn to be set")
+
+        response = self._rust_request(
+            {
+                "action": "rewrite_sql",
+                "models_yaml": self._models_yaml(),
+                "sql": sql,
+            }
+        )
+        if response["status"] == "error":
+            raise ValueError(response["error"])
+        return self._conn.execute(response["sql"])
+
+    def explain(self, **_kwargs: Any):
+        raise NotImplementedError("pure Rust test adapter does not support explain plans yet")
+
+    def get_catalog_metadata(self, schema: str = "public") -> dict[str, Any]:
+        response = self._rust_request(
+            {
+                "action": "catalog_metadata",
+                "models_yaml": self._models_yaml(),
+                "schema": schema,
+            }
+        )
+        if response["status"] == "error":
+            raise ValueError(response["error"])
+        return response["catalog"]
+
+    def get_model(self, name: str) -> Model:
+        return self._graph.get_model(name)
+
+    def list_models(self) -> list[str]:
+        return list(self._graph.models.keys())
+
+    def get_metric(self, name: str) -> Metric:
+        return self._graph.get_metric(name)
+
+    def list_metrics(self) -> list[str]:
+        return list(self._graph.metrics.keys())
+
+    def close(self) -> None:
+        if self._owns_conn and self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    def _rust_validate(self) -> None:
+        response = self._rust_request({"action": "validate", "models_yaml": self._models_yaml()})
+        if response["status"] == "error":
+            raise ModelValidationError(response["error"])
+
+    def _initial_connection(self, connection: Any):
+        if not isinstance(connection, str):
+            return connection
+        if not connection.startswith("duckdb://"):
+            return None
+        database = connection.removeprefix("duckdb://")
+        if database in {"", "/:memory:", ":memory:"}:
+            database = ":memory:"
+        conn = duckdb.connect(database)
+        for statement in self.init_sql or []:
+            conn.execute(statement)
+        self._owns_conn = True
+        return conn
+
+    def _rust_request(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return _rust_request(payload)
+
+    def _models_yaml(self) -> str:
+        return yaml.safe_dump(
+            {
+                "models": [_model_to_rust_dict(model) for model in self.graph.models.values()],
+                "metrics": [_metric_to_rust_dict(metric) for metric in self.graph.metrics.values()],
+            },
+            sort_keys=False,
+        )
+
+    def _rust_join_path(self, from_model: str, to_model: str) -> list[RustJoinPath]:
+        response = self._rust_request(
+            {
+                "action": "join_path",
+                "models_yaml": self._models_yaml(),
+                "from_model": from_model,
+                "to_model": to_model,
+            }
+        )
+        if response["status"] == "error":
+            _raise_graph_error(response["error"])
+        return [
+            RustJoinPath(
+                from_model=step["from_model"],
+                to_model=step["to_model"],
+                from_columns=step["from_columns"],
+                to_columns=step["to_columns"],
+                relationship=step["relationship"],
+            )
+            for step in response["path"]
+        ]
+
+
+class RustSemanticGraphDirectAdapter:
+    """SemanticGraph-compatible test adapter that delegates graph behavior to Rust."""
+
+    def __init__(self):
+        self._models: dict[str, Model] = {}
+        self._metrics: dict[str, Metric] = {}
+        self.table_calculations: dict[str, object] = {}
+        self.parameters: dict[str, object] = {}
+        self._adjacency_dirty = True
+
+    @property
+    def models(self) -> dict[str, Model]:
+        return self._models
+
+    @property
+    def metrics(self) -> dict[str, Metric]:
+        return self._metrics
+
+    def add_model(self, model: Model) -> None:
+        response = _rust_request(
+            {
+                "action": "graph_add_model",
+                "models_yaml": self._models_yaml(),
+                "model_yaml": _single_model_yaml(model),
+            }
+        )
+        if response["status"] == "error":
+            _raise_graph_error(response["error"])
+        self._models[model.name] = model
+        for metric in model.metrics:
+            if metric.type != "time_comparison":
+                continue
+            metric_response = _rust_request(
+                {
+                    "action": "graph_get_metric",
+                    "models_yaml": self._models_yaml(),
+                    "name": metric.name,
+                }
+            )
+            if metric_response["status"] == "error":
+                _raise_graph_error(metric_response["error"])
+            self._metrics[metric.name] = metric
+        self._adjacency_dirty = True
+
+    def add_metric(self, measure: Metric) -> None:
+        response = _rust_request(
+            {
+                "action": "graph_add_metric",
+                "models_yaml": self._models_yaml(),
+                "metric_yaml": _single_metric_yaml(measure),
+            }
+        )
+        if response["status"] == "error":
+            _raise_graph_error(response["error"])
+        self._metrics[measure.name] = measure
+
+    def add_table_calculation(self, calc) -> None:
+        response = _rust_request(
+            {
+                "action": "graph_add_table_calculation",
+                "models_yaml": self._models_yaml(),
+                "table_calculations_json": self._table_calculations_json(),
+                "table_calculation_json": _table_calculation_to_rust_dict(calc),
+            }
+        )
+        if response["status"] == "error":
+            _raise_graph_error(response["error"])
+        self.table_calculations[calc.name] = calc
+
+    def get_model(self, name: str) -> Model:
+        response = _rust_request(
+            {
+                "action": "graph_get_model",
+                "models_yaml": self._models_yaml(),
+                "name": name,
+            }
+        )
+        if response["status"] == "error":
+            _raise_graph_error(response["error"])
+        return self._models[name]
+
+    def get_metric(self, name: str) -> Metric:
+        response = _rust_request(
+            {
+                "action": "graph_get_metric",
+                "models_yaml": self._models_yaml(),
+                "name": name,
+            }
+        )
+        if response["status"] == "error":
+            _raise_graph_error(response["error"])
+        return self._metrics[name]
+
+    def get_table_calculation(self, name: str):
+        response = _rust_request(
+            {
+                "action": "graph_get_table_calculation",
+                "models_yaml": self._models_yaml(),
+                "table_calculations_json": self._table_calculations_json(),
+                "name": name,
+            }
+        )
+        if response["status"] == "error":
+            _raise_graph_error(response["error"])
+        return self.table_calculations[name]
+
+    def build_adjacency(self) -> None:
+        response = _rust_request(
+            {
+                "action": "graph_build_adjacency",
+                "models_yaml": self._models_yaml(),
+            }
+        )
+        if response["status"] == "error":
+            _raise_graph_error(response["error"])
+        self._adjacency_dirty = False
+
+    def find_relationship_path(self, from_model: str, to_model: str) -> list[RustJoinPath]:
+        response = _rust_request(
+            {
+                "action": "join_path",
+                "models_yaml": self._models_yaml(),
+                "from_model": from_model,
+                "to_model": to_model,
+            }
+        )
+        if response["status"] == "error":
+            _raise_graph_error(response["error"])
+        self._adjacency_dirty = False
+        return [
+            RustJoinPath(
+                from_model=step["from_model"],
+                to_model=step["to_model"],
+                from_columns=step["from_columns"],
+                to_columns=step["to_columns"],
+                relationship=step["relationship"],
+            )
+            for step in response["path"]
+        ]
+
+    def _models_yaml(self) -> str:
+        return _graph_yaml(self._models, self._metrics)
+
+    def _table_calculations_json(self) -> list[dict[str, Any]]:
+        return [_table_calculation_to_rust_dict(calc) for calc in self.table_calculations.values()]
+
+
+@dataclass(frozen=True)
+class RustJoinPath:
+    from_model: str
+    to_model: str
+    from_columns: list[str]
+    to_columns: list[str]
+    relationship: str
+
+    @property
+    def from_entity(self) -> str:
+        return self.from_columns[0] if self.from_columns else ""
+
+    @property
+    def to_entity(self) -> str:
+        return self.to_columns[0] if self.to_columns else ""
+
+
+class RustSemanticGraphFacade:
+    def __init__(self, adapter: RustSemanticLayerAdapter):
+        self._adapter = adapter
+
+    @property
+    def models(self):
+        return self._adapter._graph.models
+
+    @property
+    def metrics(self):
+        return self._adapter._graph.metrics
+
+    def get_model(self, name: str) -> Model:
+        return self._adapter._graph.get_model(name)
+
+    def get_metric(self, name: str) -> Metric:
+        return self._adapter._graph.get_metric(name)
+
+    def find_relationship_path(self, from_model: str, to_model: str) -> list[RustJoinPath]:
+        return self._adapter._rust_join_path(from_model, to_model)
+
+
+class RustSQLGeneratorAdapter:
+    """SQLGenerator-compatible test wrapper backed by the pure Rust adapter."""
+
+    def __init__(
+        self,
+        graph,
+        dialect: str = "duckdb",
+        preagg_database: str | None = None,
+        preagg_schema: str | None = None,
+    ):
+        self.graph = graph
+        self.dialect = dialect
+        self.preagg_database = preagg_database
+        self.preagg_schema = preagg_schema
+
+    def generate(
+        self,
+        metrics: list[str] | None = None,
+        dimensions: list[str] | None = None,
+        filters: list[str] | None = None,
+        segments: list[str] | None = None,
+        order_by: list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        parameters: dict[str, Any] | None = None,
+        ungrouped: bool = False,
+        use_preaggregations: bool = False,
+        aliases: dict[str, str] | None = None,
+        skip_default_time_dimensions: bool = False,
+    ) -> str:
+        if offset is not None:
+            raise NotImplementedError("pure Rust test adapter does not support offset yet")
+        if parameters:
+            raise NotImplementedError("pure Rust test adapter does not support template parameters yet")
+        if use_preaggregations:
+            raise NotImplementedError("pure Rust test adapter does not support pre-aggregation routing yet")
+        if aliases:
+            raise NotImplementedError("pure Rust test adapter does not support custom aliases yet")
+
+        response = _rust_request(
+            {
+                "action": "compile",
+                "models_yaml": _graph_yaml_from_graph(self.graph),
+                "metrics": metrics or [],
+                "dimensions": dimensions or [],
+                "filters": filters or [],
+                "segments": segments or [],
+                "order_by": order_by or [],
+                "limit": limit,
+                "ungrouped": ungrouped,
+                "skip_default_time_dimensions": skip_default_time_dimensions,
+                "dialect": self.dialect,
+            }
+        )
+        if response["status"] == "error":
+            raise QueryValidationError(response["error"])
+        return response["sql"]
+
+    def generate_view(
+        self,
+        view_name: str,
+        metrics: list[str] | None = None,
+        dimensions: list[str] | None = None,
+        filters: list[str] | None = None,
+        order_by: list[str] | None = None,
+        limit: int | None = None,
+    ) -> str:
+        if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_.]*$", view_name):
+            raise ValueError(f"Invalid view name: {view_name}")
+        query_sql = self.generate(metrics, dimensions, filters, order_by=order_by, limit=limit)
+        return f"CREATE VIEW {view_name} AS\n{query_sql}"
+
+
+class RustQueryRewriterAdapter:
+    """QueryRewriter-compatible test wrapper backed by the pure Rust adapter."""
+
+    def __init__(self, graph: RustSemanticGraphFacade, dialect: str = "duckdb"):
+        if not isinstance(graph, RustSemanticGraphFacade):
+            raise TypeError("RustQueryRewriterAdapter requires RustSemanticGraphFacade")
+        if dialect != "duckdb":
+            raise NotImplementedError(f"pure Rust test adapter does not support dialect '{dialect}' yet")
+        self._adapter = graph._adapter
+
+    def rewrite(self, sql: str, strict: bool = True) -> str:
+        stripped = sql.strip()
+        upper = stripped.upper()
+
+        if not strict:
+            if "AGGREGATE(" in upper:
+                return sql
+            try:
+                return self.rewrite(sql, strict=True)
+            except ValueError:
+                return sql
+
+        if not upper.startswith("SELECT"):
+            raise ValueError("Only SELECT queries are supported")
+        if upper == "SELECT *":
+            raise ValueError("SELECT * requires a FROM clause")
+        if upper.startswith("SELECT FROM WHERE"):
+            raise ValueError("Failed to parse SQL")
+        if upper.startswith("SELECT FROM"):
+            raise ValueError("Query must select at least one metric or dimension")
+
+        response = self._adapter._rust_request(
+            {
+                "action": "rewrite_sql",
+                "models_yaml": self._adapter._models_yaml(),
+                "sql": sql,
+            }
+        )
+        if response["status"] == "error":
+            error = response["error"]
+            if "parse" in error.lower():
+                raise ValueError(f"Failed to parse SQL: {error}") from None
+            raise ValueError(error)
+        return response["sql"]
+
+
+def rust_build_symmetric_aggregate_sql(
+    measure_expr: str,
+    primary_key: str,
+    agg_type: str,
+    model_alias: str | None = None,
+    dialect: str = "duckdb",
+) -> str:
+    response = _rust_request(
+        {
+            "action": "symmetric_aggregate_sql",
+            "measure_expr": measure_expr,
+            "primary_key": primary_key,
+            "agg_type": agg_type,
+            "model_alias": model_alias,
+            "dialect": dialect,
+        }
+    )
+    if response["status"] == "error":
+        raise ValueError(response["error"])
+    return response["sql"]
+
+
+def rust_needs_symmetric_aggregate(relationship: str, is_base_model: bool) -> bool:
+    response = _rust_request(
+        {
+            "action": "needs_symmetric_aggregate",
+            "relationship": relationship,
+            "is_base_model": is_base_model,
+        }
+    )
+    if response["status"] == "error":
+        raise ValueError(response["error"])
+    return bool(response["value"])
+
+
+def _model_to_rust_dict(model: Model) -> dict[str, Any]:
+    return _drop_none(
+        {
+            "name": model.name,
+            "table": model.table,
+            "sql": model.sql,
+            "source_uri": model.source_uri,
+            "extends": model.extends,
+            "primary_key": model.primary_key,
+            "primary_key_columns": model.primary_key_columns,
+            "unique_keys": model.unique_keys,
+            "description": model.description,
+            "metadata": model.metadata,
+            "meta": model.meta,
+            "default_time_dimension": model.default_time_dimension,
+            "default_grain": model.default_grain,
+            "dimensions": [_dimension_to_rust_dict(dimension) for dimension in model.dimensions],
+            "metrics": [_metric_to_rust_dict(metric) for metric in model.metrics],
+            "relationships": [_relationship_to_rust_dict(relationship) for relationship in model.relationships],
+            "segments": [_segment_to_rust_dict(segment) for segment in model.segments],
+            "pre_aggregations": [_pre_aggregation_to_rust_dict(preagg) for preagg in model.pre_aggregations],
+        }
+    )
+
+
+def _dimension_to_rust_dict(dimension) -> dict[str, Any]:
+    return _drop_none(
+        {
+            "name": dimension.name,
+            "type": dimension.type,
+            "sql": dimension.sql,
+            "granularity": dimension.granularity,
+            "supported_granularities": dimension.supported_granularities,
+            "description": dimension.description,
+            "label": dimension.label,
+            "metadata": dimension.metadata,
+            "meta": dimension.meta,
+            "format": dimension.format,
+            "value_format_name": dimension.value_format_name,
+            "parent": dimension.parent,
+            "window": dimension.window,
+            "public": dimension.public,
+        }
+    )
+
+
+def _metric_to_rust_dict(metric: Metric) -> dict[str, Any]:
+    return _drop_none(
+        {
+            "name": metric.name,
+            "type": metric.type,
+            "agg": metric.agg,
+            "sql": metric.sql,
+            "numerator": metric.numerator,
+            "denominator": metric.denominator,
+            "offset_window": metric.offset_window,
+            "base_metric": metric.base_metric,
+            "window": metric.window,
+            "grain_to_date": metric.grain_to_date,
+            "window_expression": metric.window_expression,
+            "window_frame": metric.window_frame,
+            "window_order": metric.window_order,
+            "comparison_type": metric.comparison_type,
+            "time_offset": metric.time_offset,
+            "calculation": metric.calculation,
+            "entity": metric.entity,
+            "base_event": metric.base_event,
+            "conversion_event": metric.conversion_event,
+            "conversion_window": metric.conversion_window,
+            "steps": metric.steps,
+            "cohort_event": metric.cohort_event,
+            "activity_event": metric.activity_event,
+            "periods": metric.periods,
+            "retention_granularity": metric.retention_granularity,
+            "inner_metrics": metric.inner_metrics,
+            "entity_dimensions": metric.entity_dimensions,
+            "having": metric.having,
+            "filters": metric.filters,
+            "fill_nulls_with": metric.fill_nulls_with,
+            "description": metric.description,
+            "label": metric.label,
+            "metadata": metric.metadata,
+            "meta": metric.meta,
+            "format": metric.format,
+            "value_format_name": metric.value_format_name,
+            "drill_fields": metric.drill_fields,
+            "non_additive_dimension": metric.non_additive_dimension,
+            "public": metric.public,
+        }
+    )
+
+
+def _relationship_to_rust_dict(relationship) -> dict[str, Any]:
+    return _drop_none(
+        {
+            "name": relationship.name,
+            "type": relationship.type,
+            "foreign_key": relationship.foreign_key,
+            "primary_key": relationship.primary_key,
+            "through": getattr(relationship, "through", None),
+            "through_foreign_key": getattr(relationship, "through_foreign_key", None),
+            "related_foreign_key": getattr(relationship, "related_foreign_key", None),
+            "sql": getattr(relationship, "sql", None),
+            "metadata": relationship.metadata,
+        }
+    )
+
+
+def _segment_to_rust_dict(segment) -> dict[str, Any]:
+    return _drop_none(
+        {
+            "name": segment.name,
+            "sql": segment.sql,
+            "description": segment.description,
+            "public": segment.public,
+        }
+    )
+
+
+def _pre_aggregation_to_rust_dict(preagg) -> dict[str, Any]:
+    return preagg.model_dump(mode="json", exclude_none=True)
+
+
+def _table_calculation_to_rust_dict(calc) -> dict[str, Any]:
+    return _drop_none(
+        {
+            "name": calc.name,
+            "type": calc.type,
+            "description": calc.description,
+            "expression": calc.expression,
+            "field": calc.field,
+            "partition_by": calc.partition_by,
+            "order_by": calc.order_by,
+            "window_size": calc.window_size,
+        }
+    )
+
+
+def _drop_none(value: dict[str, Any]) -> dict[str, Any]:
+    return {key: item for key, item in value.items() if item is not None}
+
+
+def _single_model_yaml(model: Model) -> str:
+    return _graph_yaml({model.name: model}, {})
+
+
+def _single_metric_yaml(metric: Metric) -> str:
+    return _graph_yaml({}, {metric.name: metric})
+
+
+def _graph_yaml(models: dict[str, Model], metrics: dict[str, Metric]) -> str:
+    return yaml.safe_dump(
+        {
+            "models": [_model_to_rust_dict(model) for model in models.values()],
+            "metrics": [_metric_to_rust_dict(metric) for metric in metrics.values()],
+        },
+        sort_keys=False,
+    )
+
+
+def _graph_yaml_from_graph(graph) -> str:
+    return _graph_yaml(graph.models, graph.metrics)
+
+
+def _rust_request(payload: dict[str, Any]) -> dict[str, Any]:
+    _ensure_rust_adapter_binary()
+    result = subprocess.run(
+        [str(RUST_ADAPTER_BIN)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        cwd=ROOT,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr or result.stdout)
+    return json.loads(result.stdout)
+
+
+def _raise_graph_error(error: str) -> None:
+    normalized = _normalize_graph_error(error)
+    if (
+        re.search(r"^Model .+ not found$", normalized)
+        or re.search(r"^Measure .+ not found$", normalized)
+        or re.search(r"^Table calculation .+ not found$", normalized)
+    ):
+        raise KeyError(normalized)
+    raise ValueError(normalized)
+
+
+def _normalize_graph_error(error: str) -> str:
+    message = error.removeprefix("Validation error: ")
+
+    if match := re.search(r"Model not found: '([^']+)'", message):
+        return f"Model {match.group(1)} not found"
+    if match := re.search(r"Model '([^']+)' already exists", message):
+        return f"Model {match.group(1)} already exists"
+    if match := re.search(r"Metric not found: '([^']+)'", message):
+        return f"Measure {match.group(1)} not found"
+    if match := re.search(r"Measure not found: '([^']+)'", message):
+        return f"Measure {match.group(1)} not found"
+    if match := re.search(r"Table calculation '([^']+)' already exists", message):
+        return f"Table calculation {match.group(1)} already exists"
+    if match := re.search(r"Table calculation '([^']+)' not found", message):
+        return f"Table calculation {match.group(1)} not found"
+
+    return message.replace("'", "")
+
+
+def _ensure_rust_adapter_binary() -> None:
+    if RUST_ADAPTER_BIN.exists() and not _rust_sources_newer_than_binary():
+        return
+    result = subprocess.run(
+        [
+            "cargo",
+            "build",
+            "--quiet",
+            "--manifest-path",
+            str(RUST_MANIFEST),
+            "--example",
+            "parity_adapter",
+        ],
+        text=True,
+        capture_output=True,
+        cwd=ROOT,
+        env={**os.environ, "CARGO_TARGET_DIR": str(RUST_TARGET_DIR)},
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr or result.stdout)
+
+
+def _rust_sources_newer_than_binary() -> bool:
+    binary_mtime = RUST_ADAPTER_BIN.stat().st_mtime
+    rust_root = ROOT / "sidemantic-rs"
+    candidates = [RUST_MANIFEST, *(rust_root / "src").rglob("*.rs"), *(rust_root / "examples").rglob("*.rs")]
+    return any(path.stat().st_mtime > binary_mtime for path in candidates)


### PR DESCRIPTION
Adds a test-only pure Rust Python test parity harness that drives the pure Rust implementation through existing Python semantic-layer behavior instead of handwritten smoke cases.

Includes:
- Cargo example JSON adapter for pure Rust validate, compile, rewrite, graph, and symmetric aggregate operations.
- Python pytest adapter and parity inventory for core graph, SQL generation, SQL rewriter, metrics, joins, dates, segments, and symmetric aggregate tests.
- Rust parity fixes for graph-level metrics, config-loaded metrics, composite keys, relationship dimensions, date granularity SQL, relative dates, and symmetric aggregate SQL.

Current local validation:
- Full Python suite: 4220 passed, 40 skipped, 70 xfailed, 77 deselected.
- Pure Rust Python test parity file: 257 passed, 52 expected xfailed; stale xfail audit clean.
- Rust tests passed.
- Ruff check and format check passed.