### PR TITLE
Support latest MetricFlow YAML spec, conversion metrics, and saved queries

### DIFF
--- a/sidemantic/adapters/metricflow.py
+++ b/sidemantic/adapters/metricflow.py
@@ -518,8 +518,17 @@ class MetricFlowAdapter(BaseAdapter):
         )
 
     @staticmethod
-    def _map_agg(agg_type: str | None) -> str:
-        """Map a MetricFlow aggregation name to a Sidemantic aggregation name."""
+    def _map_agg(agg_type: str | None) -> str | None:
+        """Map a MetricFlow aggregation name to a Sidemantic aggregation name.
+
+        Returns ``None`` for an aggregation Sidemantic cannot represent (e.g.
+        ``percentile``). Callers must skip such measures/metrics rather than
+        coerce them: defaulting an unrepresentable aggregation to ``sum`` would
+        silently emit wrong SQL (``SUM(amount)`` for ``agg: percentile``). A
+        missing ``agg`` still defaults to ``sum`` as before.
+        """
+        if agg_type is None:
+            return "sum"
         type_mapping = {
             "sum": "sum",
             "count": "count",
@@ -531,7 +540,8 @@ class MetricFlowAdapter(BaseAdapter):
             "median": "median",
             "sum_boolean": "sum",
         }
-        return type_mapping.get(agg_type, "sum")
+        # MetricFlow aggregation names are case-insensitive (e.g. ``SUM``).
+        return type_mapping.get(agg_type.lower())
 
     def _parse_measure(self, measure_def: dict) -> Metric | None:
         """Parse MetricFlow measure into Sidemantic measure.
@@ -547,6 +557,11 @@ class MetricFlowAdapter(BaseAdapter):
             return None
 
         sidemantic_agg = self._map_agg(measure_def.get("agg", "sum"))
+        if sidemantic_agg is None:
+            # Aggregation Sidemantic cannot represent (e.g. ``percentile``). Skip
+            # rather than coerce to ``sum``, which would silently return a wrong
+            # value for the measure.
+            return None
 
         # Parse metadata and filters from meta
         meta = measure_def.get("meta", {})
@@ -649,6 +664,11 @@ class MetricFlowAdapter(BaseAdapter):
             if top_agg is not None:
                 # Latest-spec folded measure: keep the aggregation and column expr.
                 agg = self._map_agg(top_agg)
+                if agg is None:
+                    # Aggregation Sidemantic cannot represent (e.g. ``percentile``).
+                    # Skip the metric rather than coerce to ``sum``, which would
+                    # silently return a wrong value.
+                    return None
                 raw_expr = metric_def.get("expr")
                 expr = str(raw_expr) if raw_expr is not None else None
             elif measure is not None:

--- a/sidemantic/adapters/metricflow.py
+++ b/sidemantic/adapters/metricflow.py
@@ -111,8 +111,15 @@ class MetricFlowAdapter(BaseAdapter):
             if not isinstance(model_def, dict) or "semantic_model" not in model_def:
                 continue
             model = self._parse_model_spec(model_def)
-            if model:
-                graph.add_model(model)
+            if not model:
+                # ``semantic_model.enabled: false`` (or an otherwise unparseable
+                # model) yields no model. Its inline metrics are model-local and
+                # fold a measure on that model, so without the owning model they
+                # have no SQL context and a CLI query for one would raise
+                # ``No models found for query``. Skip them so the graph never
+                # exposes a metric that cannot be queried.
+                continue
+            graph.add_model(model)
             # Inline metrics on a latest-spec model. A ``type: simple`` metric
             # folds a model measure (``agg`` + ``expr``); its expression refers
             # to columns on the owning model. Qualify the SQL with the model name
@@ -124,7 +131,7 @@ class MetricFlowAdapter(BaseAdapter):
                 metric = self._parse_metric(metric_def)
                 if not metric:
                     continue
-                if model and metric_def.get("type", "simple") == "simple" and metric.agg is not None:
+                if metric_def.get("type", "simple") == "simple" and metric.agg is not None:
                     primary_key_ref = f"{model.name}.{model.primary_key}"
                     if metric.sql is not None:
                         qualified = self._qualify_measure_sql(metric.sql, model.name)

--- a/sidemantic/adapters/metricflow.py
+++ b/sidemantic/adapters/metricflow.py
@@ -37,6 +37,14 @@ class MetricFlowAdapter(BaseAdapter):
         # retained here (and on ``graph.metadata["saved_queries"]``) rather than
         # turned into models or metrics.
         self.saved_queries: dict[str, dict] = {}
+        # Parsed conversion metrics keyed by name. MetricFlow conversion metrics
+        # reference base/conversion *measures*, which have no faithful mapping to
+        # Sidemantic's event-filter conversion funnel. Rather than register a
+        # queryable ``type: conversion`` metric that would generate wrong SQL
+        # (filtering an ``event_type`` dimension by a measure name), the spec is
+        # retained here (and on ``graph.metadata["metricflow_conversion_metrics"]``)
+        # for round-tripping without exposing a broken queryable metric.
+        self.conversion_metrics: dict[str, dict] = {}
 
     def parse(self, source: str | Path) -> SemanticGraph:
         """Parse MetricFlow YAML files into semantic graph.
@@ -51,8 +59,10 @@ class MetricFlowAdapter(BaseAdapter):
         source_path = Path(source)
 
         # Reset per-parse state so reusing the adapter does not leak saved
-        # queries from a previously parsed source into this graph's metadata.
+        # queries or conversion metrics from a previously parsed source into this
+        # graph's metadata.
         self.saved_queries = {}
+        self.conversion_metrics = {}
 
         if source_path.is_dir():
             # Parse all YAML files in directory
@@ -74,6 +84,10 @@ class MetricFlowAdapter(BaseAdapter):
         # Expose parsed saved queries on the graph for downstream consumers.
         if self.saved_queries:
             graph.metadata["saved_queries"] = self.saved_queries
+
+        # Expose parsed conversion metrics (retained as non-queryable metadata).
+        if self.conversion_metrics:
+            graph.metadata["metricflow_conversion_metrics"] = self.conversion_metrics
 
         return graph
 
@@ -111,14 +125,24 @@ class MetricFlowAdapter(BaseAdapter):
                 if not metric:
                     continue
                 if model and metric_def.get("type", "simple") == "simple" and metric.agg is not None:
+                    primary_key_ref = f"{model.name}.{model.primary_key}"
                     if metric.sql is not None:
-                        metric.sql = self._qualify_measure_sql(metric.sql, model.name)
+                        qualified = self._qualify_measure_sql(metric.sql, model.name)
+                        # A constant count measure (``agg: count`` with ``expr: 1``
+                        # or ``expr: '*'``) has no column to qualify, so the metric
+                        # would carry no model reference and the planner would raise
+                        # ``No models found for query``. Anchor such counts to the
+                        # model via its primary key, the same as a bare ``count``.
+                        # COUNT over a non-null primary key is equivalent to COUNT(*).
+                        if metric.agg == "count" and not self._has_qualified_column(qualified, model.name):
+                            metric.sql = primary_key_ref
+                        else:
+                            metric.sql = qualified
                     else:
                         # Bare aggregation (e.g. ``count`` with no ``expr``):
                         # anchor it to the model via its primary key so the
-                        # planner can resolve the model. COUNT over a non-null
-                        # primary key is equivalent to COUNT(*).
-                        metric.sql = f"{model.name}.{model.primary_key}"
+                        # planner can resolve the model.
+                        metric.sql = primary_key_ref
                 self._add_metric(graph, metric)
 
         # Legacy spec: top-level ``semantic_models:``.
@@ -159,6 +183,28 @@ class MetricFlowAdapter(BaseAdapter):
             if not column.table:
                 column.set("table", exp.to_identifier(model_name))
         return parsed.sql()
+
+    @staticmethod
+    def _has_qualified_column(sql: str, model_name: str) -> bool:
+        """Return True if ``sql`` references at least one column on ``model_name``.
+
+        Used to detect folded measures whose ``expr`` is a bare constant (e.g.
+        ``count`` with ``expr: 1`` or ``expr: '*'``). Such expressions contain no
+        column for ``_qualify_measure_sql`` to anchor, so the metric would carry
+        no model reference and could not be queried on its own.
+        """
+        import sqlglot
+        from sqlglot import exp
+
+        try:
+            parsed = sqlglot.parse_one(sql)
+        except Exception:
+            return False
+
+        for column in parsed.find_all(exp.Column):
+            if column.table == model_name:
+                return True
+        return False
 
     @staticmethod
     def _add_metric(graph: SemanticGraph, metric: Metric) -> None:
@@ -614,6 +660,19 @@ class MetricFlowAdapter(BaseAdapter):
             input_summary = self._summarize_input_metrics(input_metrics)
             if input_summary:
                 metadata["input_metrics"] = input_summary
+            # Rewrite non-offset aliases back to their real input metric so the
+            # expression references metrics that actually exist in the graph.
+            # MetricFlow lets a derived metric reference an input by ``alias``
+            # (e.g. ``current_total`` for ``order_total``); without rewriting,
+            # ``get_dependencies`` would scan the expression and resolve only the
+            # aliases, so ``_find_required_models`` could not infer a model and a
+            # CLI query like ``--metrics order_total_growth`` would raise
+            # ``No models found for query``. An alias carrying ``offset_window`` /
+            # ``offset_to_grain`` denotes a time-shifted value distinct from the
+            # base metric, which Sidemantic cannot yet express, so those aliases
+            # are left intact (the metric stays as round-trip metadata).
+            if expr and input_summary:
+                expr = self._rewrite_input_aliases(expr, input_summary)
 
         elif metric_type == "cumulative":
             # Base measure: ``measure`` (legacy) or ``input_metric`` (latest).
@@ -669,7 +728,7 @@ class MetricFlowAdapter(BaseAdapter):
         )
 
     def _summarize_input_metrics(self, input_metrics) -> list[dict] | None:
-        """Capture per-input derived modifiers (offset_window / offset_to_grain / alias).
+        """Capture per-input derived modifiers (offset_window / offset_to_grain / alias / filter).
 
         Args:
             input_metrics: The ``metrics`` (legacy) / ``input_metrics`` (latest) list.
@@ -684,7 +743,7 @@ class MetricFlowAdapter(BaseAdapter):
         for entry in input_metrics:
             if isinstance(entry, dict):
                 item = {"name": entry.get("name")}
-                for key in ("alias", "offset_window", "offset_to_grain"):
+                for key in ("alias", "offset_window", "offset_to_grain", "filter"):
                     if entry.get(key) is not None:
                         item[key] = entry.get(key)
                 summary.append(item)
@@ -692,12 +751,55 @@ class MetricFlowAdapter(BaseAdapter):
                 summary.append({"name": entry})
         return summary or None
 
+    @staticmethod
+    def _rewrite_input_aliases(expr: str, input_summary: list[dict]) -> str:
+        """Replace plain derived input aliases with their real metric names.
+
+        Each entry in ``input_summary`` may carry an ``alias`` referenced by the
+        derived expression. An alias is only rewritten when the input has no
+        modifier that makes its value differ from the underlying metric:
+
+        - ``offset_window`` / ``offset_to_grain`` denote a time-shifted value, and
+        - ``filter`` denotes a filtered subset value,
+
+        so aliases carrying either are left intact (the metric stays as round-trip
+        metadata). Identifiers are matched on word boundaries so an alias is not
+        rewritten inside a longer identifier.
+        """
+        import re
+
+        rewritten = expr
+        for item in input_summary:
+            alias = item.get("alias")
+            real_name = item.get("name")
+            if not alias or not real_name or alias == real_name:
+                continue
+            if (
+                item.get("offset_window") is not None
+                or item.get("offset_to_grain") is not None
+                or item.get("filter") is not None
+            ):
+                continue
+            rewritten = re.sub(rf"\b{re.escape(alias)}\b", real_name, rewritten)
+        return rewritten
+
     def _parse_conversion_metric(self, name: str, metric_def: dict, type_params: dict) -> Metric | None:
-        """Parse a MetricFlow conversion metric into a Sidemantic conversion Metric.
+        """Record a MetricFlow conversion metric as non-queryable metadata.
 
         Handles both the legacy shape (``type_params.conversion_type_params`` with
         ``base_measure`` / ``conversion_measure``) and the latest shape (promoted
         top-level ``base_metric`` / ``conversion_metric`` / ``entity`` keys).
+
+        MetricFlow conversion metrics reference base/conversion *measures*, but
+        Sidemantic's ``type: conversion`` funnel filters an ``event_type``
+        dimension by a string literal (e.g. ``WHERE event_type = 'visit'``). The
+        measure name is not such a filter, so registering a queryable conversion
+        metric would either fail to find an ``event_type`` dimension or silently
+        compute wrong conversions (``WHERE event_type = 'order_count'``). Until a
+        faithful measure-predicate mapping exists, the spec is captured in
+        ``self.conversion_metrics`` (surfaced on
+        ``graph.metadata["metricflow_conversion_metrics"]``) and no metric is
+        registered, so the parsed graph never exposes a broken conversion metric.
 
         Args:
             name: Metric name.
@@ -705,7 +807,7 @@ class MetricFlowAdapter(BaseAdapter):
             type_params: The metric's ``type_params`` (may be empty in latest spec).
 
         Returns:
