### PR TITLE
Update OSI spec compatibility

### DIFF
--- a/docs/compatibility/osi.md
+++ b/docs/compatibility/osi.md
@@ -1,6 +1,6 @@
 # OSI Compatibility
 
-Sidemantic's OSI adapter parses [Open Semantic Interface](https://github.com/open-semantic-interchange/OSI) YAML files and maps OSI concepts to Sidemantic's semantic model (Model, Dimension, Metric, Relationship). It also supports exporting back to OSI YAML, including multi-dialect SQL transpilation via sqlglot.
+Sidemantic's OSI adapter parses [Open Semantic Interchange](https://github.com/open-semantic-interchange/OSI) YAML files and maps OSI concepts to Sidemantic's semantic model (Model, Dimension, Metric, Relationship). It also supports exporting back to OSI YAML, including multi-dialect SQL transpilation via sqlglot.
 
 Features are marked **supported**, **partial support**, or **unsupported**. Partial support entries include notes explaining the limitation. Properties that parse without error but have no Sidemantic equivalent are grouped together per section rather than listed individually.
 
@@ -12,10 +12,11 @@ Features are marked **supported**, **partial support**, or **unsupported**. Part
 |---------|--------|
 | `semantic_model` (list of models) | Supported |
 | Multiple semantic models in one file | Supported (each iterated independently) |
-| `name` (semantic model name) | Partial support: parsed but not stored. The graph has no concept of a top-level model name. Individual datasets become named Models. |
-| `description` (semantic model description) | Partial support: parsed but not stored on the graph. |
-
-Not mapped: `version`.
+| `version` | Supported. Current exports emit `0.2.0.dev0`; imports preserve the source version in `SemanticGraph.metadata["osi"]["version"]`. |
+| `name` (semantic model name) | Supported as metadata. Stored in `SemanticGraph.metadata["osi"]["semantic_models"]` and reused on export. Individual datasets still become named Models. |
+| `description` (semantic model description) | Supported as graph metadata and reused on export. |
+| `ai_context` (semantic model level) | Supported as graph metadata and reused on export. |
+| `custom_extensions` (semantic model level) | Supported as graph metadata and reused on export. |
 
 ---
 
@@ -32,7 +33,6 @@ Not mapped: `version`.
 | `fields` | Supported (mapped to Dimensions) |
 | `ai_context` | Supported (stored in `Model.meta["ai_context"]`) |
 | `custom_extensions` (dataset level) | Supported (stored in `Model.meta["custom_extensions"]`) |
-| `custom_extensions` (semantic_model level) | Unsupported |
 | Dataset without `name` | Supported (gracefully skipped) |
 | Multi-file directory parsing (recursive `.yml`/`.yaml` discovery) | Supported |
 | Default primary key when omitted | Supported (defaults to `"id"`) |
