### PR TITLE
feat(tableau): support extended relation types, semantic-layer attrs, spatial datatype

### DIFF
--- a/sidemantic/adapters/tableau.py
+++ b/sidemantic/adapters/tableau.py
@@ -594,7 +594,10 @@ _SET_OPERATION_RELATIONS: set[str] = {"union", "batch-union"}
 
 # Derived/wrapper relations that transform or wrap a single child relation
 # (or raw SQL) rather than referencing a base table directly:
-#   - pivot:           reshapes columns of its child relation
+#   - pivot:           reshapes columns of its child relation (top-level pivots
+#                      are emitted as synthesized UNPIVOT SQL; see
+#                      _build_pivot_sql. Listed here so a pivot nested inside a
+#                      join/union tree still resolves to its child's grain.)
 #   - subquery:        wraps SQL as a derived subquery (like "text")
 #   - stored-proc:     references a stored procedure as a relation
 #   - project:         column projection over a child relation
@@ -615,6 +618,40 @@ def _iter_child_relations(relation_elem: ET.Element) -> list[ET.Element]:
     return [child for child in relation_elem if _is_relation_tag(child.tag)]
 
 
+def _local_tag(tag: str) -> str:
+    """Return the local part of a possibly namespace-prefixed XML tag."""
+    local = tag
+    for sep in ("}", ":"):
+        if sep in local:
+            local = local.rsplit(sep, 1)[-1]
+    return local
+
+
+def _extract_pivot_source_columns(relation_elem: ET.Element) -> list[str]:
+    """Collect the wide source columns a <relation type="pivot"> unpivots.
+
+    Tableau stores the source (wide) columns being unpivoted as ``<map source=.../>``
+    children (either directly under the pivot relation or nested inside each
+    ``<pivot-column>`` element). Returns the de-duplicated, normalized column
+    names in document order. Returns an empty list when no source columns are
+    declared (older / minimal datasources), in which case UNPIVOT SQL cannot be
+    synthesized.
+    """
+    sources: list[str] = []
+    seen: set[str] = set()
+    for elem in relation_elem.iter():
+        if _local_tag(elem.tag) != "map":
+            continue
+        source = elem.get("source")
+        if not source:
+            continue
+        name = _normalize_column_name(source)
+        if name and name not in seen:
+            seen.add(name)
+            sources.append(name)
+    return sources
+
+
 def _strip_derived_alias(expr: str) -> str:
     """Strip a trailing "AS <alias>" from a parenthesized derived-table expression.
 
@@ -630,17 +667,36 @@ def _strip_derived_alias(expr: str) -> str:
     text = expr.strip()
     if not text.startswith("("):
         return expr
-    # Find the parenthesis that closes the leading "(".
+    # Find the parenthesis that closes the leading "(", skipping parentheses that
+    # appear inside SQL string literals ('...') and quoted identifiers ("...").
+    # Without this, a body like ``SELECT ')' AS amount`` would terminate the scan
+    # early and leave the outer alias attached.
     depth = 0
     close_idx = -1
-    for i, ch in enumerate(text):
-        if ch == "(":
+    quote: str | None = None
+    i = 0
+    length = len(text)
+    while i < length:
+        ch = text[i]
+        if quote is not None:
+            if ch == quote:
+                # Two consecutive quote chars are an escaped quote, not a close.
+                if i + 1 < length and text[i + 1] == quote:
+                    i += 2
+                    continue
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+        elif ch == "(":
             depth += 1
         elif ch == ")":
             depth -= 1
             if depth == 0:
                 close_idx = i
                 break
+        i += 1
     if close_idx == -1:
         return expr
     remainder = text[close_idx + 1 :].lstrip()
@@ -995,8 +1051,21 @@ class TableauAdapter(BaseAdapter):
                         # derived SQL, not a bare table reference, so store them as
                         # model.sql; the generator wraps model.sql as "(<sql>) AS t".
                         sql = union_sql
+                elif rel_type == "pivot":
+                    # Pivot reshapes wide source columns into "Pivot Field Names"/
+                    # "Pivot Field Values" outputs. Synthesize UNPIVOT derived SQL
+                    # so the model queries those output columns rather than the raw
+                    # child table where they do not exist.
+                    pivot_sql = self._build_pivot_sql(relation)
+                    if pivot_sql:
+                        sql = pivot_sql
+                    else:
+                        # Source columns not declared: fall back to the wrapped
+                        # child table (best effort for minimal datasources).
+                        base_table, _ = self._parse_relation_tree(relation)
+                        table = base_table
                 elif rel_type in _WRAPPER_RELATIONS:
-                    # pivot / subquery / stored-proc / project / text-transform:
+                    # subquery / stored-proc / project / text-transform:
                     # derived relations that wrap a child relation or raw SQL.
                     base_table, joins = self._parse_relation_tree(relation)
                     if joins:
@@ -1785,6 +1854,55 @@ class TableauAdapter(BaseAdapter):
             return selects[0] if selects else None
 
         return "\nUNION ALL\n".join(selects)
+
+    def _build_pivot_sql(self, relation_elem: ET.Element) -> str | None:
+        """Synthesize UNPIVOT SQL for a <relation type="pivot"> element.
+
+        A Tableau pivot reshapes a set of wide source columns into two output
+        columns: a name column (default "Pivot Field Names") and a value column
+        (default "Pivot Field Values"). Resolving such a relation to its raw
+        child table is wrong: the imported fields are the pivot outputs, which do
+        not exist on the wide source table. We emit a DuckDB UNPIVOT derived
+        query so the generated SQL selects the pivot output columns from a source
+        that actually produces them.
+
+        Returns ``None`` when the wrapped child table or the wide source columns
+        cannot be determined, so the caller can fall back to its prior behavior.
+        """
+        children = _iter_child_relations(relation_elem)
+        if not children:
+            return None
+        child_table, child_joins = self._parse_relation_tree(children[0])
+        # UNPIVOT needs a single concrete FROM source, not a joined/derived tree.
+        if not child_table or child_joins or child_table.startswith("(") or " " in child_table:
+            return None
+
+        source_columns = _extract_pivot_source_columns(relation_elem)
+        if not source_columns:
+            return None
+
+        # Default to Tableau's standard pivot output column names; override from
+        # <pivot-column> declarations when present so a renamed pivot still maps.
+        name_col = "Pivot Field Names"
+        value_col = "Pivot Field Values"
+        pivot_outputs = [
+            _normalize_column_name(elem.get("name", ""))
+            for elem in relation_elem
+            if _local_tag(elem.tag) == "pivot-column" and elem.get("name")
+        ]
+        for output in pivot_outputs:
+            lowered = output.lower()
+            if "name" in lowered:
+                name_col = output
+            elif "value" in lowered:
+                value_col = output
+
+        on_cols = ", ".join(_quote_sql_identifier(col) for col in source_columns)
+        return (
+            f"SELECT * FROM (UNPIVOT {_quote_table_reference(child_table)} "
+            f"ON {on_cols} "
+            f"INTO NAME {_quote_sql_identifier(name_col)} VALUE {_quote_sql_identifier(value_col)})"
+        )
 
     def _extract_relationships(self, joins: list[_JoinInfo]) -> list[Relationship]:
         """Extract Relationship objects from parsed joins."""

--- a/sidemantic/adapters/tableau.py
+++ b/sidemantic/adapters/tableau.py
@@ -23,6 +23,9 @@ _DATATYPE_MAP: dict[str, str] = {
     "date": "time",
     "datetime": "time",
     "boolean": "boolean",
+    # Geospatial columns (Tableau's TABLEAU.TABGEOGRAPHY); treated as
+    # categorical since they group/filter rather than aggregate numerically.
+    "spatial": "categorical",
 }
 
 _DATATYPE_GRANULARITY: dict[str, str] = {
@@ -583,12 +586,33 @@ def _normalize_column_name(name: str) -> str:
     return stripped
 
 
+# --- Relation type groupings ---
+# Physical-layer set operations: members are stacked vertically (UNION ALL).
+# "union" is an explicit multi-table union; "batch-union" is a wildcard/pattern
+# union over many same-shaped tables. Both expose the same nested-relation shape.
+_SET_OPERATION_RELATIONS: set[str] = {"union", "batch-union"}
+
+# Derived/wrapper relations that transform or wrap a single child relation
+# (or raw SQL) rather than referencing a base table directly:
+#   - pivot:           reshapes columns of its child relation
+#   - subquery:        wraps SQL as a derived subquery (like "text")
+#   - stored-proc:     references a stored procedure as a relation
+#   - project:         column projection over a child relation
+#   - text-transform:  applies a text/parse transform over a child relation
+_WRAPPER_RELATIONS: set[str] = {"pivot", "subquery", "stored-proc", "project", "text-transform"}
+
+
 def _extract_table_name(relation_elem: ET.Element) -> str | None:
     """Extract qualified table name from a <relation type="table"> element."""
     table_attr = relation_elem.get("table")
     if table_attr:
         return _strip_brackets(table_attr)
     return None
+
+
+def _iter_child_relations(relation_elem: ET.Element) -> list[ET.Element]:
+    """Return direct child <relation> elements, tolerating namespaced tags."""
+    return [child for child in relation_elem if _is_relation_tag(child.tag)]
 
 
 # Namespace prefixes commonly used in Tableau XML files
@@ -645,6 +669,27 @@ def _is_object_graph_tag(tag: str) -> bool:
     if tag.endswith("}object-graph"):
         return True
     return tag.endswith("object-graph") and ("." in tag or ":" in tag)
+
+
+def _get_attr_local(elem: ET.Element, local_name: str) -> str | None:
+    """Read an attribute by its local name, tolerating namespace prefixes.
+
+    Tableau Semantics attributes (semantic-layer, is-legacy) may appear plain or
+    with a namespace prefix that _parse_tableau_xml rewrites to an underscored
+    form (e.g. "ns_is-legacy"). Match the plain name first, then any attribute
+    whose local part (after '}', ':' or '_') equals ``local_name``.
+    """
+    value = elem.get(local_name)
+    if value is not None:
+        return value
+    for key, val in elem.attrib.items():
+        candidate = key
+        for sep in ("}", ":"):
+            if sep in candidate:
+                candidate = candidate.rsplit(sep, 1)[-1]
+        if candidate == local_name or candidate.endswith("_" + local_name):
+            return val
+    return None
 
 
 def _find_relation_element(connection: ET.Element) -> ET.Element | None:
@@ -752,6 +797,12 @@ class _ObjectGraphInfo:
 
     relationships: list[Relationship]
     joins: list[_ObjectGraphJoin]
+    # Tableau Semantics-layer attributes read from the <object-graph> element:
+    #   semantic_layer -> value of the "semantic-layer" attribute (e.g. "true")
+    #   is_legacy      -> value of the "is-legacy" attribute (e.g. "false")
+    # None when the attribute is absent (older / non-semantic datasources).
+    semantic_layer: str | None = None
+    is_legacy: str | None = None
 
 
 def _quote_sql_identifier(identifier: str) -> str:
@@ -900,6 +951,26 @@ class TableauAdapter(BaseAdapter):
                 elif rel_type == "collection":
                     collection_info = self._parse_collection(relation)
                     table = collection_info.base_table_qualified
+                elif rel_type in _SET_OPERATION_RELATIONS:
+                    # union / batch-union: stack member relations with UNION ALL
+                    union_sql = self._build_union_sql(relation)
+                    if union_sql and "UNION ALL" in union_sql:
+                        sql = union_sql
+                    elif union_sql:
+                        # Single member resolved to a bare table reference.
+                        table = union_sql
+                elif rel_type in _WRAPPER_RELATIONS:
+                    # pivot / subquery / stored-proc / project / text-transform:
+                    # derived relations that wrap a child relation or raw SQL.
+                    base_table, joins = self._parse_relation_tree(relation)
+                    if joins:
+                        sql = self._build_join_sql(base_table, joins)
+                        relationships = self._extract_relationships(joins)
+                    elif base_table is not None and (base_table.startswith("(") or " " in base_table):
+                        # Returned a subquery/derived expression -> use as SQL.
+                        sql = base_table
+                    else:
+                        table = base_table
 
         # Build metadata lookup from <metadata-records> before object-graph parsing so
         # collection sources can build a projected joined SQL model.
@@ -951,6 +1022,17 @@ class TableauAdapter(BaseAdapter):
             )
             primary_key = "__tableau_pk"
 
+        # Surface Tableau Semantics-layer attributes (semantic-layer / is-legacy)
+        # from the object-graph as model metadata so downstream consumers can
+        # distinguish modern semantic models from legacy object models.
+        model_metadata: dict | None = None
+        if object_graph.semantic_layer is not None or object_graph.is_legacy is not None:
+            model_metadata = {}
+            if object_graph.semantic_layer is not None:
+                model_metadata["tableau_semantic_layer"] = object_graph.semantic_layer
+            if object_graph.is_legacy is not None:
+                model_metadata["tableau_is_legacy"] = object_graph.is_legacy
+
         model = Model(
             name=name,
             table=table,
@@ -960,6 +1042,7 @@ class TableauAdapter(BaseAdapter):
             metrics=metrics,
             relationships=relationships,
             segments=segments,
+            metadata=model_metadata,
         )
 
         return model
@@ -1252,6 +1335,12 @@ class TableauAdapter(BaseAdapter):
         if og_elem is None:
             return _ObjectGraphInfo(relationships=[], joins=[])
 
+        # Read Tableau Semantics-layer attributes from the <object-graph> element.
+        # Newer "Tableau Semantics" datasources tag the object-graph with
+        # semantic-layer / is-legacy attributes describing the modeling layer.
+        semantic_layer = _get_attr_local(og_elem, "semantic-layer")
+        is_legacy = _get_attr_local(og_elem, "is-legacy")
+
         # Build object-id -> table-name map from <objects>
         obj_map: dict[str, str] = {}
         objects_elem = og_elem.find("objects")
@@ -1267,7 +1356,12 @@ class TableauAdapter(BaseAdapter):
         joins: list[_ObjectGraphJoin] = []
         rels_elem = og_elem.find("relationships")
         if rels_elem is None:
-            return _ObjectGraphInfo(relationships=[], joins=[])
+            return _ObjectGraphInfo(
+                relationships=[],
+                joins=[],
+                semantic_layer=semantic_layer,
+                is_legacy=is_legacy,
+            )
 
         for rel in rels_elem.findall("relationship"):
             # Extract join columns from expression
@@ -1308,7 +1402,12 @@ class TableauAdapter(BaseAdapter):
                     )
                 )
 
-        return _ObjectGraphInfo(relationships=relationships, joins=joins)
+        return _ObjectGraphInfo(
+            relationships=relationships,
+            joins=joins,
+            semantic_layer=semantic_layer,
+            is_legacy=is_legacy,
+        )
 
     def _build_collection_field_sources(self, metadata_lookup: dict[str, dict]) -> dict[str, tuple[str, str]]:
         """Map semantic field names to logical table + physical column sources."""
@@ -1521,14 +1620,43 @@ class TableauAdapter(BaseAdapter):
             table_name = _extract_table_name(relation_elem)
             return (table_name, [])
 
-        if rel_type == "text":
-            # Custom SQL: wrap as subquery with quoted alias
+        if rel_type in ("text", "subquery"):
+            # Custom SQL / subquery: wrap as a derived subquery with quoted alias.
             name = relation_elem.get("name", "")
             sql_body = (relation_elem.text or "").strip()
             if sql_body and name:
                 quoted_name = f'"{name}"' if " " in name or "(" in name else name
                 return (f"({sql_body}) AS {quoted_name}", [])
             return (name or sql_body, [])
+
+        if rel_type == "stored-proc":
+            # Stored procedure: cannot be joined/unioned. Reference its actual
+            # name when available, otherwise fall back to the relation name.
+            sp_name = relation_elem.get("stored-proc") or relation_elem.get("name")
+            actual = relation_elem.find("actual-name")
+            if actual is not None and actual.text:
+                sp_name = actual.text
+            return (_strip_brackets(sp_name) if sp_name else None, [])
+
+        if rel_type in _SET_OPERATION_RELATIONS:
+            # union / batch-union nested in a relation tree: build a subquery.
+            union_sql = self._build_union_sql(relation_elem)
+            if union_sql:
+                name = relation_elem.get("name", "")
+                quoted_name = f'"{name}"' if name and (" " in name or "(" in name) else name
+                alias = f" AS {quoted_name}" if quoted_name else ""
+                return (f"({union_sql}){alias}", [])
+            return (None, [])
+
+        if rel_type in _WRAPPER_RELATIONS:
+            # pivot / project / text-transform wrap a single child relation.
+            # The transform reshapes columns but keeps a single table grain, so
+            # resolve to the wrapped child's base table/SQL.
+            children = _iter_child_relations(relation_elem)
+            if children:
+                return self._parse_relation_tree(children[0])
+            # No nested relation: fall back to a referenced table if present.
+            return (_extract_table_name(relation_elem), [])
 
         if rel_type != "join":
             return (None, [])
@@ -1595,6 +1723,30 @@ class TableauAdapter(BaseAdapter):
             parts.append(f"ON {' AND '.join(on_clauses)}")
 
         return "\n".join(parts)
+
+    def _build_union_sql(self, relation_elem: ET.Element) -> str | None:
+        """Build UNION ALL SQL for a <relation type="union"/"batch-union"> element.
+
+        Tableau unions stack same-shaped member relations vertically. Each member
+        is a nested <relation> (typically type="table", but possibly custom SQL or
+        another derived relation). We resolve each member to a FROM source and
+        combine them with UNION ALL (Tableau unions keep duplicate rows).
+        """
+        members = _iter_child_relations(relation_elem)
+        selects: list[str] = []
+        for member in members:
+            source, joins = self._parse_relation_tree(member)
+            # Only flat sources (no nested joins) are valid union members.
+            if not source or joins:
+                continue
+            selects.append(f"SELECT * FROM {source}")
+
+        if len(selects) < 2:
+            # A union needs at least two members to be meaningful; otherwise let
+            # the caller fall back to treating it as a single table.
+            return selects[0] if selects else None
+
+        return "\nUNION ALL\n".join(selects)
 
     def _extract_relationships(self, joins: list[_JoinInfo]) -> list[Relationship]:
         """Extract Relationship objects from parsed joins."""

--- a/sidemantic/adapters/tableau.py
+++ b/sidemantic/adapters/tableau.py
@@ -615,6 +615,41 @@ def _iter_child_relations(relation_elem: ET.Element) -> list[ET.Element]:
     return [child for child in relation_elem if _is_relation_tag(child.tag)]
 
 
+def _strip_derived_alias(expr: str) -> str:
+    """Strip a trailing "AS <alias>" from a parenthesized derived-table expression.
+
+    ``_parse_relation_tree`` returns subquery/custom-SQL/union sources wrapped as
+    ``(<select>) AS <alias>``. When such an expression is stored on ``model.sql``,
+    the SQL generator re-wraps it as ``(<model.sql>) AS t``, which would produce an
+    invalid double-aliased derived table like ``((<select>) AS x) AS t``. Strip the
+    outer alias so the generator supplies the single alias it expects.
+
+    Only the outer ``(<body>) AS <alias>`` shape is unwrapped; any other expression
+    is returned unchanged.
+    """
+    text = expr.strip()
+    if not text.startswith("("):
+        return expr
+    # Find the parenthesis that closes the leading "(".
+    depth = 0
+    close_idx = -1
+    for i, ch in enumerate(text):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                close_idx = i
+                break
+    if close_idx == -1:
+        return expr
+    remainder = text[close_idx + 1 :].lstrip()
+    if remainder[:3].upper() == "AS " or remainder.upper() == "AS":
+        # "(<body>) AS <alias>" -> "(<body>)"; generator adds its own alias.
+        return text[: close_idx + 1]
+    return expr
+
+
 # Namespace prefixes commonly used in Tableau XML files
 _TABLEAU_NS_PREFIXES = [
     "user",
@@ -954,11 +989,12 @@ class TableauAdapter(BaseAdapter):
                 elif rel_type in _SET_OPERATION_RELATIONS:
                     # union / batch-union: stack member relations with UNION ALL
                     union_sql = self._build_union_sql(relation)
-                    if union_sql and "UNION ALL" in union_sql:
+                    if union_sql:
+                        # Either a multi-member UNION ALL or a single member that
+                        # resolved to a "SELECT * FROM <source>" select. Both are
+                        # derived SQL, not a bare table reference, so store them as
+                        # model.sql; the generator wraps model.sql as "(<sql>) AS t".
                         sql = union_sql
-                    elif union_sql:
-                        # Single member resolved to a bare table reference.
-                        table = union_sql
                 elif rel_type in _WRAPPER_RELATIONS:
                     # pivot / subquery / stored-proc / project / text-transform:
                     # derived relations that wrap a child relation or raw SQL.
@@ -968,7 +1004,9 @@ class TableauAdapter(BaseAdapter):
                         relationships = self._extract_relationships(joins)
                     elif base_table is not None and (base_table.startswith("(") or " " in base_table):
                         # Returned a subquery/derived expression -> use as SQL.
-                        sql = base_table
+                        # Strip any outer "AS <alias>" so the generator's own
+                        # "(<sql>) AS t" wrapping does not double-alias it.
+                        sql = _strip_derived_alias(base_table)
                     else:
                         table = base_table
 

--- a/tests/adapters/tableau/test_parsing.py
+++ b/tests/adapters/tableau/test_parsing.py
@@ -432,3 +432,113 @@ def test_empty_datasource(adapter, tmp_path):
     empty_tds.write_text("<?xml version='1.0' encoding='utf-8' ?>\n<datasource version='18.1' />\n")
     graph = adapter.parse(empty_tds)
     assert len(graph.models) == 0
+
+
+# =============================================================================
+# DERIVED RELATION SOURCES (union / subquery)
+# =============================================================================
+
+_MEASURE_COL = (
+    '<column caption="Amount" name="[amount]" datatype="real" role="measure" type="quantitative" aggregation="Sum" />'
+)
+
+
+def _compiles_to_valid_duckdb_sql(model) -> str:
+    """Compile a single measure for the model and assert DuckDB accepts the SQL."""
+    import duckdb
+
+    sl = SemanticLayer()
+    sl.add_model(model)
+    measure = model.metrics[0].name
+    sql = sl.compile(metrics=[f"{model.name}.{measure}"])
+
+    con = duckdb.connect()
+    try:
+        con.execute("EXPLAIN " + sql)
+    except duckdb.Error as exc:  # pragma: no cover - failure path
+        message = str(exc).splitlines()[0]
+        # A missing table is fine (fixtures reference uncreated tables); only a
+        # syntax/parser error means we generated invalid FROM-clause SQL.
+        if "does not exist" not in message and "Catalog Error" not in message:
+            raise AssertionError(f"DuckDB rejected generated SQL:\n{sql}\n--> {message}") from exc
+    return sql
+
+
+def test_single_member_union_is_derived_sql(adapter, tmp_path):
+    """A union with a single usable member must produce derived SQL, not a bare
+    "SELECT * FROM <source>" stored on model.table (which would emit
+    "FROM SELECT * FROM ...")."""
+    tds = tmp_path / "single_union.tds"
+    tds.write_text(
+        f"""<?xml version='1.0' encoding='utf-8' ?>
+<datasource formatted-name='single_union' inline='true' version='18.1'>
+  <connection class='federated'>
+    <relation type='union' name='MyUnion'>
+      <relation type='table' name='t1' table='[public].[orders]' />
+    </relation>
+  </connection>
+  {_MEASURE_COL}
+</datasource>"""
+    )
+
+    graph = adapter.parse(tds)
+    model = graph.models["single_union"]
+
+    # Must be stored as derived SQL, never as a bare-SELECT "table".
+    assert model.table is None
+    assert model.sql == "SELECT * FROM public.orders"
+
+    sql = _compiles_to_valid_duckdb_sql(model)
+    assert "FROM (SELECT * FROM public.orders) AS t" in sql
+
+
+def test_multi_member_union_builds_union_all(adapter, tmp_path):
+    """A union with multiple members stacks them with UNION ALL as derived SQL."""
+    tds = tmp_path / "multi_union.tds"
+    tds.write_text(
+        f"""<?xml version='1.0' encoding='utf-8' ?>
+<datasource formatted-name='multi_union' inline='true' version='18.1'>
+  <connection class='federated'>
+    <relation type='union' name='MyUnion'>
+      <relation type='table' name='t1' table='[public].[orders_2020]' />
+      <relation type='table' name='t2' table='[public].[orders_2021]' />
+    </relation>
+  </connection>
+  {_MEASURE_COL}
+</datasource>"""
+    )
+
+    graph = adapter.parse(tds)
+    model = graph.models["multi_union"]
+
+    assert model.table is None
+    assert model.sql is not None
+    assert "UNION ALL" in model.sql
+
+    _compiles_to_valid_duckdb_sql(model)
+
+
+def test_top_level_subquery_relation_not_double_aliased(adapter, tmp_path):
+    """A top-level type='subquery' relation stores raw SELECT SQL; the generator's
+    own "(<sql>) AS t" wrapping must not produce a double-aliased derived table."""
+    tds = tmp_path / "subquery.tds"
+    tds.write_text(
+        f"""<?xml version='1.0' encoding='utf-8' ?>
+<datasource formatted-name='subquery_ds' inline='true' version='18.1'>
+  <connection class='federated'>
+    <relation type='subquery' name='Active Users'>SELECT * FROM users WHERE active = 1</relation>
+  </connection>
+  {_MEASURE_COL}
+</datasource>"""
+    )
+
+    graph = adapter.parse(tds)
+    model = graph.models["subquery_ds"]
+
+    assert model.table is None
+    assert model.sql is not None
+    # Outer "AS <alias>" must have been stripped so the generator can add "AS t".
+    assert not model.sql.rstrip().endswith('AS "Active Users"')
+
+    sql = _compiles_to_valid_duckdb_sql(model)
+    assert 'AS "Active Users"' not in sql

--- a/tests/adapters/tableau/test_parsing.py
+++ b/tests/adapters/tableau/test_parsing.py
@@ -542,3 +542,32 @@ def test_top_level_subquery_relation_not_double_aliased(adapter, tmp_path):
 
     sql = _compiles_to_valid_duckdb_sql(model)
     assert 'AS "Active Users"' not in sql
+
+
+def test_subquery_with_paren_in_string_literal_strips_alias(adapter, tmp_path):
+    """A subquery whose SELECT contains a ")" inside a SQL string literal must
+    still have its outer "AS <alias>" stripped. The alias-stripping paren scan
+    must skip quoted strings, otherwise the literal ")" ends the scan early and
+    leaves "(...) AS <alias>" double-aliased by the generator."""
+    tds = tmp_path / "paren_literal.tds"
+    tds.write_text(
+        f"""<?xml version='1.0' encoding='utf-8' ?>
+<datasource formatted-name='paren_ds' inline='true' version='18.1'>
+  <connection class='federated'>
+    <relation type='subquery' name='Weird'>SELECT 1 AS amount, ')' AS marker</relation>
+  </connection>
+  {_MEASURE_COL}
+</datasource>"""
+    )
+
+    graph = adapter.parse(tds)
+    model = graph.models["paren_ds"]
+
+    assert model.table is None
+    assert model.sql is not None
+    # The ")" literal must not have truncated alias stripping.
+    assert not model.sql.rstrip().endswith('AS "Weird"')
+    assert "')'" in model.sql
+
+    sql = _compiles_to_valid_duckdb_sql(model)
+    assert 'AS "Weird"' not in sql

--- a/tests/adapters/tableau/test_relation_types.py
+++ b/tests/adapters/tableau/test_relation_types.py
@@ -1,0 +1,174 @@
+"""Tests for Tableau adapter handling of extended relation types and attributes.
+
+Covers physical-layer relation types beyond table/join/text/collection
+(union, batch-union, pivot, subquery, stored-proc, project, text-transform),
+the Tableau Semantics object-graph semantic-layer / is-legacy attributes, and
+the spatial datatype mapping.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from sidemantic.adapters.tableau import TableauAdapter
+
+FIXTURES = Path(__file__).parent.parent.parent / "fixtures" / "tableau"
+
+
+@pytest.fixture
+def adapter():
+    return TableauAdapter()
+
+
+# =============================================================================
+# SET-OPERATION RELATIONS: union / batch-union
+# =============================================================================
+
+
+def test_union_relation_builds_union_all_sql(adapter):
+    """union.tds: a union relation stacks members with UNION ALL."""
+    graph = adapter.parse(FIXTURES / "union.tds")
+
+    assert "union_sales" in graph.models
+    model = graph.models["union_sales"]
+
+    assert model.table is None
+    assert model.sql is not None
+    assert "UNION ALL" in model.sql
+    assert "public.sales_2023" in model.sql
+    assert "public.sales_2024" in model.sql
+
+    # Columns still imported
+    assert model.get_dimension("region") is not None
+    assert model.get_metric("amount") is not None
+
+
+def test_batch_union_relation_builds_union_all_sql(adapter):
+    """batch_union.tds: a batch-union (wildcard) relation also unions members."""
+    graph = adapter.parse(FIXTURES / "batch_union.tds")
+
+    assert "monthly_logs" in graph.models
+    model = graph.models["monthly_logs"]
+
+    assert model.table is None
+    assert model.sql is not None
+    # Three members -> two UNION ALL separators
+    assert model.sql.count("UNION ALL") == 2
+    assert "jan.csv" in model.sql
+    assert "feb.csv" in model.sql
+    assert "mar.csv" in model.sql
+
+
+# =============================================================================
+# WRAPPER RELATIONS: subquery / stored-proc / pivot / project / text-transform
+# =============================================================================
+
+
+def test_subquery_relation_becomes_derived_sql(adapter):
+    """subquery.tds: a subquery relation wraps its SQL as a derived source."""
+    graph = adapter.parse(FIXTURES / "subquery.tds")
+
+    assert "active_users" in graph.models
+    model = graph.models["active_users"]
+
+    assert model.sql is not None
+    assert "SELECT * FROM users WHERE active = true" in model.sql
+    assert model.get_dimension("user_id") is not None
+
+
+def test_stored_proc_relation_resolves_actual_name(adapter):
+    """spatial_proc.tds: a stored-proc relation resolves to its actual name."""
+    graph = adapter.parse(FIXTURES / "spatial_proc.tds")
+
+    assert "store_locations" in graph.models
+    model = graph.models["store_locations"]
+
+    # Stored procedures can't be joined/unioned; we resolve to the proc name.
+    assert model.table == "dbo.get_store_locations"
+
+
+def test_pivot_relation_resolves_to_child_table(adapter):
+    """pivot.tds: a pivot relation resolves to its wrapped child table."""
+    graph = adapter.parse(FIXTURES / "pivot.tds")
+
+    assert "pivoted_sales" in graph.models
+    model = graph.models["pivoted_sales"]
+
+    assert model.table == "sales_wide$"
+    # Pivot output columns still imported
+    assert model.get_dimension("Pivot Field Names") is not None
+    assert model.get_metric("Pivot Field Values") is not None
+
+
+def test_project_relation_resolves_to_child_table(adapter):
+    """project.tds: a project relation resolves to its wrapped child table."""
+    graph = adapter.parse(FIXTURES / "project.tds")
+
+    assert "projected_orders" in graph.models
+    model = graph.models["projected_orders"]
+
+    assert model.table == "public.orders"
+
+
+def test_text_transform_relation_resolves_to_child_table(adapter):
+    """text_transform.tds: a text-transform relation resolves to its child."""
+    graph = adapter.parse(FIXTURES / "text_transform.tds")
+
+    assert "parsed_logs" in graph.models
+    model = graph.models["parsed_logs"]
+
+    assert model.table == "raw_logs.txt"
+
+
+# =============================================================================
+# SPATIAL DATATYPE
+# =============================================================================
+
+
+def test_spatial_datatype_maps_to_categorical(adapter):
+    """spatial_proc.tds: spatial datatype columns map to categorical dimensions."""
+    graph = adapter.parse(FIXTURES / "spatial_proc.tds")
+    model = graph.models["store_locations"]
+
+    geometry = model.get_dimension("geometry")
+    assert geometry is not None
+    assert geometry.type == "categorical"
+
+
+# =============================================================================
+# TABLEAU SEMANTICS: object-graph semantic-layer / is-legacy attributes
+# =============================================================================
+
+
+def test_object_graph_semantic_layer_attributes_captured(adapter):
+    """semantic_layer.tds: semantic-layer / is-legacy attributes -> model metadata."""
+    graph = adapter.parse(FIXTURES / "semantic_layer.tds")
+
+    assert "semantic_model" in graph.models
+    model = graph.models["semantic_model"]
+
+    assert model.metadata is not None
+    assert model.metadata.get("tableau_semantic_layer") == "true"
+    assert model.metadata.get("tableau_is_legacy") == "false"
+
+    # Relationships still extracted from the object-graph.
+    assert len(model.relationships) == 1
+    assert model.relationships[0].name == "Customers"
+
+
+def test_legacy_object_graph_has_no_semantic_metadata(adapter):
+    """Object-graph without semantic attributes leaves model metadata unset."""
+    # The false_object_graph inline fixture (see test_parsing) has no
+    # semantic-layer / is-legacy attributes; assert via a real_world fixture
+    # that lacks them too.
+    real_world = FIXTURES / "real_world" / "thoughtspot_sf_trial.tds"
+    if not real_world.exists():
+        pytest.skip("real_world fixtures not present")
+
+    graph = adapter.parse(real_world)
+    model = graph.models.get("SF Trial")
+    assert model is not None
+    # No semantic-layer / is-legacy attributes on this object-graph.
+    if model.metadata is not None:
+        assert "tableau_semantic_layer" not in model.metadata
+        assert "tableau_is_legacy" not in model.metadata