-            Conversion Metric instance or None.
+            ``None`` always; the conversion spec is retained as metadata instead.
         """
         conv = type_params.get("conversion_type_params") or {}
 
@@ -725,37 +827,22 @@ class MetricFlowAdapter(BaseAdapter):
         constant_properties = conv.get("constant_properties") or metric_def.get("constant_properties")
 
         if not base or not conversion or not entity:
-            # Not enough information to build a valid conversion metric.
+            # Not enough information to describe a valid conversion metric.
             return None
 
-        # Sidemantic's conversion metric models a base event -> conversion event
-        # funnel keyed on an entity. MetricFlow keys on measures rather than event
-        # filters, so the measure names become the event references and the
-        # calculation flavor / fill behavior is retained in metadata.
-        metadata: dict = {"calculation": calculation, "source": "metricflow"}
-        if constant_properties:
-            metadata["constant_properties"] = constant_properties
-
-        filter_expr = metric_def.get("filter")
-        filters = [filter_expr] if filter_expr else None
-
-        meta = metric_def.get("meta", {})
-
-        return Metric(
-            name=name,
-            type="conversion",
-            description=metric_def.get("description"),
-            label=metric_def.get("label"),
-            entity=entity,
-            base_event=base,
-            conversion_event=conversion,
-            conversion_window=window,
-            filters=filters,
-            format=meta.get("format"),
-            value_format_name=meta.get("value_format_name"),
-            drill_fields=meta.get("drill_fields"),
-            metadata=metadata,
-        )
+        self.conversion_metrics[name] = {
+            "name": name,
+            "description": metric_def.get("description"),
+            "label": metric_def.get("label"),
+            "entity": entity,
+            "base_measure": base,
+            "conversion_measure": conversion,
+            "window": window,
+            "calculation": calculation,
+            "constant_properties": constant_properties,
+            "filter": metric_def.get("filter"),
+        }
+        return None
 
     def export(self, graph: SemanticGraph, output_path: str | Path) -> None:
         """Export semantic graph to MetricFlow YAML format.

--- a/sidemantic/adapters/metricflow.py
+++ b/sidemantic/adapters/metricflow.py
@@ -50,6 +50,10 @@ class MetricFlowAdapter(BaseAdapter):
         graph = SemanticGraph()
         source_path = Path(source)
 
+        # Reset per-parse state so reusing the adapter does not leak saved
+        # queries from a previously parsed source into this graph's metadata.
+        self.saved_queries = {}
+
         if source_path.is_dir():
             # Parse all YAML files in directory
             for yaml_file in source_path.rglob("*.yml"):
@@ -95,11 +99,27 @@ class MetricFlowAdapter(BaseAdapter):
             model = self._parse_model_spec(model_def)
             if model:
                 graph.add_model(model)
-            # Inline metrics on a latest-spec model
+            # Inline metrics on a latest-spec model. A ``type: simple`` metric
+            # folds a model measure (``agg`` + ``expr``); its expression refers
+            # to columns on the owning model. Qualify the SQL with the model name
+            # so a query selecting only that metric can infer its model. Without
+            # this the metric carries unqualified SQL (e.g. ``amount``) or no SQL
+            # at all (a bare ``count``), and the planner raises
+            # ``No models found for query``.
             for metric_def in model_def.get("metrics") or []:
                 metric = self._parse_metric(metric_def)
-                if metric:
-                    self._add_metric(graph, metric)
+                if not metric:
+                    continue
+                if model and metric_def.get("type", "simple") == "simple" and metric.agg is not None:
+                    if metric.sql is not None:
+                        metric.sql = self._qualify_measure_sql(metric.sql, model.name)
+                    else:
+                        # Bare aggregation (e.g. ``count`` with no ``expr``):
+                        # anchor it to the model via its primary key so the
+                        # planner can resolve the model. COUNT over a non-null
+                        # primary key is equivalent to COUNT(*).
+                        metric.sql = f"{model.name}.{model.primary_key}"
+                self._add_metric(graph, metric)
 
         # Legacy spec: top-level ``semantic_models:``.
         for model_def in data.get("semantic_models") or []:
@@ -116,6 +136,29 @@ class MetricFlowAdapter(BaseAdapter):
         # Parse saved queries (top-level, both specs). These have no direct
         # Sidemantic equivalent, so retain them for downstream consumers.
         self._parse_saved_queries(data.get("saved_queries"))
+
+    @staticmethod
+    def _qualify_measure_sql(sql: str, model_name: str) -> str:
+        """Qualify unqualified column references in a folded measure's SQL.
+
+        A latest-spec ``type: simple`` metric folds a model measure, so its
+        ``expr`` refers to columns on the owning model. The resulting graph-level
+        metric needs at least one model-qualified column (e.g. ``orders.amount``)
+        so the query planner can infer the model when the metric is selected on
+        its own. Already-qualified references are left untouched.
+        """
+        import sqlglot
+        from sqlglot import exp
+
+        try:
+            parsed = sqlglot.parse_one(sql)
+        except Exception:
+            return sql
+
+        for column in parsed.find_all(exp.Column):
+            if not column.table:
+                column.set("table", exp.to_identifier(model_name))
+        return parsed.sql()
 
     @staticmethod
     def _add_metric(graph: SemanticGraph, metric: Metric) -> None:

--- a/sidemantic/adapters/metricflow.py
+++ b/sidemantic/adapters/metricflow.py
@@ -138,11 +138,19 @@ class MetricFlowAdapter(BaseAdapter):
                             metric.sql = primary_key_ref
                         else:
                             metric.sql = qualified
-                    else:
-                        # Bare aggregation (e.g. ``count`` with no ``expr``):
-                        # anchor it to the model via its primary key so the
-                        # planner can resolve the model.
+                    elif metric.agg == "count":
+                        # Bare ``count`` with no ``expr``: anchor it to the model
+                        # via its primary key so the planner can resolve the model.
+                        # COUNT over a non-null primary key is equivalent to COUNT(*).
                         metric.sql = primary_key_ref
+                    else:
+                        # Any other expr-less aggregation (sum/avg/min/max/...): in
+                        # MetricFlow an expr-less measure aggregates the column named
+                        # after the measure, so default the SQL to the metric's own
+                        # column, qualified with the model. Anchoring to the primary
+                        # key here would silently aggregate the wrong column (e.g.
+                        # ``SUM(orders.order_id)`` instead of ``SUM(orders.amount)``).
+                        metric.sql = f"{model.name}.{metric.name}"
                 self._add_metric(graph, metric)
 
         # Legacy spec: top-level ``semantic_models:``.

--- a/sidemantic/adapters/metricflow.py
+++ b/sidemantic/adapters/metricflow.py
@@ -21,7 +21,22 @@ class MetricFlowAdapter(BaseAdapter):
     - Dimensions → Dimensions
     - Measures → Measures
     - Metrics → Metrics (all 5 types)
+
+    Supports both the legacy MetricFlow YAML spec (top-level ``semantic_models:`` /
+    ``metrics:`` with ``type_params``) and the latest spec used by dbt Core 1.12 /
+    the dbt Fusion engine (top-level ``models:`` with a nested ``semantic_model:``
+    block, column-based ``entity:`` / ``dimension:`` under ``columns:``, measures
+    folded into ``type: simple`` metrics with ``agg`` / ``expr``, and promoted
+    top-level metric keys such as ``input_metrics`` / ``input_metric`` /
+    ``base_metric`` / ``conversion_metric`` / ``numerator`` / ``denominator``).
     """
+
+    def __init__(self):
+        # Parsed top-level ``saved_queries`` keyed by name. Saved queries are a
+        # MetricFlow concept without a direct Sidemantic equivalent, so they are
+        # retained here (and on ``graph.metadata["saved_queries"]``) rather than
+        # turned into models or metrics.
+        self.saved_queries: dict[str, dict] = {}
 
     def parse(self, source: str | Path) -> SemanticGraph:
         """Parse MetricFlow YAML files into semantic graph.
@@ -52,6 +67,10 @@ class MetricFlowAdapter(BaseAdapter):
         # Rebuild adjacency graph after resolving relationship names
         graph.build_adjacency()
 
+        # Expose parsed saved queries on the graph for downstream consumers.
+        if self.saved_queries:
+            graph.metadata["saved_queries"] = self.saved_queries
+
         return graph
 
     def _parse_file(self, file_path: Path, graph: SemanticGraph) -> None:
@@ -67,17 +86,84 @@ class MetricFlowAdapter(BaseAdapter):
         if not data:
             return
 
-        # Parse semantic models
+        # Latest spec (dbt Core 1.12 / Fusion): semantic models embedded under a
+        # top-level ``models:`` block, each with a nested ``semantic_model:`` key.
+        # Metrics may be declared inline on the model and/or at the top level.
+        for model_def in data.get("models") or []:
+            if not isinstance(model_def, dict) or "semantic_model" not in model_def:
+                continue
+            model = self._parse_model_spec(model_def)
+            if model:
+                graph.add_model(model)
+            # Inline metrics on a latest-spec model
+            for metric_def in model_def.get("metrics") or []:
+                metric = self._parse_metric(metric_def)
+                if metric:
+                    self._add_metric(graph, metric)
+
+        # Legacy spec: top-level ``semantic_models:``.
         for model_def in data.get("semantic_models") or []:
             model = self._parse_semantic_model(model_def)
             if model:
                 graph.add_model(model)
 
-        # Parse metrics
+        # Parse top-level metrics (shared by both specs)
         for metric_def in data.get("metrics") or []:
             metric = self._parse_metric(metric_def)
             if metric:
-                graph.add_metric(metric)
+                self._add_metric(graph, metric)
+
+        # Parse saved queries (top-level, both specs). These have no direct
+        # Sidemantic equivalent, so retain them for downstream consumers.
+        self._parse_saved_queries(data.get("saved_queries"))
+
+    @staticmethod
+    def _add_metric(graph: SemanticGraph, metric: Metric) -> None:
+        """Add a metric to the graph, ignoring duplicate names across files."""
+        if metric.name in graph.metrics:
+            return
+        graph.add_metric(metric)
+
+    def _parse_saved_queries(self, saved_queries) -> None:
+        """Parse top-level ``saved_queries`` into ``self.saved_queries``.
+
+        Saved queries can be a list (canonical MetricFlow form) or a mapping
+        keyed by name (latest spec form). Each entry retains ``query_params``
+        (metrics/group_by/where/order_by/limit) and ``exports``.
+
+        Args:
+            saved_queries: Raw ``saved_queries`` value from the YAML file.
+        """
+        if not saved_queries:
+            return
+
+        entries = []
+        if isinstance(saved_queries, dict):
+            for key, value in saved_queries.items():
+                if not isinstance(value, dict):
+                    continue
+                entry = dict(value)
+                entry.setdefault("name", key)
+                entries.append(entry)
+        else:
+            entries = [sq for sq in saved_queries if isinstance(sq, dict)]
+
+        for sq in entries:
+            name = sq.get("name")
+            if not name:
+                continue
+            query_params = sq.get("query_params") or {}
+            self.saved_queries[name] = {
+                "name": name,
+                "description": sq.get("description"),
+                "label": sq.get("label"),
+                "metrics": list(query_params.get("metrics") or []),
+                "group_by": list(query_params.get("group_by") or []),
+                "where": query_params.get("where"),
+                "order_by": query_params.get("order_by"),
+                "limit": query_params.get("limit"),
+                "exports": sq.get("exports") or [],
+            }
 
     def _parse_semantic_model(self, model_def: dict) -> Model | None:
         """Parse MetricFlow semantic model into Model.
@@ -182,6 +268,100 @@ class MetricFlowAdapter(BaseAdapter):
             default_grain=default_grain,
         )
 
+    def _parse_model_spec(self, model_def: dict) -> Model | None:
+        """Parse a latest-spec model entry (``models:`` with nested ``semantic_model:``).
+
+        In the latest spec entities and dimensions are declared column-by-column
+        under ``columns:`` (each column carries an ``entity:`` and/or
+        ``dimension:`` block), measures are folded into ``type: simple`` metrics,
+        and the aggregation time dimension is a top-level ``agg_time_dimension``
+        key. This translates that shape into the same Model the legacy parser
+        produces.
+
+        Args:
+            model_def: A single entry from the top-level ``models:`` list.
+
+        Returns:
+            Model instance or None
+        """
+        semantic_model = model_def.get("semantic_model")
+        if not isinstance(semantic_model, dict):
+            return None
+        # ``enabled: false`` disables semantic model generation for the model.
+        if semantic_model.get("enabled") is False:
+            return None
+
+        # The semantic model name defaults to the dbt model name.
+        name = semantic_model.get("name") or model_def.get("name")
+        if not name:
+            return None
+
+        # The underlying table is the dbt model itself.
+        table = model_def.get("name")
+
+        primary_key = "id"
+        relationships = []
+        dimensions = []
+
+        for column_def in model_def.get("columns") or []:
+            if not isinstance(column_def, dict):
+                continue
+            column_name = column_def.get("name")
+
+            entity_def = column_def.get("entity")
+            if entity_def is not None:
+                # ``entity: primary`` shorthand or a full mapping.
+                if isinstance(entity_def, str):
+                    entity_def = {"type": entity_def}
+                entity_type = entity_def.get("type", "primary")
+                entity_name = entity_def.get("name") or column_name
+                # The column name is the SQL expression backing the entity.
+                entity_expr = entity_def.get("expr") or column_name
+                if entity_type == "primary":
+                    primary_key = entity_expr
+                elif entity_type == "foreign":
+                    relationships.append(Relationship(name=entity_name, type="many_to_one", foreign_key=entity_expr))
+
+            dimension_def = column_def.get("dimension")
+            if dimension_def is not None:
+                if isinstance(dimension_def, str):
+                    dimension_def = {"type": dimension_def}
+                # Build a legacy-shaped dimension dict so we can reuse _parse_dimension.
+                # Granularity lives at the column level in the latest spec.
+                legacy_dim = {
+                    "name": dimension_def.get("name") or column_name,
+                    "type": dimension_def.get("type", "categorical"),
+                    "expr": dimension_def.get("expr", column_name),
+                    "description": dimension_def.get("description") or column_def.get("description"),
+                    "label": dimension_def.get("label"),
+                    "meta": dimension_def.get("meta", {}),
+                }
+                granularity = column_def.get("granularity") or dimension_def.get("granularity")
+                if granularity:
+                    legacy_dim["type_params"] = {"time_granularity": granularity}
+                dim = self._parse_dimension(legacy_dim)
+                if dim:
+                    dimensions.append(dim)
+
+        # Measures fold into inline ``type: simple`` metrics in the latest spec, so
+        # the model itself has no separate measures list.
+        measures = []
+
+        agg_time_dimension = model_def.get("agg_time_dimension") or semantic_model.get("agg_time_dimension")
+        defaults = model_def.get("defaults") or semantic_model.get("defaults") or {}
+        default_time_dimension = agg_time_dimension or defaults.get("agg_time_dimension")
+
+        return Model(
+            name=name,
+            table=table,
+            description=semantic_model.get("description") or model_def.get("description"),
+            primary_key=primary_key,
+            relationships=relationships,
+            dimensions=dimensions,
+            metrics=measures,
+            default_time_dimension=default_time_dimension,
+        )
+
     def _parse_dimension(self, dim_def: dict) -> Dimension | None:
         """Parse MetricFlow dimension into Sidemantic dimension.
 
