### PR TITLE
Detect unversioned native metrics-only YAML files in directory loader

### DIFF
--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -351,9 +351,26 @@ def _looks_like_semantic_yaml_text(content: str) -> bool:
 
 def _looks_like_native_sidemantic_yaml(data: dict) -> bool:
     """Return True for explicit native Sidemantic YAML files without models."""
-    if not isinstance(data, dict) or data.get("version") != 1:
+    from sidemantic.adapters.sidemantic import METRIC_FIELDS, NATIVE_FORMAT_VERSION, ROOT_FIELDS
+
+    if not isinstance(data, dict):
         return False
-    return any(_yaml_has_top_level_key(data, key) for key in ("metrics", "parameters", "sql_metrics", "sql_segments"))
+    if not any(_yaml_has_top_level_key(data, key) for key in ("metrics", "parameters", "sql_metrics", "sql_segments")):
+        return False
+    if data.get("version") == NATIVE_FORMAT_VERSION:
+        return True
+    if data.get("version") is not None:
+        return False
+
+    # The version key is optional in the native format. Unversioned files count
+    # as native when their root keys match the native schema and metric entries
+    # use flat native fields (MetricFlow nests details under type_params).
+    if not set(data) <= ROOT_FIELDS:
+        return False
+    metrics = data.get("metrics") or []
+    if not isinstance(metrics, list):
+        return False
+    return all(isinstance(metric_def, dict) and set(metric_def) <= METRIC_FIELDS for metric_def in metrics)
 
 
 def _yaml_has_top_level_key(data: dict, key: str) -> bool:

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -201,6 +201,87 @@ metrics:
     assert metric.denominator == "orders.order_count"
 
 
+def test_load_from_directory_detects_unversioned_native_metrics_only_file(tmp_path):
+    """Native metrics-only files without a version key must not route to MetricFlow."""
+    (tmp_path / "models.yml").write_text(
+        """
+models:
+  - name: orders
+    table: orders
+    primary_key: id
+    metrics:
+      - name: revenue
+        agg: sum
+        sql: amount
+      - name: order_count
+        agg: count
+"""
+    )
+    (tmp_path / "metrics.yml").write_text(
+        """
+metrics:
+  - name: total_revenue
+    sql: orders.revenue
+
+  - name: completion_rate
+    type: ratio
+    numerator: orders.revenue
+    denominator: orders.order_count
+
+  - name: revenue_per_order
+    type: derived
+    sql: total_revenue / order_count
+"""
+    )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, tmp_path)
+
+    metric = layer.graph.metrics["completion_rate"]
+    assert metric._source_format == "Sidemantic"
+    assert metric.numerator == "orders.revenue"
+    assert metric.denominator == "orders.order_count"
+    assert layer.graph.metrics["total_revenue"].sql == "orders.revenue"
+    assert layer.graph.metrics["revenue_per_order"].type == "derived"
+
+
+def test_load_from_directory_loads_ecommerce_example():
+    """The ecommerce example uses unversioned native metric files and must load."""
+    examples_dir = Path(__file__).parent.parent / "examples" / "ecommerce" / "models"
+
+    layer = SemanticLayer()
+    load_from_directory(layer, examples_dir)
+
+    assert "orders" in layer.graph.models
+    metric = layer.graph.metrics["completion_rate"]
+    assert metric.numerator == "orders.completed_orders"
+    assert metric.denominator == "orders.order_count"
+
+
+def test_load_from_directory_routes_metricflow_metrics_only_file_to_metricflow(tmp_path):
+    """MetricFlow metrics files keep routing to MetricFlow via type_params."""
+    (tmp_path / "metrics.yml").write_text(
+        """
+metrics:
+  - name: revenue_per_order
+    type: ratio
+    type_params:
+      numerator:
+        name: revenue
+      denominator:
+        name: order_count
+"""
+    )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, tmp_path)
+
+    metric = layer.graph.metrics["revenue_per_order"]
+    assert metric._source_format == "MetricFlow"
+    assert metric.numerator == "revenue"
+    assert metric.denominator == "order_count"
+
+
 def test_load_from_directory_resolves_native_graph_metric_inheritance_across_files(tmp_path):
     (tmp_path / "base_metrics.yml").write_text(
         """


### PR DESCRIPTION
## Summary

`sidemantic info examples/ecommerce/models` failed with:

```
Could not parse examples/ecommerce/models/metrics.yml: 1 validation error for Metric
  Value error, ratio metric requires 'numerator' field
```

The YAML defines `numerator`/`denominator` correctly, but the directory loader's format detection misrouted the file. Native metrics-only files were only recognized as native when they carried `version: 1`; without it, the file fell through to the MetricFlow heuristic (top-level `metrics:` plus `type: ` in content). The MetricFlow adapter expects ratio numerator/denominator nested under `type_params`, found none on the flat native syntax, and built a ratio metric with `numerator=None`, failing validation.

Since the version key is optional in the native format (`validate_native_format_version` accepts a missing version), this is a loader detection bug, not stale example syntax.

## Fix

`_looks_like_native_sidemantic_yaml` now also accepts unversioned files when their root keys are a subset of the native `ROOT_FIELDS` and every metric entry uses only native `METRIC_FIELDS`. Real MetricFlow files are unaffected because their metrics nest details under `type_params`, which is not a native metric field, so they still fall through to the MetricFlow heuristic.

## Tests

- Regression test loading the real `examples/ecommerce/models` directory, asserting `completion_rate` keeps its numerator/denominator
- A tmp-path fixture mirroring the unversioned metrics-only shape (untyped, ratio, and derived metrics)
- A guard test that a `type_params`-style MetricFlow metrics file still routes to the MetricFlow adapter