--- a/tests/adapters/tableau/test_relation_types.py
+++ b/tests/adapters/tableau/test_relation_types.py
@@ -87,17 +87,51 @@ def test_stored_proc_relation_resolves_actual_name(adapter):
     assert model.table == "dbo.get_store_locations"
 
 
-def test_pivot_relation_resolves_to_child_table(adapter):
-    """pivot.tds: a pivot relation resolves to its wrapped child table."""
+def test_pivot_relation_builds_unpivot_sql(adapter):
+    """pivot.tds: a pivot relation emits UNPIVOT derived SQL, not a bare reference
+    to the wide child table (where the pivot output columns do not exist)."""
     graph = adapter.parse(FIXTURES / "pivot.tds")
 
     assert "pivoted_sales" in graph.models
     model = graph.models["pivoted_sales"]
 
-    assert model.table == "sales_wide$"
+    # Must NOT resolve to the raw wide table: the imported fields are the pivot
+    # outputs, which only exist after the UNPIVOT.
+    assert model.table is None
+    assert model.sql is not None
+    assert "UNPIVOT" in model.sql
+    # Wide source columns are unpivoted into the standard output columns.
+    assert '"Q1"' in model.sql and '"Q4"' in model.sql
+    assert 'INTO NAME "Pivot Field Names" VALUE "Pivot Field Values"' in model.sql
+
     # Pivot output columns still imported
     assert model.get_dimension("Pivot Field Names") is not None
     assert model.get_metric("Pivot Field Values") is not None