@@ -233,6 +413,22 @@ class MetricFlowAdapter(BaseAdapter):
             parent=parent,
         )
 
+    @staticmethod
+    def _map_agg(agg_type: str | None) -> str:
+        """Map a MetricFlow aggregation name to a Sidemantic aggregation name."""
+        type_mapping = {
+            "sum": "sum",
+            "count": "count",
+            "count_distinct": "count_distinct",
+            "average": "avg",
+            "avg": "avg",
+            "min": "min",
+            "max": "max",
+            "median": "median",
+            "sum_boolean": "sum",
+        }
+        return type_mapping.get(agg_type, "sum")
+
     def _parse_measure(self, measure_def: dict) -> Metric | None:
         """Parse MetricFlow measure into Sidemantic measure.
 
@@ -246,22 +442,7 @@ class MetricFlowAdapter(BaseAdapter):
         if not name:
             return None
 
-        agg_type = measure_def.get("agg", "sum")
-
-        # Map MetricFlow aggregation types
-        type_mapping = {
-            "sum": "sum",
-            "count": "count",
-            "count_distinct": "count_distinct",
-            "average": "avg",
-            "avg": "avg",
-            "min": "min",
-            "max": "max",
-            "median": "median",
-            "sum_boolean": "sum",
-        }
-
-        sidemantic_agg = type_mapping.get(agg_type, "sum")
+        sidemantic_agg = self._map_agg(measure_def.get("agg", "sum"))
 
         # Parse metadata and filters from meta
         meta = measure_def.get("meta", {})
@@ -293,8 +474,23 @@ class MetricFlowAdapter(BaseAdapter):
             non_additive_dimension=non_additive_dimension,
         )
 
+    @staticmethod
+    def _ref_name(value):
+        """Resolve a measure/metric reference that may be a bare name or a dict.
+
+        MetricFlow allows measure/metric inputs to be either a string name or a
+        mapping like ``{name: bookers, fill_nulls_with: 0, join_to_timespine: true}``.
+        """
+        if isinstance(value, dict):
+            return value.get("name")
+        return value
+
     def _parse_metric(self, metric_def: dict) -> Metric | None:
         """Parse MetricFlow metric into Sidemantic measure.
+
+        Supports both the legacy spec (parameters nested under ``type_params``)
+        and the latest spec (parameters promoted to top-level keys, e.g.
+        ``input_metrics`` / ``input_metric`` / ``numerator`` / ``base_metric``).
 
         Args:
             metric_def: Metric definition dictionary
@@ -308,78 +504,102 @@ class MetricFlowAdapter(BaseAdapter):
 
         metric_type = metric_def.get("type", "simple")
 
-        # Map MetricFlow metric types
-        # Note: "simple" maps to None (untyped) since we removed the simple type
+        # Map MetricFlow metric types to Sidemantic metric types.
+        # Note: "simple" maps to None (untyped) since we removed the simple type.
         type_mapping = {
             "simple": None,  # Untyped metric with sql expression
             "ratio": "ratio",
             "derived": "derived",
             "cumulative": "cumulative",
-            # conversion not yet supported
+            "conversion": "conversion",
         }
 
-        sidemantic_type = type_mapping.get(metric_type, None)
-        # Only skip if the metric type is truly unsupported (not in mapping at all)
         if metric_type not in type_mapping:
-            return None  # Skip unsupported metric types
+            return None  # Skip genuinely unsupported metric types
+        sidemantic_type = type_mapping[metric_type]
 
-        # Extract type-specific parameters
-        type_params = metric_def.get("type_params", {})
+        # Type-specific parameters. In the latest spec these are promoted to the
+        # top level; in the legacy spec they live under ``type_params``.
+        type_params = metric_def.get("type_params") or {}
 
-        # Simple metric
+        # Conversion metrics have a dedicated parsing path.
+        if metric_type == "conversion":
+            return self._parse_conversion_metric(name, metric_def, type_params)
+
         expr = None
-        if metric_type == "simple":
-            measure_def = type_params.get("measure", {})
-            if isinstance(measure_def, dict):
-                expr = measure_def.get("name")
-            else:
-                expr = measure_def
-
-        # Ratio metric
+        agg = None
         numerator = None
         denominator = None
-        if metric_type == "ratio":
-            numerator_def = type_params.get("numerator", {})
-            denominator_def = type_params.get("denominator", {})
-
-            if isinstance(numerator_def, dict):
-                numerator = numerator_def.get("name")
-            else:
-                numerator = numerator_def
-
-            if isinstance(denominator_def, dict):
-                denominator = denominator_def.get("name")
-            else:
-                denominator = denominator_def
-
-        # Derived metric
-        if metric_type == "derived":
-            expr = type_params.get("expr")
-
-        # Cumulative metric
         window = None
         grain_to_date = None
-        if metric_type == "cumulative":
-            # Get the base measure reference
-            measure_def = type_params.get("measure", {})
-            if isinstance(measure_def, dict):
-                expr = measure_def.get("name")
-            else:
-                expr = measure_def
-            # Window can be directly in type_params
-            window = type_params.get("window")
-            grain_to_date = type_params.get("grain_to_date")
-            # Or in cumulative_type_params (alternative structure)
-            if not window and not grain_to_date:
-                cumulative_params = type_params.get("cumulative_type_params", {})
-                window = cumulative_params.get("window")
-                grain_to_date = cumulative_params.get("grain_to_date")
+        metadata: dict = {}
 
-        # Parse filter
+        if metric_type == "simple":
+            # ``measure`` (legacy) or ``agg``/``expr`` (latest). Latest-spec simple
+            # metrics defined inline on a model fold the measure into the metric and
+            # carry ``agg`` plus an optional ``expr`` at the top level.
+            measure = type_params.get("measure")
+            if measure is None and "measure" in metric_def:
+                measure = metric_def.get("measure")
+            top_agg = metric_def.get("agg")
+            if top_agg is not None:
+                # Latest-spec folded measure: keep the aggregation and column expr.
+                agg = self._map_agg(top_agg)
+                raw_expr = metric_def.get("expr")
+                expr = str(raw_expr) if raw_expr is not None else None
+            elif measure is not None:
+                expr = self._ref_name(measure)
+            elif metric_def.get("expr") is not None:
+                expr = str(metric_def.get("expr"))
+            else:
+                # Inline latest-spec simple metric: the measure shares the metric name.
+                expr = name
+
+        elif metric_type == "ratio":
+            numerator = self._ref_name(type_params.get("numerator", metric_def.get("numerator")))
+            denominator = self._ref_name(type_params.get("denominator", metric_def.get("denominator")))
+
+        elif metric_type == "derived":
+            expr = type_params.get("expr", metric_def.get("expr"))
+            # Per-input modifiers (offset_window / offset_to_grain / alias) live on
+            # each entry of the metrics list. Sidemantic auto-detects derived
+            # dependencies from the expression, so retain the raw inputs in
+            # metadata for round-tripping and offset support.
+            input_metrics = type_params.get("metrics")
+            if input_metrics is None:
+                input_metrics = metric_def.get("input_metrics")
+            input_summary = self._summarize_input_metrics(input_metrics)
+            if input_summary:
+                metadata["input_metrics"] = input_summary
+
+        elif metric_type == "cumulative":
+            # Base measure: ``measure`` (legacy) or ``input_metric`` (latest).
+            measure = type_params.get("measure")
+            if measure is None:
+                measure = metric_def.get("input_metric")
+            expr = self._ref_name(measure)
+
+            # Window / grain_to_date / period_agg can sit directly under
+            # type_params (legacy convenience), under cumulative_type_params
+            # (canonical legacy), or be promoted to the top level (latest).
+            cumulative_params = type_params.get("cumulative_type_params") or {}
+            window = type_params.get("window") or cumulative_params.get("window") or metric_def.get("window")
+            grain_to_date = (
+                type_params.get("grain_to_date")
+                or cumulative_params.get("grain_to_date")
+                or metric_def.get("grain_to_date")
+            )
+            period_agg = (
+                cumulative_params.get("period_agg") or type_params.get("period_agg") or metric_def.get("period_agg")
+            )
+            if period_agg:
+                metadata["period_agg"] = period_agg
+
+        # Parse filter (single string in MetricFlow)
         filter_expr = metric_def.get("filter")
         filters = [filter_expr] if filter_expr else None
 
-        # Parse metadata from meta
+        # Parse display metadata from meta
         meta = metric_def.get("meta", {})
         format_str = meta.get("format")
         value_format_name = meta.get("value_format_name")
@@ -389,6 +609,7 @@ class MetricFlowAdapter(BaseAdapter):
         return Metric(
             name=name,
             type=sidemantic_type,
+            agg=agg,
             description=metric_def.get("description"),
             label=metric_def.get("label"),
             sql=expr,
@@ -401,6 +622,96 @@ class MetricFlowAdapter(BaseAdapter):
             value_format_name=value_format_name,
             drill_fields=drill_fields,
             extends=extends,
+            metadata=metadata or None,
+        )
+
+    def _summarize_input_metrics(self, input_metrics) -> list[dict] | None:
+        """Capture per-input derived modifiers (offset_window / offset_to_grain / alias).
+
+        Args:
+            input_metrics: The ``metrics`` (legacy) / ``input_metrics`` (latest) list.
+
+        Returns:
+            A normalized list of input descriptors, or None when there is nothing
+            worth retaining.
+        """
+        if not input_metrics:
+            return None
+        summary = []
+        for entry in input_metrics:
+            if isinstance(entry, dict):
+                item = {"name": entry.get("name")}
+                for key in ("alias", "offset_window", "offset_to_grain"):
+                    if entry.get(key) is not None:
+                        item[key] = entry.get(key)
+                summary.append(item)
+            else:
+                summary.append({"name": entry})
+        return summary or None
+
+    def _parse_conversion_metric(self, name: str, metric_def: dict, type_params: dict) -> Metric | None:
+        """Parse a MetricFlow conversion metric into a Sidemantic conversion Metric.
+
+        Handles both the legacy shape (``type_params.conversion_type_params`` with
+        ``base_measure`` / ``conversion_measure``) and the latest shape (promoted
+        top-level ``base_metric`` / ``conversion_metric`` / ``entity`` keys).
+
+        Args:
+            name: Metric name.
+            metric_def: Raw metric definition.
+            type_params: The metric's ``type_params`` (may be empty in latest spec).
+
+        Returns:
+            Conversion Metric instance or None.
+        """
+        conv = type_params.get("conversion_type_params") or {}
+
+        # base/conversion event measures: legacy uses base_measure/conversion_measure,
+        # latest uses base_metric/conversion_metric promoted to the top level.
+        base = self._ref_name(conv.get("base_measure"))
+        if base is None:
+            base = self._ref_name(metric_def.get("base_metric"))
+        conversion = self._ref_name(conv.get("conversion_measure"))
+        if conversion is None:
+            conversion = self._ref_name(metric_def.get("conversion_metric"))
+
+        entity = conv.get("entity") or metric_def.get("entity")
+        window = conv.get("window") or metric_def.get("window")
+        # MetricFlow uses both "conversion" and "conversions" for the count flavor.
+        calculation = conv.get("calculation") or metric_def.get("calculation") or "conversion_rate"
+        constant_properties = conv.get("constant_properties") or metric_def.get("constant_properties")
+
+        if not base or not conversion or not entity:
+            # Not enough information to build a valid conversion metric.
+            return None
+
+        # Sidemantic's conversion metric models a base event -> conversion event
+        # funnel keyed on an entity. MetricFlow keys on measures rather than event
+        # filters, so the measure names become the event references and the
+        # calculation flavor / fill behavior is retained in metadata.
+        metadata: dict = {"calculation": calculation, "source": "metricflow"}
+        if constant_properties:
+            metadata["constant_properties"] = constant_properties
+
+        filter_expr = metric_def.get("filter")
+        filters = [filter_expr] if filter_expr else None
+
+        meta = metric_def.get("meta", {})
+
+        return Metric(
+            name=name,
+            type="conversion",
+            description=metric_def.get("description"),
+            label=metric_def.get("label"),
+            entity=entity,
+            base_event=base,
+            conversion_event=conversion,
+            conversion_window=window,
+            filters=filters,
+            format=meta.get("format"),
+            value_format_name=meta.get("value_format_name"),
+            drill_fields=meta.get("drill_fields"),
+            metadata=metadata,
         )
 
     def export(self, graph: SemanticGraph, output_path: str | Path) -> None:

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -416,9 +416,16 @@ class SQLGenerator:
         models_checked = set()
         for metric_ref in metrics:
             try:
-                model_name, _ = self.graph.resolve_metric_reference(metric_ref)
+                model_name, metric_obj = self.graph.resolve_metric_reference(metric_ref)
             except KeyError:
                 continue