@@ -91,6 +91,9 @@ Not mapped: `type` (the OSI `type` hint on metrics, e.g. `type: count`, is ignor
 | `from_columns` / `to_columns` (single column) | Supported |
 | `from_columns` / `to_columns` (multi-column composite keys) | Supported |
 | Relationship type | Partial support: all relationships are imported as `many_to_one`. The OSI spec does not define cardinality on the `from`/`to` relationship format, and the adapter always assumes many-to-one. |
+| Relationship `name` | Supported (stored in `Relationship.metadata["osi_name"]` and reused on export) |
+| Relationship `ai_context` | Supported (stored in `Relationship.metadata["ai_context"]`) |
+| Relationship `custom_extensions` | Supported (stored in `Relationship.metadata["custom_extensions"]`) |
 | Missing `from_columns` | Supported (defaults foreign key to `{to_model}_id`) |
 | Missing `to_columns` | Supported (defaults primary key to `id`) |
 | Relationship with missing `from` or `to` | Supported (gracefully skipped) |
@@ -98,8 +101,6 @@ Not mapped: `type` (the OSI `type` hint on metrics, e.g. `type: count`, is ignor
 | `left_dataset` / `right_dataset` / `cardinality` format | Unsupported |
 
 The `left_dataset`/`right_dataset`/`cardinality` relationship format (used by some community OSI files, e.g. mdb-engine models) is not parsed. Only the `from`/`to`/`from_columns`/`to_columns` format is recognized. Files using the alternative format will parse without error, but relationships will be silently skipped.
-
-Not mapped: relationship `name`, `ai_context` on relationships.
 
 ---
 
@@ -112,8 +113,8 @@ Not mapped: relationship `name`, `ai_context` on relationships.
 | `ANSI_SQL` dialect | Supported (preferred) |
 | `SNOWFLAKE` dialect | Supported (second preference) |
 | `DATABRICKS` dialect | Supported (third preference) |
-| `BIGQUERY` dialect | Supported (used as fallback if preferred dialects absent) |
-| Other/custom dialects | Supported (used as fallback if preferred dialects absent) |
+| `MAQL`, `TABLEAU`, `MDX` dialects | Supported as fallback expressions if no preferred SQL dialect is present. The expression is preserved as text; it is not translated. |
+| Other/custom dialects | Supported on import as fallback if preferred dialects absent |
 | Multiple dialects per expression | Supported (single dialect selected by preference order) |
 | Missing `expression` block | Supported (field SQL becomes `None`) |
 
@@ -124,9 +125,10 @@ Not mapped: relationship `name`, `ai_context` on relationships.
 | Export to `ANSI_SQL` | Supported (default, expression passed through as-is) |
 | Export to `SNOWFLAKE` | Supported (transpiled from DuckDB/ANSI via sqlglot) |
 | Export to `DATABRICKS` | Supported (transpiled via sqlglot) |
-| Export to `BIGQUERY` | Supported (transpiled via sqlglot) |
+| Export to `BIGQUERY` | Unsupported (not in the current OSI dialect enum) |
+| Export to `MAQL`, `TABLEAU`, `MDX` | Unsupported (not safely generated from Sidemantic SQL) |
 | Multiple dialects in single export | Supported (pass `dialects=["ANSI_SQL", "SNOWFLAKE", ...]`) |
-| Unknown dialect on export | Supported (falls back to original expression) |
+| Unknown dialect on export | Unsupported (raises `ValueError`) |
 | Transpilation failure | Supported (falls back to original expression) |
 
 ---
@@ -140,8 +142,8 @@ Not mapped: relationship `name`, `ai_context` on relationships.
 | Dataset `ai_context` | Supported (stored in `Model.meta["ai_context"]`) |
 | Field `ai_context` | Supported (stored in `Dimension.meta["ai_context"]`) |
 | Metric `ai_context` | Supported (stored in `Metric.meta["ai_context"]`) |
-| Semantic model level `ai_context` | Partial support: parsed by YAML but not stored on the graph. |
-| Relationship `ai_context` | Unsupported |
+| Semantic model level `ai_context` | Supported (stored in `SemanticGraph.metadata["osi"]["semantic_models"]`) |
+| Relationship `ai_context` | Supported (stored in `Relationship.metadata["ai_context"]`) |
 
 Common sub-keys (`synonyms`, `instructions`, `examples`, `description_for_ai`) are all preserved as-is in the meta dictionary. No sub-key receives special handling.
 
@@ -154,9 +156,10 @@ Common sub-keys (`synonyms`, `instructions`, `examples`, `description_for_ai`) a
 | Dataset `custom_extensions` | Supported (stored in `Model.meta["custom_extensions"]`) |
 | Field `custom_extensions` | Supported (stored in `Dimension.meta["custom_extensions"]`) |
 | Metric `custom_extensions` | Supported (stored in `Metric.meta["custom_extensions"]`) |
-| Semantic model level `custom_extensions` | Unsupported |
+| Relationship `custom_extensions` | Supported (stored in `Relationship.metadata["custom_extensions"]`) |
+| Semantic model level `custom_extensions` | Supported (stored in `SemanticGraph.metadata["osi"]["semantic_models"]`) |
 
-Nested structures within `custom_extensions` (vendor configs, tag lists, etc.) are preserved verbatim as Python dicts/lists.
+Current OSI schema represents `custom_extensions` as a list of `{vendor_name, data}` objects where `data` is a JSON string. Sidemantic still imports legacy dict/list extension shapes. On export, non-standard extension payloads are wrapped as a `SIDEMANTIC` extension with stringified JSON so emitted OSI stays schema-shaped.
 
 ---
 
@@ -166,6 +169,8 @@ Sidemantic can export its semantic model back to OSI YAML format.
 
 | Feature | Status |
 |---------|--------|
+| Current OSI version | Supported (`version: "0.2.0.dev0"` emitted at file root) |
+| Semantic-model-level metadata | Supported (`name`, `description`, `ai_context`, `custom_extensions`) |
 | Datasets with `source` (table name) | Supported |
 | Datasets with `sql` (derived/subquery source) | Supported (wrapped in parentheses) |
 | Fields (dimensions) | Supported |
@@ -182,6 +187,7 @@ Sidemantic can export its semantic model back to OSI YAML format.
 | Model-level metrics | Supported (promoted to semantic_model-level metrics, field refs qualified with model name) |
 | Graph-level metrics | Supported |
 | Relationships (`many_to_one` only) | Supported |
+| Relationship `name`, `ai_context`, `custom_extensions` | Supported |
 | Non-`many_to_one` relationships | Unsupported (silently omitted from export) |
 | Multi-column relationship keys | Supported |
 | Related model PK lookup on export | Supported (when `rel.primary_key` is None, the related model's actual PK columns are used for `to_columns`) |
@@ -195,7 +201,19 @@ Sidemantic can export its semantic model back to OSI YAML format.
 
 ## Version Field
 
-Unsupported. The `version: "1.0"` key at the file root is ignored on import and not emitted on export.
+Supported. Imports preserve the source value in graph metadata. Exports always emit the current supported OSI draft version, `0.2.0.dev0`.
+
+---
+
+## Ontology Files
+
+OSI's ontology spec defines conceptual `ontology` entries plus `ontology_mappings` that embed logical semantic models. Sidemantic does not implement ontology reasoning, but it does:
+
+| Feature | Status |
+|---------|--------|
+| Top-level `ontology` | Partial support: preserved in `SemanticGraph.metadata["osi"]["ontology"]`; not converted to Models. |
+| `ontology_mappings[].semantic_model` | Supported: parsed into Sidemantic Models, Relationships, and Metrics. |
+| `ontology_mappings[].concept_mappings` | Partial support: preserved in graph metadata; not used for query planning. |
 
 ---
 

--- a/examples/osi_demo/adtech_semantic_model.yaml
+++ b/examples/osi_demo/adtech_semantic_model.yaml
@@ -1,3 +1,5 @@
+version: "0.2.0.dev0"
+
 semantic_model:
   - name: adtech_performance
     description: Complex adtech semantic layer with multi-hop joins and cross-model metrics

--- a/sidemantic/adapters/osi.py
+++ b/sidemantic/adapters/osi.py
@@ -6,6 +6,7 @@ interoperability between data analytics, AI, and BI tools.
 Spec: https://github.com/open-semantic-interchange/OSI
 """
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -30,8 +31,19 @@ class OSIAdapter(BaseAdapter):
     - OSI relationships → Relationships
     """
 
+    OSI_VERSION = "0.2.0.dev0"
+
     # OSI dialect preference order for extracting SQL expressions
-    DIALECT_PREFERENCE = ["ANSI_SQL", "SNOWFLAKE", "DATABRICKS"]
+    DIALECT_PREFERENCE = ["ANSI_SQL", "SNOWFLAKE", "DATABRICKS", "MAQL", "TABLEAU", "MDX"]
+
+    # Dialects we can safely emit from SQL expressions. The current OSI schema
+    # also allows MDX/TABLEAU/MAQL, but those are not SQL dialects sqlglot can
+    # transpile from Sidemantic SQL without changing semantics.
+    SUPPORTED_EXPORT_DIALECTS = ["ANSI_SQL", "SNOWFLAKE", "DATABRICKS"]
+    _SQLGLOT_DIALECTS = {
+        "SNOWFLAKE": "snowflake",
+        "DATABRICKS": "databricks",
+    }
 
     def parse(self, source: str | Path) -> SemanticGraph:
         """Parse OSI YAML files into semantic graph.
@@ -78,28 +90,89 @@ class OSIAdapter(BaseAdapter):
         if not data:
             return
 
-        # OSI has top-level "semantic_model" key containing list of semantic models
+        osi_meta = self._ensure_osi_metadata(graph)
+        if data.get("version"):
+            osi_meta["version"] = data["version"]
+        if data.get("ontology"):
+            osi_meta["ontology"] = data["ontology"]
+
+        for sm_def, source, mapping_def in self._iter_semantic_models(data):
+            self._remember_semantic_model_metadata(osi_meta, sm_def, source, mapping_def)
+            self._parse_semantic_model(sm_def, graph)
+
+    def _parse_semantic_model(self, sm_def: dict, graph: SemanticGraph) -> None:
+        """Parse one OSI semantic model object into the graph."""
+        # Parse datasets (equivalent to models)
+        datasets = sm_def.get("datasets") or []
+        for dataset_def in datasets:
+            model = self._parse_dataset(dataset_def)
+            if model:
+                graph.add_model(model)
+
+        # Parse relationships and attach to models
+        relationships = sm_def.get("relationships") or []
+        for rel_def in relationships:
+            self._add_relationship_to_model(rel_def, graph)
+
+        # Parse metrics (graph-level)
+        metrics = sm_def.get("metrics") or []
+        for metric_def in metrics:
+            metric = self._parse_metric(metric_def)
+            if metric:
+                graph.add_metric(metric)
+
+    def _iter_semantic_models(self, data: dict) -> list[tuple[dict, str, dict | None]]:
+        """Return top-level and ontology-mapped semantic model definitions.
+
+        The core OSI schema uses ``semantic_model`` as a top-level list. The new
+        ontology spec embeds a single semantic model under each
+        ``ontology_mappings[].semantic_model``. Those logical models can map
+        cleanly to Sidemantic models, while ontology concepts themselves are
+        preserved as metadata.
+        """
+        result: list[tuple[dict, str, dict | None]] = []
+
         semantic_models = data.get("semantic_model") or []
+        if isinstance(semantic_models, dict):
+            semantic_models = [semantic_models]
 
         for sm_def in semantic_models:
-            # Parse datasets (equivalent to models)
-            datasets = sm_def.get("datasets") or []
-            for dataset_def in datasets:
-                model = self._parse_dataset(dataset_def)
-                if model:
-                    graph.add_model(model)
+            if isinstance(sm_def, dict):
+                result.append((sm_def, "semantic_model", None))
 
-            # Parse relationships and attach to models
-            relationships = sm_def.get("relationships") or []
-            for rel_def in relationships:
-                self._add_relationship_to_model(rel_def, graph)
+        ontology_mappings = data.get("ontology_mappings") or []
+        for index, mapping_def in enumerate(ontology_mappings):
+            if not isinstance(mapping_def, dict):
+                continue
+            sm_def = mapping_def.get("semantic_model")
+            if isinstance(sm_def, dict):
+                result.append((sm_def, f"ontology_mappings[{index}].semantic_model", mapping_def))
 
-            # Parse metrics (graph-level)
-            metrics = sm_def.get("metrics") or []
-            for metric_def in metrics:
-                metric = self._parse_metric(metric_def)
-                if metric:
-                    graph.add_metric(metric)
+        return result
+
+    def _ensure_osi_metadata(self, graph: SemanticGraph) -> dict[str, Any]:
+        """Get/create the graph metadata section used by the OSI adapter."""
+        return graph.metadata.setdefault("osi", {"semantic_models": []})
+
+    def _remember_semantic_model_metadata(
+        self,
+        osi_meta: dict[str, Any],
+        sm_def: dict,
+        source: str,
+        mapping_def: dict | None,
+    ) -> None:
+        """Preserve semantic-model-level OSI fields that do not map to models."""
+        sm_meta: dict[str, Any] = {"source": source}
+        for key in ("name", "description", "ai_context", "custom_extensions"):
+            if key in sm_def:
+                sm_meta[key] = sm_def[key]
+        if mapping_def:
+            mapping_meta = {
+                key: mapping_def[key] for key in ("name", "description", "concept_mappings") if key in mapping_def
+            }
+            if mapping_meta:
+                sm_meta["ontology_mapping"] = mapping_meta
+        osi_meta.setdefault("semantic_models", []).append(sm_meta)
 
     def _parse_dataset(self, dataset_def: dict) -> Model | None:
         """Parse OSI dataset into Sidemantic Model.
@@ -146,12 +219,12 @@ class OSIAdapter(BaseAdapter):
         # Build meta from ai_context and custom_extensions
         meta = None
         ai_context = dataset_def.get("ai_context")
-        custom_extensions = dataset_def.get("custom_extensions")
-        if ai_context or custom_extensions:
+        custom_extensions = self._decode_custom_extensions(dataset_def.get("custom_extensions"))
+        if "ai_context" in dataset_def or custom_extensions is not None:
             meta = {}
-            if ai_context:
+            if "ai_context" in dataset_def:
                 meta["ai_context"] = ai_context
-            if custom_extensions:
+            if custom_extensions is not None:
                 meta["custom_extensions"] = custom_extensions
 
         return Model(
@@ -189,12 +262,12 @@ class OSIAdapter(BaseAdapter):
         # Build meta from ai_context and custom_extensions
         meta = None
         ai_context = field_def.get("ai_context")
-        custom_extensions = field_def.get("custom_extensions")
-        if ai_context or custom_extensions:
+        custom_extensions = self._decode_custom_extensions(field_def.get("custom_extensions"))
+        if "ai_context" in field_def or custom_extensions is not None:
             meta = {}
-            if ai_context:
+            if "ai_context" in field_def:
                 meta["ai_context"] = ai_context
-            if custom_extensions:
+            if custom_extensions is not None:
                 meta["custom_extensions"] = custom_extensions
 
         return Dimension(
@@ -232,12 +305,12 @@ class OSIAdapter(BaseAdapter):
         # Build meta from ai_context and custom_extensions
         meta = None
         ai_context = metric_def.get("ai_context")
-        custom_extensions = metric_def.get("custom_extensions")
-        if ai_context or custom_extensions:
+        custom_extensions = self._decode_custom_extensions(metric_def.get("custom_extensions"))
+        if "ai_context" in metric_def or custom_extensions is not None:
             meta = {}
-            if ai_context:
+            if "ai_context" in metric_def:
                 meta["ai_context"] = ai_context
-            if custom_extensions:
+            if custom_extensions is not None:
                 meta["custom_extensions"] = custom_extensions
 
         # Let the Metric class handle aggregation parsing via its model_validator.
@@ -330,17 +403,24 @@ class OSIAdapter(BaseAdapter):
             primary_key = to_columns
 
         # Create many_to_one relationship (from many -> to one)
+        metadata = {}
+        if rel_def.get("name"):
+            metadata["osi_name"] = rel_def["name"]
+        if "ai_context" in rel_def:
+            metadata["ai_context"] = rel_def.get("ai_context")
+        custom_extensions = self._decode_custom_extensions(rel_def.get("custom_extensions"))
+        if custom_extensions is not None:
+            metadata["custom_extensions"] = custom_extensions
+
         relationship = Relationship(
             name=to_model,
             type="many_to_one",
             foreign_key=foreign_key,
             primary_key=primary_key,
+            metadata=metadata or None,
         )
 
         model.relationships.append(relationship)
-
-    # Supported OSI dialects for export
-    SUPPORTED_EXPORT_DIALECTS = ["ANSI_SQL", "SNOWFLAKE", "DATABRICKS", "BIGQUERY"]
 
     def export(
         self,
@@ -353,14 +433,18 @@ class OSIAdapter(BaseAdapter):
         Args:
             graph: Semantic graph to export
             output_path: Path to output YAML file
-            dialects: List of OSI dialects to generate expressions for.
-                      Default is ["ANSI_SQL"]. Options: ANSI_SQL, SNOWFLAKE, DATABRICKS, BIGQUERY.
+            dialects: List of OSI dialects to generate SQL expressions for.
+                      Default is ["ANSI_SQL"]. Options: ANSI_SQL, SNOWFLAKE, DATABRICKS.
                       When multiple dialects specified, sqlglot is used for transpilation.
         """
         output_path = Path(output_path)
 
-        if dialects is None:
+        if not dialects:
             dialects = ["ANSI_SQL"]
+        unsupported = [dialect for dialect in dialects if dialect not in self.SUPPORTED_EXPORT_DIALECTS]
+        if unsupported:
+            supported = ", ".join(self.SUPPORTED_EXPORT_DIALECTS)
+            raise ValueError(f"Unsupported OSI export dialect(s): {', '.join(unsupported)}. Supported: {supported}")
 
         # Store dialects for use in export methods
         self._export_dialects = dialects
@@ -373,7 +457,7 @@ class OSIAdapter(BaseAdapter):
         # Build OSI semantic model
         semantic_model = self._export_semantic_model(resolved_models, graph)
 
-        data = {"semantic_model": [semantic_model]}
+        data = {"version": self._export_version(graph), "semantic_model": [semantic_model]}
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -399,13 +483,7 @@ class OSIAdapter(BaseAdapter):
                 # Use sqlglot for transpilation
                 import sqlglot
 
-                # Map OSI dialect names to sqlglot dialect names
-                dialect_map = {
-                    "SNOWFLAKE": "snowflake",
-                    "DATABRICKS": "databricks",
-                    "BIGQUERY": "bigquery",
-                }
-                target = dialect_map.get(dialect)
+                target = self._SQLGLOT_DIALECTS.get(dialect)
                 if target:
                     try:
                         transpiled = sqlglot.transpile(sql_expr, read="duckdb", write=target)[0]
@@ -432,6 +510,15 @@ class OSIAdapter(BaseAdapter):
             "name": "semantic_model",
             "description": "Semantic model exported from Sidemantic",
         }
+        osi_meta = (graph.metadata or {}).get("osi", {})
+        semantic_models_meta = osi_meta.get("semantic_models") or []
+        semantic_model_meta = semantic_models_meta[0] if semantic_models_meta else {}
+        for key in ("name", "description", "ai_context"):
+            if semantic_model_meta.get(key) is not None:
+                result[key] = semantic_model_meta[key]
+        custom_extensions = self._normalize_custom_extensions_for_export(semantic_model_meta.get("custom_extensions"))
+        if custom_extensions:
+            result["custom_extensions"] = custom_extensions
 
         # Export datasets
         datasets = []
@@ -507,7 +594,9 @@ class OSIAdapter(BaseAdapter):
             if "ai_context" in model.meta:
                 dataset["ai_context"] = model.meta["ai_context"]
             if "custom_extensions" in model.meta:
-                dataset["custom_extensions"] = model.meta["custom_extensions"]
+                custom_extensions = self._normalize_custom_extensions_for_export(model.meta["custom_extensions"])
+                if custom_extensions:
+                    dataset["custom_extensions"] = custom_extensions
 
         return dataset
 
@@ -541,7 +630,9 @@ class OSIAdapter(BaseAdapter):
             if "ai_context" in dim.meta:
                 field["ai_context"] = dim.meta["ai_context"]
             if "custom_extensions" in dim.meta:
-                field["custom_extensions"] = dim.meta["custom_extensions"]
+                custom_extensions = self._normalize_custom_extensions_for_export(dim.meta["custom_extensions"])
+                if custom_extensions:
+                    field["custom_extensions"] = custom_extensions
 
         return field
 
@@ -568,13 +659,21 @@ class OSIAdapter(BaseAdapter):
         else:
             to_columns = rel.primary_key_columns
 
-        return {
-            "name": f"{from_model}_to_{rel.name}",
+        result: dict[str, Any] = {
+            "name": (rel.metadata or {}).get("osi_name") or f"{from_model}_to_{rel.name}",
             "from": from_model,
             "to": rel.name,
             "from_columns": rel.foreign_key_columns,
             "to_columns": to_columns,
         }
+        if rel.metadata:
+            if "ai_context" in rel.metadata:
+                result["ai_context"] = rel.metadata["ai_context"]
+            if "custom_extensions" in rel.metadata:
+                custom_extensions = self._normalize_custom_extensions_for_export(rel.metadata["custom_extensions"])
+                if custom_extensions:
+                    result["custom_extensions"] = custom_extensions
+        return result
 
     def _export_metric(
         self, metric: Metric, models: dict[str, Model], model_name: str | None = None
@@ -608,9 +707,70 @@ class OSIAdapter(BaseAdapter):
             if "ai_context" in metric.meta:
                 result["ai_context"] = metric.meta["ai_context"]
             if "custom_extensions" in metric.meta:
-                result["custom_extensions"] = metric.meta["custom_extensions"]
+                custom_extensions = self._normalize_custom_extensions_for_export(metric.meta["custom_extensions"])
+                if custom_extensions:
+                    result["custom_extensions"] = custom_extensions
 
         return result
+
+    def _export_version(self, graph: SemanticGraph) -> str:
+        """Return the OSI version to emit."""
+        osi_meta = (graph.metadata or {}).get("osi", {})
+        version = osi_meta.get("version")
+        if version == self.OSI_VERSION:
+            return version
+        return self.OSI_VERSION
+
+    def _normalize_custom_extensions_for_export(self, custom_extensions: Any) -> list[dict[str, str]] | None:
+        """Normalize permissive local extension metadata to the OSI schema shape."""
+        if custom_extensions is None:
+            return None
+
+        if isinstance(custom_extensions, list):
+            normalized = []
+            for item in custom_extensions:
+                if not isinstance(item, dict):
+                    normalized.append({"vendor_name": "SIDEMANTIC", "data": self._extension_data_to_string(item)})
+                    continue
+                vendor_name = item.get("vendor_name") or item.get("vendor") or "SIDEMANTIC"
+                data = item.get("data")
+                if data is None:
+                    data = {key: value for key, value in item.items() if key not in {"vendor_name", "vendor"}}
+                normalized.append({"vendor_name": str(vendor_name), "data": self._extension_data_to_string(data)})
+            return normalized
+
+        if isinstance(custom_extensions, dict) and {"vendor_name", "data"} <= set(custom_extensions):
+            return [
+                {
+                    "vendor_name": str(custom_extensions["vendor_name"]),
+                    "data": self._extension_data_to_string(custom_extensions["data"]),
+                }
+            ]
+
+        return [{"vendor_name": "SIDEMANTIC", "data": self._extension_data_to_string(custom_extensions)}]
+
+    def _decode_custom_extensions(self, custom_extensions: Any) -> Any:
+        """Decode Sidemantic-owned extension wrappers while preserving standard OSI lists."""
+        if (
+            isinstance(custom_extensions, list)
+            and len(custom_extensions) == 1
+            and isinstance(custom_extensions[0], dict)
+            and custom_extensions[0].get("vendor_name") == "SIDEMANTIC"
+        ):
+            data = custom_extensions[0].get("data")
+            if isinstance(data, str):
+                try:
+                    return json.loads(data)
+                except json.JSONDecodeError:
+                    return data
+            return data
+        return custom_extensions
+
+    def _extension_data_to_string(self, data: Any) -> str:
+        """Convert custom extension data to the string required by OSI."""
+        if isinstance(data, str):
+            return data
+        return json.dumps(data, sort_keys=True)
 
     def _build_metric_expression(self, metric: Metric, model_name: str | None) -> str | None:
         """Build full OSI metric expression from Sidemantic metric.

--- a/sidemantic/core/semantic_graph.py
+++ b/sidemantic/core/semantic_graph.py
@@ -2,6 +2,7 @@
 
 from collections import deque
 from dataclasses import dataclass
+from typing import Any
 
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
@@ -43,6 +44,7 @@ class SemanticGraph:
         self.metrics: dict[str, Metric] = {}
         self.table_calculations: dict[str, TableCalculation] = {}
         self.parameters: dict[str, Parameter] = {}
+        self.metadata: dict[str, Any] = {}
         self._version = 0
         self._adjacency_dirty = True
         self._adjacency: dict[

--- a/tests/adapters/osi/test_parsing.py
+++ b/tests/adapters/osi/test_parsing.py
@@ -48,6 +48,123 @@ def test_import_simple_osi_example():
     assert events.default_time_dimension == "event_time"
 
 
+def test_import_current_version_and_semantic_model_metadata():
+    """Test current OSI top-level metadata is preserved on the graph."""
+    osi_yaml = {
+        "version": OSIAdapter.OSI_VERSION,
+        "semantic_model": [
+            {
+                "name": "current_model",
+                "description": "Current OSI model",
+                "ai_context": {"instructions": "Use for tests"},
+                "custom_extensions": [{"vendor_name": "DBT", "data": '{"project_name": "analytics"}'}],
+                "datasets": [
+                    {
+                        "name": "events",
+                        "source": "analytics.events",
+                        "fields": [
+                            {
+                                "name": "event_id",
+                                "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "event_id"}]},
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(osi_yaml, f)
+        temp_path = Path(f.name)
+
+    try:
+        graph = OSIAdapter().parse(temp_path)
+
+        osi_meta = graph.metadata["osi"]
+        assert osi_meta["version"] == OSIAdapter.OSI_VERSION
+        sm_meta = osi_meta["semantic_models"][0]
+        assert sm_meta["name"] == "current_model"
+        assert sm_meta["description"] == "Current OSI model"
+        assert sm_meta["ai_context"]["instructions"] == "Use for tests"
+        assert sm_meta["custom_extensions"][0]["vendor_name"] == "DBT"
+
+        OSIAdapter().export(graph, temp_path)
+        with open(temp_path) as f:
+            exported = yaml.safe_load(f)
+
+        assert exported["version"] == OSIAdapter.OSI_VERSION
+        exported_sm = exported["semantic_model"][0]
+        assert exported_sm["name"] == "current_model"
+        assert exported_sm["description"] == "Current OSI model"
+        assert exported_sm["ai_context"]["instructions"] == "Use for tests"
+        assert exported_sm["custom_extensions"][0]["vendor_name"] == "DBT"
+    finally:
+        temp_path.unlink()
+
+
+def test_import_ontology_mapping_semantic_model():
+    """Test ontology files expose mapped logical semantic models."""
+    osi_yaml = {
+        "version": OSIAdapter.OSI_VERSION,
+        "name": "flight_ontology",
+        "ontology": [
+            {
+                "concept": {"name": "Flight", "type": "EntityType", "identify_by": ["id"]},
+                "relationships": [
+                    {
+                        "name": "id",
+                        "roles": [{"concept": "String"}],
+                        "verbalizes": ["{Flight} id {String}"],
+                    }
+                ],
+            }
+        ],
+        "ontology_mappings": [
+            {
+                "name": "flights_map",
+                "description": "Flight logical mapping",
+                "semantic_model": {
+                    "name": "logical_flights",
+                    "description": "Mapped logical model",
+                    "datasets": [
+                        {
+                            "name": "flights",
+                            "source": "analytics.flights",
+                            "fields": [
+                                {
+                                    "name": "flight_id",
+                                    "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "flight_id"}]},
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "concept_mappings": [{"concept": "Flight"}],
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(osi_yaml, f)
+        temp_path = Path(f.name)
+
+    try:
+        graph = OSIAdapter().parse(temp_path)
+
+        assert "flights" in graph.models
+        assert graph.models["flights"].table == "analytics.flights"
+        osi_meta = graph.metadata["osi"]
+        assert osi_meta["ontology"][0]["concept"]["name"] == "Flight"
+        sm_meta = osi_meta["semantic_models"][0]
+        assert sm_meta["source"] == "ontology_mappings[0].semantic_model"
+        assert sm_meta["name"] == "logical_flights"
+        assert sm_meta["ontology_mapping"]["name"] == "flights_map"
+        assert sm_meta["ontology_mapping"]["concept_mappings"] == [{"concept": "Flight"}]
+    finally:
+        temp_path.unlink()
+
+
 def test_import_ecommerce_osi_example():
     """Test importing the ecommerce OSI YAML file."""
     adapter = OSIAdapter()
@@ -273,6 +390,58 @@ def test_osi_relationship_parsing():
     assert rel.type == "many_to_one"
     assert rel.foreign_key == "customer_id"
     assert rel.primary_key == "customer_id"
+    assert rel.metadata["osi_name"] == "orders_to_customers"
+
+
+def test_osi_relationship_metadata_roundtrip():
+    """Test relationship-level OSI metadata is preserved."""
+    osi_yaml = {
+        "version": OSIAdapter.OSI_VERSION,
+        "semantic_model": [
+            {
+                "name": "test",
+                "datasets": [
+                    {"name": "orders", "source": "public.orders"},
+                    {"name": "customers", "source": "public.customers"},
+                ],
+                "relationships": [
+                    {
+                        "name": "orders_to_customers",
+                        "from": "orders",
+                        "to": "customers",
+                        "from_columns": ["customer_id"],
+                        "to_columns": ["id"],
+                        "ai_context": {"synonyms": ["buyer"]},
+                        "custom_extensions": [{"vendor_name": "COMMON", "data": '{"join": "customer"}'}],
+                    }
+                ],
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(osi_yaml, f)
+        temp_path = Path(f.name)
+
+    try:
+        adapter = OSIAdapter()
+        graph = adapter.parse(temp_path)
+        rel = graph.models["orders"].relationships[0]
+        assert rel.metadata["osi_name"] == "orders_to_customers"
+        assert rel.metadata["ai_context"]["synonyms"] == ["buyer"]
+        assert rel.metadata["custom_extensions"][0]["vendor_name"] == "COMMON"
+
+        adapter.export(graph, temp_path)
+        with open(temp_path) as f:
+            data = yaml.safe_load(f)
+
+        exported_rel = data["semantic_model"][0]["relationships"][0]
+        assert exported_rel["name"] == "orders_to_customers"
+        assert exported_rel["ai_context"]["synonyms"] == ["buyer"]
+        assert exported_rel["custom_extensions"][0]["vendor_name"] == "COMMON"
+        assert isinstance(exported_rel["custom_extensions"][0]["data"], str)
+    finally:
+        temp_path.unlink()
 
 
 def test_osi_multiple_relationships():
@@ -481,6 +650,7 @@ def test_osi_export_simple_model():
             data = yaml.safe_load(f)
 
         # Verify structure
+        assert data["version"] == OSIAdapter.OSI_VERSION
         assert "semantic_model" in data
         assert len(data["semantic_model"]) == 1
 
@@ -1053,7 +1223,7 @@ def test_export_meta_as_ai_context():
 
         # Model meta
         assert dataset["ai_context"] == {"synonyms": ["revenue", "transactions"]}
-        assert dataset["custom_extensions"] == {"vendor_id": "acme123"}
+        assert dataset["custom_extensions"] == [{"vendor_name": "SIDEMANTIC", "data": '{"vendor_id": "acme123"}'}]
 
         # Field meta
         amount_field = next(f for f in dataset["fields"] if f["name"] == "amount")
@@ -1099,6 +1269,12 @@ def test_roundtrip_preserves_meta():
     try:
         # Export
         adapter.export(graph, temp_path)
+
+        with open(temp_path) as f:
+            exported = yaml.safe_load(f)
+
+        dataset = exported["semantic_model"][0]["datasets"][0]
+        assert dataset["custom_extensions"] == [{"vendor_name": "SIDEMANTIC", "data": '{"catalog_version": "2.0"}'}]
 
         # Import back
         graph2 = adapter.parse(temp_path)
@@ -1208,17 +1384,15 @@ def test_export_empty_dialects_list():
         with open(temp_path) as f:
             data = yaml.safe_load(f)
 
-        # Should still have expression structure but empty dialects
         field = data["semantic_model"][0]["datasets"][0]["fields"][0]
         assert "expression" in field
-        # Empty dialects list means no dialect expressions
-        assert field["expression"]["dialects"] == []
+        assert field["expression"]["dialects"] == [{"dialect": "ANSI_SQL", "expression": "id"}]
     finally:
         temp_path.unlink()
 
 
-def test_export_unknown_dialect_fallback():
-    """Test export with unknown dialect falls back to original expression."""
+def test_export_unknown_dialect_raises():
+    """Test export rejects dialects outside the current OSI export support."""
     model = Model(
         name="test",
         table="public.test",
@@ -1235,17 +1409,8 @@ def test_export_unknown_dialect_fallback():
         temp_path = Path(f.name)
 
     try:
-        # Unknown dialect should fallback to original expression
-        adapter.export(graph, temp_path, dialects=["UNKNOWN_DIALECT"])
-
-        with open(temp_path) as f:
-            data = yaml.safe_load(f)
-
-        field = data["semantic_model"][0]["datasets"][0]["fields"][0]
-        dialects = field["expression"]["dialects"]
-        assert len(dialects) == 1
-        assert dialects[0]["dialect"] == "UNKNOWN_DIALECT"
-        assert dialects[0]["expression"] == "id"  # Falls back to original
+        with pytest.raises(ValueError, match="Unsupported OSI export dialect"):
+            adapter.export(graph, temp_path, dialects=["UNKNOWN_DIALECT"])
     finally:
         temp_path.unlink()
 
@@ -1351,8 +1516,7 @@ def test_sqlglot_transpilation_actually_transpiles():
         temp_path = Path(f.name)
 
     try:
-        # Export with BigQuery dialect (uses CONCAT instead of ||)
-        adapter.export(graph, temp_path, dialects=["ANSI_SQL", "BIGQUERY"])
+        adapter.export(graph, temp_path, dialects=["ANSI_SQL", "SNOWFLAKE"])
 
         with open(temp_path) as f:
             data = yaml.safe_load(f)
@@ -1361,12 +1525,11 @@ def test_sqlglot_transpilation_actually_transpiles():
         dialects = field["expression"]["dialects"]
 
         ansi = next(d for d in dialects if d["dialect"] == "ANSI_SQL")
-        bigquery = next(d for d in dialects if d["dialect"] == "BIGQUERY")
+        snowflake = next(d for d in dialects if d["dialect"] == "SNOWFLAKE")
 
         # ANSI should keep ||
         assert "||" in ansi["expression"] or "col1" in ansi["expression"]
-        # BigQuery might transpile to CONCAT or keep || depending on sqlglot version
-        assert bigquery["expression"] is not None
+        assert snowflake["expression"] is not None
     finally:
         temp_path.unlink()
 
@@ -1644,22 +1807,15 @@ class TestTpcdsRetailFixture:
         assert "ai_context" in store.meta
         assert "retail location" in store.meta["ai_context"]["synonyms"]
 
-    @pytest.mark.xfail(reason="OSI adapter does not parse model-level custom_extensions (only dataset-level)")
     def test_model_level_custom_extensions(self, graph):
         """custom_extensions at semantic_model level (SALESFORCE, DBT, SNOWFLAKE) are captured.
 
-        The current adapter only parses custom_extensions at the dataset level,
-        not the semantic_model level. This is a known gap.
+        Semantic-model-level metadata is stored on the graph because it does not
+        belong to any one Sidemantic Model.
         """
-        # These are defined at the semantic_model level, not on any particular dataset
-        # The adapter would need to store them on the graph or in a separate structure
-        has_custom_ext = False
-        for model in graph.models.values():
-            if model.meta and "custom_extensions" in model.meta:
-                has_custom_ext = True
-                break
-        # Also check graph-level storage (doesn't exist yet)
-        assert has_custom_ext or hasattr(graph, "custom_extensions")
+        extensions = graph.metadata["osi"]["semantic_models"][0]["custom_extensions"]
+        vendors = {extension["vendor_name"] for extension in extensions}
+        assert {"SALESFORCE", "DBT", "SNOWFLAKE"} <= vendors
 
     def test_dimension_tables_have_no_relationships(self, graph):
         """Dimension tables (customer, date_dim, store, item) have no outbound relationships."""
@@ -1831,15 +1987,11 @@ class TestSupplyChainFixture:
         assert "country" in dim_names
         assert "reliability_rating" in dim_names
 
-    @pytest.mark.xfail(reason="OSI adapter does not parse model-level custom_extensions (only dataset-level)")
     def test_model_level_custom_extensions(self, graph):
         """custom_extensions at semantic_model level (DATABRICKS, COMMON) are captured."""
-        has_custom_ext = False
-        for model in graph.models.values():
-            if model.meta and "custom_extensions" in model.meta:
-                has_custom_ext = True
-                break
-        assert has_custom_ext or hasattr(graph, "custom_extensions")
+        extensions = graph.metadata["osi"]["semantic_models"][0]["custom_extensions"]
+        vendors = {extension["vendor_name"] for extension in extensions}
+        assert {"DATABRICKS", "COMMON"} <= vendors
 
 
 # =============================================================================
@@ -2035,15 +2187,11 @@ class TestTpcdsOsiOfficialFixture:
         metric = graph.metrics["store_productivity"]
         assert "employee" in metric.description.lower()
 
-    @pytest.mark.xfail(reason="OSI adapter does not parse semantic_model-level custom_extensions")
     def test_custom_extensions_salesforce_dbt(self, graph):
         """custom_extensions for SALESFORCE and DBT vendors are captured."""
-        has_custom_ext = False
-        for model in graph.models.values():
-            if model.meta and "custom_extensions" in model.meta:
-                has_custom_ext = True
-                break
-        assert has_custom_ext or hasattr(graph, "custom_extensions")
+        extensions = graph.metadata["osi"]["semantic_models"][0]["custom_extensions"]
+        vendors = {extension["vendor_name"] for extension in extensions}
+        assert {"SALESFORCE", "DBT"} <= vendors
 
 
 # =============================================================================

--- a/tests/fixtures/osi/ecommerce.yaml
+++ b/tests/fixtures/osi/ecommerce.yaml
@@ -1,3 +1,5 @@
+version: "0.2.0.dev0"
+
 semantic_model:
   - name: ecommerce_analytics
     description: E-commerce sales and customer analytics

--- a/tests/fixtures/osi/kitchen_sink.yaml
+++ b/tests/fixtures/osi/kitchen_sink.yaml
@@ -1,3 +1,5 @@
+version: "0.2.0.dev0"
+
 semantic_model:
   - name: tpcds_analytics
     description: TPC-DS benchmark semantic model

--- a/tests/fixtures/osi/mdb_member_knowledge.yaml
+++ b/tests/fixtures/osi/mdb_member_knowledge.yaml
@@ -12,6 +12,8 @@
 #   - Defining metrics for query routing
 # ---------------------------------------------------------------------------
 
+version: "0.2.0.dev0"
+
 semantic_model:
 - name: member_knowledge
   description: Auto-scaffolded OSI semantic model for 'member'. Generated from graph_config.node_types.

--- a/tests/fixtures/osi/mdb_movies.yaml
+++ b/tests/fixtures/osi/mdb_movies.yaml
@@ -13,6 +13,8 @@
 # Loaded by mdb-engine via osi_config.models_path in manifest.json.
 # ---------------------------------------------------------------------------
 
+version: "0.2.0.dev0"
+
 semantic_model:
   - name: movie_knowledge
     description: >

--- a/tests/fixtures/osi/simple.yaml
+++ b/tests/fixtures/osi/simple.yaml
@@ -1,3 +1,5 @@
+version: "0.2.0.dev0"
+
 semantic_model:
   - name: simple_analytics
     description: Simple analytics model

--- a/tests/fixtures/osi/supply_chain.yaml
+++ b/tests/fixtures/osi/supply_chain.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.2.0.dev0"
 
 semantic_model:
   - name: supply_chain_analytics

--- a/tests/fixtures/osi/tpcds_osi_official.yaml
+++ b/tests/fixtures/osi/tpcds_osi_official.yaml
@@ -6,7 +6,7 @@
 # This example demonstrates the OSI Core Metadata Spec using the TPC-DS benchmark schema
 # TPC-DS is a decision support benchmark with a realistic retail business model
 
-version: "1.0"
+version: "0.2.0.dev0"
 
 semantic_model:
   - name: tpcds_retail_model
@@ -572,7 +572,7 @@ semantic_model:
             },
             "tableau_semantics": {
               "published": true,
-              "version": "1.0"
+              "version": "0.1.1"
             }
           }
 

--- a/tests/fixtures/osi/tpcds_retail.yaml
+++ b/tests/fixtures/osi/tpcds_retail.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.2.0.dev0"
 
 semantic_model:
   - name: tpcds_retail_model


### PR DESCRIPTION
Updates the OSI adapter for the current 0.2.0.dev0 spec shape, including semantic-model metadata preservation, stricter dialect handling, relationship metadata roundtrips, normalized custom extensions, and ontology mapping imports.

Also refreshes OSI fixtures/examples and compatibility docs to reflect the current upstream schema behavior.