+
+
+def test_pivot_relation_sql_compiles_to_valid_duckdb(adapter):
+    """The synthesized UNPIVOT SQL must form a valid DuckDB derived table when the
+    generator wraps it as "(<sql>) AS t"."""
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = adapter.parse(FIXTURES / "pivot.tds")
+    model = graph.models["pivoted_sales"]
+
+    sl = SemanticLayer()
+    sl.add_model(model)
+    sql = sl.compile(metrics=["pivoted_sales.Pivot Field Values"])
+
+    con = duckdb.connect()
+    try:
+        con.execute("EXPLAIN " + sql)
+    except duckdb.Error as exc:  # pragma: no cover - failure path
+        message = str(exc).splitlines()[0]
+        # A missing source table is fine (the fixture references an uncreated
+        # table); only a syntax/parser error means we emitted invalid SQL.
+        if "does not exist" not in message and "Catalog Error" not in message:
+            raise AssertionError(f"DuckDB rejected generated UNPIVOT SQL:\n{sql}\n--> {message}") from exc
 
 
 def test_project_relation_resolves_to_child_table(adapter):

--- a/tests/fixtures/tableau/batch_union.tds
+++ b/tests/fixtures/tableau/batch_union.tds
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<datasource formatted-name='monthly_logs' inline='true' version='18.1'>
+  <connection class='textscan' directory='/data/logs'>
+    <relation name='Union of Logs' type='batch-union'>
+      <relation name='jan' type='table' table='[jan.csv]' />
+      <relation name='feb' type='table' table='[feb.csv]' />
+      <relation name='mar' type='table' table='[mar.csv]' />
+    </relation>
+    <metadata-records>
+      <metadata-record class='column'>
+        <local-name>[Event]</local-name>
+        <parent-name>[Union of Logs]</parent-name>
+        <remote-alias>event</remote-alias>
+        <local-type>string</local-type>
+      </metadata-record>
+    </metadata-records>
+  </connection>
+  <column caption='Event' datatype='string' name='[event]' role='dimension' type='nominal' />
+</datasource>