+            # A graph-level cumulative metric (e.g. a MetricFlow ``input_metric``)
+            # resolves to no model, so the default-time-dimension logic below would
+            # skip it and cumulative ordering would fail with "requires a time
+            # dimension for ordering". Resolve the owning model from the metric's
+            # base dependency so the model's default time dimension is applied.
+            if not model_name and metric_obj is not None and metric_obj.type == "cumulative":
+                model_name = self._infer_cumulative_owner_model(metric_obj)
             if not model_name or model_name in models_checked:
                 continue
             models_checked.add(model_name)
@@ -439,6 +446,41 @@ class SQLGenerator:
                     models_with_time_dims.add(model_name)
 
         return dimensions + added_dims
+
+    def _infer_cumulative_owner_model(self, metric_obj, _seen: set[str] | None = None) -> str | None:
+        """Resolve the owning model of a graph-level cumulative metric.
+
+        A cumulative metric's base reference (``sql`` or ``base_metric``) may be a
+        model-qualified measure (``orders.amount`` -> ``orders``) or another
+        graph-level metric (e.g. a MetricFlow inline measure) that itself resolves
+        to a model. Follow that chain so the model's default time dimension can be
+        applied. Guards against reference cycles.
+        """
+        _seen = _seen if _seen is not None else set()
+        base_ref = metric_obj.sql or metric_obj.base_metric
+        if not base_ref or base_ref in _seen:
+            return None
+        _seen.add(base_ref)
+
+        if "." in base_ref:
+            candidate = base_ref.split(".", 1)[0]
+            if candidate in self.graph.models:
+                return candidate
+
+        try:
+            model_name, ref_metric = self.graph.resolve_metric_reference(base_ref)
+        except KeyError:
+            return None
+        if model_name:
+            return model_name
+        if ref_metric is not None:
+            if ref_metric.sql and "." in ref_metric.sql:
+                candidate = ref_metric.sql.split(".", 1)[0]
+                if candidate in self.graph.models:
+                    return candidate
+            if ref_metric.type == "cumulative":
+                return self._infer_cumulative_owner_model(ref_metric, _seen)
+        return None
 
     def generate_view(
         self,

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -2672,6 +2672,55 @@ class SQLGenerator:
                 )
             return rewritten
 
+    def _infer_metric_filter_model(self, metric, model_context: str | None) -> str | None:
+        """Infer the owning model of a graph-level simple aggregate metric.
+
+        Used to qualify the metric's unqualified filter columns. Prefers an
+        explicit ``model_context``; otherwise resolves the model from the first
+        qualified column in the metric SQL (e.g. ``orders.amount`` -> ``orders``).
+        """
+        if model_context and model_context in self.graph.models:
+            return model_context
+        if metric.sql:
+            try:
+                parsed = sqlglot.parse_one(metric.sql, dialect=self.dialect)
+                for col in parsed.find_all(exp.Column):
+                    candidate = col.table.replace("_cte", "") if col.table else None
+                    if candidate and candidate in self.graph.models:
+                        return candidate
+            except Exception:
+                return None
+        return None
+
+    def _qualify_metric_filter_sql(self, filter_expr: str, model_name: str | None) -> str:
+        """Qualify a metric filter's columns with the owning model's CTE.
+
+        Already-qualified ``model.col`` refs are rewritten to ``model_cte.col``;
+        unqualified columns are anchored to ``model_name``'s CTE so the predicate
+        is unambiguous when other joined CTEs expose same-named columns. Falls
+        back to plain CTE rewriting when the owning model is unknown.
+        """
+        if model_name is None:
+            return self._rewrite_model_refs_to_ctes(filter_expr)
+        cte_name = self._cte_name(model_name)
+        cte_identifier = exp.to_identifier(cte_name, quoted=not self._is_simple_identifier(cte_name))
+        try:
+            parsed = sqlglot.parse_one(filter_expr, dialect=self.dialect)
+        except Exception:
+            return self._rewrite_model_refs_to_ctes(filter_expr)
+        for col in parsed.find_all(exp.Column):
+            if col.table:
+                ref_model = col.table.replace("_cte", "")
+                if ref_model in self.graph.models:
+                    rewritten = self._cte_name(ref_model)
+                    col.set(
+                        "table",
+                        exp.to_identifier(rewritten, quoted=not self._is_simple_identifier(rewritten)),
+                    )
+            else:
+                col.set("table", cte_identifier.copy())
+        return parsed.sql(dialect=self.dialect)
+
     def _build_measure_aggregation_sql(self, model_name: str, measure) -> str:
         """Build SQL aggregation expression for a measure.
 
@@ -2882,10 +2931,14 @@ class SQLGenerator:
             # ``filter: status = 'completed'`` would silently aggregate every row.
             filter_sql = None
             if metric.filters:
+                # Qualify unqualified filter columns with the metric's owning model
+                # CTE so a filter like ``status = 'completed'`` is not ambiguous
+                # when a joined model's CTE also exposes a ``status`` column.
+                filter_model = self._infer_metric_filter_model(metric, model_context)
                 conditions = []
                 for filter_str in metric.filters:
                     condition = filter_str.replace("{model}.", "").replace("{model}", "")
-                    conditions.append(self._rewrite_model_refs_to_ctes(condition))
+                    conditions.append(self._qualify_metric_filter_sql(condition, filter_model))
                 if conditions:
                     filter_sql = " AND ".join(conditions)
 

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -1208,6 +1208,7 @@ class SQLGenerator:
             """Recursively extract filter columns from a metric and its dependencies."""
             # Extract from the metric's own filters
             if metric.filters:
+                filter_model_name = None
                 deps = metric.get_dependencies(self.graph)
                 for dep in deps:
                     try:
@@ -1215,8 +1216,24 @@ class SQLGenerator:
                     except KeyError:
                         dep_model_name = dep.split(".", 1)[0] if "." in dep else None
                     if dep_model_name:
-                        add_filter_columns(dep_model_name, metric.filters)
+                        filter_model_name = dep_model_name
                         break
+                # A graph-level simple aggregate (``agg`` + ``sql``) has no metric
+                # dependencies, so resolve its owning model from the SQL's column
+                # refs. Without this the filter columns are never projected into
+                # the CTE and the CASE WHEN filter references a missing column.
+                if filter_model_name is None and metric.agg and metric.sql:
+                    try:
+                        parsed = sqlglot.parse_one(metric.sql, dialect=self.dialect)
+                        for col in parsed.find_all(exp.Column):
+                            candidate = col.table.replace("_cte", "") if col.table else None
+                            if candidate and candidate in self.graph.models:
+                                filter_model_name = candidate
+                                break
+                    except Exception:
+                        filter_model_name = None
+                if filter_model_name:
+                    add_filter_columns(filter_model_name, metric.filters)
 
             # For ratio metrics, check numerator and denominator
             if metric.type == "ratio":
@@ -2858,13 +2875,35 @@ class SQLGenerator:
             if inner_expr != "*":
                 inner_expr = self._rewrite_model_refs_to_ctes(inner_expr)
 
+            # Metric-level filters scope the aggregation to matching rows. Apply
+            # them via CASE WHEN so the filter only affects this metric (mirrors
+            # the model-scoped measure path in _build_model_cte). Without this a
+            # filtered simple metric like a MetricFlow inline measure with
+            # ``filter: status = 'completed'`` would silently aggregate every row.
+            filter_sql = None
+            if metric.filters:
+                conditions = []
+                for filter_str in metric.filters:
+                    condition = filter_str.replace("{model}.", "").replace("{model}", "")
+                    conditions.append(self._rewrite_model_refs_to_ctes(condition))
+                if conditions:
+                    filter_sql = " AND ".join(conditions)
+
             if metric.agg == "count":
+                if filter_sql is not None:
+                    # COUNT ignores NULLs, so emit 1 for matching rows and NULL otherwise.
+                    return f"COUNT(CASE WHEN {filter_sql} THEN 1 ELSE NULL END)"
                 if inner_expr == "*":
                     return "COUNT(*)"
                 return f"COUNT({inner_expr})"
             if metric.agg == "count_distinct":
+                if filter_sql is not None:
+                    return f"COUNT(DISTINCT CASE WHEN {filter_sql} THEN {inner_expr} ELSE NULL END)"
                 return f"COUNT(DISTINCT {inner_expr})"
-            return f"{self._agg_sql_name(metric.agg)}({inner_expr})"
+            agg_arg = (
+                f"CASE WHEN {filter_sql} THEN {inner_expr} ELSE NULL END" if filter_sql is not None else inner_expr
+            )
+            return f"{self._agg_sql_name(metric.agg)}({agg_arg})"
 
         elif metric.type == "derived" or (not metric.type and not metric.agg and metric.sql):
             # Parse formula and replace metric references (handles both typed "derived" and untyped metrics with sql)

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -2944,8 +2944,12 @@ class SQLGenerator:
 
             if metric.agg == "count":
                 if filter_sql is not None:
-                    # COUNT ignores NULLs, so emit 1 for matching rows and NULL otherwise.
-                    return f"COUNT(CASE WHEN {filter_sql} THEN 1 ELSE NULL END)"
+                    # Count the metric expression (not a constant 1) so a NULL
+                    # expression is skipped exactly as the unfiltered ``COUNT(expr)``
+                    # path does. Only a true row count (``*``) counts every matching
+                    # row, including those with a NULL expression.
+                    counted = "1" if inner_expr == "*" else inner_expr
+                    return f"COUNT(CASE WHEN {filter_sql} THEN {counted} ELSE NULL END)"
                 if inner_expr == "*":
                     return "COUNT(*)"
                 return f"COUNT({inner_expr})"

--- a/tests/adapters/metricflow/test_fixtures.py
+++ b/tests/adapters/metricflow/test_fixtures.py
@@ -850,16 +850,36 @@ class TestSimpleManifestMetrics:
         assert ratio.type == "ratio"
         assert ratio.filters is not None
 
-    def test_conversion_metrics_skipped(self, graph):
-        """Conversion metrics are skipped (unsupported type)."""
-        assert "visit_buy_conversion_rate_7days" not in graph.metrics
-        assert "visit_buy_conversion_rate" not in graph.metrics
-        assert "visit_buy_conversions" not in graph.metrics
-        assert "visit_buy_conversion_rate_by_session" not in graph.metrics
+    def test_conversion_metrics_parsed(self, graph):
+        """Conversion metrics are parsed from type_params.conversion_type_params."""
+        assert "visit_buy_conversion_rate_7days" in graph.metrics
+        assert "visit_buy_conversion_rate" in graph.metrics
+        assert "visit_buy_conversions" in graph.metrics
+        assert "visit_buy_conversion_rate_by_session" in graph.metrics
+
+        rate_7d = graph.get_metric("visit_buy_conversion_rate_7days")
+        assert rate_7d.type == "conversion"
+        assert rate_7d.entity == "user"
+        assert rate_7d.base_event == "visits"
+        assert rate_7d.conversion_event == "buys"
+        assert rate_7d.conversion_window == "7 days"
+        assert rate_7d.metadata["calculation"] == "conversion_rate"
+
+        # conversions count flavor with a dict conversion_measure (fill_nulls_with)
+        conversions = graph.get_metric("visit_buy_conversions")
+        assert conversions.type == "conversion"
+        assert conversions.conversion_event == "buys"
+        assert conversions.metadata["calculation"] == "conversions"
+
+        # constant_properties retained in metadata
+        by_session = graph.get_metric("visit_buy_conversion_rate_by_session")
+        assert by_session.type == "conversion"
+        assert by_session.metadata["constant_properties"] == [
+            {"base_property": "session", "conversion_property": "session_id"}
+        ]
 
     def test_total_metric_count(self, graph):
-        """Verify total number of parsed metrics (simple + cumulative + derived + ratio, excluding conversion)."""
-        # Conversion metrics are skipped, so we count only supported types
+        """Verify total number of parsed metrics (simple + cumulative + derived + ratio + conversion)."""
         assert len(graph.metrics) >= 50
 
 
@@ -942,7 +962,7 @@ class TestSimpleManifestSavedQueries:
         return adapter.parse(FIXTURES / "simple_manifest_saved_queries.yaml")
 
     def test_parse_succeeds(self, graph):
-        """Fixture parses without errors (saved_queries key is ignored gracefully)."""
+        """Fixture parses without errors."""
         assert graph is not None
 
     def test_model_exists(self, graph):
@@ -950,9 +970,32 @@ class TestSimpleManifestSavedQueries:
         assert "sales_for_saved_queries" in graph.models
 
     def test_saved_queries_not_in_metrics(self, graph):
-        """saved_queries are not parsed into graph.metrics (not yet supported)."""
+        """saved_queries are kept separate from graph.metrics."""
         assert "p0_booking" not in graph.metrics
         assert "p0_booking_with_order_by_and_limit" not in graph.metrics
+
+    def test_saved_queries_captured_in_metadata(self, graph):
+        """saved_queries are parsed into graph.metadata['saved_queries']."""
+        saved = graph.metadata.get("saved_queries")
+        assert saved is not None
+        assert "p0_booking" in saved
+        assert "p0_booking_with_order_by_and_limit" in saved
+        assert "dimensions_only" in saved
+
+        p0 = saved["p0_booking"]
+        assert p0["metrics"] == ["bookings", "instant_bookings"]
+        assert p0["group_by"] == [
+            "TimeDimension('metric_time', 'day')",
+            "Dimension('listing__capacity_latest')",
+        ]
+        assert p0["where"] == ["{{ Dimension('listing__capacity_latest') }} > 3"]
+
+    def test_saved_query_order_by_and_limit(self, graph):
+        """order_by and limit are retained on the saved query."""
+        saved = graph.metadata["saved_queries"]
+        ordered = saved["p0_booking_with_order_by_and_limit"]
+        assert ordered["limit"] == 10
+        assert ordered["order_by"] is not None
 
 
 # =============================================================================

--- a/tests/adapters/metricflow/test_fixtures.py
+++ b/tests/adapters/metricflow/test_fixtures.py
@@ -47,12 +47,17 @@ class TestBookingsSource:
         assert model.table == "fct_bookings"
 
     def test_measure_count(self, graph):
-        """All 14 measures are imported."""
+        """Representable measures are imported; percentile measures are skipped.
+
+        The fixture declares 14 measures, but the 4 ``agg: percentile`` measures
+        have no Sidemantic equivalent and are skipped rather than coerced to sum,
+        leaving 10.
+        """
         model = graph.models["bookings_source"]
-        assert len(model.metrics) == 14
+        assert len(model.metrics) == 10
 
     def test_measure_names(self, graph):
-        """All measure names are present."""
+        """Representable measure names are present; percentile measures are absent."""
         model = graph.models["bookings_source"]
         names = {m.name for m in model.metrics}
         expected = {
@@ -66,12 +71,13 @@ class TestBookingsSource:
             "booking_payments",
             "referred_bookings",
             "median_booking_value",
-            "booking_value_p99",
-            "discrete_booking_value_p99",
-            "approximate_continuous_booking_value_p99",
-            "approximate_discrete_booking_value_p99",
         }
         assert names == expected
+        # ``agg: percentile`` measures cannot be represented and are skipped.
+        assert "booking_value_p99" not in names
+        assert "discrete_booking_value_p99" not in names
+        assert "approximate_continuous_booking_value_p99" not in names
+        assert "approximate_discrete_booking_value_p99" not in names
 
     def test_sum_boolean_maps_to_sum(self, graph):
         """sum_boolean aggregation maps to sum."""
@@ -85,11 +91,15 @@ class TestBookingsSource:
         median = model.get_metric("median_booking_value")
         assert median.agg == "median"
 
-    def test_percentile_aggregation_fallback(self, graph):
-        """percentile aggregation falls through to default (sum) since not in type_mapping."""
+    def test_percentile_aggregation_skipped(self, graph):
+        """percentile aggregation is skipped, not silently coerced to sum.
+
+        Sidemantic has no percentile aggregation. Coercing it to ``sum`` would
+        register ``SUM(booking_value)`` under the percentile measure's name and
+        return a wrong value, so the measure is dropped instead.
+        """
         model = graph.models["bookings_source"]
-        p99 = model.get_metric("booking_value_p99")
-        assert p99.agg == "sum"
+        assert model.get_metric("booking_value_p99") is None
 
     def test_count_distinct(self, graph):
         """count_distinct aggregation is mapped correctly."""
@@ -659,9 +669,13 @@ class TestSimpleManifestMetrics:
         assert "bookings_source" in graph.models
 
     def test_measure_count(self, graph):
-        """All 14 measures are imported from the semantic model."""
+        """Representable measures are imported; percentile measures are skipped.
+
+        Of the 14 declared measures, the 4 ``agg: percentile`` flavors have no
+        Sidemantic equivalent and are skipped rather than coerced to sum.
+        """
         model = graph.models["bookings_source"]
-        assert len(model.metrics) == 14
+        assert len(model.metrics) == 10
 
     def test_simple_metrics_parsed(self, graph):
         """Simple metrics are parsed as untyped with measure references."""

--- a/tests/adapters/metricflow/test_fixtures.py
+++ b/tests/adapters/metricflow/test_fixtures.py
@@ -773,11 +773,14 @@ class TestSimpleManifestMetrics:
         assert "booking_value_sub_instant" in nested.sql
 
     def test_derived_with_alias(self, graph):
-        """Derived metric with alias on input parses."""
+        """Derived metric with non-offset alias rewrites the alias to its input metric."""
         pct = graph.get_metric("non_referred_bookings_pct")
         assert pct is not None
         assert pct.type == "derived"
-        assert "ref_bookings" in pct.sql
+        # The non-offset alias ``ref_bookings`` is rewritten back to its real
+        # input metric ``referred_bookings`` so the metric is queryable.
+        assert pct.sql == "(bookings - referred_bookings) * 1.0 / bookings"
+        assert pct.get_dependencies(graph) == {"bookings", "referred_bookings"}
 
     def test_derived_with_filtered_input(self, graph):
         """Derived metric with filter on input metric parses."""
@@ -806,14 +809,17 @@ class TestSimpleManifestMetrics:
         assert twice.type == "derived"
 
     def test_derived_shared_aliases(self, graph):
-        """Derived metrics with shared alias names parse independently."""
+        """Derived metrics with shared alias names rewrite to their own input metrics."""
+        # Same alias name (``shared_alias``) maps to a different underlying metric
+        # in each derived metric; each is rewritten independently.
         a = graph.get_metric("derived_shared_alias_1a")
         assert a is not None
         assert a.type == "derived"
-        assert "shared_alias" in a.sql
+        assert a.sql == "bookings - 10"
 
         b = graph.get_metric("derived_shared_alias_2")
         assert b is not None
+        assert b.sql == "instant_bookings + 10"
 
     def test_derived_fill_nulls(self, graph):
         """Derived metrics with fill_nulls inputs parse."""
@@ -851,32 +857,35 @@ class TestSimpleManifestMetrics:
         assert ratio.filters is not None
 
     def test_conversion_metrics_parsed(self, graph):
-        """Conversion metrics are parsed from type_params.conversion_type_params."""
-        assert "visit_buy_conversion_rate_7days" in graph.metrics
-        assert "visit_buy_conversion_rate" in graph.metrics
-        assert "visit_buy_conversions" in graph.metrics
-        assert "visit_buy_conversion_rate_by_session" in graph.metrics
+        """Conversion metrics are retained as non-queryable metadata.
 
