### PR TITLE
Trim redundant crossfilter per-tick queries

### DIFF
--- a/sidemantic/viz.py
+++ b/sidemantic/viz.py
@@ -1436,15 +1436,24 @@ class CrossfilterPlanner:
             # Without a metric-range brush the scatter view is the current grid.
             scatter = current
         mark("scatter")
-        if preagg is not None:
+        if preagg is not None and self.chart.limit is None:
             # Interaction preaggs guarantee additive metrics, so KPI totals are a
             # rollup of the current grid we already fetched—derive, don't rescan.
             # Always emit one KPI row (NULL metrics when empty), matching the
             # aggregate-query path so the dashboard keeps stable KPI fields.
+            # Only valid when current is the full grid; a LIMIT pages it, so the
+            # derived totals would undercount—fall back to the aggregate query.
             kpis = {
                 "rows": [self._aggregate_rows(current["rows"], metric_aliases)],
                 "sql": current["sql"],
             }
+        elif preagg is not None:
+            kpis = self._aggregate_interaction_preagg(
+                [],
+                self._filter_expressions(selection, preagg=preagg),
+                metric_aliases,
+                preagg,
+            )
         else:
             kpis = self._query_chart(
                 [],

--- a/sidemantic/viz.py
+++ b/sidemantic/viz.py
@@ -1439,8 +1439,10 @@ class CrossfilterPlanner:
         if preagg is not None:
             # Interaction preaggs guarantee additive metrics, so KPI totals are a
             # rollup of the current grid we already fetched—derive, don't rescan.
+            # Always emit one KPI row (NULL metrics when empty), matching the
+            # aggregate-query path so the dashboard keeps stable KPI fields.
             kpis = {
-                "rows": [self._aggregate_rows(current["rows"], metric_aliases)] if current["rows"] else [],
+                "rows": [self._aggregate_rows(current["rows"], metric_aliases)],
                 "sql": current["sql"],
             }
         else:

--- a/sidemantic/viz.py
+++ b/sidemantic/viz.py
@@ -1425,20 +1425,24 @@ class CrossfilterPlanner:
                 limit=self.chart.limit,
             )
         mark("trend")
-        scatter = self._query_chart(
-            self.chart.dimensions,
-            self._filter_expressions(selection, ignore="metricRange", preagg=preagg),
-            preagg=preagg,
-            limit=self.chart.limit,
-        )
+        if self._selection_has(selection, "metricRange"):
+            scatter = self._query_chart(
+                self.chart.dimensions,
+                self._filter_expressions(selection, ignore="metricRange", preagg=preagg),
+                preagg=preagg,
+                limit=self.chart.limit,
+            )
+        else:
+            # Without a metric-range brush the scatter view is the current grid.
+            scatter = current
         mark("scatter")
         if preagg is not None:
-            kpis = self._aggregate_interaction_preagg(
-                [],
-                self._filter_expressions(selection, preagg=preagg),
-                metric_aliases,
-                preagg,
-            )
+            # Interaction preaggs guarantee additive metrics, so KPI totals are a
+            # rollup of the current grid we already fetched—derive, don't rescan.
+            kpis = {
+                "rows": [self._aggregate_rows(current["rows"], metric_aliases)] if current["rows"] else [],
+                "sql": current["sql"],
+            }
         else:
             kpis = self._query_chart(
                 [],
@@ -1654,6 +1658,26 @@ class CrossfilterPlanner:
         if preagg is not None:
             return selection.table_expressions(self.context, ignore=ignore)
         return selection.expressions(self.context, ignore=ignore)
+
+    def _selection_has(self, selection: CrossfilterSelection, ignore_key: str) -> bool:
+        """Whether any active filter would be dropped by ``ignore=ignore_key``."""
+        return any(_filter_ignore_key(filter_def, self.context) == ignore_key for filter_def in selection.filters)
+
+    def _aggregate_rows(self, rows: list[dict[str, Any]], metric_aliases: list[str]) -> dict[str, Any]:
+        """Roll up already-fetched grid rows to a single total per additive metric."""
+        result: dict[str, Any] = {}
+        for metric in metric_aliases:
+            agg = self.metric_aggs.get(metric)
+            values = [row[metric] for row in rows if row.get(metric) is not None]
+            if not values:
+                result[metric] = None
+            elif agg == "min":
+                result[metric] = min(values)
+            elif agg == "max":
+                result[metric] = max(values)
+            else:
+                result[metric] = sum(values)
+        return result
 
     def _query_chart(
         self,

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1219,6 +1219,21 @@ def test_crossfilter_example_supports_massive_semantic_model():
     assert response["views"]["kpis"]["order_count"] > 0
 
 
+def test_crossfilter_preagg_empty_selection_keeps_kpi_fields():
+    layer = build_layer(large_records=1_000, massive_records=3_000)
+    chart = _build_chart(layer, "orders_20m", "Revenue Performance Explorer")
+    session = chart.crossfilter(interaction_preaggregations=True)
+
+    response = session.query([DimensionEquals("region", "__no_such_region__")], event="empty-test")
+
+    assert response["diagnostics"]["used_interaction_preagg"] is True
+    kpis = response["views"]["kpis"]
+    # Deriving KPIs from an empty grid must still emit every metric field (NULL),
+    # matching the aggregate-query path so the dashboard keeps stable KPI tiles.
+    assert "order_count" in kpis
+    assert kpis["order_count"] is None
+
+
 def test_crossfilter_example_supports_extreme_semantic_model():
     layer = build_layer(large_records=1_000, extreme_records=4_000)
     chart = _build_chart(layer, "orders_100m", "Revenue Performance Explorer")

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1234,6 +1234,25 @@ def test_crossfilter_preagg_empty_selection_keeps_kpi_fields():
     assert kpis["order_count"] is None
 
 
+def test_crossfilter_preagg_kpis_total_full_grid_despite_limit():
+    layer = _build_layer()
+    metrics = ["orders.revenue", "orders.order_count"]
+    by = ["orders.created_at__month", "orders.region"]
+    limited = layer.chart(metrics, by=by, limit=1).crossfilter(interaction_preaggregations=True)
+    unlimited = layer.chart(metrics, by=by).crossfilter(interaction_preaggregations=True)
+
+    # North spans two month groups; a filter + event makes the session build the preagg.
+    selection = [DimensionEquals("region", "North")]
+    limited_resp = limited.query(selection, event="limit-test")
+    unlimited_resp = unlimited.query(selection, event="limit-test")
+
+    assert limited_resp["diagnostics"]["used_interaction_preagg"] is True
+    # LIMIT pages `current` to one group, but KPI totals must still reflect the
+    # full filtered grid, not the single returned page.
+    assert len(limited_resp["views"]["table"]) == 1
+    assert limited_resp["views"]["kpis"]["order_count"] == unlimited_resp["views"]["kpis"]["order_count"] == 2
+
+
 def test_crossfilter_example_supports_extreme_semantic_model():
     layer = build_layer(large_records=1_000, extreme_records=4_000)
     chart = _build_chart(layer, "orders_100m", "Revenue Performance Explorer")


### PR DESCRIPTION
Follow-up to #188.

`CrossfilterPlanner.query` recomputed every panel on each interaction tick, even when the result was already in hand. Two redundant queries removed (no behavior change — every panel returns the same numbers):

- **scatter** — identical to the `current` grid unless a metric-range brush is active. Reuse `current` in that case instead of re-querying.
- **kpis** — with interaction preaggs the additive-metric guard means the KPI totals are a rollup of the `current` grid we already fetched, so they're derived in Python instead of a second scan of the preagg table. The non-preagg path keeps its SQL query so non-additive aggregates (e.g. `avg`) stay correct.

For the 5-dimension example explorer, a typical brush tick (no metric brush, preagg on) drops from 8 serial queries to 6.

Full suite green (4419 passed), ruff lint/format clean.

Not included: collapsing the remaining `current` + `trend` + N `bars` into a single `GROUPING SETS` scan per filter-set — a larger, dialect-sensitive change left as a potential follow-up.