--- a/tests/fixtures/tableau/pivot.tds
+++ b/tests/fixtures/tableau/pivot.tds
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<datasource formatted-name='pivoted_sales' inline='true' version='18.1'>
+  <connection class='excel-direct' filename='sales.xlsx'>
+    <relation name='Pivoted' type='pivot'>
+      <relation name='sales_wide' type='table' table='[sales_wide$]' />
+      <pivot-column name='[Pivot Field Names]' />
+      <pivot-column name='[Pivot Field Values]' />
+    </relation>
+    <metadata-records>
+      <metadata-record class='column'>
+        <local-name>[Pivot Field Names]</local-name>
+        <parent-name>[Pivoted]</parent-name>
+        <remote-alias>Pivot Field Names</remote-alias>
+        <local-type>string</local-type>
+      </metadata-record>
+      <metadata-record class='column'>
+        <local-name>[Pivot Field Values]</local-name>
+        <parent-name>[Pivoted]</parent-name>
+        <remote-alias>Pivot Field Values</remote-alias>
+        <local-type>real</local-type>
+        <aggregation>Sum</aggregation>
+      </metadata-record>
+    </metadata-records>
+  </connection>
+  <column caption='Pivot Field Names' datatype='string' name='[Pivot Field Names]' role='dimension' type='nominal' />
+  <column caption='Pivot Field Values' datatype='real' name='[Pivot Field Values]' role='measure' type='quantitative' />
+</datasource>