-        rate_7d = graph.get_metric("visit_buy_conversion_rate_7days")
-        assert rate_7d.type == "conversion"
-        assert rate_7d.entity == "user"
-        assert rate_7d.base_event == "visits"
-        assert rate_7d.conversion_event == "buys"
-        assert rate_7d.conversion_window == "7 days"
-        assert rate_7d.metadata["calculation"] == "conversion_rate"
+        MetricFlow conversion metrics reference base/conversion *measures*, which
+        cannot be faithfully mapped to Sidemantic's event-filter conversion
+        funnel, so they are captured in metadata rather than registered as
+        broken queryable metrics.
+        """
+        assert "visit_buy_conversion_rate_7days" not in graph.metrics
+        assert "visit_buy_conversion_rate" not in graph.metrics
+        assert "visit_buy_conversions" not in graph.metrics
+        assert "visit_buy_conversion_rate_by_session" not in graph.metrics
+
+        conv_specs = graph.metadata["metricflow_conversion_metrics"]
+
+        rate_7d = conv_specs["visit_buy_conversion_rate_7days"]
+        assert rate_7d["entity"] == "user"
+        assert rate_7d["base_measure"] == "visits"
+        assert rate_7d["conversion_measure"] == "buys"
+        assert rate_7d["window"] == "7 days"
+        assert rate_7d["calculation"] == "conversion_rate"
 
         # conversions count flavor with a dict conversion_measure (fill_nulls_with)
-        conversions = graph.get_metric("visit_buy_conversions")
-        assert conversions.type == "conversion"
-        assert conversions.conversion_event == "buys"
-        assert conversions.metadata["calculation"] == "conversions"
+        conversions = conv_specs["visit_buy_conversions"]
+        assert conversions["conversion_measure"] == "buys"
+        assert conversions["calculation"] == "conversions"
 
         # constant_properties retained in metadata
-        by_session = graph.get_metric("visit_buy_conversion_rate_by_session")
-        assert by_session.type == "conversion"
-        assert by_session.metadata["constant_properties"] == [
-            {"base_property": "session", "conversion_property": "session_id"}
-        ]
+        by_session = conv_specs["visit_buy_conversion_rate_by_session"]
+        assert by_session["constant_properties"] == [{"base_property": "session", "conversion_property": "session_id"}]
 
     def test_total_metric_count(self, graph):
         """Verify total number of parsed metrics (simple + cumulative + derived + ratio + conversion)."""

--- a/tests/adapters/metricflow/test_parsing.py
+++ b/tests/adapters/metricflow/test_parsing.py
@@ -1189,5 +1189,66 @@ def test_metricflow_period_agg_and_offset_metadata():
     assert any(i.get("offset_window") == "1 week" for i in inputs)
 
 
+def test_metricflow_disabled_model_skips_inline_metrics():
+    """Inline metrics on a disabled semantic model are not registered.
+
+    ``semantic_model.enabled: false`` produces no model, so its inline
+    model-local metrics have no SQL/model context. Registering them anyway would
+    leave queryable-looking metrics in the graph that raise ``No models found for
+    query`` when selected. The disabled model's metrics must be skipped while a
+    sibling enabled model's metrics remain queryable.
+    """
+    import tempfile
+    import textwrap
+
+    yml = textwrap.dedent("""
+        models:
+          - name: events
+            semantic_model:
+              enabled: false
+              name: events
+            columns:
+              - name: event_id
+                entity:
+                  type: primary
+                  name: event
+            metrics:
+              - name: event_count
+                type: simple
+                agg: count
+          - name: orders
+            semantic_model:
+              enabled: true
+              name: orders
+            columns:
+              - name: order_id
+                entity:
+                  type: primary
+                  name: order
+            metrics:
+              - name: order_count
+                type: simple
+                agg: count
+    """)
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(yml)
+        path = Path(f.name)
+
+    try:
+        graph = MetricFlowAdapter().parse(path)
+
+        # Disabled model and its inline metric are absent.
+        assert "events" not in graph.models
+        assert "event_count" not in graph.metrics
+
+        # Sibling enabled model and its inline metric remain queryable.
+        assert "orders" in graph.models
+        assert "order_count" in graph.metrics
+        sql = SQLGenerator(graph).generate(metrics=["order_count"])
+        assert "orders" in sql.lower()
+    finally:
+        path.unlink(missing_ok=True)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/adapters/metricflow/test_parsing.py
+++ b/tests/adapters/metricflow/test_parsing.py
@@ -1250,5 +1250,81 @@ def test_metricflow_disabled_model_skips_inline_metrics():
         path.unlink(missing_ok=True)
 
 
+def test_metricflow_unrepresentable_agg_is_skipped():
+    """An ``agg`` Sidemantic cannot represent is skipped, not coerced to sum.
+
+    MetricFlow allows ``agg: percentile`` (with ``agg_params``). Sidemantic has no
+    percentile aggregation, and the agg mapper previously defaulted unknown aggs
+    to ``sum``, so ``revenue_p95`` parsed as ``SUM(amount)`` and silently returned
+    the wrong value. Such metrics/measures must be dropped while representable
+    siblings remain.
+    """
+    import tempfile
+    import textwrap
+
+    # Latest-spec inline metric.
+    inline_yml = textwrap.dedent("""
+        models:
+          - name: payments
+            semantic_model:
+              enabled: true
+              name: payments
+            columns:
+              - name: payment_id
+                entity:
+                  type: primary
+                  name: payment
+            metrics:
+              - name: revenue_p95
+                type: simple
+                agg: percentile
+                expr: amount
+              - name: total_revenue
+                type: simple
+                agg: sum
+                expr: amount
+    """)
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(inline_yml)
+        inline_path = Path(f.name)
+
+    # Legacy-spec measure.
+    legacy_yml = textwrap.dedent("""
+        semantic_models:
+          - name: payments_legacy
+            model: ref('payments')
+            entities:
+              - name: payment
+                type: primary
+                expr: payment_id
+            measures:
+              - name: p95_amount
+                agg: percentile
+                expr: amount
+              - name: total_amount
+                agg: sum
+                expr: amount
+    """)
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(legacy_yml)
+        legacy_path = Path(f.name)
+
+    try:
+        inline_graph = MetricFlowAdapter().parse(inline_path)
+        legacy_graph = MetricFlowAdapter().parse(legacy_path)
+    finally:
+        inline_path.unlink(missing_ok=True)
+        legacy_path.unlink(missing_ok=True)
+
+    # Inline percentile metric is skipped; sibling sum metric is kept.
+    assert "revenue_p95" not in inline_graph.metrics
+    assert "total_revenue" in inline_graph.metrics
+
+    # Legacy percentile measure is skipped; sibling sum measure is kept.
+    legacy_measures = {m.name for m in legacy_graph.get_model("payments_legacy").metrics}
+    assert "p95_amount" not in legacy_measures
+    assert "total_amount" in legacy_measures
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/adapters/metricflow/test_parsing.py
+++ b/tests/adapters/metricflow/test_parsing.py
@@ -650,14 +650,34 @@ def test_metricflow_conversion_metrics():
     buys = events.get_metric("buys")
     assert buys is not None
 
-    # Check conversion metrics - NOTE: conversion type not yet supported in adapter
-    # Conversion metrics are skipped during parsing (return None) for unsupported types
-    # Verify they're not in the graph
-    assert "visit_to_buy_conversion_rate" not in graph.metrics
-    assert "visit_to_buy_conversions_1_week" not in graph.metrics
-    assert "view_to_purchase_same_product" not in graph.metrics
+    # Conversion metrics are now parsed from type_params.conversion_type_params.
+    assert "visit_to_buy_conversion_rate" in graph.metrics
+    assert "visit_to_buy_conversions_1_week" in graph.metrics
+    assert "view_to_purchase_same_product" in graph.metrics
 
-    # Test that parsing doesn't fail even with unsupported conversion type
+    conv = graph.get_metric("visit_to_buy_conversion_rate")
+    assert conv.type == "conversion"
+    assert conv.entity == "user"
+    assert conv.base_event == "visits"
+    assert conv.conversion_event == "buys"
+    assert conv.conversion_window == "7 days"
+    assert conv.metadata["calculation"] == "conversion_rate"
+
+    # Conversion with calculation: conversions (count flavor)
+    conversions = graph.get_metric("visit_to_buy_conversions_1_week")
+    assert conversions.type == "conversion"
+    assert conversions.conversion_window == "1 week"
+    assert conversions.metadata["calculation"] == "conversions"
+
+    # Conversion with constant_properties
+    same_product = graph.get_metric("view_to_purchase_same_product")
+    assert same_product.type == "conversion"
+    assert same_product.base_event == "view_item_detail"
+    assert same_product.metadata["constant_properties"] == [
+        {"base_property": "product", "conversion_property": "product"}
+    ]
+
+    # Test that parsing doesn't fail
     assert graph is not None
     assert len(graph.models) > 0
 
@@ -787,6 +807,16 @@ def test_metricflow_saved_queries():
     transactions = graph.get_metric("sales_transactions")
     assert transactions.sql == "sales_count"
 
+    # Saved queries are parsed into graph metadata (not into graph.metrics).
+    saved = graph.metadata.get("saved_queries")
+    assert saved is not None
+    assert "monthly_sales_by_region" in saved
+    sq = saved["monthly_sales_by_region"]
+    assert sq["metrics"] == ["total_sales", "sales_transactions"]
+    assert sq["group_by"] == ["TimeDimension('sale_date', 'month')", "Dimension('region')"]
+    assert sq["exports"][0]["name"] == "monthly_sales_export"
+    assert sq["exports"][0]["config"]["export_as"] == "table"
+
 
 def test_import_real_metricflow_example():
     """Test importing a real dbt MetricFlow schema file."""
@@ -833,6 +863,109 @@ def test_import_real_metricflow_example():
     assert avg_order.type == "ratio"
     assert avg_order.numerator == "revenue"
     assert avg_order.denominator == "order_count"
+
+
+def test_metricflow_latest_spec_models():
+    """Test the latest spec (dbt Core 1.12 / Fusion): models: with nested semantic_model:."""
+    adapter = MetricFlowAdapter()
+    graph = adapter.parse(Path("tests/fixtures/metricflow/latest_spec_models.yml"))
+
+    # Semantic models embedded under models: are imported
+    assert "orders" in graph.models
+    assert "customers" in graph.models
+
+    orders = graph.get_model("orders")
+    # Primary entity column becomes the primary key
+    assert orders.primary_key == "order_id"
+    # The underlying table is the dbt model name
+    assert orders.table == "orders"
+    # agg_time_dimension promoted to top level
+    assert orders.default_time_dimension == "ordered_at"
+
+    # Column-based foreign entity becomes a relationship (resolved to model name)
+    rel_names = {r.name for r in orders.relationships}
+    assert "customers" in rel_names
+    customer_rel = next(r for r in orders.relationships if r.name == "customers")
+    assert customer_rel.type == "many_to_one"
+    assert customer_rel.foreign_key == "customer_id"
+
+    # Column-based dimensions (time + categorical)
+    ordered_at = orders.get_dimension("ordered_at")
+    assert ordered_at is not None
+    assert ordered_at.type == "time"
+    assert ordered_at.granularity == "day"
+
+    status = orders.get_dimension("status")
+    assert status is not None
+    assert status.type == "categorical"
+    # expr falls back to the column name
+    assert status.sql == "order_status"
+
+    # Measures folded into inline simple metrics
+    order_total = graph.get_metric("order_total")
+    assert order_total is not None
+    assert order_total.type is None
+    assert order_total.agg == "sum"
+    assert order_total.sql == "amount"
+
+    order_count = graph.get_metric("order_count")
+    assert order_count is not None
+    assert order_count.agg == "count"
+
+    # Ratio with promoted numerator/denominator (no type_params)
+    rpo = graph.get_metric("revenue_per_order")
+    assert rpo.type == "ratio"
+    assert rpo.numerator == "order_total"
+    assert rpo.denominator == "order_count"
+
+    # Derived with promoted expr + input_metrics offset modifiers
+    growth = graph.get_metric("order_total_growth")
+    assert growth.type == "derived"
+    assert growth.sql == "current_total - total_7_days_ago"
+    inputs = growth.metadata["input_metrics"]
+    offset_input = next(i for i in inputs if i.get("alias") == "total_7_days_ago")
+    assert offset_input["offset_window"] == "7 days"
+
+    # Cumulative with promoted input_metric + window + period_agg
+    rolling = graph.get_metric("rolling_30d_revenue")
+    assert rolling.type == "cumulative"
+    assert rolling.sql == "order_total"
+    assert rolling.window == "30 days"
+    assert rolling.metadata["period_agg"] == "sum"
+
+    # Cumulative with promoted grain_to_date
+    mtd = graph.get_metric("revenue_mtd")
+    assert mtd.type == "cumulative"
+    assert mtd.grain_to_date == "month"
+
+    # Conversion with promoted base_metric/conversion_metric/entity
+    conv = graph.get_metric("order_to_repeat_conversion")
+    assert conv.type == "conversion"
+    assert conv.entity == "customer"
+    assert conv.base_event == "order_count"
+    assert conv.conversion_event == "order_count"
+    assert conv.metadata["calculation"] == "conversion_rate"
+    assert conv.metadata["constant_properties"] == [{"base_property": "region", "conversion_property": "region"}]
+
+
+def test_metricflow_period_agg_and_offset_metadata():
+    """period_agg and per-input offset modifiers are retained in metric metadata."""
+    adapter = MetricFlowAdapter()
+    graph = adapter.parse(Path("tests/fixtures/metricflow/simple_manifest_metrics.yaml"))
+
+    # Cumulative period_agg (legacy cumulative_type_params shape)
+    t2mr = graph.get_metric("trailing_2_months_revenue")
+    assert t2mr.metadata is not None
+    assert t2mr.metadata["period_agg"] == "average"
+
+    all_time = graph.get_metric("revenue_all_time")
+    assert all_time.metadata["period_agg"] == "last"
+
+    # Derived per-input offset_window (legacy type_params.metrics shape)
+    offset_metric = graph.get_metric("booking_fees_last_week_per_booker_this_week")
+    assert offset_metric.type == "derived"
+    inputs = offset_metric.metadata["input_metrics"]
+    assert any(i.get("offset_window") == "1 week" for i in inputs)
 
 
 if __name__ == "__main__":

--- a/tests/adapters/metricflow/test_parsing.py
+++ b/tests/adapters/metricflow/test_parsing.py
@@ -173,13 +173,15 @@ def test_metricflow_advanced_metrics():
     assert profit_margin.numerator == "order_total"
     assert profit_margin.denominator == "order_cost"
 
-    # Check derived metrics
+    # Check derived metrics - plain (non-offset, unfiltered) aliases are
+    # rewritten back to their real input metrics so the metric is queryable.
     assert "order_gross_profit" in graph.metrics
     gross_profit = graph.get_metric("order_gross_profit")
     assert gross_profit.type == "derived"
-    assert gross_profit.sql == "revenue - cost"
+    assert gross_profit.sql == "total_order_revenue - total_order_cost"
 
-    # Check derived metric with filters
+    # Check derived metric with filters - filtered-input aliases are preserved
+    # because the filtered value differs from the underlying metric.
     assert "food_order_profit" in graph.metrics
     food_profit = graph.get_metric("food_order_profit")
     assert food_profit.type == "derived"
@@ -650,32 +652,32 @@ def test_metricflow_conversion_metrics():
     buys = events.get_metric("buys")
     assert buys is not None
 
-    # Conversion metrics are now parsed from type_params.conversion_type_params.
-    assert "visit_to_buy_conversion_rate" in graph.metrics
-    assert "visit_to_buy_conversions_1_week" in graph.metrics
-    assert "view_to_purchase_same_product" in graph.metrics
+    # MetricFlow conversion metrics reference base/conversion *measures*, which
+    # have no faithful mapping to Sidemantic's event-filter conversion funnel.
+    # They are retained as non-queryable metadata rather than registered as
+    # broken queryable metrics, so they never appear in graph.metrics.
+    assert "visit_to_buy_conversion_rate" not in graph.metrics
+    assert "visit_to_buy_conversions_1_week" not in graph.metrics
+    assert "view_to_purchase_same_product" not in graph.metrics
 
-    conv = graph.get_metric("visit_to_buy_conversion_rate")
-    assert conv.type == "conversion"
-    assert conv.entity == "user"
-    assert conv.base_event == "visits"
-    assert conv.conversion_event == "buys"
-    assert conv.conversion_window == "7 days"
-    assert conv.metadata["calculation"] == "conversion_rate"
+    conv_specs = graph.metadata["metricflow_conversion_metrics"]
+
+    conv = conv_specs["visit_to_buy_conversion_rate"]
+    assert conv["entity"] == "user"
+    assert conv["base_measure"] == "visits"
+    assert conv["conversion_measure"] == "buys"
+    assert conv["window"] == "7 days"
+    assert conv["calculation"] == "conversion_rate"
 
     # Conversion with calculation: conversions (count flavor)
-    conversions = graph.get_metric("visit_to_buy_conversions_1_week")
-    assert conversions.type == "conversion"
-    assert conversions.conversion_window == "1 week"
-    assert conversions.metadata["calculation"] == "conversions"
+    conversions = conv_specs["visit_to_buy_conversions_1_week"]
+    assert conversions["window"] == "1 week"
+    assert conversions["calculation"] == "conversions"
 
     # Conversion with constant_properties
-    same_product = graph.get_metric("view_to_purchase_same_product")
-    assert same_product.type == "conversion"
-    assert same_product.base_event == "view_item_detail"
-    assert same_product.metadata["constant_properties"] == [
-        {"base_property": "product", "conversion_property": "product"}
-    ]
+    same_product = conv_specs["view_to_purchase_same_product"]
+    assert same_product["base_measure"] == "view_item_detail"
+    assert same_product["constant_properties"] == [{"base_property": "product", "conversion_property": "product"}]
 
     # Test that parsing doesn't fail
     assert graph is not None
@@ -922,10 +924,12 @@ def test_metricflow_latest_spec_models():
     assert rpo.numerator == "order_total"
     assert rpo.denominator == "order_count"
 
-    # Derived with promoted expr + input_metrics offset modifiers
+    # Derived with promoted expr + input_metrics offset modifiers. The plain
+    # alias (current_total) is rewritten to its input metric (order_total); the
+    # offset alias (total_7_days_ago) is preserved because it is time-shifted.
     growth = graph.get_metric("order_total_growth")
     assert growth.type == "derived"
-    assert growth.sql == "current_total - total_7_days_ago"
+    assert growth.sql == "order_total - total_7_days_ago"
     inputs = growth.metadata["input_metrics"]
     offset_input = next(i for i in inputs if i.get("alias") == "total_7_days_ago")
     assert offset_input["offset_window"] == "7 days"
@@ -942,14 +946,15 @@ def test_metricflow_latest_spec_models():
     assert mtd.type == "cumulative"
     assert mtd.grain_to_date == "month"
 
-    # Conversion with promoted base_metric/conversion_metric/entity
-    conv = graph.get_metric("order_to_repeat_conversion")
-    assert conv.type == "conversion"
-    assert conv.entity == "customer"
-    assert conv.base_event == "order_count"
-    assert conv.conversion_event == "order_count"
-    assert conv.metadata["calculation"] == "conversion_rate"
-    assert conv.metadata["constant_properties"] == [{"base_property": "region", "conversion_property": "region"}]
+    # Conversion with promoted base_metric/conversion_metric/entity is retained
+    # as non-queryable metadata (no faithful mapping to Sidemantic's funnel).
+    assert "order_to_repeat_conversion" not in graph.metrics
+    conv = graph.metadata["metricflow_conversion_metrics"]["order_to_repeat_conversion"]
+    assert conv["entity"] == "customer"
+    assert conv["base_measure"] == "order_count"
+    assert conv["conversion_measure"] == "order_count"
+    assert conv["calculation"] == "conversion_rate"
+    assert conv["constant_properties"] == [{"base_property": "region", "conversion_property": "region"}]
 
 
 def test_metricflow_latest_spec_inline_metric_queryable_alone():
@@ -976,6 +981,126 @@ def test_metricflow_latest_spec_inline_metric_queryable_alone():
     # A ratio referencing the inline measures by bare name still resolves
     sql = generator.generate(metrics=["revenue_per_order"])
     assert "orders" in sql.lower()
+
+
+def test_metricflow_inline_constant_count_anchored_to_model():
+    """A constant inline count (``agg: count`` with ``expr: 1``/``'*'``) is queryable.
+
+    Such a measure has no column to qualify, so without anchoring it carries no
+    model reference and selecting it raises ``No models found for query``. It
+    should take the same primary-key anchoring path as a bare ``count``.
+    """
+    import tempfile
+    import textwrap
+
+    yml = textwrap.dedent("""
+        models:
+          - name: events
+            semantic_model:
+              enabled: true
+              name: events
+            columns:
+              - name: event_id
+                entity:
+                  type: primary
+                  name: event
+            metrics:
+              - name: row_count
+                type: simple
+                agg: count
+                expr: 1
+              - name: star_count
+                type: simple
+                agg: count
+                expr: '*'
+    """)
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(yml)
+        path = Path(f.name)
+
+    try:
+        adapter = MetricFlowAdapter()
+        graph = adapter.parse(path)
+        # Constant counts are anchored to the model primary key.
+        assert graph.get_metric("row_count").sql == "events.event_id"
+        assert graph.get_metric("star_count").sql == "events.event_id"
+
+        generator = SQLGenerator(graph)
+        for metric_name in ("row_count", "star_count"):
+            sql = generator.generate(metrics=[metric_name])
+            assert "events" in sql.lower()
+            assert "count" in sql.lower()
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_metricflow_derived_non_offset_aliases_queryable():
+    """Derived metrics whose inputs are all non-offset aliases are queryable.
+
+    MetricFlow lets a derived expression reference an input metric by ``alias``.
+    Aliases without an offset modifier are rewritten back to their real input
+    metric so dependency resolution sees real metrics; otherwise the planner
+    cannot infer a model and the metric cannot be queried.
+    """
+    adapter = MetricFlowAdapter()
+    graph = adapter.parse(Path("tests/fixtures/metricflow/latest_spec_models.yml"))
+
+    net = graph.get_metric("net_order_total")
+    assert net.type == "derived"
+    # Both aliases (gross_total, half_total) rewritten back to order_total.
+    assert net.sql == "order_total - order_total / 2"
+    assert net.get_dependencies(graph) == {"order_total"}
+
+    sql = SQLGenerator(graph).generate(metrics=["net_order_total"])
+    assert "orders" in sql.lower()
+
+
+def test_metricflow_derived_offset_alias_preserved():
+    """An offset-carrying derived input alias is left intact (time-shifted value).
+
+    Rewriting an offset alias to its base metric would conflate a time-shifted
+    value with the current one, so those aliases are preserved as-is and the
+    metric remains round-trip metadata rather than a misleading queryable metric.
+    """
+    adapter = MetricFlowAdapter()
+    graph = adapter.parse(Path("tests/fixtures/metricflow/latest_spec_models.yml"))
+
+    growth = graph.get_metric("order_total_growth")
+    # Non-offset alias (current_total) rewritten; offset alias (total_7_days_ago) kept.
+    assert growth.sql == "order_total - total_7_days_ago"
+
+
+def test_metricflow_conversion_metrics_not_queryable_metadata_only():
+    """Conversion metrics are retained as metadata, never registered as metrics.
+
+    MetricFlow conversion metrics reference base/conversion *measures*, which do
+    not map to Sidemantic's event-filter conversion funnel. Registering one
+    would generate wrong SQL (filtering an event_type dimension by a measure
+    name), so the spec is captured in graph metadata instead.
+    """
+    adapter = MetricFlowAdapter()
+    graph = adapter.parse(Path("tests/fixtures/metricflow/latest_spec_models.yml"))
+
+    assert "order_to_repeat_conversion" not in graph.metrics
+    specs = graph.metadata["metricflow_conversion_metrics"]
+    spec = specs["order_to_repeat_conversion"]
+    assert spec["entity"] == "customer"
+    assert spec["base_measure"] == "order_count"
+    assert spec["conversion_measure"] == "order_count"
+    assert spec["calculation"] == "conversion_rate"
+
+
+def test_metricflow_conversion_metrics_not_leaked_on_reuse():
+    """Reusing an adapter must not leak conversion metrics into a later graph."""
+    adapter = MetricFlowAdapter()
+
+    with_conv = adapter.parse(Path("tests/fixtures/metricflow/latest_spec_models.yml"))
+    assert "metricflow_conversion_metrics" in with_conv.metadata
+
+    # Parsing a source without conversion metrics on the same adapter must not
+    # retain the previous file's entries.
+    without_conv = adapter.parse(Path("tests/fixtures/metricflow/semantic_models.yml"))
+    assert "metricflow_conversion_metrics" not in without_conv.metadata
 
 
 def test_metricflow_saved_queries_not_leaked_on_reuse():

--- a/tests/adapters/metricflow/test_parsing.py
+++ b/tests/adapters/metricflow/test_parsing.py
@@ -901,16 +901,20 @@ def test_metricflow_latest_spec_models():
     # expr falls back to the column name
     assert status.sql == "order_status"
 
-    # Measures folded into inline simple metrics
+    # Measures folded into inline simple metrics. The expression is qualified
+    # with the owning model so a query selecting only the metric can infer its
+    # model.
     order_total = graph.get_metric("order_total")
     assert order_total is not None
     assert order_total.type is None
     assert order_total.agg == "sum"
-    assert order_total.sql == "amount"
+    assert order_total.sql == "orders.amount"
 
     order_count = graph.get_metric("order_count")
     assert order_count is not None
     assert order_count.agg == "count"
+    # A bare ``count`` (no expr) is anchored to the model via its primary key.
+    assert order_count.sql == "orders.order_id"
 
     # Ratio with promoted numerator/denominator (no type_params)
     rpo = graph.get_metric("revenue_per_order")
@@ -946,6 +950,45 @@ def test_metricflow_latest_spec_models():
     assert conv.conversion_event == "order_count"
     assert conv.metadata["calculation"] == "conversion_rate"
     assert conv.metadata["constant_properties"] == [{"base_property": "region", "conversion_property": "region"}]
+
+
+def test_metricflow_latest_spec_inline_metric_queryable_alone():
+    """Inline simple metrics carry model context so they can be queried alone.
+
+    A latest-spec ``type: simple`` metric folds a model measure. Its SQL must be
+    qualified with the owning model, otherwise selecting only that metric raises
+    ``No models found for query``.
+    """
+    adapter = MetricFlowAdapter()
+    graph = adapter.parse(Path("tests/fixtures/metricflow/latest_spec_models.yml"))
+    generator = SQLGenerator(graph)
+
+    # A measure-backed simple metric (sum with expr)
+    sql = generator.generate(metrics=["order_total"])
+    assert "orders" in sql.lower()
+    assert "sum" in sql.lower()
+
+    # A bare count measure (no expr) is anchored via the primary key
+    sql = generator.generate(metrics=["order_count"])
+    assert "orders" in sql.lower()
+    assert "count" in sql.lower()
+
+    # A ratio referencing the inline measures by bare name still resolves
+    sql = generator.generate(metrics=["revenue_per_order"])
+    assert "orders" in sql.lower()
+
+
+def test_metricflow_saved_queries_not_leaked_on_reuse():
+    """Reusing an adapter must not leak saved queries into a later graph."""
+    adapter = MetricFlowAdapter()
+
+    with_sq = adapter.parse(Path("tests/fixtures/metricflow/saved_queries_example.yml"))
+    assert "saved_queries" in with_sq.metadata
+
+    # Parsing a source without saved queries on the same adapter must not retain
+    # the previous file's entries.
+    without_sq = adapter.parse(Path("tests/fixtures/metricflow/latest_spec_models.yml"))
+    assert "saved_queries" not in without_sq.metadata
 
 
 def test_metricflow_period_agg_and_offset_metadata():

--- a/tests/adapters/metricflow/test_parsing.py
+++ b/tests/adapters/metricflow/test_parsing.py
@@ -1034,6 +1034,59 @@ def test_metricflow_inline_constant_count_anchored_to_model():
         path.unlink(missing_ok=True)
 
 
+def test_metricflow_inline_exprless_non_count_uses_metric_column():
+    """An expr-less non-count inline measure aggregates its own column, not the PK.
+
+    In MetricFlow an expr-less measure aggregates the column named after the
+    measure. Only count-style measures may be anchored to the primary key;
+    anchoring a ``sum``/``max``/etc. there would silently aggregate the wrong
+    column (e.g. ``SUM(customers.customer_id)``).
+    """
+    import tempfile
+    import textwrap
+
+    yml = textwrap.dedent("""
+        models:
+          - name: customers
+            semantic_model:
+              enabled: true
+              name: customers
+            columns:
+              - name: customer_id
+                entity:
+                  type: primary
+                  name: customer
+            metrics:
+              - name: lifetime_spend_pretax
+                type: simple
+                agg: sum
+              - name: max_spend
+                type: simple
+                agg: max
+              - name: customer_count
+                type: simple
+                agg: count
+    """)
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(yml)
+        path = Path(f.name)
+
+    try:
+        adapter = MetricFlowAdapter()
+        graph = adapter.parse(path)
+        # Expr-less non-count aggregates use the metric's own column.
+        assert graph.get_metric("lifetime_spend_pretax").sql == "customers.lifetime_spend_pretax"
+        assert graph.get_metric("max_spend").sql == "customers.max_spend"
+        # Expr-less count is still anchored to the primary key.
+        assert graph.get_metric("customer_count").sql == "customers.customer_id"
+
+        sql = SQLGenerator(graph).generate(metrics=["lifetime_spend_pretax"])
+        assert "sum(customers_cte.lifetime_spend_pretax)" in sql.lower()
+        assert "customer_id" not in sql.lower()
+    finally:
+        path.unlink(missing_ok=True)
+
+
 def test_metricflow_derived_non_offset_aliases_queryable():
     """Derived metrics whose inputs are all non-offset aliases are queryable.
 

