### PR TITLE
Improve BSL compatibility with current upstream syntax

### DIFF
--- a/sidemantic-schema.json
+++ b/sidemantic-schema.json
@@ -1116,7 +1116,7 @@
       "type": "object"
     },
     "Relationship": {
-      "description": "Represents a relationship between models.\n\nRelationship types:\n- many_to_one: This model has a foreign key to another\n- one_to_one: This model is referenced by another with unique constraint\n- one_to_many: This model is referenced by another\n- many_to_many: This model relates to another through a junction table",
+      "description": "Represents a relationship between models.\n\nRelationship types:\n- many_to_one: This model has a foreign key to another\n- one_to_one: This model is referenced by another with unique constraint\n- one_to_many: This model is referenced by another\n- many_to_many: This model relates to another through a junction table\n- cross: This model should be cross joined to another",
       "properties": {
         "foreign_key": {
           "anyOf": [
@@ -1220,7 +1220,8 @@
             "many_to_one",
             "one_to_one",
             "one_to_many",
-            "many_to_many"
+            "many_to_many",
+            "cross"
           ],
           "title": "Type",
           "type": "string"
@@ -2908,7 +2909,7 @@
             "type": "object"
           },
           "Relationship": {
-            "description": "Represents a relationship between models.\n\nRelationship types:\n- many_to_one: This model has a foreign key to another\n- one_to_one: This model is referenced by another with unique constraint\n- one_to_many: This model is referenced by another\n- many_to_many: This model relates to another through a junction table",
+            "description": "Represents a relationship between models.\n\nRelationship types:\n- many_to_one: This model has a foreign key to another\n- one_to_one: This model is referenced by another with unique constraint\n- one_to_many: This model is referenced by another\n- many_to_many: This model relates to another through a junction table\n- cross: This model should be cross joined to another",
             "properties": {
               "foreign_key": {
                 "anyOf": [
@@ -3012,7 +3013,8 @@
                   "many_to_one",
                   "one_to_one",
                   "one_to_many",
-                  "many_to_many"
+                  "many_to_many",
+                  "cross"
                 ],
                 "title": "Type",
                 "type": "string"

--- a/sidemantic/adapters/bsl.py
+++ b/sidemantic/adapters/bsl.py
@@ -10,6 +10,7 @@ Transforms BSL definitions into Sidemantic format:
 - BSL joins -> Relationships
 """
 
+import re
 from pathlib import Path
 
 import yaml
@@ -397,7 +398,7 @@ class BSLAdapter(BaseAdapter):
 
     def _add_join_alias_models(self, graph: SemanticGraph) -> None:
         """Add cloned target models for BSL join aliases and self-joins."""
-        aliases: dict[str, str] = {}
+        alias_refs: dict[str, list[tuple[Model, Relationship, str]]] = {}
 
         for model in list(graph.models.values()):
             for rel in model.relationships:
@@ -407,24 +408,108 @@ class BSLAdapter(BaseAdapter):
                 alias = rel.metadata.get("bsl_alias")
                 if not target_model or not alias or alias == target_model:
                     continue
-                aliases[alias] = target_model
+                alias_refs.setdefault(alias, []).append((model, rel, target_model))
 
-        for alias, target_model in aliases.items():
-            if alias in graph.models or target_model not in graph.models:
-                continue
-            target = graph.models[target_model]
-            metadata = dict(target.metadata or {})
-            metadata["bsl_alias_of"] = target_model
-            graph.add_model(
-                target.model_copy(
-                    deep=True,
-                    update={
-                        "name": alias,
-                        "relationships": [],
-                        "metadata": metadata,
-                    },
-                )
+        for alias, refs in alias_refs.items():
+            targets = {target_model for _, _, target_model in refs}
+            existing = graph.models.get(alias)
+            existing_alias_target = (existing.metadata or {}).get("bsl_alias_of") if existing else None
+            can_use_global_alias = (
+                len(targets) == 1
+                and (existing is None or existing_alias_target == next(iter(targets)))
+                and alias not in targets
             )
+
+            if can_use_global_alias:
+                target_model = next(iter(targets))
+                self._clone_join_alias_model(graph, alias, target_model)
+                continue
+
+            for model, rel, target_model in refs:
+                if target_model not in graph.models:
+                    continue
+                scoped_alias = self._scoped_join_alias_name(graph, model.name, alias)
+                self._retarget_join_alias(model, rel, alias, scoped_alias)
+                self._clone_join_alias_model(graph, scoped_alias, target_model, source_model=model.name, alias=alias)
+
+        self._remove_unreferenced_bsl_alias_models(graph)
+
+    def _clone_join_alias_model(
+        self,
+        graph: SemanticGraph,
+        alias_name: str,
+        target_model: str,
+        source_model: str | None = None,
+        alias: str | None = None,
+    ) -> None:
+        """Clone a target model under a BSL join alias name."""
+        if alias_name in graph.models or target_model not in graph.models:
+            return
+
+        target = graph.models[target_model]
+        metadata = dict(target.metadata or {})
+        metadata["bsl_alias_of"] = target_model
+        if source_model:
+            metadata["bsl_alias_source_model"] = source_model
+        if alias:
+            metadata["bsl_alias"] = alias
+        graph.add_model(
+            target.model_copy(
+                deep=True,
+                update={
+                    "name": alias_name,
+                    "relationships": [],
+                    "metadata": metadata,
+                },
+            )
+        )
+
+    def _scoped_join_alias_name(self, graph: SemanticGraph, source_model: str, alias: str) -> str:
+        """Return a stable graph model name for a source-scoped BSL join alias."""
+        base = f"{source_model}_{alias}"
+        candidate = base
+        suffix = 2
+        while candidate in graph.models:
+            metadata = graph.models[candidate].metadata or {}
+            if metadata.get("bsl_alias_source_model") == source_model and metadata.get("bsl_alias") == alias:
+                return candidate
+            candidate = f"{base}_{suffix}"
+            suffix += 1
+        return candidate
+
+    def _retarget_join_alias(self, model: Model, rel: Relationship, alias: str, scoped_alias: str) -> None:
+        """Point a BSL relationship and local alias references at a scoped alias model."""
+        if rel.name == scoped_alias:
+            return
+
+        metadata = dict(rel.metadata or {})
+        metadata["bsl_scoped_alias"] = scoped_alias
+        rel.metadata = metadata
+        rel.name = scoped_alias
+
+        pattern = re.compile(rf"(?<![\w.]){re.escape(alias)}\.")
+        replacement = f"{scoped_alias}."
+
+        for metric in model.metrics:
+            if metric.sql:
+                metric.sql = pattern.sub(replacement, metric.sql)
+        for dimension in model.dimensions:
+            if dimension.sql:
+                dimension.sql = pattern.sub(replacement, dimension.sql)
+
+    def _remove_unreferenced_bsl_alias_models(self, graph: SemanticGraph) -> None:
+        """Drop stale synthetic BSL alias models after aliases are retargeted."""
+        referenced_models = {
+            rel.name
+            for model in graph.models.values()
+            for rel in model.relationships
+            if rel.metadata and rel.metadata.get("bsl_alias")
+        }
+        for model_name, model in list(graph.models.items()):
+            metadata = model.metadata or {}
+            if metadata.get("bsl_alias_of") and model_name not in referenced_models:
+                del graph.models[model_name]
+                graph._mark_dirty()
 
     def export(self, graph: SemanticGraph, output_path: str | Path) -> None:
         """Export semantic graph to BSL YAML format.
@@ -549,7 +634,8 @@ class BSLAdapter(BaseAdapter):
             joins = {}
             for rel in model.relationships:
                 join_def = self._export_join(rel)
-                joins[rel.name] = join_def
+                join_name = (rel.metadata or {}).get("bsl_alias", rel.name)
+                joins[join_name] = join_def
             model_def["joins"] = joins
 
         return {model.name: model_def}

--- a/sidemantic/adapters/bsl.py
+++ b/sidemantic/adapters/bsl.py
@@ -19,6 +19,7 @@ from sidemantic.adapters.bsl_expr import (
     GRANULARITY_TO_TIME_GRAIN,
     TIME_GRAIN_MAP,
     _sql_to_bsl_expr,
+    bsl_calc_to_sql,
     bsl_filter_to_sql,
     bsl_to_sql,
     is_calc_measure_expr,
@@ -79,6 +80,7 @@ class BSLAdapter(BaseAdapter):
             # Parse single file
             self._parse_file(source_path, graph)
 
+        self._add_join_alias_models(graph)
         return graph
 
     def _parse_file(self, file_path: Path, graph: SemanticGraph) -> None:
@@ -104,7 +106,7 @@ class BSLAdapter(BaseAdapter):
                 if model:
                     graph.add_model(model)
 
-    def _parse_model(self, name: str, model_def: dict, profile: str | None = None) -> Model | None:
+    def _parse_model(self, name: str, model_def: dict, profile: str | dict | None = None) -> Model | None:
         """Parse a BSL model definition into a Sidemantic Model.
 
         Args:
@@ -117,6 +119,7 @@ class BSLAdapter(BaseAdapter):
         """
         table = model_def.get("table")
         description = model_def.get("description")
+        database = model_def.get("database")
 
         # Primary key: explicit field > is_entity dimension > default "id"
         primary_key = model_def.get("primary_key")
@@ -129,6 +132,8 @@ class BSLAdapter(BaseAdapter):
                 dimensions.append(dim)
                 if not primary_key and isinstance(dim_def, dict) and dim_def.get("is_entity"):
                     primary_key = dim_name
+                for derived_dim in self._parse_derived_dimensions(dim_name, dim_def, dim):
+                    dimensions.append(derived_dim)
 
         if not primary_key:
             primary_key = "id"
@@ -158,6 +163,10 @@ class BSLAdapter(BaseAdapter):
                 for i, dim in enumerate(dimensions):
                     if dim.name == time_dim_name and not dim.granularity:
                         dimensions[i] = dim.model_copy(update={"granularity": grain})
+        elif time_dim_name:
+            for i, dim in enumerate(dimensions):
+                if dim.name == time_dim_name and not dim.granularity:
+                    dimensions[i] = dim.model_copy(update={"granularity": "day"})
 
         # Measures and calculated measures
         metrics = []
@@ -167,10 +176,8 @@ class BSLAdapter(BaseAdapter):
                 metrics.append(metric)
 
         for measure_name, measure_def in (model_def.get("calculated_measures") or {}).items():
-            metric = self._parse_measure(measure_name, measure_def)
+            metric = self._parse_measure(measure_name, measure_def, calculated=True)
             if metric:
-                if metric.type != "derived":
-                    metric = metric.model_copy(update={"type": "derived"})
                 metrics.append(metric)
 
         # Joins
@@ -185,13 +192,19 @@ class BSLAdapter(BaseAdapter):
         # Keep model.table for migrator indexing; generator and exporters
         # that check model.sql first will use the filtered subquery.
         model_sql = None
-        metadata = None
+        metadata = {}
+        if profile is not None:
+            metadata["bsl_profile"] = profile
+        if database is not None:
+            metadata["bsl_database"] = database
+        metadata["bsl_table"] = table
+
         filter_expr = model_def.get("filter")
         if filter_expr:
             filter_str = str(filter_expr)
             filter_sql = bsl_filter_to_sql(filter_str)
             model_sql = f"SELECT * FROM {table} WHERE {filter_sql}"
-            metadata = {"bsl_filter": filter_str}
+            metadata["bsl_filter"] = filter_str
 
         return Model(
             name=name,
@@ -204,7 +217,7 @@ class BSLAdapter(BaseAdapter):
             relationships=relationships,
             default_time_dimension=default_time_dimension,
             default_grain=default_grain,
-            metadata=metadata,
+            metadata=metadata or None,
         )
 
     def _parse_dimension(self, name: str, dim_def: str | dict) -> Dimension | None:
@@ -213,27 +226,44 @@ class BSLAdapter(BaseAdapter):
             expr = dim_def
             description = None
             is_time = False
+            is_event_timestamp = False
             time_grain = None
+            source_metadata = None
+            derived_dimensions = None
+            is_entity = False
         else:
             expr = dim_def.get("expr", f"_.{name}")
             description = dim_def.get("description")
             is_time = dim_def.get("is_time_dimension", False)
+            is_event_timestamp = dim_def.get("is_event_timestamp", False)
             time_grain = dim_def.get("smallest_time_grain")
+            source_metadata = dim_def.get("metadata")
+            derived_dimensions = dim_def.get("derived_dimensions")
+            is_entity = dim_def.get("is_entity", False)
 
         sql_expr, agg_type, date_part = bsl_to_sql(expr)
 
         dim_type = "categorical"
         granularity = None
 
-        if is_time:
+        if is_time or is_event_timestamp:
             dim_type = "time"
-            if time_grain:
-                granularity = TIME_GRAIN_MAP.get(time_grain, "day")
+            granularity = TIME_GRAIN_MAP.get(time_grain, "day") if time_grain else "day"
 
         if date_part:
             dim_type = "categorical"
             if sql_expr:
                 sql_expr = f"EXTRACT({date_part.upper()} FROM {sql_expr})"
+
+        metadata = {"bsl_expr": expr}
+        if source_metadata is not None:
+            metadata["bsl_metadata"] = source_metadata
+        if is_event_timestamp:
+            metadata["bsl_is_event_timestamp"] = True
+        if derived_dimensions:
+            metadata["bsl_derived_dimensions"] = list(derived_dimensions)
+        if is_entity:
+            metadata["bsl_is_entity"] = True
 
         return Dimension(
             name=name,
@@ -241,26 +271,61 @@ class BSLAdapter(BaseAdapter):
             sql=sql_expr,
             granularity=granularity,
             description=description,
-            metadata={"bsl_expr": expr},
+            metadata=metadata,
         )
 
-    def _parse_measure(self, name: str, measure_def: str | dict) -> Metric | None:
+    def _parse_derived_dimensions(self, base_name: str, dim_def: str | dict, dim: Dimension) -> list[Dimension]:
+        """Create Sidemantic dimensions for BSL derived dimension parts."""
+        if not isinstance(dim_def, dict):
+            return []
+
+        parts = dim_def.get("derived_dimensions") or []
+        if isinstance(parts, str):
+            parts = [parts]
+
+        derived = []
+        for part in parts:
+            if part not in {"year", "month", "day", "hour", "minute", "second", "week", "quarter"}:
+                continue
+            derived.append(
+                Dimension(
+                    name=f"{base_name}_{part}",
+                    type="categorical",
+                    sql=f"EXTRACT({part.upper()} FROM {dim.sql})",
+                    metadata={
+                        "bsl_generated_from": base_name,
+                        "bsl_derived_part": part,
+                    },
+                )
+            )
+        return derived
+
+    def _parse_measure(self, name: str, measure_def: str | dict, calculated: bool = False) -> Metric | None:
         """Parse BSL measure (simple or extended form)."""
         if isinstance(measure_def, str):
             expr = measure_def
             description = None
+            source_metadata = None
         else:
             expr = measure_def.get("expr", "")
             description = measure_def.get("description")
+            source_metadata = measure_def.get("metadata")
+
+        metadata = {"bsl_expr": expr}
+        if source_metadata is not None:
+            metadata["bsl_metadata"] = source_metadata
 
         # Calc measures reference other measures by name (no _. prefix)
-        if is_calc_measure_expr(expr):
+        if calculated or is_calc_measure_expr(expr):
             return Metric(
                 name=name,
                 type="derived",
-                sql=expr,
+                sql=bsl_calc_to_sql(expr) if calculated else expr,
                 description=description,
-                metadata={"bsl_expr": expr},
+                metadata={
+                    **metadata,
+                    "bsl_is_calculated_measure": True,
+                },
             )
 
         sql_expr, agg_type, date_part = bsl_to_sql(expr)
@@ -273,7 +338,7 @@ class BSLAdapter(BaseAdapter):
             agg=agg_type,
             sql=sql_expr,
             description=description,
-            metadata={"bsl_expr": expr},
+            metadata=metadata,
         )
 
     def _parse_join(self, name: str, join_def: dict) -> Relationship | None:
@@ -296,6 +361,7 @@ class BSLAdapter(BaseAdapter):
             "one_to_many": "one_to_many",
             "many_to_one": "many_to_one",
             "many_to_many": "many_to_many",
+            "cross": "cross",
         }
         rel_type = type_mapping.get(join_type, "many_to_one")
 
@@ -311,12 +377,54 @@ class BSLAdapter(BaseAdapter):
                 else:
                     foreign_key = with_expr
 
+        metadata = {
+            "bsl_model": target_model,
+            "bsl_alias": name,
+            "bsl_join_type": join_type,
+        }
+        if "how" in join_def:
+            metadata["bsl_how"] = join_def["how"]
+        if "with" in join_def:
+            metadata["bsl_with"] = join_def["with"]
+
         return Relationship(
-            name=target_model,
+            name=name,
             type=rel_type,
             foreign_key=foreign_key,
             primary_key=primary_key,
+            metadata=metadata,
         )
+
+    def _add_join_alias_models(self, graph: SemanticGraph) -> None:
+        """Add cloned target models for BSL join aliases and self-joins."""
+        aliases: dict[str, str] = {}
+
+        for model in list(graph.models.values()):
+            for rel in model.relationships:
+                if not rel.metadata:
+                    continue
+                target_model = rel.metadata.get("bsl_model")
+                alias = rel.metadata.get("bsl_alias")
+                if not target_model or not alias or alias == target_model:
+                    continue
+                aliases[alias] = target_model
+
+        for alias, target_model in aliases.items():
+            if alias in graph.models or target_model not in graph.models:
+                continue
+            target = graph.models[target_model]
+            metadata = dict(target.metadata or {})
+            metadata["bsl_alias_of"] = target_model
+            graph.add_model(
+                target.model_copy(
+                    deep=True,
+                    update={
+                        "name": alias,
+                        "relationships": [],
+                        "metadata": metadata,
+                    },
+                )
+            )
 
     def export(self, graph: SemanticGraph, output_path: str | Path) -> None:
         """Export semantic graph to BSL YAML format.
@@ -336,16 +444,21 @@ class BSLAdapter(BaseAdapter):
         if output_path.is_dir() or not output_path.suffix:
             output_path.mkdir(parents=True, exist_ok=True)
             for model in resolved_models.values():
+                if model.metadata and model.metadata.get("bsl_alias_of"):
+                    continue
                 model_data = self._export_model(model)
+                self._add_profile_to_export(model_data, model)
                 model_file = output_path / f"{model.name}.yml"
                 with open(model_file, "w") as f:
                     yaml.dump(model_data, f, sort_keys=False, default_flow_style=False)
         else:
             # Single file with all models
-            data = {}
+            data = self._shared_profile_export_data(resolved_models.values())
 
             # Export each model
             for model in resolved_models.values():
+                if model.metadata and model.metadata.get("bsl_alias_of"):
+                    continue
                 model_data = self._export_model(model)
                 data.update(model_data)
 
@@ -353,15 +466,41 @@ class BSLAdapter(BaseAdapter):
             with open(output_path, "w") as f:
                 yaml.dump(data, f, sort_keys=False, default_flow_style=False)
 
+    def _add_profile_to_export(self, data: dict, model: Model) -> None:
+        metadata = model.metadata or {}
+        if "bsl_profile" in metadata:
+            data["profile"] = metadata["bsl_profile"]
+
+    def _shared_profile_export_data(self, models) -> dict:
+        profiles = []
+        for model in models:
+            if model.metadata and model.metadata.get("bsl_alias_of"):
+                continue
+            metadata = model.metadata or {}
+            if "bsl_profile" in metadata:
+                profiles.append(metadata["bsl_profile"])
+
+        if not profiles:
+            return {}
+
+        first_profile = profiles[0]
+        if all(profile == first_profile for profile in profiles):
+            return {"profile": first_profile}
+
+        return {}
+
     def _export_model(self, model: Model) -> dict:
         """Export a Sidemantic Model to BSL format."""
         model_def = {}
 
         if model.table:
-            model_def["table"] = model.table
+            model_def["table"] = (model.metadata or {}).get("bsl_table", model.table)
 
         if model.description:
             model_def["description"] = model.description
+
+        if model.metadata and "bsl_database" in model.metadata:
+            model_def["database"] = model.metadata["bsl_database"]
 
         if model.primary_key and model.primary_key != "id":
             model_def["primary_key"] = model.primary_key
@@ -379,6 +518,8 @@ class BSLAdapter(BaseAdapter):
         # Export dimensions
         dimensions = {}
         for dim in model.dimensions:
+            if dim.metadata and dim.metadata.get("bsl_generated_from"):
+                continue
             dim_data = self._export_dimension(dim, model.primary_key)
             dimensions[dim.name] = dim_data
 
@@ -387,12 +528,21 @@ class BSLAdapter(BaseAdapter):
 
         # Export measures
         measures = {}
+        calculated_measures = {}
         for metric in model.metrics:
             measure_data = self._export_measure(metric)
-            measures[metric.name] = measure_data
+            if (metric.metadata and metric.metadata.get("bsl_is_calculated_measure")) or metric.type in (
+                "derived",
+                "ratio",
+            ):
+                calculated_measures[metric.name] = measure_data
+            else:
+                measures[metric.name] = measure_data
 
         if measures:
             model_def["measures"] = measures
+        if calculated_measures:
+            model_def["calculated_measures"] = calculated_measures
 
         # Export joins (from relationships)
         if model.relationships:
@@ -412,7 +562,16 @@ class BSLAdapter(BaseAdapter):
         else:
             bsl_expr = sql_to_bsl(dim.sql, None, None)
 
-        needs_extended = dim.description or dim.type == "time" or dim.granularity or dim.name == primary_key
+        metadata = dim.metadata or {}
+        needs_extended = (
+            dim.description
+            or dim.type == "time"
+            or dim.granularity
+            or dim.name == primary_key
+            or "bsl_metadata" in metadata
+            or metadata.get("bsl_is_event_timestamp")
+            or metadata.get("bsl_derived_dimensions")
+        )
 
         if not needs_extended:
             return bsl_expr
@@ -425,6 +584,9 @@ class BSLAdapter(BaseAdapter):
         if dim.type == "time":
             result["is_time_dimension"] = True
 
+        if metadata.get("bsl_is_event_timestamp"):
+            result["is_event_timestamp"] = True
+
         if dim.granularity:
             time_grain = GRANULARITY_TO_TIME_GRAIN.get(dim.granularity)
             if time_grain:
@@ -432,6 +594,12 @@ class BSLAdapter(BaseAdapter):
 
         if dim.name == primary_key:
             result["is_entity"] = True
+
+        if metadata.get("bsl_derived_dimensions"):
+            result["derived_dimensions"] = metadata["bsl_derived_dimensions"]
+
+        if "bsl_metadata" in metadata:
+            result["metadata"] = metadata["bsl_metadata"]
 
         return result
 
@@ -454,9 +622,17 @@ class BSLAdapter(BaseAdapter):
             else:
                 bsl_expr = _sql_to_bsl_expr(metric.sql or metric.name, metric.agg)
 
-        if not metric.description:
+        result_metadata = (metric.metadata or {}).get("bsl_metadata")
+
+        if not metric.description and result_metadata is None:
             return bsl_expr
-        return {"expr": bsl_expr, "description": metric.description}
+
+        result = {"expr": bsl_expr}
+        if metric.description:
+            result["description"] = metric.description
+        if result_metadata is not None:
+            result["metadata"] = result_metadata
+        return result
 
     def _export_join(self, rel: Relationship) -> dict:
         """Export relationship to BSL join format.
@@ -473,15 +649,21 @@ class BSLAdapter(BaseAdapter):
             "one_to_many": "many",
             "one_to_one": "one_to_one",
             "many_to_many": "many_to_many",
+            "cross": "cross",
         }
 
+        metadata = rel.metadata or {}
         join_def = {
-            "model": rel.name,
-            "type": type_mapping.get(rel.type, "one"),
+            "model": metadata.get("bsl_model", rel.name),
+            "type": metadata.get("bsl_join_type", type_mapping.get(rel.type, "one")),
         }
+        if "bsl_how" in metadata:
+            join_def["how"] = metadata["bsl_how"]
 
         # Use with: shorthand for single-column FK without explicit primary_key
-        if rel.foreign_key and not rel.primary_key and isinstance(rel.foreign_key, str):
+        if "bsl_with" in metadata:
+            join_def["with"] = metadata["bsl_with"]
+        elif rel.foreign_key and not rel.primary_key and isinstance(rel.foreign_key, str):
             join_def["with"] = f"_.{rel.foreign_key}"
         else:
             if rel.foreign_key:

--- a/sidemantic/adapters/bsl_expr.py
+++ b/sidemantic/adapters/bsl_expr.py
@@ -83,6 +83,19 @@ def _collect_attrs(node: ast.AST) -> list[str]:
     return []
 
 
+def _collect_name_attrs(node: ast.AST) -> list[str]:
+    """Collect an attribute chain rooted at any Python name."""
+    attrs = []
+    while isinstance(node, ast.Attribute):
+        attrs.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        attrs.append(node.id)
+        attrs.reverse()
+        return attrs
+    return []
+
+
 # Python AST operator to SQL operator
 _OP_MAP: dict[type, str] = {
     ast.Add: "+",
@@ -111,6 +124,9 @@ def _expr_to_sql(node: ast.AST) -> str | None:
     if isinstance(node, ast.Attribute):
         attrs = _collect_attrs(node)
         if attrs:
+            return ".".join(attrs)
+        attrs = _collect_name_attrs(node)
+        if attrs and attrs[0] != "_":
             return ".".join(attrs)
         return None
 
@@ -252,6 +268,9 @@ def _filter_node_to_sql(node: ast.AST) -> str | None:
         attrs = _collect_attrs(node)
         if attrs:
             return ".".join(attrs)
+        attrs = _collect_name_attrs(node)
+        if attrs and attrs[0] != "_":
+            return ".".join(attrs)
         return None
 
     if isinstance(node, ast.Constant):
@@ -303,6 +322,111 @@ def bsl_filter_to_sql(expr: str) -> str:
         f"Cannot translate BSL filter expression to SQL: {expr!r}. "
         "Supported: comparisons, &/|, ~, isin/notin/between/isnull/notnull."
     )
+
+
+def _calc_node_to_sql(node: ast.AST) -> str | None:
+    """Convert a BSL calculated-measure AST node to SQL-like metric refs."""
+    if isinstance(node, ast.Attribute):
+        attrs = _collect_attrs(node)
+        if attrs:
+            return ".".join(attrs)
+        attrs = _collect_name_attrs(node)
+        if attrs and attrs[0] != "_":
+            return ".".join(attrs)
+        return None
+
+    if isinstance(node, ast.Name):
+        if node.id == "_":
+            return None
+        return node.id
+
+    if isinstance(node, ast.BinOp):
+        left = _calc_node_to_sql(node.left)
+        right = _calc_node_to_sql(node.right)
+        op = _OP_MAP.get(type(node.op))
+        if left is None or right is None or op is None:
+            return None
+        if isinstance(node.left, ast.BinOp):
+            left = f"({left})"
+        if isinstance(node.right, ast.BinOp):
+            right = f"({right})"
+        return f"{left} {op} {right}"
+
+    if isinstance(node, ast.Compare):
+        left = _calc_node_to_sql(node.left)
+        if left is None or len(node.ops) != 1 or len(node.comparators) != 1:
+            return None
+        op = _CMP_OP_MAP.get(type(node.ops[0]))
+        right = _calc_node_to_sql(node.comparators[0])
+        if op is None or right is None:
+            return None
+        return f"{left} {op} {right}"
+
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, str):
+            escaped = node.value.replace("'", "''")
+            return f"'{escaped}'"
+        if isinstance(node.value, bool):
+            return "TRUE" if node.value else "FALSE"
+        if node.value is None:
+            return "NULL"
+        if isinstance(node.value, (int, float)):
+            return str(node.value)
+
+    if isinstance(node, ast.UnaryOp):
+        operand = _calc_node_to_sql(node.operand)
+        if operand is None:
+            return None
+        if isinstance(node.op, ast.USub):
+            return f"-{operand}"
+        if isinstance(node.op, ast.UAdd):
+            return operand
+        if isinstance(node.op, ast.Not):
+            return f"NOT ({operand})"
+
+    if isinstance(node, ast.BoolOp):
+        op = "AND" if isinstance(node.op, ast.And) else "OR"
+        parts = [f"({part})" for part in (_calc_node_to_sql(value) for value in node.values) if part]
+        if len(parts) == len(node.values):
+            return f" {op} ".join(parts)
+        return None
+
+    if isinstance(node, ast.Call):
+        if isinstance(node.func, ast.Attribute):
+            method = node.func.attr
+            if isinstance(node.func.value, ast.Name) and node.func.value.id == "_" and method == "all":
+                if len(node.args) != 1:
+                    return None
+                arg = _calc_node_to_sql(node.args[0])
+                if arg is None:
+                    return None
+                return f"__bsl_all({arg})"
+        if isinstance(node.func, ast.Name):
+            args = [_calc_node_to_sql(arg) for arg in node.args]
+            if any(arg is None for arg in args):
+                return None
+            return f"{node.func.id.upper()}({', '.join(args)})"
+
+    return None
+
+
+def bsl_calc_to_sql(expr: str) -> str:
+    """Convert a BSL calculated measure expression to Sidemantic metric SQL.
+
+    BSL calculated measures are evaluated against the deferred ``_`` scope, so
+    ``_.revenue / _.orders`` means "aggregate revenue divided by aggregate
+    orders". The generated SQL keeps metric names as dependencies for the
+    Sidemantic query compiler to replace later.
+    """
+    try:
+        tree = ast.parse(expr.strip(), mode="eval")
+    except SyntaxError:
+        return expr
+
+    result = _calc_node_to_sql(tree.body)
+    if result is None:
+        raise ValueError(f"Cannot translate BSL calculated measure expression to SQL: {expr!r}")
+    return result
 
 
 def _sql_to_bsl_expr(sql: str, agg: str | None) -> str:

--- a/sidemantic/core/dependency_analyzer.py
+++ b/sidemantic/core/dependency_analyzer.py
@@ -11,15 +11,19 @@ def extract_column_references(sql_expr: str) -> set[str]:
 
     Returns set of column names (without table prefixes).
     """
+    return {name for _, name in _extract_column_reference_parts(sql_expr)}
+
+
+def _extract_column_reference_parts(sql_expr: str) -> list[tuple[str | None, str]]:
+    """Extract column references as optional table/model qualifier plus column name."""
     try:
         parsed = sqlglot.parse_one(sql_expr, read="duckdb")
     except Exception:
-        return set()
+        return []
 
-    columns = set()
+    columns = []
     for col in parsed.find_all(exp.Column):
-        # Get column name without table prefix
-        columns.add(col.name)
+        columns.append((col.table or None, col.name))
 
     return columns
 
@@ -66,53 +70,68 @@ def extract_metric_dependencies(metric_obj, graph=None, model_context=None) -> s
             # Expression metric with inline aggregations - no measure dependencies
             return deps
 
-        # Extract column references from expression
-        refs = extract_column_references(metric_obj.sql)
-
         # Use graph to resolve references if available
         if graph:
-            for ref in refs:
-                # Check if it's already qualified (model.measure)
-                if "." in ref:
-                    deps.add(ref)
-                else:
-                    # Try to resolve as metric first
-                    resolved = False
+            for qualifier, ref in _extract_column_reference_parts(metric_obj.sql):
+                resolved = False
+
+                if qualifier:
+                    qualified_ref = f"{qualifier}.{ref}"
                     try:
-                        if graph.get_metric(ref):
-                            deps.add(ref)
+                        model = graph.get_model(qualifier)
+                        if model and model.get_metric(ref):
+                            deps.add(qualified_ref)
                             resolved = True
-                            continue
-                    except KeyError:
+                    except (KeyError, AttributeError):
                         pass
 
-                    # If we have model context, check that model first
-                    if not resolved and model_context:
+                    if not resolved:
                         try:
-                            model = graph.get_model(model_context)
-                            if model and model.get_metric(ref):
-                                deps.add(f"{model_context}.{ref}")
+                            if graph.get_metric(qualified_ref):
+                                deps.add(qualified_ref)
                                 resolved = True
+                        except KeyError:
+                            pass
+
+                    if resolved:
+                        continue
+
+                # Try to resolve as metric first
+                try:
+                    if graph.get_metric(ref):
+                        deps.add(ref)
+                        resolved = True
+                        continue
+                except KeyError:
+                    pass
+
+                # If we have model context, check that model first
+                if not resolved and model_context:
+                    try:
+                        model = graph.get_model(model_context)
+                        if model and model.get_metric(ref):
+                            deps.add(f"{model_context}.{ref}")
+                            resolved = True
+                    except (KeyError, AttributeError):
+                        pass
+
+                # Search all models for this measure name (fallback)
+                if not resolved:
+                    for model_name, model in graph.models.items():
+                        try:
+                            if model.get_metric(ref):
+                                deps.add(f"{model_name}.{ref}")
+                                resolved = True
+                                break
                         except (KeyError, AttributeError):
                             pass
 
-                    # Search all models for this measure name (fallback)
-                    if not resolved:
-                        for model_name, model in graph.models.items():
-                            try:
-                                if model.get_metric(ref):
-                                    deps.add(f"{model_name}.{ref}")
-                                    resolved = True
-                                    break
-                            except (KeyError, AttributeError):
-                                pass
-
-                    # If not resolved, keep as-is (might be a metric not yet added)
-                    if not resolved:
-                        deps.add(ref)
+                # If not resolved, keep as-is (might be a metric not yet added)
+                if not resolved:
+                    deps.add(ref)
         else:
             # Without graph, just return raw column names
-            deps.update(refs)
+            deps.update(extract_column_references(metric_obj.sql))
 
     # Cumulative metric - depends on its base measure (stored in expr)
     elif metric_obj.type == "cumulative":

--- a/sidemantic/core/relationship.py
+++ b/sidemantic/core/relationship.py
@@ -13,10 +13,11 @@ class Relationship(BaseModel):
     - one_to_one: This model is referenced by another with unique constraint
     - one_to_many: This model is referenced by another
     - many_to_many: This model relates to another through a junction table
+    - cross: This model should be cross joined to another
     """
 
     name: str = Field(description="Name of the related model")
-    type: Literal["many_to_one", "one_to_one", "one_to_many", "many_to_many"] = Field(
+    type: Literal["many_to_one", "one_to_one", "one_to_many", "many_to_many", "cross"] = Field(
         description="Type of relationship"
     )
     foreign_key: str | list[str] | None = Field(
@@ -60,6 +61,8 @@ class Relationship(BaseModel):
     @property
     def foreign_key_columns(self) -> list[str]:
         """Get foreign key as list of columns (normalizes single string to list)."""
+        if self.type == "cross":
+            return []
         if self.foreign_key is None:
             # Default: {name}_id for many_to_one
             if self.type == "many_to_one":
@@ -72,6 +75,8 @@ class Relationship(BaseModel):
     @property
     def primary_key_columns(self) -> list[str]:
         """Get primary key as list of columns (normalizes single string to list)."""
+        if self.type == "cross":
+            return []
         if self.primary_key is None:
             return ["id"]
         if isinstance(self.primary_key, str):

--- a/sidemantic/core/semantic_graph.py
+++ b/sidemantic/core/semantic_graph.py
@@ -225,6 +225,11 @@ class SemanticGraph:
                 if related_model not in self.models:
                     continue  # Skip if related model doesn't exist yet
 
+                if relationship.type == "cross":
+                    add_edge(model_name, related_model, [], [], "cross")
+                    add_edge(related_model, model_name, [], [], "cross")
+                    continue
+
                 if relationship.type == "many_to_many":
                     junction_model = relationship.through
                     if not junction_model or junction_model not in self.models:

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import yaml
+
 if TYPE_CHECKING:
     from sidemantic.core.semantic_layer import SemanticLayer
 
@@ -101,39 +103,56 @@ def load_from_directory(layer: "SemanticLayer", directory: str | Path) -> None:
         elif suffix in (".yml", ".yaml"):
             # Try to detect which format by reading the file
             content = file_path.read_text()
+            yaml_data = _load_yaml_mapping(content)
             # Check for MetricFlow before Sidemantic native since
             # "semantic_models:" contains "models:" as a substring
-            if "semantic_models:" in content:
+            if _yaml_has_top_level_key(yaml_data, "semantic_models"):
                 adapter = MetricFlowAdapter()
-            elif "semantic_model:" in content and "datasets:" in content:
+            elif _yaml_has_top_level_key(yaml_data, "semantic_model") and _yaml_has_top_level_key(
+                yaml_data, "datasets"
+            ):
                 adapter = OSIAdapter()
-            elif "cubes:" in content or "views:" in content and "measures:" in content:
+            elif _yaml_has_top_level_key(yaml_data, "cubes") or (
+                _yaml_has_top_level_key(yaml_data, "views") and _contains_yaml_key(yaml_data, "measures")
+            ):
                 adapter = CubeAdapter()
             # Check for Sidemantic native format (explicit models: key)
-            elif "models:" in content:
+            elif _yaml_has_top_level_key(yaml_data, "models"):
                 adapter = SidemanticAdapter()
-            elif "metrics:" in content and "type: " in content:
+            elif _yaml_has_top_level_key(yaml_data, "metrics") and "type: " in content:
                 adapter = MetricFlowAdapter()
-            elif "base_sql_table:" in content and "measures:" in content:
+            elif _contains_yaml_key(yaml_data, "base_sql_table") and _contains_yaml_key(yaml_data, "measures"):
                 adapter = HexAdapter()
-            elif "table:" in content and "db_table:" in content and "columns:" in content:
+            elif (
+                _contains_yaml_key(yaml_data, "table")
+                and _contains_yaml_key(yaml_data, "db_table")
+                and _contains_yaml_key(yaml_data, "columns")
+            ):
                 adapter = ThoughtSpotAdapter()
-            elif "worksheet:" in content and "worksheet_columns:" in content:
+            elif _contains_yaml_key(yaml_data, "worksheet") and _contains_yaml_key(yaml_data, "worksheet_columns"):
                 adapter = ThoughtSpotAdapter()
-            elif "tables:" in content and "base_table:" in content:
+            elif _yaml_has_top_level_key(yaml_data, "tables") and _contains_yaml_key(yaml_data, "base_table"):
                 # Snowflake Cortex Semantic Model format
                 adapter = SnowflakeAdapter()
-            elif "_." in content and ("dimensions:" in content or "measures:" in content):
+            elif _looks_like_bsl_yaml(yaml_data):
                 # BSL format uses _.column syntax for expressions
                 adapter = BSLAdapter()
             elif "type: metrics_view" in content:
                 adapter = RillAdapter()
-            elif "table_name:" in content and "columns:" in content and "metrics:" in content:
+            elif (
+                _contains_yaml_key(yaml_data, "table_name")
+                and _contains_yaml_key(yaml_data, "columns")
+                and _contains_yaml_key(yaml_data, "metrics")
+            ):
                 adapter = SupersetAdapter()
             elif (
-                "measures:" in content
-                and "dimensions:" in content
-                and ("table_name:" in content or "table:" in content or "schema:" in content)
+                _contains_yaml_key(yaml_data, "measures")
+                and _contains_yaml_key(yaml_data, "dimensions")
+                and (
+                    _contains_yaml_key(yaml_data, "table_name")
+                    or _contains_yaml_key(yaml_data, "table")
+                    or _contains_yaml_key(yaml_data, "schema")
+                )
             ):
                 adapter = OmniAdapter()
 
@@ -222,6 +241,69 @@ def _looks_like_python_semantic_definition(file_path: Path) -> bool:
             "Metric(",
         )
     )
+
+
+def _load_yaml_mapping(content: str) -> dict:
+    """Parse YAML content and return a mapping, or an empty mapping on failure."""
+    try:
+        data = yaml.safe_load(content)
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _yaml_has_top_level_key(data: dict, key: str) -> bool:
+    """Return True when a YAML mapping has an exact top-level key."""
+    return isinstance(data, dict) and key in data
+
+
+def _contains_yaml_key(value: object, key: str) -> bool:
+    """Return True when a parsed YAML object contains an exact key anywhere."""
+    if isinstance(value, dict):
+        if key in value:
+            return True
+        return any(_contains_yaml_key(nested, key) for nested in value.values())
+    if isinstance(value, list):
+        return any(_contains_yaml_key(item, key) for item in value)
+    return False
+
+
+def _contains_bsl_expr(value: object) -> bool:
+    """Return True when a YAML object contains a BSL deferred expression string."""
+    if isinstance(value, str):
+        return "_." in value
+    if isinstance(value, dict):
+        return any(_contains_bsl_expr(nested) for nested in value.values())
+    if isinstance(value, list):
+        return any(_contains_bsl_expr(item) for item in value)
+    return False
+
+
+def _looks_like_bsl_yaml(data: dict) -> bool:
+    """Detect Boring Semantic Layer YAML without substring false positives."""
+    if not isinstance(data, dict):
+        return False
+
+    model_section_keys = {
+        "calculated_measures",
+        "database",
+        "dimensions",
+        "filter",
+        "joins",
+        "measures",
+        "primary_key",
+        "time_dimension",
+    }
+
+    for model_name, model_def in data.items():
+        if model_name == "profile":
+            continue
+        if not isinstance(model_def, dict) or "table" not in model_def:
+            continue
+        if model_section_keys.intersection(model_def) or _contains_bsl_expr(model_def):
+            return True
+
+    return False
 
 
 def _extract_models_from_python_namespace(namespace: dict, fallback_models: dict) -> dict:

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -173,6 +173,11 @@ def load_from_directory(layer: "SemanticLayer", directory: str | Path) -> None:
                 # Skip files that fail to parse
                 logging.warning("Could not parse %s: %s", file_path, e)
 
+    # BSL files are parsed one at a time during auto-discovery. Finalize join
+    # aliases after all files have been loaded so aliases can target models
+    # declared in separate files.
+    _finalize_bsl_join_aliases(all_models)
+
     # Infer cross-model relationships based on naming conventions
     _infer_relationships(all_models)
 
@@ -212,6 +217,22 @@ def _load_sml_directory(layer: "SemanticLayer", directory: Path, all_models: dic
         if model.name not in layer.graph.models:
             layer.add_model(model)
     layer.graph.build_adjacency()
+
+
+def _finalize_bsl_join_aliases(all_models: dict) -> None:
+    """Add BSL join alias models once directory-level loading has all models."""
+    if not all_models:
+        return
+
+    from sidemantic.adapters.bsl import BSLAdapter
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    for model in all_models.values():
+        graph.add_model(model)
+
+    BSLAdapter()._add_join_alias_models(graph)
+    all_models.update(graph.models)
 
 
 def _looks_like_python_semantic_definition(file_path: Path) -> bool:

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -231,7 +231,13 @@ def _finalize_bsl_join_aliases(all_models: dict) -> None:
     for model in all_models.values():
         graph.add_model(model)
 
+    existing_alias_models = {
+        name for name, model in all_models.items() if model.metadata and model.metadata.get("bsl_alias_of")
+    }
     BSLAdapter()._add_join_alias_models(graph)
+    for name in existing_alias_models:
+        if name not in graph.models:
+            all_models.pop(name, None)
     all_models.update(graph.models)
 
 

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -857,7 +857,29 @@ class SQLGenerator:
             """Recursively collect models needed from a metric."""
             if "." in metric_ref:
                 # Direct measure reference (model.measure)
-                add_model(metric_ref.split(".")[0])
+                model_name, measure_name = metric_ref.split(".", 1)
+                add_model(model_name)
+                try:
+                    model = self.graph.get_model(model_name)
+                    measure = model.get_metric(measure_name) if model else None
+                except KeyError:
+                    measure = None
+
+                if measure:
+                    if measure.type == "ratio":
+                        if measure.numerator:
+                            collect_models_from_metric(measure.numerator)
+                        if measure.denominator:
+                            collect_models_from_metric(measure.denominator)
+                    elif measure.type == "derived" or (not measure.type and not measure.agg and measure.sql):
+                        for ref_metric in measure.get_dependencies(self.graph, model_name):
+                            collect_models_from_metric(ref_metric)
+                        if measure.sql and "." in measure.sql:
+                            for ref_model_name in self._extract_models_from_sql(measure.sql):
+                                add_model(ref_model_name)
+                    elif measure.agg and measure.sql and "." in measure.sql:
+                        for ref_model_name in self._extract_models_from_sql(measure.sql):
+                            add_model(ref_model_name)
             else:
                 # It's a metric, need to resolve its dependencies
                 try:
@@ -2734,22 +2756,24 @@ class SQLGenerator:
                 # Use regex to only replace whole word matches
                 import re
 
-                # For qualified names (model.measure), also match unqualified version (measure)
+                # For qualified names (model.measure), preserve explicit qualification.
                 if "." in metric_name:
                     # Split into model and measure parts
                     parts = metric_name.split(".")
                     measure_only = parts[1]
 
-                    # First try to replace qualified form if present
+                    # First try to replace qualified form if present.
                     pattern = r"\b" + re.escape(metric_name).replace(r"\.", r"\.") + r"\b"
-                    formula = re.sub(pattern, f"({metric_sql})", formula)
-
-                    # Then also replace unqualified form (measure name only)
-                    pattern = r"\b" + re.escape(measure_only) + r"\b"
-                    formula = re.sub(pattern, f"({metric_sql})", formula)
+                    if re.search(pattern, formula):
+                        formula = re.sub(pattern, f"({metric_sql})", formula)
+                    else:
+                        # If the dependency resolved from an unqualified reference
+                        # (e.g. count -> orders.count), replace only bare refs.
+                        pattern = r"(?<!\.)\b" + re.escape(measure_only) + r"\b"
+                        formula = re.sub(pattern, f"({metric_sql})", formula)
                 else:
                     # For simple names, use word boundaries
-                    pattern = r"\b" + re.escape(metric_name) + r"\b"
+                    pattern = r"(?<!\.)\b" + re.escape(metric_name) + r"\b"
                     formula = re.sub(pattern, f"({metric_sql})", formula)
 
             for placeholder, metric_ref in bsl_all_placeholders.items():

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -1263,7 +1263,7 @@ class SQLGenerator:
         """
         model = self.graph.get_model(model_name)
         all_models = all_models or {model_name}
-        needs_joins = len(all_models) > 1
+        needs_keyed_joins = self._model_needs_keyed_join_columns(model_name, all_models)
 
         # Find which dimensions are actually needed
         needed_dimensions = self._find_needed_dimensions(
@@ -1276,7 +1276,7 @@ class SQLGenerator:
         # Track all columns added (not just join keys) to avoid duplicates
         columns_added = set()
 
-        include_primary_keys = needs_joins or ungrouped or bool(model.sql)
+        include_primary_keys = needs_keyed_joins or ungrouped or bool(model.sql)
         if include_primary_keys:
             for pk_col in model.primary_key_columns:
                 if pk_col not in columns_added:
@@ -1289,7 +1289,9 @@ class SQLGenerator:
                 # Handle multi-column foreign keys
                 for fk in relationship.foreign_key_columns:
                     # Add FK if: (1) we're joining to this related model, OR (2) FK is requested as dimension
-                    should_include = (needs_joins and relationship.name in all_models) or fk in needed_dimensions
+                    should_include = (
+                        needs_keyed_joins and relationship.name in all_models and relationship.type != "cross"
+                    ) or fk in needed_dimensions
                     if should_include and fk not in columns_added:
                         select_cols.append(f"{self._quote_identifier(fk)} AS {self._quote_alias(fk)}")
                         columns_added.add(fk)
@@ -1297,7 +1299,7 @@ class SQLGenerator:
                         needed_dimensions.discard(fk)
 
         # Check if other models have has_many/has_one pointing to this model
-        if needs_joins:
+        if needs_keyed_joins:
             for other_model_name, other_model in self.graph.models.items():
                 if other_model_name not in all_models:
                     continue
@@ -1575,6 +1577,25 @@ class SQLGenerator:
         )
 
         return cte_sql
+
+    def _model_needs_keyed_join_columns(self, model_name: str, all_models: set[str]) -> bool:
+        """Return whether this model needs columns for non-cross joins in this query."""
+        if len(all_models) <= 1:
+            return False
+
+        model = self.graph.get_model(model_name)
+        for relationship in model.relationships:
+            if relationship.name in all_models and relationship.type != "cross":
+                return True
+
+        for other_model_name, other_model in self.graph.models.items():
+            if other_model_name not in all_models:
+                continue
+            for relationship in other_model.relationships:
+                if relationship.name == model_name and relationship.type != "cross":
+                    return True
+
+        return False
 
     def _has_fanout_joins(self, base_model_name: str, other_models: list[str]) -> dict[str, bool]:
         """Determine which models need symmetric aggregates due to fan-out.

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -1280,6 +1280,13 @@ class SQLGenerator:
                 if other_model_name not in all_models:
                     continue
                 for other_join in other_model.relationships:
+                    if other_join.name == model_name and other_join.type == "many_to_one":
+                        for pk in (
+                            other_join.primary_key_columns if other_join.primary_key else model.primary_key_columns
+                        ):
+                            if pk not in columns_added:
+                                select_cols.append(f"{self._quote_identifier(pk)} AS {self._quote_alias(pk)}")
+                                columns_added.add(pk)
                     if other_join.name == model_name and other_join.type in (
                         "one_to_one",
                         "one_to_many",
@@ -1595,6 +1602,43 @@ class SQLGenerator:
                 needs_symmetric[other_model] = False
 
         return needs_symmetric
+
+    def _explicit_join_type_for_path(self, join_path) -> str | None:
+        """Return an adapter-provided SQL join type for a join path step."""
+        relation = None
+        reverse = False
+
+        try:
+            from_model = self.graph.get_model(join_path.from_model)
+            relation = next((rel for rel in from_model.relationships if rel.name == join_path.to_model), None)
+        except KeyError:
+            relation = None
+
+        if relation is None:
+            try:
+                to_model = self.graph.get_model(join_path.to_model)
+                relation = next((rel for rel in to_model.relationships if rel.name == join_path.from_model), None)
+                reverse = relation is not None
+            except KeyError:
+                relation = None
+
+        if not relation or not relation.metadata or "bsl_how" not in relation.metadata:
+            return None
+
+        how = str(relation.metadata["bsl_how"]).lower()
+        if reverse and how == "left":
+            how = "right"
+        elif reverse and how == "right":
+            how = "left"
+
+        return {
+            "inner": "inner",
+            "left": "left",
+            "right": "right",
+            "outer": "full",
+            "full": "full",
+            "full_outer": "full",
+        }.get(how)
 
     def _needs_preaggregation_for_fanout(self, metrics: list[str], dimensions: list[str]) -> bool:
         """Determine if pre-aggregation is needed to avoid fan-out.
@@ -2116,6 +2160,11 @@ class SQLGenerator:
                             continue
 
                         right_table = self._quote_identifier(self._cte_name(jp.to_model))
+                        if jp.relationship == "cross":
+                            query = query.join(right_table, join_type="cross")
+                            joined_models.add(jp.to_model)
+                            continue
+
                         # Validate column counts match for composite keys
                         if len(jp.from_columns) != len(jp.to_columns):
                             raise ValueError(
@@ -2129,8 +2178,11 @@ class SQLGenerator:
                         ]
                         join_cond = " AND ".join(join_conditions)
 
-                        # Use INNER JOIN if this model has filters applied, otherwise LEFT JOIN
-                        join_type = "inner" if jp.to_model in models_with_filters else "left"
+                        # Use adapter-provided join type when present; otherwise
+                        # INNER JOIN if this model has filters applied, else LEFT JOIN.
+                        join_type = self._explicit_join_type_for_path(jp)
+                        if join_type is None:
+                            join_type = "inner" if jp.to_model in models_with_filters else "left"
                         query = query.join(right_table, on=join_cond, join_type=join_type)
                         joined_models.add(jp.to_model)
 
@@ -2405,6 +2457,65 @@ class SQLGenerator:
             return f"COUNT({raw_col})"
         return f"{agg_func}({raw_col})"
 
+    def _build_measure_window_total_sql(self, model_name: str, measure) -> str:
+        """Build an all-rows window aggregate for a model-scoped measure."""
+        agg_func = measure.agg.upper()
+        raw_col = self._cte_ref(model_name, f"{measure.name}_raw")
+
+        if agg_func == "COUNT_DISTINCT":
+            return f"SUM(COUNT(DISTINCT {raw_col})) OVER ()"
+        if agg_func == "COUNT":
+            return f"SUM(COUNT({raw_col})) OVER ()"
+        if agg_func == "SUM":
+            return f"SUM(SUM({raw_col})) OVER ()"
+        if agg_func == "AVG":
+            return f"(SUM(SUM({raw_col})) OVER ()) / NULLIF(SUM(COUNT({raw_col})) OVER (), 0)"
+        if agg_func == "MIN":
+            return f"MIN(MIN({raw_col})) OVER ()"
+        if agg_func == "MAX":
+            return f"MAX(MAX({raw_col})) OVER ()"
+        return f"SUM({self._build_measure_aggregation_sql(model_name, measure)}) OVER ()"
+
+    def _extract_bsl_all_placeholders(self, formula: str) -> tuple[str, dict[str, str]]:
+        """Replace BSL all-measure calls with placeholders before dependency replacement."""
+        import re
+
+        placeholders: dict[str, str] = {}
+
+        def replace(match) -> str:
+            placeholder = f"__bsl_all_{len(placeholders)}"
+            placeholders[placeholder] = match.group(1).strip()
+            return placeholder
+
+        formula = re.sub(r"__bsl_all\(([A-Za-z_][A-Za-z0-9_.]*)\)", replace, formula)
+        return formula, placeholders
+
+    def _build_bsl_all_sql(self, metric_ref: str, model_context: str | None) -> str:
+        """Resolve BSL _.all(metric) to a window total over the metric aggregate."""
+        model_name = None
+        measure_name = metric_ref
+
+        if "." in metric_ref:
+            model_name, measure_name = metric_ref.split(".", 1)
+        elif model_context:
+            model_name = model_context
+        else:
+            for candidate_name, candidate_model in self.graph.models.items():
+                if candidate_model.get_metric(metric_ref):
+                    model_name = candidate_name
+                    break
+
+        if not model_name:
+            raise ValueError(f"Metric {metric_ref} not found")
+
+        model = self.graph.get_model(model_name)
+        measure = model.get_metric(measure_name)
+        if not measure:
+            raise ValueError(f"Metric {metric_ref} not found")
+        if not measure.agg:
+            return f"SUM({self._build_metric_sql(measure, model_name)}) OVER ()"
+        return self._build_measure_window_total_sql(model_name, measure)
+
     def _build_metric_sql(self, metric, model_context: str | None = None) -> str:
         """Build SQL expression for a metric.
 
@@ -2483,6 +2594,7 @@ class SQLGenerator:
                 raise ValueError(f"Derived metric {metric.name} missing sql")
 
             formula = metric.sql
+            formula, bsl_all_placeholders = self._extract_bsl_all_placeholders(formula)
 
             # Check if this is a SQL expression metric (has inline aggregations)
             # These metrics already contain complete SQL and shouldn't have dependencies replaced
@@ -2578,6 +2690,9 @@ class SQLGenerator:
                     # For simple names, use word boundaries
                     pattern = r"\b" + re.escape(metric_name) + r"\b"
                     formula = re.sub(pattern, f"({metric_sql})", formula)
+
+            for placeholder, metric_ref in bsl_all_placeholders.items():
+                formula = formula.replace(placeholder, f"({self._build_bsl_all_sql(metric_ref, model_context)})")
 
             return formula
 

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -2463,7 +2463,7 @@ class SQLGenerator:
         raw_col = self._cte_ref(model_name, f"{measure.name}_raw")
 
         if agg_func == "COUNT_DISTINCT":
-            return f"SUM(COUNT(DISTINCT {raw_col})) OVER ()"
+            return self._build_measure_total_subquery_sql(model_name, measure)
         if agg_func == "COUNT":
             return f"SUM(COUNT({raw_col})) OVER ()"
         if agg_func == "SUM":
@@ -2475,6 +2475,21 @@ class SQLGenerator:
         if agg_func == "MAX":
             return f"MAX(MAX({raw_col})) OVER ()"
         return f"SUM({self._build_measure_aggregation_sql(model_name, measure)}) OVER ()"
+
+    def _build_measure_total_subquery_sql(self, model_name: str, measure) -> str:
+        """Build a scalar all-rows aggregate from the model CTE."""
+        cte_name = self._quote_identifier(self._cte_name(model_name))
+        cte_alias = self._quote_identifier(f"{self._cte_name(model_name)}__all")
+        raw_col = f"{cte_alias}.{self._quote_identifier(f'{measure.name}_raw')}"
+        agg_func = measure.agg.upper()
+
+        if agg_func == "COUNT_DISTINCT":
+            expr = f"COUNT(DISTINCT {raw_col})"
+        else:
+            expr = self._build_measure_aggregation_sql(model_name, measure)
+            expr = expr.replace(self._cte_ref(model_name, f"{measure.name}_raw"), raw_col)
+
+        return f"(SELECT {expr} FROM {cte_name} AS {cte_alias})"
 
     def _extract_bsl_all_placeholders(self, formula: str) -> tuple[str, dict[str, str]]:
         """Replace BSL all-measure calls with placeholders before dependency replacement."""

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -1962,6 +1962,139 @@ class SQLGenerator:
 
         return full_sql
 
+    def _add_join_paths_to_query(
+        self,
+        query,
+        base_model_name: str,
+        other_models: list[str],
+        models_with_filters: set[str],
+    ):
+        """Add the same multi-hop joins used by the main grouped query."""
+        if not other_models:
+            return query
+
+        joined_models = {base_model_name}
+        for other_model in other_models:
+            join_path = self.graph.find_relationship_path(base_model_name, other_model)
+            if not join_path:
+                continue
+
+            for jp in join_path:
+                if jp.to_model in joined_models:
+                    continue
+
+                right_table = self._quote_identifier(self._cte_name(jp.to_model))
+                if jp.relationship == "cross":
+                    query = query.join(right_table, join_type="cross")
+                    joined_models.add(jp.to_model)
+                    continue
+
+                if len(jp.from_columns) != len(jp.to_columns):
+                    raise ValueError(
+                        f"Join between {jp.from_model} and {jp.to_model} has mismatched key columns: "
+                        f"from_columns has {len(jp.from_columns)}, to_columns has {len(jp.to_columns)}"
+                    )
+
+                join_conditions = [
+                    self._cte_ref(jp.from_model, fk) + " = " + self._cte_ref(jp.to_model, pk)
+                    for fk, pk in zip(jp.from_columns, jp.to_columns)
+                ]
+                join_type = self._explicit_join_type_for_path(jp)
+                if join_type is None:
+                    join_type = "inner" if jp.to_model in models_with_filters else "left"
+                query = query.join(right_table, on=" AND ".join(join_conditions), join_type=join_type)
+                joined_models.add(jp.to_model)
+
+        return query
+
+    def _split_where_having_filters(self, filters: list[str], model_names: list[str]) -> tuple[list[str], list[str]]:
+        """Split query-level filters into row filters and aggregate filters."""
+        import re
+
+        where_filters = []
+        having_filters = []
+
+        for filter_expr in filters:
+            references_metric = False
+
+            for model_name in model_names:
+                model_obj = self.graph.get_model(model_name)
+                pattern = f"{model_name}\\.([a-zA-Z_][a-zA-Z0-9_]*)"
+                matches = re.findall(pattern, filter_expr)
+                for field_name in matches:
+                    if model_obj.get_metric(field_name):
+                        references_metric = True
+                        break
+                if references_metric:
+                    break
+
+            references_window_dim = False
+            if references_metric:
+                for model_name in model_names:
+                    model_obj = self.graph.get_model(model_name)
+                    if not model_obj:
+                        continue
+                    for field_name in re.findall(f"{model_name}\\.([a-zA-Z_][a-zA-Z0-9_]*)", filter_expr):
+                        dim = model_obj.get_dimension(field_name)
+                        if dim and getattr(dim, "window", None) is not None:
+                            references_window_dim = True
+                            break
+                    if references_window_dim:
+                        break
+
+            if references_metric and not references_window_dim:
+                having_filters.append(filter_expr)
+            else:
+                where_filters.append(filter_expr)
+
+        return where_filters, having_filters
+
+    def _add_where_filters_to_query(self, query, where_filters: list[str], model_names: list[str]):
+        """Add row-level filters with CTE-qualified field references."""
+        import re
+
+        for filter_expr in where_filters:
+            parsed_filter = filter_expr
+            for model_name in model_names:
+                model_obj = self.graph.get_model(model_name)
+
+                parts = []
+                in_quotes = False
+                current = ""
+
+                for char in parsed_filter:
+                    if char == "'":
+                        if current:
+                            parts.append((current, in_quotes))
+                            current = ""
+                        in_quotes = not in_quotes
+                        parts.append(("'", False))
+                    else:
+                        current += char
+                if current:
+                    parts.append((current, in_quotes))
+
+                pattern = f"{model_name}\\.([a-zA-Z_][a-zA-Z0-9_]*)"
+
+                def replace_field(match):
+                    field_name = match.group(1)
+                    if model_obj.get_metric(field_name):
+                        return self._cte_ref(model_name, f"{field_name}_raw")
+                    return self._cte_ref(model_name, field_name)
+
+                result_parts = []
+                for part, is_quoted in parts:
+                    if is_quoted or part == "'":
+                        result_parts.append(part)
+                    else:
+                        result_parts.append(re.sub(pattern, replace_field, part))
+
+                parsed_filter = "".join(result_parts)
+
+            query = query.where(parsed_filter)
+
+        return query
+
     def _build_main_select(
         self,
         base_model_name: str,
@@ -2054,6 +2187,14 @@ class SQLGenerator:
 
             select_exprs.append(f"{self._cte_ref(model_name, cte_col_name)} AS {self._quote_alias(alias)}")
 
+        previous_bsl_all_context = getattr(self, "_bsl_all_query_context", None)
+        self._bsl_all_query_context = {
+            "base_model_name": base_model_name,
+            "other_models": other_models,
+            "filters": filters or [],
+            "models_with_filters": models_with_filters,
+        }
+
         # Add metrics
         for metric_ref in metrics:
             if "." in metric_ref:
@@ -2142,147 +2283,28 @@ class SQLGenerator:
                 else:
                     raise ValueError(f"Metric {metric_ref} not found")
 
+        if previous_bsl_all_context is None:
+            delattr(self, "_bsl_all_query_context")
+        else:
+            self._bsl_all_query_context = previous_bsl_all_context
+
         # Build query using builder API
         query = select(*select_exprs).from_(self._quote_identifier(self._cte_name(base_model_name)))
 
         # Add joins (supports multi-hop)
-        if other_models:
-            # Track which models we've already joined
-            joined_models = {base_model_name}
-
-            for other_model in other_models:
-                join_path = self.graph.find_relationship_path(base_model_name, other_model)
-                if join_path:
-                    # Apply each join in the path
-                    for jp in join_path:
-                        # Skip if we've already joined this model
-                        if jp.to_model in joined_models:
-                            continue
-
-                        right_table = self._quote_identifier(self._cte_name(jp.to_model))
-                        if jp.relationship == "cross":
-                            query = query.join(right_table, join_type="cross")
-                            joined_models.add(jp.to_model)
-                            continue
-
-                        # Validate column counts match for composite keys
-                        if len(jp.from_columns) != len(jp.to_columns):
-                            raise ValueError(
-                                f"Join between {jp.from_model} and {jp.to_model} has mismatched key columns: "
-                                f"from_columns has {len(jp.from_columns)}, to_columns has {len(jp.to_columns)}"
-                            )
-                        # Build join condition for single or multi-column keys
-                        join_conditions = [
-                            self._cte_ref(jp.from_model, fk) + " = " + self._cte_ref(jp.to_model, pk)
-                            for fk, pk in zip(jp.from_columns, jp.to_columns)
-                        ]
-                        join_cond = " AND ".join(join_conditions)
-
-                        # Use adapter-provided join type when present; otherwise
-                        # INNER JOIN if this model has filters applied, else LEFT JOIN.
-                        join_type = self._explicit_join_type_for_path(jp)
-                        if join_type is None:
-                            join_type = "inner" if jp.to_model in models_with_filters else "left"
-                        query = query.join(right_table, on=join_cond, join_type=join_type)
-                        joined_models.add(jp.to_model)
+        query = self._add_join_paths_to_query(query, base_model_name, other_models, models_with_filters)
 
         # Separate filters into WHERE (dimension/row-level) and HAVING (metric/aggregation-level)
         # Note: metric-level filters (Metric.filters) are applied via CASE WHEN inside each
         # metric's aggregation, NOT in the WHERE clause. This ensures each metric's filter
         # only affects that specific metric, not all metrics in the query.
-        where_filters = []
-        having_filters = []
-
+        where_filters, having_filters = self._split_where_having_filters(
+            filters or [], [base_model_name] + other_models
+        )
         import re
 
-        # Process query-level filters
-        for filter_expr in filters or []:
-            # Determine if this filter references a metric or dimension
-            references_metric = False
-
-            for model_name in [base_model_name] + other_models:
-                model_obj = self.graph.get_model(model_name)
-                # Check if filter contains model.metric_name
-                pattern = f"{model_name}\\.([a-zA-Z_][a-zA-Z0-9_]*)"
-                matches = re.findall(pattern, filter_expr)
-                for field_name in matches:
-                    if model_obj.get_metric(field_name):
-                        references_metric = True
-                        break
-                if references_metric:
-                    break
-
-            # Check if filter also references a window dimension.
-            # Window dims are projected as regular columns in the CTE, so
-            # they belong in WHERE, not HAVING (they aren't aggregated).
-            references_window_dim = False
-            if references_metric:
-                for model_name in [base_model_name] + other_models:
-                    model_obj = self.graph.get_model(model_name)
-                    if not model_obj:
-                        continue
-                    for field_name in re.findall(f"{model_name}\\.([a-zA-Z_][a-zA-Z0-9_]*)", filter_expr):
-                        dim = model_obj.get_dimension(field_name)
-                        if dim and getattr(dim, "window", None) is not None:
-                            references_window_dim = True
-                            break
-                    if references_window_dim:
-                        break
-
-            if references_metric and not references_window_dim:
-                having_filters.append(filter_expr)
-            else:
-                where_filters.append(filter_expr)
-
         # Add WHERE clause (dimension filters only - metric-level filters are in CASE WHEN)
-        if where_filters:
-            # Parse filters to add table aliases and handle measure vs dimension columns
-            for filter_expr in where_filters:
-                parsed_filter = filter_expr
-                for model_name in [base_model_name] + other_models:
-                    # Replace model.field references
-                    # Check if field is a measure (needs _raw suffix) or dimension
-                    model_obj = self.graph.get_model(model_name)
-
-                    # Split by quotes to avoid replacing inside string literals
-                    parts = []
-                    in_quotes = False
-                    current = ""
-
-                    for char in parsed_filter:
-                        if char == "'":
-                            if current:
-                                parts.append((current, in_quotes))
-                                current = ""
-                            in_quotes = not in_quotes
-                            parts.append(("'", False))
-                        else:
-                            current += char
-                    if current:
-                        parts.append((current, in_quotes))
-
-                    # Only replace in non-quoted parts
-                    pattern = f"{model_name}\\.([a-zA-Z_][a-zA-Z0-9_]*)"
-
-                    def replace_field(match):
-                        field_name = match.group(1)
-                        # Check if it's a measure
-                        if model_obj.get_metric(field_name):
-                            return self._cte_ref(model_name, f"{field_name}_raw")
-                        else:
-                            # It's a dimension or other column
-                            return self._cte_ref(model_name, field_name)
-
-                    result_parts = []
-                    for part, is_quoted in parts:
-                        if is_quoted or part == "'":
-                            result_parts.append(part)
-                        else:
-                            result_parts.append(re.sub(pattern, replace_field, part))
-
-                    parsed_filter = "".join(result_parts)
-
-                query = query.where(parsed_filter)
+        query = self._add_where_filters_to_query(query, where_filters, [base_model_name] + other_models)
 
         # Add GROUP BY (all dimensions by position)
         # Skip GROUP BY for ungrouped queries
@@ -2463,7 +2485,7 @@ class SQLGenerator:
         raw_col = self._cte_ref(model_name, f"{measure.name}_raw")
 
         if agg_func == "COUNT_DISTINCT":
-            return self._build_measure_total_subquery_sql(model_name, measure)
+            return self._build_bsl_count_distinct_total_sql(model_name, measure)
         if agg_func == "COUNT":
             return f"SUM(COUNT({raw_col})) OVER ()"
         if agg_func == "SUM":
@@ -2490,6 +2512,30 @@ class SQLGenerator:
             expr = expr.replace(self._cte_ref(model_name, f"{measure.name}_raw"), raw_col)
 
         return f"(SELECT {expr} FROM {cte_name} AS {cte_alias})"
+
+    def _build_bsl_count_distinct_total_sql(self, model_name: str, measure) -> str:
+        """Build BSL _.all() SQL for a count-distinct measure."""
+        context = getattr(self, "_bsl_all_query_context", None)
+        if not context:
+            return self._build_measure_total_subquery_sql(model_name, measure)
+
+        base_model_name = context["base_model_name"]
+        other_models = context["other_models"]
+        models_with_filters = context["models_with_filters"]
+        filters = context["filters"]
+        query_model_names = [base_model_name] + other_models
+
+        if model_name not in query_model_names:
+            return self._build_measure_total_subquery_sql(model_name, measure)
+
+        query = select(f"COUNT(DISTINCT {self._cte_ref(model_name, f'{measure.name}_raw')})").from_(
+            self._quote_identifier(self._cte_name(base_model_name))
+        )
+        query = self._add_join_paths_to_query(query, base_model_name, other_models, models_with_filters)
+        where_filters, _ = self._split_where_having_filters(filters, query_model_names)
+        query = self._add_where_filters_to_query(query, where_filters, query_model_names)
+
+        return f"({query.sql(dialect=self.dialect, pretty=True)})"
 
     def _extract_bsl_all_placeholders(self, formula: str) -> tuple[str, dict[str, str]]:
         """Replace BSL all-measure calls with placeholders before dependency replacement."""

--- a/sidemantic/sql/query_rewriter.py
+++ b/sidemantic/sql/query_rewriter.py
@@ -121,6 +121,8 @@ class QueryRewriter:
         self.dialect = dialect
         self.use_preaggregations = use_preaggregations
         self.generator = SQLGenerator(graph, dialect=dialect)
+        self._rewrite_cache: dict[tuple[object, ...], str] = {}
+        self._rewrite_cache_limit = 256
         self._use_rust_rewriter = os.getenv("SIDEMANTIC_RS_REWRITER", "0") == "1"
         self._rust_no_fallback = os.getenv("SIDEMANTIC_RS_NO_FALLBACK", "0") == "1"
         self._rust_module = None
@@ -155,15 +157,25 @@ class QueryRewriter:
                        Only raised when strict=True
         """
         sql = sql.strip()
+        cache_key = (getattr(self.graph, "_version", 0), self.dialect, self.use_preaggregations, strict, sql)
+        cached = self._rewrite_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        def cache_result(result: str) -> str:
+            if len(self._rewrite_cache) >= self._rewrite_cache_limit:
+                self._rewrite_cache.pop(next(iter(self._rewrite_cache)))
+            self._rewrite_cache[cache_key] = result
+            return result
 
         if self._looks_like_yardstick_query(sql):
             try:
-                return self._rewrite_yardstick_query(sql, strict=strict)
+                return cache_result(self._rewrite_yardstick_query(sql, strict=strict))
             except Exception:
                 if strict:
                     raise
                 # Keep non-strict passthrough behavior when Yardstick rewrite cannot be applied safely.
-                return sql
+                return cache_result(sql)
 
         # Handle multiple statements (some PostgreSQL clients send these).
         # Use sqlglot.parse() so semicolons inside string literals are not
@@ -175,12 +187,12 @@ class QueryRewriter:
                 if strict:
                     raise
                 # In non-strict mode, pass through unparseable SQL
-                return sql
+                return cache_result(sql)
             if len(statements) > 1:
                 if strict:
                     raise ValueError("Multiple statements are not supported")
                 # In non-strict mode, pass through
-                return sql
+                return cache_result(sql)
 
         # Parse SQL
         try:
@@ -189,39 +201,39 @@ class QueryRewriter:
             if strict:
                 raise ValueError(f"Failed to parse SQL: {e}")
             # In non-strict mode, pass through unparseable SQL (e.g., SHOW, SET commands)
-            return sql
+            return cache_result(sql)
 
         if not isinstance(parsed, (exp.Select, exp.SetOperation)):
             if strict:
                 raise ValueError("Only SELECT queries are supported")
             # In non-strict mode, pass through non-SELECT queries
-            return sql
+            return cache_result(sql)
 
         if isinstance(parsed, exp.SetOperation):
             if not self._expression_tree_references_semantic_model(parsed):
-                return sql
+                return cache_result(sql)
             self._raise_on_user_cte_name_collision(parsed)
-            return self._rewrite_set_operation(parsed)
+            return cache_result(self._rewrite_set_operation(parsed))
 
         if self._contains_implicit_yardstick_measure_query(parsed):
             try:
-                return self._rewrite_yardstick_query(sql, strict=strict, allow_plain_measures=True)
+                return cache_result(self._rewrite_yardstick_query(sql, strict=strict, allow_plain_measures=True))
             except Exception:
                 if strict:
                     raise
-                return sql
+                return cache_result(sql)
 
         # Projection-only SQL (no root FROM/CTE) should pass through unless Yardstick paths above matched.
         if parsed.args.get("from") is None and parsed.args.get("with") is None:
             if any(isinstance(expr, exp.Star) for expr in parsed.expressions):
                 if strict:
                     raise ValueError("SELECT * requires a FROM clause with a single table")
-                return sql
-            return sql
+                return cache_result(sql)
+            return cache_result(sql)
 
         references_semantic_model = self._select_tree_references_semantic_model(parsed)
         if not references_semantic_model:
-            return sql
+            return cache_result(sql)
 
         self._raise_on_user_cte_name_collision(parsed)
 
@@ -229,7 +241,7 @@ class QueryRewriter:
             rust_sql = self._prepare_sql_for_rust(parsed, sql)
             rust_rewritten = self._rewrite_with_rust(rust_sql, strict=strict)
             if rust_rewritten is not None:
-                return rust_rewritten
+                return cache_result(rust_rewritten)
 
         # Check if this is a CTE-based query or has subqueries
         has_ctes = parsed.args.get("with") is not None
@@ -238,10 +250,10 @@ class QueryRewriter:
 
         if has_ctes or has_subquery_in_from or has_subquery_in_joins:
             # Handle CTEs and subqueries
-            return self._rewrite_with_ctes_or_subqueries(parsed)
+            return cache_result(self._rewrite_with_ctes_or_subqueries(parsed))
 
         # Otherwise, treat as simple semantic layer query
-        return self._rewrite_simple_query(parsed)
+        return cache_result(self._rewrite_simple_query(parsed))
 
     def _source_aliases(self, select: exp.Select) -> dict[str, str]:
         """Map source aliases in this SELECT scope to semantic model names."""

--- a/tests/adapters/bsl/test_parsing.py
+++ b/tests/adapters/bsl/test_parsing.py
@@ -1415,6 +1415,8 @@ accounts:
         import tempfile
         from pathlib import Path
 
+        import duckdb
+
         from sidemantic.sql.generator import SQLGenerator
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
@@ -1447,6 +1449,14 @@ facts:
                 skip_default_time_dimensions=True,
             )
             assert "CROSS JOIN facts_cte" in sql
+            assert "id AS id" not in sql
+
+            conn = duckdb.connect(":memory:")
+            conn.execute("CREATE TABLE calendar(day DATE)")
+            conn.execute("INSERT INTO calendar VALUES (DATE '2024-01-01')")
+            conn.execute("CREATE TABLE facts(id INTEGER)")
+            conn.execute("INSERT INTO facts VALUES (1)")
+            assert len(conn.execute(sql).fetchall()) == 1
         finally:
             temp_path.unlink(missing_ok=True)
 

--- a/tests/adapters/bsl/test_parsing.py
+++ b/tests/adapters/bsl/test_parsing.py
@@ -418,6 +418,57 @@ events:
         assert by_segment["a"] == pytest.approx(0.5)
         assert by_segment["b"] == pytest.approx(1.0)
 
+    def test_bsl_all_count_distinct_preserves_joined_filters(self, tmp_path):
+        """_.all() over count_distinct should use the joined filtered row set."""
+        from sidemantic import SemanticLayer
+
+        bsl_file = tmp_path / "orders.yml"
+        bsl_file.write_text(
+            """
+orders:
+  table: orders
+  dimensions:
+    order_id:
+      expr: _.order_id
+      is_entity: true
+    customer_id: _.customer_id
+  measures:
+    users: _.user_id.nunique()
+  calculated_measures:
+    user_share: _.users / _.all(_.users)
+  joins:
+    customers:
+      model: customers
+      type: one
+      left_on: customer_id
+      right_on: customer_id
+
+customers:
+  table: customers
+  dimensions:
+    customer_id:
+      expr: _.customer_id
+      is_entity: true
+    region: _.region
+"""
+        )
+
+        layer = SemanticLayer(connection="duckdb:///:memory:")
+        layer.graph = BSLAdapter().parse(bsl_file)
+        layer.adapter.execute("CREATE TABLE orders (order_id INTEGER, customer_id INTEGER, user_id INTEGER)")
+        layer.adapter.execute("INSERT INTO orders VALUES (1, 1, 1), (2, 2, 2), (3, 2, 3), (4, 1, 4)")
+        layer.adapter.execute("CREATE TABLE customers (customer_id INTEGER, region VARCHAR)")
+        layer.adapter.execute("INSERT INTO customers VALUES (1, 'US'), (2, 'EU')")
+
+        result = layer.query(
+            metrics=["orders.user_share"],
+            dimensions=["customers.region"],
+            filters=["customers.region = 'EU'"],
+        )
+        rows = result.fetchall()
+
+        assert [(region, float(user_share)) for region, user_share in rows] == [("EU", pytest.approx(1.0))]
+
 
 class TestBSLAdapterExport:
     """Tests for BSL adapter export functionality."""

--- a/tests/adapters/bsl/test_parsing.py
+++ b/tests/adapters/bsl/test_parsing.py
@@ -6,6 +6,7 @@ from sidemantic.adapters.bsl import BSLAdapter
 from sidemantic.adapters.bsl_expr import (
     ParsedExpr,
     _sql_to_bsl_expr,
+    bsl_calc_to_sql,
     bsl_filter_to_sql,
     bsl_to_sql,
     is_calc_measure_expr,
@@ -242,6 +243,16 @@ class TestCalcMeasures:
         assert "NULLIF" not in result
         assert "revenue" in result
 
+    def test_bsl_deferred_calc_measure_refs(self):
+        """Test translating current BSL calculated-measure syntax."""
+        assert bsl_calc_to_sql("_.total_a / _.total_b") == "total_a / total_b"
+
+    def test_bsl_all_calc_measure_ref(self):
+        """Test translating BSL _.all() calculated-measure syntax."""
+        assert bsl_calc_to_sql("_.total_distance / _.all(_.total_distance) * 100") == (
+            "(total_distance / __bsl_all(total_distance)) * 100"
+        )
+
 
 class TestBSLAdapterImport:
     """Tests for BSL adapter import functionality."""
@@ -320,7 +331,8 @@ class TestBSLAdapterImport:
         rel_names = {r.name for r in flights.relationships}
         assert "carriers" in rel_names
         assert "aircraft" in rel_names
-        assert "airports" in rel_names
+        assert "origin_airport" in rel_names
+        assert "origin_airport" in graph.models
 
         # Verify carriers join details
         carriers_rel = next(r for r in flights.relationships if r.name == "carriers")
@@ -328,10 +340,16 @@ class TestBSLAdapterImport:
         assert carriers_rel.foreign_key == "carrier"
         assert carriers_rel.primary_key == "code"
 
+        origin_rel = next(r for r in flights.relationships if r.name == "origin_airport")
+        assert origin_rel.metadata["bsl_model"] == "airports"
+        assert origin_rel.foreign_key == "origin"
+        assert origin_rel.primary_key == "code"
+
         # Verify aircraft has its own join to aircraft_models
         aircraft = graph.models["aircraft"]
         assert len(aircraft.relationships) == 1
-        assert aircraft.relationships[0].name == "aircraft_models"
+        assert aircraft.relationships[0].name == "models"
+        assert aircraft.relationships[0].metadata["bsl_model"] == "aircraft_models"
 
     def test_import_directory(self):
         """Test importing multiple files individually.
@@ -478,7 +496,7 @@ class TestBSLAdapterExportDetailed:
             with open(temp_path) as f:
                 data = yaml.safe_load(f)
 
-            measures = data["sales"]["measures"]
+            measures = data["sales"]["calculated_measures"]
 
             # Derived metric should preserve the SQL expression
             avg_order = measures["avg_order_value"]
@@ -825,6 +843,54 @@ test_model:
             model = layer.graph.models["test_model"]
             assert model.table == "test_table"
 
+    def test_auto_detect_bsl_with_model_name_containing_models(self):
+        """BSL detection should not confuse aircraft_models with native models:."""
+        import tempfile
+        from pathlib import Path
+
+        from sidemantic import SemanticLayer
+        from sidemantic.loaders import load_from_directory
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bsl_file = Path(tmpdir) / "flights.yml"
+            bsl_file.write_text("""
+aircraft_models:
+  table: aircraft_models_tbl
+  dimensions:
+    code: _.code
+  measures:
+    model_count: _.count()
+""")
+
+            layer = SemanticLayer()
+            load_from_directory(layer, tmpdir)
+
+            assert "aircraft_models" in layer.graph.models
+
+    def test_auto_detect_bsl_with_measure_name_containing_views(self):
+        """BSL detection should not confuse total_page_views with Cube views:."""
+        import tempfile
+        from pathlib import Path
+
+        from sidemantic import SemanticLayer
+        from sidemantic.loaders import load_from_directory
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bsl_file = Path(tmpdir) / "ga_sessions.yaml"
+            bsl_file.write_text("""
+ga_sessions:
+  table: ga_sample
+  dimensions:
+    visit_id: _.visitId
+  measures:
+    total_page_views: _.totals.pageviews.sum()
+""")
+
+            layer = SemanticLayer()
+            load_from_directory(layer, tmpdir)
+
+            assert "ga_sessions" in layer.graph.models
+
     def test_auto_detect_distinguishes_formats(self):
         """Test that BSL is distinguished from other YAML formats."""
         # BSL uses _.column syntax
@@ -857,6 +923,272 @@ models:
 
         # Check that BSL pattern doesn't match Sidemantic
         assert not ("_." in sidemantic_content and "dimensions:" in sidemantic_content)
+
+
+class TestBSLCurrentSyntaxSupport:
+    """Tests for current upstream BSL YAML features."""
+
+    def test_deferred_calculated_measure_compiles(self):
+        import tempfile
+        from pathlib import Path
+
+        from sidemantic.sql.generator import SQLGenerator
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write("""
+test:
+  table: events
+  dimensions:
+    category: _.category
+  measures:
+    total_a: _.a.sum()
+    total_b: _.b.sum()
+  calculated_measures:
+    ratio: _.total_a / _.total_b
+""")
+            temp_path = Path(f.name)
+
+        try:
+            graph = BSLAdapter().parse(temp_path)
+            ratio = graph.models["test"].get_metric("ratio")
+            assert ratio.type == "derived"
+            assert ratio.sql == "total_a / total_b"
+
+            sql = SQLGenerator(graph).generate(
+                metrics=["test.ratio"],
+                dimensions=["test.category"],
+                skip_default_time_dimensions=True,
+            )
+            assert "_." not in sql
+            assert "SUM(test_cte.total_a_raw)" in sql
+            assert "SUM(test_cte.total_b_raw)" in sql
+        finally:
+            temp_path.unlink(missing_ok=True)
+
+    def test_all_calculated_measure_compiles_to_window_total(self):
+        import tempfile
+        from pathlib import Path
+
+        from sidemantic.sql.generator import SQLGenerator
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write("""
+flights:
+  table: flights_tbl
+  dimensions:
+    carrier: _.carrier
+  measures:
+    total_distance: _.distance.sum()
+  calculated_measures:
+    pct_of_total: _.total_distance / _.all(_.total_distance) * 100
+""")
+            temp_path = Path(f.name)
+
+        try:
+            graph = BSLAdapter().parse(temp_path)
+            pct = graph.models["flights"].get_metric("pct_of_total")
+            assert pct.sql == "(total_distance / __bsl_all(total_distance)) * 100"
+
+            sql = SQLGenerator(graph).generate(
+                metrics=["flights.pct_of_total"],
+                dimensions=["flights.carrier"],
+                skip_default_time_dimensions=True,
+            )
+            assert "_.all" not in sql
+            assert "SUM(SUM(flights_cte.total_distance_raw)) OVER ()" in sql
+        finally:
+            temp_path.unlink(missing_ok=True)
+
+    def test_event_timestamp_derived_dimensions_metadata_and_export(self):
+        import tempfile
+        from pathlib import Path
+
+        import yaml
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write("""
+profile:
+  type: duckdb
+  database: ":memory:"
+events:
+  table: events
+  database:
+    - analytics
+    - prod
+  dimensions:
+    occurred_at:
+      expr: _.occurred_at
+      is_event_timestamp: true
+      derived_dimensions: [year, month]
+      metadata:
+        semantic_type: event_time
+  measures:
+    total_revenue:
+      expr: _.revenue.sum()
+      metadata:
+        currency: USD
+  calculated_measures:
+    pct_revenue:
+      expr: _.total_revenue / _.all(_.total_revenue) * 100
+      metadata:
+        unit: percent
+""")
+            temp_path = Path(f.name)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as export_file:
+            export_path = Path(export_file.name)
+
+        try:
+            adapter = BSLAdapter()
+            graph = adapter.parse(temp_path)
+            model = graph.models["events"]
+            assert model.metadata["bsl_profile"] == {"type": "duckdb", "database": ":memory:"}
+            assert model.metadata["bsl_database"] == ["analytics", "prod"]
+
+            occurred_at = model.get_dimension("occurred_at")
+            assert occurred_at.type == "time"
+            assert occurred_at.metadata["bsl_is_event_timestamp"] is True
+            assert occurred_at.metadata["bsl_derived_dimensions"] == ["year", "month"]
+            assert occurred_at.metadata["bsl_metadata"] == {"semantic_type": "event_time"}
+            assert model.get_dimension("occurred_at_year") is not None
+            assert model.get_dimension("occurred_at_month") is not None
+
+            total_revenue = model.get_metric("total_revenue")
+            assert total_revenue.metadata["bsl_metadata"] == {"currency": "USD"}
+
+            adapter.export(graph, export_path)
+            with open(export_path) as f:
+                exported = yaml.safe_load(f)
+
+            event_def = exported["events"]
+            assert exported["profile"] == {"type": "duckdb", "database": ":memory:"}
+            assert event_def["database"] == ["analytics", "prod"]
+            assert "occurred_at_year" not in event_def["dimensions"]
+            occurred_export = event_def["dimensions"]["occurred_at"]
+            assert occurred_export["is_event_timestamp"] is True
+            assert occurred_export["derived_dimensions"] == ["year", "month"]
+            assert occurred_export["metadata"] == {"semantic_type": "event_time"}
+            assert event_def["measures"]["total_revenue"]["metadata"] == {"currency": "USD"}
+            assert event_def["calculated_measures"]["pct_revenue"]["metadata"] == {"unit": "percent"}
+        finally:
+            temp_path.unlink(missing_ok=True)
+            export_path.unlink(missing_ok=True)
+
+    def test_join_aliases_self_join_and_how_roundtrip(self):
+        import tempfile
+        from pathlib import Path
+
+        import yaml
+
+        from sidemantic.sql.generator import SQLGenerator
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write("""
+airports:
+  table: airports
+  dimensions:
+    code: _.code
+    city: _.city
+
+flights:
+  table: flights
+  dimensions:
+    origin: _.origin
+    destination: _.destination
+  measures:
+    flight_count: _.count()
+  joins:
+    origin_airport:
+      model: airports
+      type: one
+      how: inner
+      left_on: origin
+      right_on: code
+    destination_airport:
+      model: airports
+      type: one
+      left_on: destination
+      right_on: code
+""")
+            temp_path = Path(f.name)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as export_file:
+            export_path = Path(export_file.name)
+
+        try:
+            adapter = BSLAdapter()
+            graph = adapter.parse(temp_path)
+            assert "origin_airport" in graph.models
+            assert "destination_airport" in graph.models
+
+            flights = graph.models["flights"]
+            origin_rel = flights.relationships[0]
+            assert origin_rel.name == "origin_airport"
+            assert origin_rel.metadata["bsl_model"] == "airports"
+            assert origin_rel.metadata["bsl_how"] == "inner"
+
+            sql = SQLGenerator(graph).generate(
+                metrics=["flights.flight_count"],
+                dimensions=["origin_airport.city", "destination_airport.city"],
+                skip_default_time_dimensions=True,
+            )
+            assert "origin_airport_cte" in sql
+            assert "destination_airport_cte" in sql
+            assert "INNER JOIN flights_cte" in sql
+            assert "origin_airport_cte.code = flights_cte.origin" in sql
+            assert "flights_cte.destination = destination_airport_cte.code" in sql
+
+            adapter.export(graph, export_path)
+            with open(export_path) as f:
+                exported = yaml.safe_load(f)
+            joins = exported["flights"]["joins"]
+            assert joins["origin_airport"]["model"] == "airports"
+            assert joins["origin_airport"]["how"] == "inner"
+            assert joins["destination_airport"]["model"] == "airports"
+            assert "origin_airport" not in exported
+            assert "destination_airport" not in exported
+        finally:
+            temp_path.unlink(missing_ok=True)
+            export_path.unlink(missing_ok=True)
+
+    def test_cross_join_compiles(self):
+        import tempfile
+        from pathlib import Path
+
+        from sidemantic.sql.generator import SQLGenerator
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write("""
+calendar:
+  table: calendar
+  dimensions:
+    day: _.day
+
+facts:
+  table: facts
+  dimensions:
+    id: _.id
+  measures:
+    fact_count: _.count()
+  joins:
+    calendar:
+      model: calendar
+      type: cross
+""")
+            temp_path = Path(f.name)
+
+        try:
+            graph = BSLAdapter().parse(temp_path)
+            rel = graph.models["facts"].relationships[0]
+            assert rel.type == "cross"
+            sql = SQLGenerator(graph).generate(
+                metrics=["facts.fact_count"],
+                dimensions=["calendar.day"],
+                skip_default_time_dimensions=True,
+            )
+            assert "CROSS JOIN facts_cte" in sql
+        finally:
+            temp_path.unlink(missing_ok=True)
 
 
 class TestBSLCompoundExpressions:
@@ -989,14 +1321,14 @@ class TestBSLAdapterHealthcare:
         graph = adapter.parse("tests/fixtures/bsl/healthcare.yml")
         encounters = graph.models["encounters"]
 
-        patient_rel = next(r for r in encounters.relationships if r.name == "patients")
+        patient_rel = next(r for r in encounters.relationships if r.name == "patient")
         assert patient_rel.foreign_key == "patient_id"
         assert patient_rel.type == "many_to_one"
 
-        org_rel = next(r for r in encounters.relationships if r.name == "organizations")
+        org_rel = next(r for r in encounters.relationships if r.name == "organization")
         assert org_rel.foreign_key == "organization_id"
 
-        payer_rel = next(r for r in encounters.relationships if r.name == "payers")
+        payer_rel = next(r for r in encounters.relationships if r.name == "payer")
         assert payer_rel.foreign_key == "payer_id"
 
     def test_import_healthcare_primary_key(self):
@@ -1036,7 +1368,7 @@ class TestBSLAdapterNycTaxi:
         graph = adapter.parse("tests/fixtures/bsl/nyc_taxi.yml")
         trips = graph.models["fhvhv_trips"]
 
-        pickup_rel = next(r for r in trips.relationships if r.name == "taxi_zones")
+        pickup_rel = next(r for r in trips.relationships if r.name == "pickup_zone")
         assert pickup_rel.foreign_key == "PULocationID"
 
 

--- a/tests/adapters/bsl/test_parsing.py
+++ b/tests/adapters/bsl/test_parsing.py
@@ -385,6 +385,39 @@ class TestBSLAdapterImport:
         assert "conditions" in graph5.models
         assert "medications" in graph5.models
 
+    def test_bsl_all_count_distinct_uses_global_distinct_denominator(self, tmp_path):
+        """_.all() over count_distinct should not sum grouped distinct counts."""
+        from sidemantic import SemanticLayer
+
+        bsl_file = tmp_path / "events.yml"
+        bsl_file.write_text(
+            """
+events:
+  table: events
+  dimensions:
+    event_id:
+      expr: _.event_id
+      is_entity: true
+    segment: _.segment
+  measures:
+    users: _.user_id.nunique()
+  calculated_measures:
+    user_share: _.users / _.all(_.users)
+"""
+        )
+
+        layer = SemanticLayer(connection="duckdb:///:memory:")
+        layer.graph = BSLAdapter().parse(bsl_file)
+        layer.adapter.execute("CREATE TABLE events (event_id INTEGER, segment VARCHAR, user_id INTEGER)")
+        layer.adapter.execute("INSERT INTO events VALUES (1, 'a', 1), (2, 'b', 1), (3, 'b', 2)")
+
+        result = layer.query(metrics=["events.user_share"], dimensions=["events.segment"])
+        rows = result.fetchall()
+
+        by_segment = {segment: float(user_share) for segment, user_share in rows}
+        assert by_segment["a"] == pytest.approx(0.5)
+        assert by_segment["b"] == pytest.approx(1.0)
+
 
 class TestBSLAdapterExport:
     """Tests for BSL adapter export functionality."""

--- a/tests/adapters/bsl/test_parsing.py
+++ b/tests/adapters/bsl/test_parsing.py
@@ -1083,6 +1083,60 @@ flights:
         finally:
             temp_path.unlink(missing_ok=True)
 
+    def test_qualified_calculated_measure_compiles_joined_measure(self):
+        import tempfile
+        from pathlib import Path
+
+        from sidemantic.sql.generator import SQLGenerator
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write("""
+orders:
+  table: orders
+  dimensions:
+    order_id:
+      expr: _.order_id
+      is_entity: true
+    customer_id: _.customer_id
+  measures:
+    count: _.count()
+  calculated_measures:
+    customer_order_ratio: _.customers.count / _.count
+  joins:
+    customers:
+      model: customers
+      type: one
+      left_on: customer_id
+      right_on: customer_id
+
+customers:
+  table: customers
+  dimensions:
+    customer_id:
+      expr: _.customer_id
+      is_entity: true
+  measures:
+    count: _.count()
+""")
+            temp_path = Path(f.name)
+
+        try:
+            graph = BSLAdapter().parse(temp_path)
+            metric = graph.models["orders"].get_metric("customer_order_ratio")
+            assert metric.sql == "customers.count / count"
+
+            sql = SQLGenerator(graph).generate(
+                metrics=["orders.customer_order_ratio"],
+                dimensions=["orders.customer_id"],
+                skip_default_time_dimensions=True,
+            )
+            assert "customers.(" not in sql
+            assert "JOIN customers_cte" in sql
+            assert "COUNT(customers_cte.count_raw)" in sql
+            assert "COUNT(orders_cte.count_raw)" in sql
+        finally:
+            temp_path.unlink(missing_ok=True)
+
     def test_event_timestamp_derived_dimensions_metadata_and_export(self):
         import tempfile
         from pathlib import Path

--- a/tests/adapters/bsl/test_parsing.py
+++ b/tests/adapters/bsl/test_parsing.py
@@ -1289,6 +1289,128 @@ flights:
             temp_path.unlink(missing_ok=True)
             export_path.unlink(missing_ok=True)
 
+    def test_reused_join_aliases_scope_to_source_model(self):
+        import tempfile
+        from pathlib import Path
+
+        import yaml
+
+        from sidemantic.sql.generator import SQLGenerator
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write("""
+orders:
+  table: orders
+  dimensions:
+    order_id:
+      expr: _.order_id
+      is_entity: true
+    user_id: _.user_id
+  measures:
+    count: _.count()
+  calculated_measures:
+    user_count_ratio: _.user.count / _.count
+  joins:
+    user:
+      model: customers
+      type: one
+      left_on: user_id
+      right_on: customer_id
+
+events:
+  table: events
+  dimensions:
+    event_id:
+      expr: _.event_id
+      is_entity: true
+    account_id: _.account_id
+  measures:
+    count: _.count()
+  calculated_measures:
+    user_count_ratio: _.user.count / _.count
+  joins:
+    user:
+      model: accounts
+      type: one
+      left_on: account_id
+      right_on: account_id
+
+customers:
+  table: customers
+  dimensions:
+    customer_id:
+      expr: _.customer_id
+      is_entity: true
+    name: _.name
+  measures:
+    count: _.count()
+
+accounts:
+  table: accounts
+  dimensions:
+    account_id:
+      expr: _.account_id
+      is_entity: true
+    name: _.name
+  measures:
+    count: _.count()
+""")
+            temp_path = Path(f.name)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as export_file:
+            export_path = Path(export_file.name)
+
+        try:
+            adapter = BSLAdapter()
+            graph = adapter.parse(temp_path)
+
+            assert "user" not in graph.models
+            assert "orders_user" in graph.models
+            assert "events_user" in graph.models
+            assert graph.models["orders_user"].table == "customers"
+            assert graph.models["events_user"].table == "accounts"
+
+            orders_rel = graph.models["orders"].relationships[0]
+            events_rel = graph.models["events"].relationships[0]
+            assert orders_rel.name == "orders_user"
+            assert orders_rel.metadata["bsl_alias"] == "user"
+            assert events_rel.name == "events_user"
+            assert events_rel.metadata["bsl_alias"] == "user"
+
+            orders_metric = graph.models["orders"].get_metric("user_count_ratio")
+            events_metric = graph.models["events"].get_metric("user_count_ratio")
+            assert orders_metric.sql == "orders_user.count / count"
+            assert events_metric.sql == "events_user.count / count"
+
+            orders_sql = SQLGenerator(graph).generate(
+                metrics=["orders.user_count_ratio"],
+                dimensions=["orders.order_id"],
+                skip_default_time_dimensions=True,
+            )
+            assert "JOIN orders_user_cte" in orders_sql
+            assert "events_user_cte" not in orders_sql
+            assert "FROM customers" in orders_sql
+
+            events_sql = SQLGenerator(graph).generate(
+                metrics=["events.user_count_ratio"],
+                dimensions=["events.event_id"],
+                skip_default_time_dimensions=True,
+            )
+            assert "JOIN events_user_cte" in events_sql
+            assert "orders_user_cte" not in events_sql
+            assert "FROM accounts" in events_sql
+
+            adapter.export(graph, export_path)
+            with open(export_path) as f:
+                exported = yaml.safe_load(f)
+            assert exported["orders"]["joins"]["user"]["model"] == "customers"
+            assert exported["events"]["joins"]["user"]["model"] == "accounts"
+            assert "orders_user" not in exported
+            assert "events_user" not in exported
+        finally:
+            temp_path.unlink(missing_ok=True)
+            export_path.unlink(missing_ok=True)
+
     def test_cross_join_compiles(self):
         import tempfile
         from pathlib import Path

--- a/tests/adapters/bsl/test_roundtrip.py
+++ b/tests/adapters/bsl/test_roundtrip.py
@@ -252,7 +252,8 @@ def test_bsl_flights_with_joins():
     rel_names = {r.name for r in flights.relationships}
     assert "carriers" in rel_names
     assert "aircraft" in rel_names
-    assert "airports" in rel_names
+    assert "origin_airport" in rel_names
+    assert "origin_airport" in graph1.models
 
     # Export and re-import
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
@@ -267,6 +268,7 @@ def test_bsl_flights_with_joins():
         assert len(flights2.relationships) == 3
         rel_names2 = {r.name for r in flights2.relationships}
         assert "carriers" in rel_names2
+        assert "origin_airport" in rel_names2
         carriers_rel = next(r for r in flights2.relationships if r.name == "carriers")
         assert carriers_rel.type == "many_to_one"
 
@@ -313,7 +315,7 @@ def test_healthcare_roundtrip():
         assert "encounter_class" in emergency.sql
 
         # With: joins preserved
-        patient_rel = next(r for r in encounters2.relationships if r.name == "patients")
+        patient_rel = next(r for r in encounters2.relationships if r.name == "patient")
         assert patient_rel.foreign_key == "patient_id"
 
     finally:

--- a/tests/core/test_directory_loaders.py
+++ b/tests/core/test_directory_loaders.py
@@ -101,3 +101,47 @@ FROM sales;
     assert sales.get_metric("revenue") is not None
     assert getattr(sales, "_source_format", None) == "Yardstick"
     assert getattr(sales, "_source_file", None) == "sales.sql"
+
+
+def test_load_from_directory_finalizes_bsl_join_aliases_across_files(tmp_path):
+    """BSL join aliases should work when the target model is in a separate file."""
+    (tmp_path / "flights.yml").write_text(
+        """
+flights:
+  table: flights
+  dimensions:
+    flight_id:
+      expr: _.flight_id
+      is_entity: true
+    origin: _.origin
+  measures:
+    count: _.count()
+  joins:
+    origin_airport:
+      model: airports
+      type: one
+      left_on: origin
+      right_on: code
+"""
+    )
+    (tmp_path / "airports.yml").write_text(
+        """
+airports:
+  table: airports
+  dimensions:
+    code:
+      expr: _.code
+      is_entity: true
+    name: _.name
+"""
+    )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, tmp_path)
+
+    assert "origin_airport" in layer.graph.models
+    assert layer.graph.find_relationship_path("flights", "origin_airport")
+
+    sql = layer.compile(metrics=["flights.count"], dimensions=["origin_airport.name"])
+    assert "origin_airport_cte" in sql
+    assert "origin_airport_cte.code = flights_cte.origin" in sql

--- a/tests/core/test_directory_loaders.py
+++ b/tests/core/test_directory_loaders.py
@@ -145,3 +145,84 @@ airports:
     sql = layer.compile(metrics=["flights.count"], dimensions=["origin_airport.name"])
     assert "origin_airport_cte" in sql
     assert "origin_airport_cte.code = flights_cte.origin" in sql
+
+
+def test_load_from_directory_scopes_reused_bsl_join_aliases(tmp_path):
+    """BSL join aliases are local to their source model, even across files."""
+    (tmp_path / "orders.yml").write_text(
+        """
+orders:
+  table: orders
+  dimensions:
+    order_id:
+      expr: _.order_id
+      is_entity: true
+    user_id: _.user_id
+  measures:
+    count: _.count()
+  joins:
+    user:
+      model: customers
+      type: one
+      left_on: user_id
+      right_on: customer_id
+"""
+    )
+    (tmp_path / "events.yml").write_text(
+        """
+events:
+  table: events
+  dimensions:
+    event_id:
+      expr: _.event_id
+      is_entity: true
+    account_id: _.account_id
+  measures:
+    count: _.count()
+  joins:
+    user:
+      model: accounts
+      type: one
+      left_on: account_id
+      right_on: account_id
+"""
+    )
+    (tmp_path / "customers.yml").write_text(
+        """
+customers:
+  table: customers
+  dimensions:
+    customer_id:
+      expr: _.customer_id
+      is_entity: true
+    name: _.name
+"""
+    )
+    (tmp_path / "accounts.yml").write_text(
+        """
+accounts:
+  table: accounts
+  dimensions:
+    account_id:
+      expr: _.account_id
+      is_entity: true
+    name: _.name
+"""
+    )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, tmp_path)
+
+    assert "user" not in layer.graph.models
+    assert layer.graph.models["orders_user"].table == "customers"
+    assert layer.graph.models["events_user"].table == "accounts"
+    assert layer.graph.find_relationship_path("orders", "orders_user")
+    assert layer.graph.find_relationship_path("events", "events_user")
+
+    orders_sql = layer.compile(metrics=["orders.count"], dimensions=["orders_user.name"])
+    assert "orders_user_cte" in orders_sql
+    assert "FROM customers" in orders_sql
+
+    events_sql = layer.compile(metrics=["events.count"], dimensions=["events_user.name"])
+    assert "events_user_cte" in events_sql
+    assert "FROM accounts" in events_sql


### PR DESCRIPTION
Improves Boring Semantic Layer compatibility with the current upstream examples and YAML syntax.

This fixes YAML auto-detection false positives, adds support for current calculated_measures expressions including _.all(...), preserves profile/database and metadata fields, and handles join aliases, self-joins, cross joins, and BSL join how settings in generated SQL.

The root cause was that BSL detection used substring checks and the adapter only modeled the older core YAML shape, so recent upstream examples either routed to the wrong adapter or dropped or compiled newer fields incorrectly.