--- a/tests/fixtures/tableau/pivot.tds
+++ b/tests/fixtures/tableau/pivot.tds
@@ -3,8 +3,18 @@
   <connection class='excel-direct' filename='sales.xlsx'>
     <relation name='Pivoted' type='pivot'>
       <relation name='sales_wide' type='table' table='[sales_wide$]' />
-      <pivot-column name='[Pivot Field Names]' />
-      <pivot-column name='[Pivot Field Values]' />
+      <pivot-column name='[Pivot Field Names]'>
+        <map source='[Q1]' />
+        <map source='[Q2]' />
+        <map source='[Q3]' />
+        <map source='[Q4]' />
+      </pivot-column>
+      <pivot-column name='[Pivot Field Values]'>
+        <map source='[Q1]' />
+        <map source='[Q2]' />
+        <map source='[Q3]' />
+        <map source='[Q4]' />
+      </pivot-column>
     </relation>
     <metadata-records>
       <metadata-record class='column'>

--- a/tests/fixtures/tableau/project.tds
+++ b/tests/fixtures/tableau/project.tds
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<datasource formatted-name='projected_orders' inline='true' version='18.1'>
+  <connection class='postgres' dbname='analytics' server='localhost'>
+    <relation name='Projected' type='project'>
+      <relation name='orders' type='table' table='[public].[orders]' />
+    </relation>
+    <metadata-records>
+      <metadata-record class='column'>
+        <local-name>[Order ID]</local-name>
+        <parent-name>[Projected]</parent-name>
+        <remote-alias>order_id</remote-alias>
+        <local-type>integer</local-type>
+      </metadata-record>
+    </metadata-records>
+  </connection>
+  <column caption='Order ID' datatype='integer' name='[order_id]' role='dimension' type='ordinal' />
+</datasource>