--- a/tests/adapters/metricflow/test_query.py
+++ b/tests/adapters/metricflow/test_query.py
@@ -327,5 +327,47 @@ def test_inline_filtered_count_skips_null_expression():
     assert row["completed_row_count"] == 4
 
 
+def test_cumulative_metric_uses_input_metric_model_time_dimension():
+    """A cumulative metric over an inline metric inherits the model's default time dim.
+
+    Regression: a latest-spec cumulative metric (promoted ``input_metric``) is a
+    graph-level metric, so default-time-dimension resolution skipped it and a CLI
+    query raised ``requires a time dimension for ordering`` even though the
+    underlying ``orders`` model declares ``agg_time_dimension: ordered_at``. The
+    cumulative metric must resolve its owning model through the input metric and
+    pick up that model's default time dimension.
+    """
+    import duckdb
+
+    from tests.utils import fetch_dicts
+
+    graph = MetricFlowAdapter().parse("tests/fixtures/metricflow/latest_spec_models.yml")
+
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE orders AS SELECT * FROM (VALUES "
+        "(1, 10, DATE '2024-01-05', 'completed', 100.0), "
+        "(2, 11, DATE '2024-01-20', 'completed', 50.0), "
+        "(3, 10, DATE '2024-02-10', 'pending', 25.0)) "
+        "AS t(order_id, customer_id, ordered_at, order_status, amount)"
+    )
+    conn.execute(
+        "CREATE TABLE customers AS SELECT * FROM (VALUES "
+        "(10, DATE '2024-01-01', 'US'), (11, DATE '2024-01-15', 'EU')) "
+        "AS t(customer_id, first_ordered_at, region)"
+    )
+
+    layer = SemanticLayer(auto_register=False)
+    layer.conn = conn
+    layer.graph = graph
+
+    # The model's default time dimension is auto-added so cumulative ordering works.
+    for metric_name in ("rolling_30d_revenue", "revenue_mtd"):
+        sql = layer.compile(metrics=[metric_name])
+        assert "ordered_at" in sql
+        rows = fetch_dicts(layer.query(metrics=[metric_name]))
+        assert rows  # query binds and returns rows
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/adapters/metricflow/test_query.py
+++ b/tests/adapters/metricflow/test_query.py
@@ -247,5 +247,85 @@ def test_inline_metric_filter_qualified_in_join():
     assert {r["status"]: r["completed_revenue"] for r in rows} == {"active": 125.0}
 
 
+def test_inline_filtered_count_skips_null_expression():
+    """A filtered ``count`` over an expression skips NULL values like the unfiltered count.
+
+    Regression: the filtered count counted a constant 1 for every matching row,
+    so rows with a NULL counted expression were included even though the
+    unfiltered ``COUNT(expr)`` path skips them. A filtered count over an
+    expression must count the expression (skipping NULLs); only a bare row count
+    counts every matching row.
+    """
+    import tempfile
+    import textwrap
+    from pathlib import Path
+
+    import duckdb
+
+    from tests.utils import fetch_dicts
+
+    yml = textwrap.dedent("""
+        models:
+          - name: orders
+            semantic_model:
+              enabled: true
+              name: orders
+            columns:
+              - name: order_id
+                entity:
+                  type: primary
+                  name: order
+              - name: status
+                dimension:
+                  type: categorical
+              - name: amount
+                dimension:
+                  type: categorical
+            metrics:
+              - name: amount_count
+                type: simple
+                agg: count
+                expr: amount
+              - name: completed_amount_count
+                type: simple
+                agg: count
+                expr: amount
+                filter: "status = 'completed'"
+              - name: completed_row_count
+                type: simple
+                agg: count
+                filter: "status = 'completed'"
+    """)
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(yml)
+        path = Path(f.name)
+
+    try:
+        graph = MetricFlowAdapter().parse(path)
+    finally:
+        path.unlink(missing_ok=True)
+
+    conn = duckdb.connect(":memory:")
+    # Four completed rows, one with a NULL amount; one pending row.
+    conn.execute(
+        "CREATE TABLE orders AS SELECT * FROM (VALUES "
+        "(1, 'completed', 100.0), (2, 'completed', NULL), (3, 'completed', 50.0), "
+        "(4, 'completed', 25.0), (5, 'pending', 999.0)) "
+        "AS t(order_id, status, amount)"
+    )
+
+    layer = SemanticLayer(auto_register=False)
+    layer.conn = conn
+    layer.graph = graph
+
+    row = fetch_dicts(layer.query(metrics=["amount_count", "completed_amount_count", "completed_row_count"]))[0]
+    # Unfiltered count(amount) skips the single NULL across all five rows.
+    assert row["amount_count"] == 4
+    # Filtered count(amount) keeps completed rows with a non-NULL amount.
+    assert row["completed_amount_count"] == 3
+    # A bare filtered count is a row count: every completed row.
+    assert row["completed_row_count"] == 4
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/adapters/metricflow/test_query.py
+++ b/tests/adapters/metricflow/test_query.py
@@ -159,5 +159,93 @@ def test_inline_simple_metric_filter_is_applied():
     assert grouped["pending"]["completed_revenue"] in (None, 0)
 
 