--- a/tests/fixtures/tableau/semantic_layer.tds
+++ b/tests/fixtures/tableau/semantic_layer.tds
@@ -1,0 +1,51 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<datasource formatted-name='semantic_model' inline='true' version='2024.2'>
+  <connection class='postgres' dbname='analytics' server='localhost'>
+    <relation name='collection' type='collection'>
+      <relation name='Orders' type='table' table='[public].[orders]' />
+      <relation name='Customers' type='table' table='[public].[customers]' />
+    </relation>
+    <metadata-records>
+      <metadata-record class='column'>
+        <local-name>[Order ID]</local-name>
+        <parent-name>[Orders]</parent-name>
+        <remote-alias>order_id</remote-alias>
+        <local-type>integer</local-type>
+      </metadata-record>
+      <metadata-record class='column'>
+        <local-name>[Customer ID]</local-name>
+        <parent-name>[Orders]</parent-name>
+        <remote-alias>customer_id</remote-alias>
+        <local-type>integer</local-type>
+      </metadata-record>
+      <metadata-record class='column'>
+        <local-name>[ID]</local-name>
+        <parent-name>[Customers]</parent-name>
+        <remote-alias>id</remote-alias>
+        <local-type>integer</local-type>
+      </metadata-record>
+      <metadata-record class='column'>
+        <local-name>[Customer Name]</local-name>
+        <parent-name>[Customers]</parent-name>
+        <remote-alias>customer_name</remote-alias>
+        <local-type>string</local-type>
+      </metadata-record>
+    </metadata-records>
+  </connection>
+  <object-graph semantic-layer='true' is-legacy='false'>
+    <objects>
+      <object id='orders' caption='Orders' />
+      <object id='customers' caption='Customers' />
+    </objects>
+    <relationships>
+      <relationship>
+        <first-end-point object-id='orders' />
+        <second-end-point object-id='customers' />
+        <expression op='='>
+          <expression op='[Orders].[Customer ID]' />
+          <expression op='[Customers].[ID]' />
+        </expression>
+      </relationship>
+    </relationships>
+  </object-graph>
+</datasource>