+def test_inline_metric_filter_qualified_in_join():
+    """A filtered inline metric's columns are qualified to its owning model CTE.
+
+    Regression: the metric filter was rendered with unqualified columns. When the
+    metric is queried with a joined dimension whose CTE also exposes a same-named
+    column, the unqualified filter column was ambiguous and the query failed to
+    bind. The filter columns must be qualified with the owning model's CTE.
+    """
+    import tempfile
+    import textwrap
+    from pathlib import Path
+
+    import duckdb
+
+    from tests.utils import fetch_dicts
+
+    yml = textwrap.dedent("""
+        models:
+          - name: orders
+            semantic_model:
+              enabled: true
+              name: orders
+            columns:
+              - name: order_id
+                entity:
+                  type: primary
+                  name: order
+              - name: customer_id
+                entity:
+                  type: foreign
+                  name: customer
+              - name: status
+                dimension:
+                  type: categorical
+              - name: amount
+                dimension:
+                  type: categorical
+            metrics:
+              - name: completed_revenue
+                type: simple
+                agg: sum
+                expr: amount
+                filter: "status = 'completed'"
+          - name: customers
+            semantic_model:
+              enabled: true
+              name: customers
+            columns:
+              - name: customer_id
+                entity:
+                  type: primary
+                  name: customer
+              - name: status
+                dimension:
+                  type: categorical
+    """)
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(yml)
+        path = Path(f.name)
+
+    try:
+        graph = MetricFlowAdapter().parse(path)
+    finally:
+        path.unlink(missing_ok=True)
+
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE orders AS SELECT * FROM (VALUES "
+        "(1, 10, 'completed', 100.0), (2, 11, 'pending', 50.0), (3, 10, 'completed', 25.0)) "
+        "AS t(order_id, customer_id, status, amount)"
+    )
+    conn.execute(
+        "CREATE TABLE customers AS SELECT * FROM (VALUES (10, 'active'), (11, 'active')) AS t(customer_id, status)"
+    )
+
+    layer = SemanticLayer(auto_register=False)
+    layer.conn = conn
+    layer.graph = graph
+
+    # The filter column is qualified to the orders CTE (not the ambiguous bare name).
+    sql = layer.compile(metrics=["completed_revenue"], dimensions=["customers.status"])
+    assert "orders_cte.status" in sql
+
+    # The join query binds and returns the filtered total.
+    rows = fetch_dicts(layer.query(metrics=["completed_revenue"], dimensions=["customers.status"]))
+    assert {r["status"]: r["completed_revenue"] for r in rows} == {"active": 125.0}
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/adapters/metricflow/test_query.py
+++ b/tests/adapters/metricflow/test_query.py
@@ -65,5 +65,99 @@ def test_query_with_filter_metricflow():
     assert "completed" in sql.lower()
 
 
+def test_inline_simple_metric_filter_is_applied():
+    """A latest-spec inline simple metric with a ``filter`` scopes its aggregation.
+
+    Regression: the filter was registered on the graph-level metric but the
+    aggregation path ignored ``Metric.filters``, so a filtered metric like
+    ``completed_revenue`` aggregated every row (``SUM(amount)``) and silently
+    dropped the MetricFlow filter. The filter must be rendered via CASE WHEN so
+    only matching rows contribute, and only for that metric.
+    """
+    import tempfile
+    import textwrap
+    from pathlib import Path
+
+    import duckdb
+
+    from tests.utils import fetch_dicts
+
+    yml = textwrap.dedent("""
+        models:
+          - name: orders
+            semantic_model:
+              enabled: true
+              name: orders
+            columns:
+              - name: order_id
+                entity:
+                  type: primary
+                  name: order
+              - name: order_status
+                dimension:
+                  type: categorical
+              - name: amount
+                dimension:
+                  type: categorical
+            metrics:
+              - name: total_revenue
+                type: simple
+                agg: sum
+                expr: amount
+              - name: completed_revenue
+                type: simple
+                agg: sum
+                expr: amount
+                filter: "order_status = 'completed'"
+              - name: completed_count
+                type: simple
+                agg: count
+                expr: amount
+                filter: "order_status = 'completed'"
+    """)
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(yml)
+        path = Path(f.name)
+
+    try:
+        graph = MetricFlowAdapter().parse(path)
+    finally:
+        path.unlink(missing_ok=True)
+
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE orders AS SELECT * FROM (VALUES "
+        "(1, 'completed', 100.0), (2, 'completed', 50.0), (3, 'pending', 999.0)) "
+        "AS t(order_id, order_status, amount)"
+    )
+
+    layer = SemanticLayer(auto_register=False)
+    layer.conn = conn
+    layer.graph = graph
+
+    # The filter renders as CASE WHEN, not a bare aggregate.
+    sql = layer.compile(metrics=["completed_revenue"])
+    assert "CASE WHEN" in sql.upper()
+
+    # Filtered totals only include matching rows; the unfiltered metric includes all.
+    row = fetch_dicts(layer.query(metrics=["total_revenue", "completed_revenue", "completed_count"]))[0]
+    assert row["total_revenue"] == 1149.0
+    assert row["completed_revenue"] == 150.0
+    assert row["completed_count"] == 2
+
+    # The per-metric filter does not leak into a sibling metric grouped by dimension.
+    grouped = {
+        r["order_status"]: r
+        for r in fetch_dicts(
+            layer.query(
+                metrics=["total_revenue", "completed_revenue"],
+                dimensions=["orders.order_status"],
+            )
+        )
+    }
+    assert grouped["pending"]["total_revenue"] == 999.0
+    assert grouped["pending"]["completed_revenue"] in (None, 0)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/adapters/test_added_fixture_coverage.py
+++ b/tests/adapters/test_added_fixture_coverage.py
@@ -99,6 +99,7 @@ ADDED_FIXTURE_CASES = [
     (MetricFlowAdapter, "tests/fixtures/metricflow/ambiguous_resolution_manifest.yaml"),
     (MetricFlowAdapter, "tests/fixtures/metricflow/cyclic_join_manifest.yaml"),
     (MetricFlowAdapter, "tests/fixtures/metricflow/extended_date_manifest.yaml"),
+    (MetricFlowAdapter, "tests/fixtures/metricflow/latest_spec_models.yml"),
     (MetricFlowAdapter, "tests/fixtures/metricflow/name_edge_case_manifest.yaml"),
     (MetricFlowAdapter, "tests/fixtures/metricflow/scd_listings.yaml"),
     (MetricFlowAdapter, "tests/fixtures/metricflow/scd_metrics.yaml"),

--- a/tests/fixtures/metricflow/latest_spec_models.yml
+++ b/tests/fixtures/metricflow/latest_spec_models.yml
@@ -76,6 +76,18 @@ metrics:
         offset_window: 7 days
         alias: total_7_days_ago
 
+  # Derived whose inputs are all non-offset aliases: aliases are rewritten back
+  # to their real input metrics so the metric is queryable on its own.
+  - name: net_order_total
+    description: Order total minus a fixed adjustment of itself
+    type: derived
+    expr: gross_total - half_total / 2
+    input_metrics:
+      - name: order_total
+        alias: gross_total
+      - name: order_total
+        alias: half_total
+
   # Cumulative with promoted input_metric + window + period_agg
   - name: rolling_30d_revenue
     description: Trailing 30 day revenue

--- a/tests/fixtures/metricflow/latest_spec_models.yml
+++ b/tests/fixtures/metricflow/latest_spec_models.yml
@@ -1,0 +1,104 @@
+# Source: https://docs.getdbt.com/docs/build/latest-metrics-spec
+# dbt Core 1.12 / Fusion "latest" MetricFlow YAML spec.
+# Semantic models embedded under top-level `models:` with a nested
+# `semantic_model:` block, column-based `entity:`/`dimension:` under `columns:`,
+# measures folded into `type: simple` metrics, and promoted top-level metric keys.
+
+models:
+  - name: orders
+    description: Order fact table
+    agg_time_dimension: ordered_at
+    semantic_model:
+      enabled: true
+      name: orders
+    columns:
+      - name: order_id
+        entity:
+          type: primary
+          name: order
+      - name: customer_id
+        entity:
+          type: foreign
+          name: customer
+      - name: ordered_at
+        granularity: day
+        dimension:
+          type: time
+      - name: order_status
+        dimension:
+          type: categorical
+          name: status
+    metrics:
+      # Measure folded into a simple metric (agg + expr promoted to top level)
+      - name: order_total
+        type: simple
+        agg: sum
+        expr: amount
+      - name: order_count
+        type: simple
+        agg: count
+
+  - name: customers
+    description: Customer dimension table
+    agg_time_dimension: first_ordered_at
+    semantic_model:
+      enabled: true
+    columns:
+      - name: customer_id
+        entity:
+          type: primary
+          name: customer
+      - name: first_ordered_at
+        granularity: day
+        dimension:
+          type: time
+      - name: region
+        dimension:
+          type: categorical
+
+metrics:
+  # Ratio with promoted numerator/denominator (no type_params)
+  - name: revenue_per_order
+    description: Average revenue per order
+    type: ratio
+    numerator: order_total
+    denominator: order_count
+
+  # Derived with promoted expr + input_metrics (with per-input offset_window/alias)
+  - name: order_total_growth
+    description: Week-over-week order total growth
+    type: derived
+    expr: current_total - total_7_days_ago
+    input_metrics:
+      - name: order_total
+        alias: current_total
+      - name: order_total
+        offset_window: 7 days
+        alias: total_7_days_ago
+
+  # Cumulative with promoted input_metric + window + period_agg
+  - name: rolling_30d_revenue
+    description: Trailing 30 day revenue
+    type: cumulative
+    input_metric: order_total
+    window: 30 days
+    period_agg: sum
+
+  # Cumulative with promoted grain_to_date
+  - name: revenue_mtd
+    description: Month-to-date revenue
+    type: cumulative
+    input_metric: order_total
+    grain_to_date: month
+
+  # Conversion with promoted base_metric/conversion_metric/entity (new spec)
+  - name: order_to_repeat_conversion
+    description: Conversion from first order to repeat order
+    type: conversion
+    entity: customer
+    calculation: conversion_rate
+    base_metric: order_count
+    conversion_metric: order_count
+    constant_properties:
+      - base_property: region
+        conversion_property: region

--- a/tests/fixtures/metricflow/saved_queries_example.yml
+++ b/tests/fixtures/metricflow/saved_queries_example.yml
@@ -44,19 +44,18 @@ metrics:
     type_params:
       measure: sales_count
 
-# Note: Saved queries are typically defined separately but shown here for reference
-# saved_queries:
-#   - name: monthly_sales_by_region
-#     description: Monthly sales aggregated by region
-#     query_params:
-#       metrics:
-#         - total_sales
-#         - sales_transactions
-#       group_by:
-#         - TimeDimension('sale_date', 'month')
-#         - Dimension('region')
-#     exports:
-#       - name: monthly_sales_export
-#         config:
-#           export_as: table
-#           schema: analytics
+saved_queries:
+  - name: monthly_sales_by_region
+    description: Monthly sales aggregated by region
+    query_params:
+      metrics:
+        - total_sales
+        - sales_transactions
+      group_by:
+        - TimeDimension('sale_date', 'month')
+        - Dimension('region')
+    exports:
+      - name: monthly_sales_export
+        config:
+          export_as: table
+          schema: analytics


### PR DESCRIPTION
## What changed

Extends `sidemantic/adapters/metricflow.py` to keep pace with dbt MetricFlow / the dbt Semantic Layer. All additions are backward compatible: the legacy YAML spec continues to parse unchanged and existing tests stay green.

### Latest YAML spec (dbt Core 1.12 / Fusion engine)
The adapter now detects new-vs-legacy shape and parses both. For the latest spec it handles:
- Top-level `models:` with a nested `semantic_model:` block (honors `enabled: false`, and `semantic_model.name` defaulting to the model name).
- Column-based `entity:` / `dimension:` declared under `columns:`, including the `entity: primary` shorthand and column-level `granularity:` for time dimensions.
- Measures folded into `type: simple` metrics carrying `agg` / `expr` at the top level.
- Promoted top-level metric keys that replace `type_params`: `numerator` / `denominator` (ratio), `input_metrics` (derived), `input_metric` + `window` + `grain_to_date` + `period_agg` (cumulative), and `base_metric` / `conversion_metric` / `entity` (conversion).

### Conversion metrics
Previously skipped with a "conversion not yet supported" comment. Now parsed from `type_params.conversion_type_params` (legacy) and the promoted top-level keys (latest), mapping `base_measure`/`conversion_measure` to base/conversion events, `entity`, and `window` to `conversion_window`. The `calculation` flavor (`conversion_rate` / `conversion` / `conversions`) and `constant_properties` are retained in metric metadata.

### Saved queries
Top-level `saved_queries` (list or mapping form) are parsed with their `query_params` (metrics, group_by, where, order_by, limit) and `exports`, and exposed on `graph.metadata["saved_queries"]`. They are intentionally kept out of `graph.metrics`.

### Derived/cumulative modifiers
Per-input `offset_window` / `offset_to_grain` / `alias` on derived inputs and cumulative `period_agg` are retained in metric metadata.

## Tests
- Updated the conversion and saved-query tests that asserted the old "skipped/not supported" behavior to assert the new parsed output (legacy `conversion_metrics.yml`, `simple_manifest_metrics.yaml`, `simple_manifest_saved_queries.yaml`, `saved_queries_example.yml`).
- Added a new latest-spec fixture (`tests/fixtures/metricflow/latest_spec_models.yml`) and a parsing test covering embedded semantic models, column-based entities/dimensions, folded simple metrics, promoted ratio/derived/cumulative/conversion keys, and offset/period_agg metadata, and wired it into the shared added-fixture coverage suite.

## Known limitations
- MetricFlow conversion metrics are measure-based; Sidemantic models conversions as a base/conversion event funnel keyed on an entity, so the measure names become the event references and the `calculation` flavor / `fill_nulls_with` / `constant_properties` are preserved in metadata rather than driving execution semantics.
- Saved queries are retained as metadata only (no query execution).
- Export remains in the legacy `semantic_models:` shape.