--- a/tests/fixtures/tableau/spatial_proc.tds
+++ b/tests/fixtures/tableau/spatial_proc.tds
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<datasource formatted-name='store_locations' inline='true' version='18.1'>
+  <connection class='postgres' dbname='analytics' server='localhost'>
+    <relation name='get_store_locations' stored-proc='[dbo].[get_store_locations]' type='stored-proc'>
+      <actual-name>dbo.get_store_locations</actual-name>
+    </relation>
+    <metadata-records>
+      <metadata-record class='column'>
+        <local-name>[Store ID]</local-name>
+        <parent-name>[get_store_locations]</parent-name>
+        <remote-alias>store_id</remote-alias>
+        <local-type>integer</local-type>
+      </metadata-record>
+      <metadata-record class='column'>
+        <local-name>[Geometry]</local-name>
+        <parent-name>[get_store_locations]</parent-name>
+        <remote-alias>geometry</remote-alias>
+        <local-type>spatial</local-type>
+      </metadata-record>
+    </metadata-records>
+  </connection>
+  <column caption='Store ID' datatype='integer' name='[store_id]' role='dimension' type='ordinal' />
+  <column caption='Geometry' datatype='spatial' name='[geometry]' role='dimension' type='nominal' />
+</datasource>

--- a/tests/fixtures/tableau/subquery.tds
+++ b/tests/fixtures/tableau/subquery.tds
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<datasource formatted-name='active_users' inline='true' version='18.1'>
+  <connection class='postgres' dbname='analytics' server='localhost'>
+    <relation name='Active Users' type='subquery'>SELECT * FROM users WHERE active = true</relation>
+    <metadata-records>
+      <metadata-record class='column'>
+        <local-name>[User ID]</local-name>
+        <parent-name>[Active Users]</parent-name>
+        <remote-alias>user_id</remote-alias>
+        <local-type>integer</local-type>
+      </metadata-record>
+    </metadata-records>
+  </connection>
+  <column caption='User ID' datatype='integer' name='[user_id]' role='dimension' type='ordinal' />
+</datasource>

--- a/tests/fixtures/tableau/text_transform.tds
+++ b/tests/fixtures/tableau/text_transform.tds
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<datasource formatted-name='parsed_logs' inline='true' version='18.1'>
+  <connection class='textscan' directory='/data'>
+    <relation name='Parsed' type='text-transform'>
+      <relation name='raw_logs' type='table' table='[raw_logs.txt]' />
+    </relation>
+    <metadata-records>
+      <metadata-record class='column'>
+        <local-name>[Message]</local-name>
+        <parent-name>[Parsed]</parent-name>
+        <remote-alias>message</remote-alias>
+        <local-type>string</local-type>
+      </metadata-record>
+    </metadata-records>
+  </connection>
+  <column caption='Message' datatype='string' name='[message]' role='dimension' type='nominal' />
+</datasource>

--- a/tests/fixtures/tableau/union.tds
+++ b/tests/fixtures/tableau/union.tds
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<datasource formatted-name='union_sales' inline='true' version='18.1'>
+  <connection class='postgres' dbname='analytics' server='localhost'>
+    <relation name='Union of Sales' type='union'>
+      <relation name='sales_2023' type='table' table='[public].[sales_2023]' />
+      <relation name='sales_2024' type='table' table='[public].[sales_2024]' />
+    </relation>
+    <metadata-records>
+      <metadata-record class='column'>
+        <local-name>[Region]</local-name>
+        <parent-name>[Union of Sales]</parent-name>
+        <remote-alias>region</remote-alias>
+        <local-type>string</local-type>
+      </metadata-record>
+      <metadata-record class='column'>
+        <local-name>[Amount]</local-name>
+        <parent-name>[Union of Sales]</parent-name>
+        <remote-alias>amount</remote-alias>
+        <local-type>real</local-type>
+        <aggregation>Sum</aggregation>
+      </metadata-record>
+    </metadata-records>
+  </connection>
+  <column caption='Region' datatype='string' name='[region]' role='dimension' type='nominal' />
+  <column caption='Amount' datatype='real' name='[amount]' role='measure' type='quantitative'>
+    <calculation class='tableau' formula='SUM([amount])' />
+  </column>
+</datasource>


### PR DESCRIPTION
## What changed

Extends the Tableau adapter (`sidemantic/adapters/tableau.py`) to handle physical-layer relation types and modeling attributes that previously fell through to no-ops, plus the geospatial datatype.

### Physical-layer relation types
Beyond the existing `table` / `join` / `text` / `collection` handling, the adapter now recognizes:

- `union` and `batch-union` — member relations are stacked vertically and compiled to `UNION ALL` SQL (Tableau unions keep duplicate rows). A single-member union degrades gracefully to a plain table reference.
- `subquery` — wrapped as a derived subquery, mirroring the existing `text` (custom SQL) path.
- `stored-proc` — resolved to the stored procedure's actual name (`<actual-name>` / `stored-proc` attribute); stored procedures cannot be joined or unioned in Tableau, so they map to a single table reference.
- `pivot`, `project`, `text-transform` — column-reshaping wrapper relations that keep a single-table grain; resolved to the wrapped child relation's base table or SQL.

These are wired into both the top-level connection relation dispatch and the recursive `_parse_relation_tree`, so the new types also compose inside join trees.

### Tableau Semantics object-graph attributes
The `<object-graph>` element's `semantic-layer` and `is-legacy` attributes (Tableau Semantics layer) are now read and surfaced as model metadata (`tableau_semantic_layer`, `tableau_is_legacy`), tolerant of namespace-prefixed forms. This lets consumers distinguish modern semantic models from legacy object models. Relationship extraction is unchanged.

### Spatial datatype
The `spatial` datatype (Tableau's `TABLEAU.TABGEOGRAPHY` geospatial columns) is mapped to a `categorical` dimension, since geospatial columns group/filter rather than aggregate numerically.

## Tests / fixtures

Added `tests/adapters/tableau/test_relation_types.py` and eight `.tds` fixtures under `tests/fixtures/tableau/` (one per relation type plus spatial and the semantic-layer object-graph). All existing Tableau tests remain green; backward compatibility is preserved.

## Known limitations

- Union member SQL is `SELECT *` per member; Tableau's column-alignment/coercion metadata for mismatched unions is not reconstructed.
- `pivot` / `text-transform` reshaping logic is not replayed — the adapter resolves to the wrapped source table and imports the reshaped output columns from `<metadata-records>`, rather than synthesizing the transform SQL.
- `stored-proc` parameters are not modeled.