### PR TITLE
Add OSI support to the Rust runtime via a reusable adapter trait

### DIFF
--- a/sidemantic-rs/src/adapters/cube.rs
+++ b/sidemantic-rs/src/adapters/cube.rs
@@ -1,0 +1,344 @@
+//! Cube.js adapter: imports Cube YAML (`cubes:`) into the semantic graph.
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::{
+    Aggregation, Dimension, DimensionType, Metric, MetricType, Model, Relationship, Segment,
+};
+use crate::error::{Result, SidemanticError};
+
+use super::{Adapter, ParsedDocument};
+
+/// Adapter for importing Cube.js semantic definitions.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CubeAdapter;
+
+impl CubeAdapter {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Parse Cube YAML content into core models.
+    pub fn parse_models(&self, content: &str) -> Result<Vec<Model>> {
+        let config: CubeConfig = serde_yaml::from_str(content)
+            .map_err(|e| SidemanticError::Validation(format!("YAML parse error: {e}")))?;
+        Ok(config.into_models())
+    }
+}
+
+impl Adapter for CubeAdapter {
+    fn parse_document(&self, content: &str) -> Result<ParsedDocument> {
+        Ok(ParsedDocument {
+            models: self.parse_models(content)?,
+            ..Default::default()
+        })
+    }
+}
+
+// =============================================================================
+// Cube.js Format Schema
+// =============================================================================
+
+/// Root schema for Cube.js YAML files
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CubeConfig {
+    #[serde(default)]
+    pub cubes: Vec<CubeDefinition>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CubeDefinition {
+    pub name: String,
+    pub sql_table: Option<String>,
+    pub sql: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    pub dimensions: Vec<CubeDimension>,
+    #[serde(default)]
+    pub measures: Vec<CubeMeasure>,
+    #[serde(default)]
+    pub segments: Vec<CubeSegment>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CubeDimension {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub dim_type: Option<String>,
+    pub sql: Option<String>,
+    pub description: Option<String>,
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CubeMeasure {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub measure_type: Option<String>,
+    pub sql: Option<String>,
+    pub description: Option<String>,
+    pub title: Option<String>,
+    #[serde(default)]
+    pub filters: Vec<CubeFilter>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CubeFilter {
+    pub sql: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CubeSegment {
+    pub name: String,
+    pub sql: String,
+    pub description: Option<String>,
+}
+
+// =============================================================================
+// Conversion to Core Types
+// =============================================================================
+
+impl CubeConfig {
+    /// Convert to list of core Model types
+    pub fn into_models(self) -> Vec<Model> {
+        self.cubes.into_iter().map(|c| c.into_model()).collect()
+    }
+}
+
+impl CubeDefinition {
+    fn into_model(self) -> Model {
+        // Infer primary key from name (cube_name -> cube_name_id or id)
+        let primary_key = "id".to_string();
+
+        Model {
+            name: self.name,
+            table: self.sql_table,
+            sql: self.sql,
+            source_uri: None,
+            extends: None,
+            primary_key: primary_key.clone(),
+            primary_key_columns: vec![primary_key],
+            unique_keys: None,
+            dimensions: self
+                .dimensions
+                .into_iter()
+                .map(|d| d.into_dimension())
+                .collect(),
+            metrics: self.measures.into_iter().map(|m| m.into_metric()).collect(),
+            relationships: Vec::<Relationship>::new(), // Cube.js uses joins differently
+            segments: self
+                .segments
+                .into_iter()
+                .map(|s| s.into_segment())
+                .collect(),
+            pre_aggregations: Vec::new(),
+            default_time_dimension: None,
+            default_grain: None,
+            label: None,
+            description: self.description,
+            metadata: None,
+            meta: None,
+        }
+    }
+}
+
+impl CubeDimension {
+    fn into_dimension(self) -> Dimension {
+        let dim_type = match self.dim_type.as_deref() {
+            Some("time") => DimensionType::Time,
+            Some("boolean") => DimensionType::Boolean,
+            Some("number") => DimensionType::Numeric,
+            _ => DimensionType::Categorical, // string, etc.
+        };
+
+        // Strip ${CUBE}. prefix from SQL
+        let sql = self.sql.map(|s| strip_cube_placeholder(&s));
+
+        Dimension {
+            name: self.name,
+            r#type: dim_type,
+            sql,
+            granularity: None,
+            supported_granularities: None,
+            label: self.title,
+            description: self.description,
+            metadata: None,
+            meta: None,
+            format: None,
+            value_format_name: None,
+            parent: None,
+            window: None,
+            public: true,
+        }
+    }
+}
+
+impl CubeMeasure {
+    fn into_metric(self) -> Metric {
+        // Map Cube.js measure types to aggregations
+        let (metric_type, agg) = match self.measure_type.as_deref() {
+            Some("count") => (MetricType::Simple, Some(Aggregation::Count)),
+            Some("countDistinct") | Some("count_distinct") => {
+                (MetricType::Simple, Some(Aggregation::CountDistinct))
+            }
+            Some("sum") => (MetricType::Simple, Some(Aggregation::Sum)),
+            Some("avg") => (MetricType::Simple, Some(Aggregation::Avg)),
+            Some("min") => (MetricType::Simple, Some(Aggregation::Min)),
+            Some("max") => (MetricType::Simple, Some(Aggregation::Max)),
+            Some("stddev") => (MetricType::Simple, Some(Aggregation::Stddev)),
+            Some("stddev_pop") => (MetricType::Simple, Some(Aggregation::StddevPop)),
+            Some("variance") => (MetricType::Simple, Some(Aggregation::Variance)),
+            Some("variance_pop") => (MetricType::Simple, Some(Aggregation::VariancePop)),
+            Some("number") => (MetricType::Derived, None), // derived/calculated
+            _ => (MetricType::Simple, Some(Aggregation::Sum)),
+        };
+
+        // Strip ${CUBE}. prefix from SQL
+        let sql = self.sql.map(|s| strip_cube_placeholder(&s));
+
+        // Convert filters
+        let filters = self
+            .filters
+            .into_iter()
+            .map(|f| strip_cube_placeholder(&f.sql))
+            .collect();
+
+        Metric {
+            name: self.name,
+            extends: None,
+            r#type: metric_type,
+            agg,
+            sql,
+            numerator: None,
+            denominator: None,
+            offset_window: None,
+            filters,
+            label: self.title,
+            description: self.description,
+            metadata: None,
+            meta: None,
+            window: None,
+            grain_to_date: None,
+            window_expression: None,
+            window_frame: None,
+            window_order: None,
+            base_metric: None,
+            comparison_type: None,
+            time_offset: None,
+            calculation: None,
+            entity: None,
+            base_event: None,
+            conversion_event: None,
+            conversion_window: None,
+            steps: None,
+            cohort_event: None,
+            activity_event: None,
+            periods: None,
+            retention_granularity: None,
+            inner_metrics: None,
+            entity_dimensions: None,
+            having: None,
+            fill_nulls_with: None,
+            format: None,
+            value_format_name: None,
+            drill_fields: None,
+            non_additive_dimension: None,
+            public: true,
+        }
+    }
+}
+
+impl CubeSegment {
+    fn into_segment(self) -> Segment {
+        // Convert ${CUBE} to {model} for our segment format
+        let sql = self.sql.replace("${CUBE}", "{model}");
+
+        Segment {
+            name: self.name,
+            sql,
+            description: self.description,
+            public: true,
+        }
+    }
+}
+
+/// Strip ${CUBE}. prefix from SQL expressions
+fn strip_cube_placeholder(sql: &str) -> String {
+    sql.replace("${CUBE}.", "").replace("${CUBE}", "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_cube_yaml() {
+        let yaml = r#"
+cubes:
+  - name: orders
+    sql_table: orders
+
+    dimensions:
+      - name: status
+        sql: "${CUBE}.status"
+        type: string
+      - name: created_at
+        sql: "${CUBE}.created_at"
+        type: time
+
+    measures:
+      - name: count
+        type: count
+      - name: revenue
+        sql: "${CUBE}.amount"
+        type: sum
+
+    segments:
+      - name: completed
+        sql: "${CUBE}.status = 'completed'"
+"#;
+
+        let config: CubeConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.cubes.len(), 1);
+
+        let models = config.into_models();
+        let orders = &models[0];
+        assert_eq!(orders.name, "orders");
+        assert_eq!(orders.dimensions.len(), 2);
+        assert_eq!(orders.metrics.len(), 2);
+        assert_eq!(orders.segments.len(), 1);
+
+        // Check ${CUBE} was stripped from dimension SQL
+        assert_eq!(orders.dimensions[0].sql, Some("status".to_string()));
+
+        // Check ${CUBE} was converted to {model} in segment
+        assert_eq!(orders.segments[0].sql, "{model}.status = 'completed'");
+    }
+
+    #[test]
+    fn test_strip_cube_placeholder() {
+        assert_eq!(strip_cube_placeholder("${CUBE}.status"), "status");
+        assert_eq!(
+            strip_cube_placeholder("${CUBE}.amount > 100"),
+            "amount > 100"
+        );
+    }
+
+    #[test]
+    fn test_cube_adapter_parse_document() {
+        let yaml = r#"
+cubes:
+  - name: orders
+    sql_table: orders
+    measures:
+      - name: revenue
+        sql: "${CUBE}.amount"
+        type: sum
+"#;
+        let parsed = CubeAdapter::new().parse_document(yaml).unwrap();
+        assert_eq!(parsed.models.len(), 1);
+        assert_eq!(parsed.models[0].name, "orders");
+        assert!(parsed.graph_metrics.is_empty());
+        assert!(!parsed.explicit_relationships);
+    }
+}

--- a/sidemantic-rs/src/adapters/mod.rs
+++ b/sidemantic-rs/src/adapters/mod.rs
@@ -1,0 +1,51 @@
+//! Reusable adapters for importing and exporting external semantic-layer formats.
+//!
+//! Each adapter implements the [`Adapter`] trait, turning a format-specific
+//! document into models + graph-level extras ([`ParsedDocument`]) and,
+//! optionally, serializing a [`SemanticGraph`] back out.
+//!
+//! The config loader dispatches to these adapters by detected format. Native
+//! Sidemantic YAML/SQL remains built into the loader; everything else
+//! (Cube, OSI, and future importers) lives here.
+
+use crate::core::{Metric, Model, Parameter, SemanticGraph};
+use crate::error::{Result, SidemanticError};
+
+pub mod cube;
+pub mod osi;
+
+pub use cube::CubeAdapter;
+pub use osi::OsiAdapter;
+
+/// Result of parsing a single external-format document.
+#[derive(Debug, Default)]
+pub struct ParsedDocument {
+    /// Models declared in the document, in declaration order.
+    pub models: Vec<Model>,
+    /// Graph-level metrics added directly to the graph (not assigned to an
+    /// owning model the way native top-level metrics are).
+    pub graph_metrics: Vec<Metric>,
+    /// Graph-level parameters.
+    pub parameters: Vec<Parameter>,
+    /// Graph-level metadata payload (format-specific import state). Stored
+    /// verbatim on [`SemanticGraph::set_metadata`].
+    pub metadata: Option<serde_json::Value>,
+    /// When true, the format specifies relationships explicitly and the loader
+    /// must not infer foreign-key relationships for these models.
+    pub explicit_relationships: bool,
+}
+
+/// A reusable importer/exporter for an external semantic-layer format.
+pub trait Adapter {
+    /// Parse a single document's text into models and graph-level extras.
+    fn parse_document(&self, content: &str) -> Result<ParsedDocument>;
+
+    /// Export a semantic graph to this format's text representation.
+    ///
+    /// Adapters that only support import inherit the default, which errors.
+    fn export_string(&self, _graph: &SemanticGraph) -> Result<String> {
+        Err(SidemanticError::Validation(
+            "this adapter does not support export".to_string(),
+        ))
+    }
+}

--- a/sidemantic-rs/src/adapters/osi.rs
+++ b/sidemantic-rs/src/adapters/osi.rs
@@ -1,0 +1,1497 @@
+//! OSI (Open Semantic Interchange) adapter.
+//!
+//! OSI is a vendor-agnostic semantic model specification. This adapter imports
+//! and exports OSI YAML at parity with the Python `OSIAdapter`:
+//!
+//! - OSI `semantic_model` / `ontology_mappings[].semantic_model` → graph
+//! - OSI `datasets` → models
+//! - OSI `fields` → dimensions
+//! - OSI `metrics` → graph-level metrics
+//! - OSI `relationships` → many-to-one relationships
+//!
+//! Semantic-model-level metadata (name, description, ai_context,
+//! custom_extensions, ontology) round-trips through the graph metadata payload.
+//!
+//! Spec: <https://github.com/open-semantic-interchange/OSI>
+
+use polyglot_sql::{DialectType, Expression};
+use serde_json::{Map as JsonMap, Value as Json};
+use serde_yaml::{Mapping as YamlMap, Value as Yaml};
+
+use crate::config::schema::metric_from_sql_expression;
+use crate::core::{
+    Aggregation, Dimension, DimensionType, Metric, MetricType, Model, Relationship,
+    RelationshipType, SemanticGraph,
+};
+use crate::error::{Result, SidemanticError};
+
+use super::{Adapter, ParsedDocument};
+
+/// OSI spec version emitted on export.
+pub const OSI_VERSION: &str = "0.2.0.dev0";
+
+/// Dialect preference order for extracting SQL expressions on import.
+const DIALECT_PREFERENCE: &[&str] = &[
+    "ANSI_SQL",
+    "SNOWFLAKE",
+    "DATABRICKS",
+    "MAQL",
+    "TABLEAU",
+    "MDX",
+];
+
+/// Dialects we can safely emit (and transpile to) on export.
+const SUPPORTED_EXPORT_DIALECTS: &[&str] = &["ANSI_SQL", "SNOWFLAKE", "DATABRICKS"];
+
+/// Adapter for importing/exporting OSI (Open Semantic Interchange) YAML.
+#[derive(Debug, Clone)]
+pub struct OsiAdapter {
+    dialects: Vec<String>,
+}
+
+impl Default for OsiAdapter {
+    fn default() -> Self {
+        Self {
+            dialects: vec!["ANSI_SQL".to_string()],
+        }
+    }
+}
+
+impl OsiAdapter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the SQL dialects emitted on export (default `["ANSI_SQL"]`).
+    pub fn with_dialects(mut self, dialects: Vec<String>) -> Self {
+        self.dialects = dialects;
+        self
+    }
+
+    /// Parse a single OSI document into a complete semantic graph.
+    ///
+    /// Convenience wrapper used by tests and the OSI adapter API; the config
+    /// loader uses [`Adapter::parse_document`] so it can merge multiple files.
+    pub fn parse_str(&self, content: &str) -> Result<SemanticGraph> {
+        let doc = self.parse_document(content)?;
+        let mut graph = SemanticGraph::new();
+        for model in doc.models {
+            graph.add_model(model)?;
+        }
+        for metric in doc.graph_metrics {
+            if graph.get_metric(&metric.name).is_none() {
+                graph.add_metric(metric)?;
+            }
+        }
+        if let Some(metadata) = doc.metadata {
+            graph.set_metadata(metadata);
+        }
+        Ok(graph)
+    }
+}
+
+impl Adapter for OsiAdapter {
+    fn parse_document(&self, content: &str) -> Result<ParsedDocument> {
+        let mut doc = ParsedDocument {
+            explicit_relationships: true,
+            ..Default::default()
+        };
+
+        if content.trim().is_empty() {
+            return Ok(doc);
+        }
+
+        let data: Json = serde_yaml::from_str(content)
+            .map_err(|e| SidemanticError::Validation(format!("OSI YAML parse error: {e}")))?;
+        let Some(root) = data.as_object() else {
+            return Ok(doc);
+        };
+
+        let mut osi_meta = JsonMap::new();
+        osi_meta.insert("semantic_models".to_string(), Json::Array(Vec::new()));
+        if let Some(version) = root.get("version") {
+            if !version.is_null() {
+                osi_meta.insert("version".to_string(), version.clone());
+            }
+        }
+        if let Some(ontology) = root.get("ontology") {
+            if !ontology.is_null() {
+                osi_meta.insert("ontology".to_string(), ontology.clone());
+            }
+        }
+
+        for (sm_def, source, mapping_def) in iter_semantic_models(root) {
+            remember_semantic_model_metadata(&mut osi_meta, sm_def, source, mapping_def);
+            parse_semantic_model(sm_def, &mut doc)?;
+        }
+
+        let mut graph_metadata = JsonMap::new();
+        graph_metadata.insert("osi".to_string(), Json::Object(osi_meta));
+        doc.metadata = Some(Json::Object(graph_metadata));
+
+        Ok(doc)
+    }
+
+    fn export_string(&self, graph: &SemanticGraph) -> Result<String> {
+        let dialects = if self.dialects.is_empty() {
+            vec!["ANSI_SQL".to_string()]
+        } else {
+            self.dialects.clone()
+        };
+        let unsupported: Vec<&str> = dialects
+            .iter()
+            .map(String::as_str)
+            .filter(|d| !SUPPORTED_EXPORT_DIALECTS.contains(d))
+            .collect();
+        if !unsupported.is_empty() {
+            return Err(SidemanticError::Validation(format!(
+                "Unsupported OSI export dialect(s): {}. Supported: {}",
+                unsupported.join(", "),
+                SUPPORTED_EXPORT_DIALECTS.join(", ")
+            )));
+        }
+
+        // Deterministic model order for stable output.
+        let mut models: Vec<&Model> = graph.models().collect();
+        models.sort_by(|a, b| a.name.cmp(&b.name));
+
+        let semantic_model = export_semantic_model(&models, graph, &dialects);
+
+        let mut root = YamlMap::new();
+        put(&mut root, "version", Yaml::String(export_version(graph)));
+        put(
+            &mut root,
+            "semantic_model",
+            Yaml::Sequence(vec![semantic_model]),
+        );
+
+        serde_yaml::to_string(&Yaml::Mapping(root))
+            .map_err(|e| SidemanticError::Validation(format!("OSI YAML serialize error: {e}")))
+    }
+}
+
+// =============================================================================
+// Import helpers
+// =============================================================================
+
+/// Top-level and ontology-mapped semantic model definitions.
+fn iter_semantic_models(root: &JsonMap<String, Json>) -> Vec<(&Json, String, Option<&Json>)> {
+    let mut result: Vec<(&Json, String, Option<&Json>)> = Vec::new();
+
+    match root.get("semantic_model") {
+        Some(Json::Array(items)) => {
+            for item in items {
+                if item.is_object() {
+                    result.push((item, "semantic_model".to_string(), None));
+                }
+            }
+        }
+        Some(sm @ Json::Object(_)) => {
+            result.push((sm, "semantic_model".to_string(), None));
+        }
+        _ => {}
+    }
+
+    if let Some(Json::Array(mappings)) = root.get("ontology_mappings") {
+        for (index, mapping_def) in mappings.iter().enumerate() {
+            let Some(mapping) = mapping_def.as_object() else {
+                continue;
+            };
+            if let Some(sm_def) = mapping.get("semantic_model") {
+                if sm_def.is_object() {
+                    result.push((
+                        sm_def,
+                        format!("ontology_mappings[{index}].semantic_model"),
+                        Some(mapping_def),
+                    ));
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Preserve semantic-model-level OSI fields that do not map to models.
+fn remember_semantic_model_metadata(
+    osi_meta: &mut JsonMap<String, Json>,
+    sm_def: &Json,
+    source: String,
+    mapping_def: Option<&Json>,
+) {
+    let Some(sm) = sm_def.as_object() else {
+        return;
+    };
+
+    let mut sm_meta = JsonMap::new();
+    sm_meta.insert("source".to_string(), Json::String(source));
+    for key in ["name", "description", "ai_context", "custom_extensions"] {
+        if let Some(value) = sm.get(key) {
+            sm_meta.insert(key.to_string(), value.clone());
+        }
+    }
+
+    if let Some(mapping) = mapping_def.and_then(Json::as_object) {
+        let mut mapping_meta = JsonMap::new();
+        for key in ["name", "description", "concept_mappings"] {
+            if let Some(value) = mapping.get(key) {
+                mapping_meta.insert(key.to_string(), value.clone());
+            }
+        }
+        if !mapping_meta.is_empty() {
+            sm_meta.insert("ontology_mapping".to_string(), Json::Object(mapping_meta));
+        }
+    }
+
+    if let Some(Json::Array(list)) = osi_meta.get_mut("semantic_models") {
+        list.push(Json::Object(sm_meta));
+    }
+}
+
+fn parse_semantic_model(sm_def: &Json, doc: &mut ParsedDocument) -> Result<()> {
+    let Some(sm) = sm_def.as_object() else {
+        return Ok(());
+    };
+
+    if let Some(Json::Array(datasets)) = sm.get("datasets") {
+        for dataset_def in datasets {
+            if let Some(model) = parse_dataset(dataset_def) {
+                doc.models.push(model);
+            }
+        }
+    }
+
+    if let Some(Json::Array(relationships)) = sm.get("relationships") {
+        for rel_def in relationships {
+            add_relationship_to_model(rel_def, &mut doc.models);
+        }
+    }
+
+    if let Some(Json::Array(metrics)) = sm.get("metrics") {
+        for metric_def in metrics {
+            if let Some(metric) = parse_metric(metric_def) {
+                doc.graph_metrics.push(metric);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_dataset(dataset_def: &Json) -> Option<Model> {
+    let dataset = dataset_def.as_object()?;
+    let name = dataset.get("name").and_then(Json::as_str)?;
+    if name.is_empty() {
+        return None;
+    }
+
+    let source = dataset
+        .get("source")
+        .and_then(Json::as_str)
+        .map(String::from);
+
+    let primary_key_columns = string_list(dataset.get("primary_key"));
+    let (primary_key, primary_key_columns) = if primary_key_columns.is_empty() {
+        ("id".to_string(), vec!["id".to_string()])
+    } else {
+        (primary_key_columns[0].clone(), primary_key_columns)
+    };
+
+    let unique_keys = dataset
+        .get("unique_keys")
+        .and_then(Json::as_array)
+        .map(|rows| rows.iter().map(|row| string_list(Some(row))).collect());
+
+    let mut dimensions = Vec::new();
+    if let Some(Json::Array(fields)) = dataset.get("fields") {
+        for field_def in fields {
+            if let Some(dim) = parse_field(field_def) {
+                dimensions.push(dim);
+            }
+        }
+    }
+
+    let default_time_dimension = dimensions
+        .iter()
+        .find(|dim| dim.r#type == DimensionType::Time)
+        .map(|dim| dim.name.clone());
+
+    let mut model = Model::new(name, primary_key);
+    model.table = source;
+    model.description = dataset
+        .get("description")
+        .and_then(Json::as_str)
+        .map(String::from);
+    model.primary_key_columns = primary_key_columns;
+    model.unique_keys = unique_keys;
+    model.dimensions = dimensions;
+    model.default_time_dimension = default_time_dimension;
+    model.meta = build_meta(dataset);
+    Some(model)
+}
+
+fn parse_field(field_def: &Json) -> Option<Dimension> {
+    let field = field_def.as_object()?;
+    let name = field.get("name").and_then(Json::as_str)?;
+    if name.is_empty() {
+        return None;
+    }
+
+    let sql = extract_expression(field.get("expression"));
+
+    let is_time = field
+        .get("dimension")
+        .and_then(Json::as_object)
+        .and_then(|dim| dim.get("is_time"))
+        .and_then(Json::as_bool)
+        .unwrap_or(false);
+
+    Some(Dimension {
+        name: name.to_string(),
+        r#type: if is_time {
+            DimensionType::Time
+        } else {
+            DimensionType::Categorical
+        },
+        sql,
+        granularity: if is_time {
+            Some("day".to_string())
+        } else {
+            None
+        },
+        supported_granularities: None,
+        label: field.get("label").and_then(Json::as_str).map(String::from),
+        description: field
+            .get("description")
+            .and_then(Json::as_str)
+            .map(String::from),
+        metadata: None,
+        meta: build_meta(field),
+        format: None,
+        value_format_name: None,
+        parent: None,
+        window: None,
+        public: true,
+    })
+}
+
+fn parse_metric(metric_def: &Json) -> Option<Metric> {
+    let metric = metric_def.as_object()?;
+    let name = metric.get("name").and_then(Json::as_str)?;
+    if name.is_empty() {
+        return None;
+    }
+
+    let expression = extract_expression(metric.get("expression"))?;
+    if expression.is_empty() {
+        return None;
+    }
+
+    let description = metric
+        .get("description")
+        .and_then(Json::as_str)
+        .map(String::from);
+    Some(metric_from_sql_expression(
+        name.to_string(),
+        Some(expression),
+        description,
+        build_meta(metric),
+    ))
+}
+
+/// Extract a SQL expression from an OSI `expression` definition, preferring
+/// ANSI_SQL and falling back through the dialect preference order.
+fn extract_expression(expression_def: Option<&Json>) -> Option<String> {
+    let dialects = expression_def?.as_object()?.get("dialects")?.as_array()?;
+
+    let mut dialect_map: Vec<(String, String)> = Vec::new();
+    for entry in dialects {
+        if let Some(obj) = entry.as_object() {
+            let name = obj.get("dialect").and_then(Json::as_str);
+            let expr = obj.get("expression").and_then(Json::as_str);
+            if let (Some(name), Some(expr)) = (name, expr) {
+                dialect_map.push((name.to_string(), expr.to_string()));
+            }
+        }
+    }
+
+    for preferred in DIALECT_PREFERENCE {
+        if let Some((_, expr)) = dialect_map.iter().find(|(name, _)| name == preferred) {
+            return Some(expr.clone());
+        }
+    }
+
+    dialects
+        .first()
+        .and_then(Json::as_object)
+        .and_then(|obj| obj.get("expression"))
+        .and_then(Json::as_str)
+        .map(String::from)
+}
+
+fn add_relationship_to_model(rel_def: &Json, models: &mut [Model]) {
+    let Some(rel) = rel_def.as_object() else {
+        return;
+    };
+    let Some(from_model) = rel.get("from").and_then(Json::as_str) else {
+        return;
+    };
+    let Some(to_model) = rel.get("to").and_then(Json::as_str) else {
+        return;
+    };
+    let Some(model) = models.iter_mut().find(|m| m.name == from_model) else {
+        return;
+    };
+
+    let from_columns = string_list(rel.get("from_columns"));
+    let to_columns = string_list(rel.get("to_columns"));
+
+    let foreign_key_columns = if from_columns.is_empty() {
+        vec![format!("{to_model}_id")]
+    } else {
+        from_columns
+    };
+    let primary_key_columns = if to_columns.is_empty() {
+        vec!["id".to_string()]
+    } else {
+        to_columns
+    };
+
+    let mut metadata = JsonMap::new();
+    if let Some(name) = rel.get("name").and_then(Json::as_str) {
+        metadata.insert("osi_name".to_string(), Json::String(name.to_string()));
+    }
+    if rel.contains_key("ai_context") {
+        metadata.insert(
+            "ai_context".to_string(),
+            rel.get("ai_context").cloned().unwrap_or(Json::Null),
+        );
+    }
+    if let Some(custom) = decode_custom_extensions(rel.get("custom_extensions")) {
+        metadata.insert("custom_extensions".to_string(), custom);
+    }
+
+    let relationship = Relationship {
+        name: to_model.to_string(),
+        r#type: RelationshipType::ManyToOne,
+        foreign_key: foreign_key_columns.first().cloned(),
+        foreign_key_columns: Some(foreign_key_columns),
+        primary_key: primary_key_columns.first().cloned(),
+        primary_key_columns: Some(primary_key_columns),
+        through: None,
+        through_foreign_key: None,
+        through_foreign_key_columns: None,
+        related_foreign_key: None,
+        related_foreign_key_columns: None,
+        sql: None,
+        metadata: if metadata.is_empty() {
+            None
+        } else {
+            Some(Json::Object(metadata))
+        },
+    };
+
+    model.relationships.push(relationship);
+}
+
+/// Build the `meta` payload from `ai_context` and `custom_extensions` keys.
+fn build_meta(obj: &JsonMap<String, Json>) -> Option<Json> {
+    let has_ai_context = obj.contains_key("ai_context");
+    let custom = decode_custom_extensions(obj.get("custom_extensions"));
+    if !has_ai_context && custom.is_none() {
+        return None;
+    }
+
+    let mut meta = JsonMap::new();
+    if has_ai_context {
+        meta.insert(
+            "ai_context".to_string(),
+            obj.get("ai_context").cloned().unwrap_or(Json::Null),
+        );
+    }
+    if let Some(custom) = custom {
+        meta.insert("custom_extensions".to_string(), custom);
+    }
+    Some(Json::Object(meta))
+}
+
+/// Decode a Sidemantic-owned extension wrapper while preserving standard lists.
+fn decode_custom_extensions(value: Option<&Json>) -> Option<Json> {
+    let value = value?;
+    if value.is_null() {
+        return None;
+    }
+
+    if let Json::Array(items) = value {
+        if items.len() == 1 {
+            if let Some(obj) = items[0].as_object() {
+                if obj.get("vendor_name").and_then(Json::as_str) == Some("SIDEMANTIC") {
+                    return match obj.get("data") {
+                        Some(Json::String(data)) => Some(
+                            serde_json::from_str::<Json>(data)
+                                .unwrap_or_else(|_| Json::String(data.clone())),
+                        ),
+                        other => other.cloned(),
+                    };
+                }
+            }
+        }
+    }
+
+    Some(value.clone())
+}
+
+fn string_list(value: Option<&Json>) -> Vec<String> {
+    value
+        .and_then(Json::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// =============================================================================
+// Export helpers
+// =============================================================================
+
+fn export_version(graph: &SemanticGraph) -> String {
+    let stored = graph
+        .metadata()
+        .and_then(|m| m.get("osi"))
+        .and_then(|osi| osi.get("version"))
+        .and_then(Json::as_str);
+    match stored {
+        Some(version) if version == OSI_VERSION => version.to_string(),
+        _ => OSI_VERSION.to_string(),
+    }
+}
+
+fn export_semantic_model(models: &[&Model], graph: &SemanticGraph, dialects: &[String]) -> Yaml {
+    let mut sm = YamlMap::new();
+    put(&mut sm, "name", Yaml::String("semantic_model".to_string()));
+    put(
+        &mut sm,
+        "description",
+        Yaml::String("Semantic model exported from Sidemantic".to_string()),
+    );
+
+    // Override with preserved semantic-model-level metadata, if any.
+    let sm_meta = graph
+        .metadata()
+        .and_then(|m| m.get("osi"))
+        .and_then(|osi| osi.get("semantic_models"))
+        .and_then(Json::as_array)
+        .and_then(|list| list.first());
+    if let Some(sm_meta) = sm_meta {
+        for key in ["name", "description", "ai_context"] {
+            if let Some(value) = sm_meta.get(key) {
+                if !value.is_null() {
+                    put(&mut sm, key, json_to_yaml(value));
+                }
+            }
+        }
+        if let Some(custom) =
+            normalize_custom_extensions_for_export(sm_meta.get("custom_extensions"))
+        {
+            put(
+                &mut sm,
+                "custom_extensions",
+                json_to_yaml(&Json::Array(custom)),
+            );
+        }
+    }
+
+    let datasets: Vec<Yaml> = models
+        .iter()
+        .map(|model| export_dataset(model, dialects))
+        .collect();
+    put(&mut sm, "datasets", Yaml::Sequence(datasets));
+
+    let mut relationships = Vec::new();
+    for model in models {
+        for rel in &model.relationships {
+            if let Some(rel_def) = export_relationship(&model.name, rel, models) {
+                relationships.push(rel_def);
+            }
+        }
+    }
+    if !relationships.is_empty() {
+        put(&mut sm, "relationships", Yaml::Sequence(relationships));
+    }
+
+    let mut metrics = Vec::new();
+    let mut graph_metrics: Vec<&Metric> = graph.metrics().collect();
+    graph_metrics.sort_by(|a, b| a.name.cmp(&b.name));
+    for metric in graph_metrics {
+        if let Some(metric_def) = export_metric(metric, None, dialects) {
+            metrics.push(metric_def);
+        }
+    }
+    for model in models {
+        for metric in &model.metrics {
+            if let Some(metric_def) = export_metric(metric, Some(&model.name), dialects) {
+                metrics.push(metric_def);
+            }
+        }
+    }
+    if !metrics.is_empty() {
+        put(&mut sm, "metrics", Yaml::Sequence(metrics));
+    }
+
+    Yaml::Mapping(sm)
+}
+
+fn export_dataset(model: &Model, dialects: &[String]) -> Yaml {
+    let mut dataset = YamlMap::new();
+    put(&mut dataset, "name", Yaml::String(model.name.clone()));
+
+    if let Some(sql) = &model.sql {
+        put(&mut dataset, "source", Yaml::String(format!("({sql})")));
+    } else if let Some(table) = &model.table {
+        put(&mut dataset, "source", Yaml::String(table.clone()));
+    }
+
+    put(
+        &mut dataset,
+        "primary_key",
+        yaml_string_seq(&model.primary_key_columns),
+    );
+
+    if let Some(unique_keys) = &model.unique_keys {
+        let rows: Vec<Yaml> = unique_keys.iter().map(|row| yaml_string_seq(row)).collect();
+        put(&mut dataset, "unique_keys", Yaml::Sequence(rows));
+    }
+
+    if let Some(description) = &model.description {
+        put(
+            &mut dataset,
+            "description",
+            Yaml::String(description.clone()),
+        );
+    }
+
+    if !model.dimensions.is_empty() {
+        let fields: Vec<Yaml> = model
+            .dimensions
+            .iter()
+            .map(|dim| export_field(dim, dialects))
+            .collect();
+        put(&mut dataset, "fields", Yaml::Sequence(fields));
+    }
+
+    apply_meta_export(&mut dataset, model.meta.as_ref());
+
+    Yaml::Mapping(dataset)
+}
+
+fn export_field(dim: &Dimension, dialects: &[String]) -> Yaml {
+    let mut field = YamlMap::new();
+    put(&mut field, "name", Yaml::String(dim.name.clone()));
+
+    let sql_expr = dim.sql.clone().unwrap_or_else(|| dim.name.clone());
+    put(
+        &mut field,
+        "expression",
+        expression_value(&sql_expr, dialects),
+    );
+
+    if dim.r#type == DimensionType::Time {
+        let mut dimension = YamlMap::new();
+        put(&mut dimension, "is_time", Yaml::Bool(true));
+        put(&mut field, "dimension", Yaml::Mapping(dimension));
+    }
+
+    if let Some(description) = &dim.description {
+        put(&mut field, "description", Yaml::String(description.clone()));
+    }
+    if let Some(label) = &dim.label {
+        put(&mut field, "label", Yaml::String(label.clone()));
+    }
+
+    apply_meta_export(&mut field, dim.meta.as_ref());
+
+    Yaml::Mapping(field)
+}
+
+fn export_relationship(from_model: &str, rel: &Relationship, models: &[&Model]) -> Option<Yaml> {
+    if rel.r#type != RelationshipType::ManyToOne {
+        return None;
+    }
+
+    let to_columns = if rel.primary_key.is_none() {
+        models
+            .iter()
+            .find(|m| m.name == rel.name)
+            .map(|m| m.primary_key_columns.clone())
+            .unwrap_or_else(|| vec!["id".to_string()])
+    } else {
+        rel.primary_key_columns()
+    };
+
+    let name = rel
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("osi_name"))
+        .and_then(Json::as_str)
+        .map(String::from)
+        .unwrap_or_else(|| format!("{from_model}_to_{}", rel.name));
+
+    let mut result = YamlMap::new();
+    put(&mut result, "name", Yaml::String(name));
+    put(&mut result, "from", Yaml::String(from_model.to_string()));
+    put(&mut result, "to", Yaml::String(rel.name.clone()));
+    put(
+        &mut result,
+        "from_columns",
+        yaml_string_seq(&rel.foreign_key_columns()),
+    );
+    put(&mut result, "to_columns", yaml_string_seq(&to_columns));
+
+    apply_meta_export(&mut result, rel.metadata.as_ref());
+
+    Some(Yaml::Mapping(result))
+}
+
+fn export_metric(metric: &Metric, model_name: Option<&str>, dialects: &[String]) -> Option<Yaml> {
+    let expression = build_metric_expression(metric, model_name)?;
+    if expression.is_empty() {
+        return None;
+    }
+
+    let mut result = YamlMap::new();
+    put(&mut result, "name", Yaml::String(metric.name.clone()));
+    put(
+        &mut result,
+        "expression",
+        expression_value(&expression, dialects),
+    );
+    if let Some(description) = &metric.description {
+        put(
+            &mut result,
+            "description",
+            Yaml::String(description.clone()),
+        );
+    }
+
+    apply_meta_export(&mut result, metric.meta.as_ref());
+
+    Some(Yaml::Mapping(result))
+}
+
+fn build_metric_expression(metric: &Metric, model_name: Option<&str>) -> Option<String> {
+    match metric.r#type {
+        MetricType::Ratio => {
+            let num = metric.numerator.clone().unwrap_or_default();
+            let denom = metric.denominator.clone().unwrap_or_default();
+            Some(format!("{num} / NULLIF({denom}, 0)"))
+        }
+        MetricType::Derived => metric.sql.clone(),
+        _ => {
+            let Some(agg) = &metric.agg else {
+                return metric.sql.clone();
+            };
+            let mut inner = metric.sql.clone().unwrap_or_else(|| "*".to_string());
+            if let Some(model_name) = model_name {
+                if inner != "*" && !inner.contains('.') {
+                    inner = format!("{model_name}.{inner}");
+                }
+            }
+            if *agg == Aggregation::CountDistinct {
+                Some(format!("COUNT(DISTINCT {inner})"))
+            } else {
+                Some(format!("{}({inner})", agg.as_sql()))
+            }
+        }
+    }
+}
+
+/// Build an OSI `expression` value (`{ dialects: [...] }`) for a SQL string,
+/// transpiling to non-ANSI dialects via polyglot-sql.
+fn expression_value(sql_expr: &str, dialects: &[String]) -> Yaml {
+    let mut entries = Vec::new();
+    for dialect in dialects {
+        let expression = if dialect == "ANSI_SQL" {
+            sql_expr.to_string()
+        } else {
+            transpile(sql_expr, dialect).unwrap_or_else(|| sql_expr.to_string())
+        };
+        let mut entry = YamlMap::new();
+        put(&mut entry, "dialect", Yaml::String(dialect.clone()));
+        put(&mut entry, "expression", Yaml::String(expression));
+        entries.push(Yaml::Mapping(entry));
+    }
+
+    let mut wrapper = YamlMap::new();
+    put(&mut wrapper, "dialects", Yaml::Sequence(entries));
+    Yaml::Mapping(wrapper)
+}
+
+/// Transpile a bare SQL expression from DuckDB/ANSI to a target dialect.
+fn transpile(sql: &str, dialect: &str) -> Option<String> {
+    let target = match dialect {
+        "SNOWFLAKE" => DialectType::Snowflake,
+        "DATABRICKS" => DialectType::Databricks,
+        _ => return None,
+    };
+
+    // Wrap so polyglot-sql parses the bare expression, then emit just the
+    // projection in the target dialect.
+    let wrapped = format!("SELECT {sql}");
+    let statement = polyglot_sql::parse_one(&wrapped, DialectType::DuckDB).ok()?;
+    if let Expression::Select(select) = statement {
+        let projection = select.expressions.into_iter().next()?;
+        return polyglot_sql::generate(&projection, target).ok();
+    }
+    None
+}
+
+/// Normalize permissive local extension metadata to the OSI schema shape:
+/// a list of `{ vendor_name, data }` where `data` is a string.
+fn normalize_custom_extensions_for_export(custom: Option<&Json>) -> Option<Vec<Json>> {
+    let custom = custom?;
+    if custom.is_null() {
+        return None;
+    }
+
+    if let Json::Array(items) = custom {
+        let mut normalized = Vec::new();
+        for item in items {
+            let Some(obj) = item.as_object() else {
+                normalized.push(extension_entry(
+                    "SIDEMANTIC",
+                    extension_data_to_string(item),
+                ));
+                continue;
+            };
+            let vendor_name = obj
+                .get("vendor_name")
+                .or_else(|| obj.get("vendor"))
+                .and_then(Json::as_str)
+                .unwrap_or("SIDEMANTIC")
+                .to_string();
+            let data = match obj.get("data") {
+                Some(data) => data.clone(),
+                None => {
+                    let mut rest = JsonMap::new();
+                    for (key, value) in obj {
+                        if key != "vendor_name" && key != "vendor" {
+                            rest.insert(key.clone(), value.clone());
+                        }
+                    }
+                    Json::Object(rest)
+                }
+            };
+            normalized.push(extension_entry(
+                &vendor_name,
+                extension_data_to_string(&data),
+            ));
+        }
+        return Some(normalized);
+    }
+
+    if let Json::Object(obj) = custom {
+        if obj.contains_key("vendor_name") && obj.contains_key("data") {
+            let vendor_name = obj
+                .get("vendor_name")
+                .and_then(Json::as_str)
+                .unwrap_or("SIDEMANTIC");
+            let data = extension_data_to_string(obj.get("data").unwrap_or(&Json::Null));
+            return Some(vec![extension_entry(vendor_name, data)]);
+        }
+    }
+
+    Some(vec![extension_entry(
+        "SIDEMANTIC",
+        extension_data_to_string(custom),
+    )])
+}
+
+fn extension_entry(vendor_name: &str, data: String) -> Json {
+    let mut entry = JsonMap::new();
+    entry.insert(
+        "vendor_name".to_string(),
+        Json::String(vendor_name.to_string()),
+    );
+    entry.insert("data".to_string(), Json::String(data));
+    Json::Object(entry)
+}
+
+fn extension_data_to_string(data: &Json) -> String {
+    match data {
+        Json::String(s) => s.clone(),
+        // Mirror Python's json.dumps(data, sort_keys=True): serde_json's default
+        // Map is sorted, and PythonJsonFormatter reproduces the ", "/": " spacing.
+        other => to_python_json(other),
+    }
+}
+
+/// Serialize a JSON value with Python `json.dumps` default separators (`, `/`: `).
+fn to_python_json(value: &Json) -> String {
+    use serde::Serialize;
+    let mut buf = Vec::new();
+    let mut serializer = serde_json::Serializer::with_formatter(&mut buf, PythonJsonFormatter);
+    if value.serialize(&mut serializer).is_err() {
+        return serde_json::to_string(value).unwrap_or_default();
+    }
+    String::from_utf8(buf).unwrap_or_default()
+}
+
+/// `serde_json` formatter matching Python's default `json.dumps` separators.
+struct PythonJsonFormatter;
+
+impl serde_json::ser::Formatter for PythonJsonFormatter {
+    fn begin_array_value<W: ?Sized + std::io::Write>(
+        &mut self,
+        writer: &mut W,
+        first: bool,
+    ) -> std::io::Result<()> {
+        if first {
+            Ok(())
+        } else {
+            writer.write_all(b", ")
+        }
+    }
+
+    fn begin_object_key<W: ?Sized + std::io::Write>(
+        &mut self,
+        writer: &mut W,
+        first: bool,
+    ) -> std::io::Result<()> {
+        if first {
+            Ok(())
+        } else {
+            writer.write_all(b", ")
+        }
+    }
+
+    fn begin_object_value<W: ?Sized + std::io::Write>(
+        &mut self,
+        writer: &mut W,
+    ) -> std::io::Result<()> {
+        writer.write_all(b": ")
+    }
+}
+
+/// Apply `ai_context`/`custom_extensions` from a `meta`-style payload to a YAML map.
+fn apply_meta_export(target: &mut YamlMap, meta: Option<&Json>) {
+    let Some(meta) = meta.and_then(Json::as_object) else {
+        return;
+    };
+    if let Some(ai_context) = meta.get("ai_context") {
+        put(target, "ai_context", json_to_yaml(ai_context));
+    }
+    if let Some(custom) = meta.get("custom_extensions") {
+        if let Some(normalized) = normalize_custom_extensions_for_export(Some(custom)) {
+            put(
+                target,
+                "custom_extensions",
+                json_to_yaml(&Json::Array(normalized)),
+            );
+        }
+    }
+}
+
+// =============================================================================
+// YAML construction helpers
+// =============================================================================
+
+fn put(map: &mut YamlMap, key: &str, value: Yaml) {
+    map.insert(Yaml::String(key.to_string()), value);
+}
+
+fn yaml_string_seq(items: &[String]) -> Yaml {
+    Yaml::Sequence(items.iter().map(|s| Yaml::String(s.clone())).collect())
+}
+
+fn json_to_yaml(value: &Json) -> Yaml {
+    serde_yaml::to_value(value).unwrap_or(Yaml::Null)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::Aggregation;
+
+    fn export_to_json(graph: &SemanticGraph, dialects: Vec<String>) -> Json {
+        let yaml = OsiAdapter::new()
+            .with_dialects(dialects)
+            .export_string(graph)
+            .unwrap();
+        serde_yaml::from_str(&yaml).unwrap()
+    }
+
+    // ----- import -----
+
+    #[test]
+    fn test_import_simple_dataset_and_fields() {
+        let yaml = r#"
+semantic_model:
+  - name: analytics
+    datasets:
+      - name: events
+        source: analytics.events
+        primary_key: [event_id]
+        fields:
+          - name: event_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: event_id
+          - name: event_time
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: event_time
+            dimension:
+              is_time: true
+"#;
+        let graph = OsiAdapter::new().parse_str(yaml).unwrap();
+        let events = graph.get_model("events").unwrap();
+        assert_eq!(events.table.as_deref(), Some("analytics.events"));
+        assert_eq!(events.primary_key, "event_id");
+        assert!(events.get_dimension("event_id").is_some());
+        let event_time = events.get_dimension("event_time").unwrap();
+        assert_eq!(event_time.r#type, DimensionType::Time);
+        assert_eq!(event_time.granularity.as_deref(), Some("day"));
+        assert_eq!(events.default_time_dimension.as_deref(), Some("event_time"));
+    }
+
+    #[test]
+    fn test_import_prefers_ansi_dialect() {
+        let yaml = r#"
+semantic_model:
+  - name: m
+    datasets:
+      - name: data
+        source: test.data
+        fields:
+          - name: full_name
+            expression:
+              dialects:
+                - dialect: SNOWFLAKE
+                  expression: "CONCAT(first, ' ', last)"
+                - dialect: ANSI_SQL
+                  expression: "first || ' ' || last"
+"#;
+        let graph = OsiAdapter::new().parse_str(yaml).unwrap();
+        let dim = graph
+            .get_model("data")
+            .unwrap()
+            .get_dimension("full_name")
+            .unwrap();
+        assert_eq!(dim.sql.as_deref(), Some("first || ' ' || last"));
+    }
+
+    #[test]
+    fn test_import_relationship_and_metric_aggregations() {
+        let yaml = r#"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: public.orders
+        primary_key: [order_id]
+        fields:
+          - name: customer_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: customer_id
+      - name: customers
+        source: public.customers
+        primary_key: [customer_id]
+        fields:
+          - name: customer_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: customer_id
+    relationships:
+      - name: orders_to_customers
+        from: orders
+        to: customers
+        from_columns: [customer_id]
+        to_columns: [customer_id]
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.amount)
+      - name: order_count
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: COUNT(*)
+      - name: avg_order_value
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: AVG(orders.amount)
+      - name: customer_count
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: COUNT(DISTINCT customers.customer_id)
+"#;
+        let graph = OsiAdapter::new().parse_str(yaml).unwrap();
+
+        let orders = graph.get_model("orders").unwrap();
+        assert_eq!(orders.relationships.len(), 1);
+        let rel = &orders.relationships[0];
+        assert_eq!(rel.name, "customers");
+        assert_eq!(rel.r#type, RelationshipType::ManyToOne);
+        assert_eq!(rel.foreign_key.as_deref(), Some("customer_id"));
+        assert_eq!(rel.primary_key.as_deref(), Some("customer_id"));
+        assert_eq!(
+            rel.metadata.as_ref().unwrap()["osi_name"],
+            Json::String("orders_to_customers".to_string())
+        );
+
+        assert_eq!(
+            graph.get_metric("total_revenue").unwrap().agg,
+            Some(Aggregation::Sum)
+        );
+        assert_eq!(
+            graph.get_metric("order_count").unwrap().agg,
+            Some(Aggregation::Count)
+        );
+        assert_eq!(
+            graph.get_metric("avg_order_value").unwrap().agg,
+            Some(Aggregation::Avg)
+        );
+        assert_eq!(
+            graph.get_metric("customer_count").unwrap().agg,
+            Some(Aggregation::CountDistinct)
+        );
+    }
+
+    #[test]
+    fn test_import_composite_key_unique_keys_and_meta() {
+        let yaml = r#"
+semantic_model:
+  - name: m
+    datasets:
+      - name: order_items
+        source: public.order_items
+        primary_key: [order_id, item_id]
+        unique_keys: [[sku], [tenant_id, slot]]
+        ai_context:
+          synonyms: [line_items]
+        custom_extensions:
+          vendor:
+            name: acme
+          tags: [important]
+        fields:
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id
+"#;
+        let graph = OsiAdapter::new().parse_str(yaml).unwrap();
+        let model = graph.get_model("order_items").unwrap();
+        assert_eq!(model.primary_key, "order_id");
+        assert_eq!(
+            model.primary_key_columns,
+            vec!["order_id".to_string(), "item_id".to_string()]
+        );
+        assert_eq!(
+            model.unique_keys.as_ref().unwrap(),
+            &vec![
+                vec!["sku".to_string()],
+                vec!["tenant_id".to_string(), "slot".to_string()]
+            ]
+        );
+        let meta = model.meta.as_ref().unwrap();
+        assert_eq!(meta["ai_context"]["synonyms"][0], "line_items");
+        assert_eq!(meta["custom_extensions"]["vendor"]["name"], "acme");
+        assert_eq!(meta["custom_extensions"]["tags"][0], "important");
+    }
+
+    #[test]
+    fn test_import_graph_metadata_and_ontology_mapping() {
+        let yaml = r#"
+version: 0.2.0.dev0
+ontology:
+  - concept:
+      name: Flight
+ontology_mappings:
+  - name: flights_map
+    description: Flight mapping
+    semantic_model:
+      name: logical_flights
+      datasets:
+        - name: flights
+          source: analytics.flights
+          fields:
+            - name: flight_id
+              expression:
+                dialects:
+                  - dialect: ANSI_SQL
+                    expression: flight_id
+    concept_mappings:
+      - concept: Flight
+"#;
+        let graph = OsiAdapter::new().parse_str(yaml).unwrap();
+        assert!(graph.get_model("flights").is_some());
+        let osi = &graph.metadata().unwrap()["osi"];
+        assert_eq!(osi["version"], "0.2.0.dev0");
+        assert_eq!(osi["ontology"][0]["concept"]["name"], "Flight");
+        let sm = &osi["semantic_models"][0];
+        assert_eq!(sm["source"], "ontology_mappings[0].semantic_model");
+        assert_eq!(sm["name"], "logical_flights");
+        assert_eq!(sm["ontology_mapping"]["name"], "flights_map");
+    }
+
+    #[test]
+    fn test_import_skips_invalid_entries_and_empty() {
+        assert_eq!(OsiAdapter::new().parse_str("").unwrap().models().count(), 0);
+
+        let yaml = r#"
+semantic_model:
+  - name: m
+    datasets:
+      - source: nameless.dataset
+      - name: data
+        source: public.data
+        fields:
+          - expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: id
+    metrics:
+      - name: bad_metric
+"#;
+        let graph = OsiAdapter::new().parse_str(yaml).unwrap();
+        assert_eq!(graph.models().count(), 1);
+        assert_eq!(graph.get_model("data").unwrap().dimensions.len(), 0);
+        assert_eq!(graph.metrics().count(), 0);
+    }
+
+    #[test]
+    fn test_decode_sidemantic_custom_extension_wrapper() {
+        let yaml = r#"
+semantic_model:
+  - name: m
+    datasets:
+      - name: data
+        source: public.data
+        custom_extensions:
+          - vendor_name: SIDEMANTIC
+            data: '{"catalog_version": "2.0"}'
+        fields:
+          - name: id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: id
+"#;
+        let graph = OsiAdapter::new().parse_str(yaml).unwrap();
+        let meta = graph.get_model("data").unwrap().meta.as_ref().unwrap();
+        assert_eq!(meta["custom_extensions"]["catalog_version"], "2.0");
+    }
+
+    // ----- export -----
+
+    fn sample_graph() -> SemanticGraph {
+        let yaml = r#"
+semantic_model:
+  - name: m
+    datasets:
+      - name: orders
+        source: public.orders
+        primary_key: [order_id]
+        description: Customer orders
+        fields:
+          - name: order_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_id
+          - name: order_date
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: order_date
+            dimension:
+              is_time: true
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.amount)
+"#;
+        OsiAdapter::new().parse_str(yaml).unwrap()
+    }
+
+    #[test]
+    fn test_export_structure() {
+        let graph = sample_graph();
+        let data = export_to_json(&graph, vec!["ANSI_SQL".to_string()]);
+        assert_eq!(data["version"], OSI_VERSION);
+        let sm = &data["semantic_model"][0];
+        let dataset = &sm["datasets"][0];
+        assert_eq!(dataset["name"], "orders");
+        assert_eq!(dataset["source"], "public.orders");
+        assert_eq!(dataset["primary_key"][0], "order_id");
+        let fields = dataset["fields"].as_array().unwrap();
+        let order_date = fields.iter().find(|f| f["name"] == "order_date").unwrap();
+        assert_eq!(order_date["dimension"]["is_time"], true);
+        assert_eq!(sm["metrics"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_export_multi_dialect_includes_all() {
+        let graph = sample_graph();
+        let data = export_to_json(
+            &graph,
+            vec!["ANSI_SQL".to_string(), "SNOWFLAKE".to_string()],
+        );
+        let field = &data["semantic_model"][0]["datasets"][0]["fields"][0];
+        let names: Vec<&str> = field["expression"]["dialects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|d| d["dialect"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"ANSI_SQL"));
+        assert!(names.contains(&"SNOWFLAKE"));
+    }
+
+    #[test]
+    fn test_export_unknown_dialect_errors() {
+        let graph = sample_graph();
+        let err = OsiAdapter::new()
+            .with_dialects(vec!["UNKNOWN".to_string()])
+            .export_string(&graph)
+            .unwrap_err();
+        assert!(err.to_string().contains("Unsupported OSI export dialect"));
+    }
+
+    #[test]
+    fn test_export_empty_dialects_defaults_to_ansi() {
+        let graph = sample_graph();
+        let data = export_to_json(&graph, vec![]);
+        let dialects = data["semantic_model"][0]["datasets"][0]["fields"][0]["expression"]
+            ["dialects"]
+            .as_array()
+            .unwrap();
+        assert_eq!(dialects.len(), 1);
+        assert_eq!(dialects[0]["dialect"], "ANSI_SQL");
+    }
+
+    #[test]
+    fn test_export_relationship_and_meta() {
+        let yaml = r#"
+semantic_model:
+  - name: m
+    datasets:
+      - name: orders
+        source: public.orders
+        primary_key: [order_id]
+        ai_context:
+          synonyms: [purchases]
+        custom_extensions:
+          catalog: v2
+        fields:
+          - name: customer_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: customer_id
+      - name: customers
+        source: public.customers
+        primary_key: [id]
+        fields:
+          - name: id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: id
+    relationships:
+      - name: orders_to_customers
+        from: orders
+        to: customers
+        from_columns: [customer_id]
+        to_columns: [id]
+"#;
+        let graph = OsiAdapter::new().parse_str(yaml).unwrap();
+        let data = export_to_json(&graph, vec!["ANSI_SQL".to_string()]);
+        let sm = &data["semantic_model"][0];
+        let rels = sm["relationships"].as_array().unwrap();
+        assert_eq!(rels.len(), 1);
+        assert_eq!(rels[0]["from"], "orders");
+        assert_eq!(rels[0]["to"], "customers");
+        assert_eq!(rels[0]["from_columns"][0], "customer_id");
+        assert_eq!(rels[0]["to_columns"][0], "id");
+
+        let orders_ds = sm["datasets"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|d| d["name"] == "orders")
+            .unwrap();
+        assert_eq!(orders_ds["ai_context"]["synonyms"][0], "purchases");
+        // permissive dict meta normalized into the OSI custom_extensions schema
+        assert_eq!(
+            orders_ds["custom_extensions"][0]["vendor_name"],
+            "SIDEMANTIC"
+        );
+        assert!(orders_ds["custom_extensions"][0]["data"].is_string());
+    }
+
+    // ----- round trip -----
+
+    #[test]
+    fn test_roundtrip_preserves_models_and_metadata() {
+        let graph = sample_graph();
+        let yaml = OsiAdapter::new().export_string(&graph).unwrap();
+        let graph2 = OsiAdapter::new().parse_str(&yaml).unwrap();
+
+        let orders = graph2.get_model("orders").unwrap();
+        assert_eq!(orders.table.as_deref(), Some("public.orders"));
+        assert_eq!(orders.primary_key, "order_id");
+        assert_eq!(
+            orders.get_dimension("order_date").unwrap().r#type,
+            DimensionType::Time
+        );
+        assert!(graph2.get_metric("total_revenue").is_some());
+
+        // Semantic-model-level metadata survives the round trip.
+        let yaml2 = OsiAdapter::new().export_string(&graph2).unwrap();
+        let data: Json = serde_yaml::from_str(&yaml2).unwrap();
+        assert_eq!(data["version"], OSI_VERSION);
+    }
+
+    #[test]
+    fn test_graph_metadata_roundtrip_preserves_semantic_model_fields() {
+        let yaml = r#"
+version: 0.2.0.dev0
+semantic_model:
+  - name: current_model
+    description: Current OSI model
+    ai_context:
+      instructions: Use for tests
+    datasets:
+      - name: events
+        source: analytics.events
+        fields:
+          - name: event_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: event_id
+"#;
+        let graph = OsiAdapter::new().parse_str(yaml).unwrap();
+        let data = export_to_json(&graph, vec!["ANSI_SQL".to_string()]);
+        let sm = &data["semantic_model"][0];
+        assert_eq!(sm["name"], "current_model");
+        assert_eq!(sm["description"], "Current OSI model");
+        assert_eq!(sm["ai_context"]["instructions"], "Use for tests");
+    }
+}

--- a/sidemantic-rs/src/adapters/osi.rs
+++ b/sidemantic-rs/src/adapters/osi.rs
@@ -80,10 +80,15 @@ impl OsiAdapter {
         for model in doc.models {
             graph.add_model(model)?;
         }
-        for metric in doc.graph_metrics {
+        // Register all graph-level metrics before validating, so a derived/ratio
+        // metric declared before the metrics it references still loads.
+        for metric in &doc.graph_metrics {
             if graph.get_metric(&metric.name).is_none() {
-                graph.add_metric(metric)?;
+                graph.add_metric_unvalidated(metric.clone())?;
             }
+        }
+        for metric in &doc.graph_metrics {
+            graph.validate_metric_dependencies(metric)?;
         }
         if let Some(metadata) = doc.metadata {
             graph.set_metadata(metadata);

--- a/sidemantic-rs/src/adapters/osi.rs
+++ b/sidemantic-rs/src/adapters/osi.rs
@@ -14,6 +14,8 @@
 //!
 //! Spec: <https://github.com/open-semantic-interchange/OSI>
 
+use std::collections::HashSet;
+
 use polyglot_sql::{DialectType, Expression};
 use serde_json::{Map as JsonMap, Value as Json};
 use serde_yaml::{Mapping as YamlMap, Value as Yaml};
@@ -622,10 +624,23 @@ fn export_semantic_model(models: &[&Model], graph: &SemanticGraph, dialects: &[S
         put(&mut sm, "relationships", Yaml::Sequence(relationships));
     }
 
+    // Metrics owned by a model are exported (qualified) in the model loop
+    // below. `graph.metrics()` can surface the same metric at graph scope
+    // (model-level time_comparison/conversion metrics are indexed there, and
+    // top-level metrics get assigned to an owner model), so exclude those names
+    // from the graph-level loop to avoid emitting duplicate OSI definitions.
+    let model_owned: HashSet<&str> = models
+        .iter()
+        .flat_map(|model| model.metrics.iter().map(|metric| metric.name.as_str()))
+        .collect();
+
     let mut metrics = Vec::new();
     let mut graph_metrics: Vec<&Metric> = graph.metrics().collect();
     graph_metrics.sort_by(|a, b| a.name.cmp(&b.name));
     for metric in graph_metrics {
+        if model_owned.contains(metric.name.as_str()) {
+            continue;
+        }
         if let Some(metric_def) = export_metric(metric, None, dialects) {
             metrics.push(metric_def);
         }
@@ -1493,5 +1508,49 @@ semantic_model:
         assert_eq!(sm["name"], "current_model");
         assert_eq!(sm["description"], "Current OSI model");
         assert_eq!(sm["ai_context"]["instructions"], "Use for tests");
+    }
+
+    #[test]
+    fn test_export_does_not_duplicate_owner_assigned_metrics() {
+        // A top-level metric assigned to an owner model lives in both
+        // `graph.metrics()` and `model.metrics`; it must be exported once.
+        let yaml = r#"
+version: 1
+models:
+  - name: orders
+    table: orders
+    primary_key: order_id
+    metrics:
+      - name: revenue
+        agg: sum
+        sql: amount
+      - name: order_count
+        agg: count
+metrics:
+  - name: revenue_per_order
+    type: ratio
+    numerator: revenue
+    denominator: order_count
+"#;
+        let graph = crate::config::load_from_string(yaml).unwrap();
+        let data = export_to_json(&graph, vec!["ANSI_SQL".to_string()]);
+        let names: Vec<&str> = data["semantic_model"][0]["metrics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|metric| metric["name"].as_str().unwrap())
+            .collect();
+
+        let mut unique = names.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            names.len(),
+            "duplicate metric names: {names:?}"
+        );
+        assert!(names.contains(&"revenue"));
+        assert!(names.contains(&"order_count"));
+        assert!(names.contains(&"revenue_per_order"));
     }
 }

--- a/sidemantic-rs/src/config/loader.rs
+++ b/sidemantic-rs/src/config/loader.rs
@@ -142,11 +142,7 @@ pub fn load_from_string_with_metadata(content: &str) -> Result<LoadedGraphMetada
             graph.add_metric(metric)?;
         }
     }
-    for metric in graph_metrics.iter().cloned() {
-        if graph.get_metric(&metric.name).is_none() {
-            graph.add_metric(metric)?;
-        }
-    }
+    register_graph_metrics(&mut graph, &graph_metrics)?;
     for parameter in top_level_parameters {
         graph.add_parameter(parameter)?;
     }
@@ -572,11 +568,7 @@ pub fn load_from_directory_with_metadata(dir: impl AsRef<Path>) -> Result<Loaded
             graph.add_metric(metric)?;
         }
     }
-    for metric in all_graph_metrics.iter().cloned() {
-        if graph.get_metric(&metric.name).is_none() {
-            graph.add_metric(metric)?;
-        }
-    }
+    register_graph_metrics(&mut graph, &all_graph_metrics)?;
     for parameter in all_top_level_parameters {
         graph.add_parameter(parameter)?;
     }
@@ -801,6 +793,23 @@ fn parse_content_with_extends(content: &str, format: ConfigFormat) -> Result<Par
             })
         }
     }
+}
+
+/// Register graph-level metrics, then validate dependencies once all are present.
+///
+/// OSI documents may declare a derived/ratio metric before the graph metrics it
+/// references; registering before validating keeps loading order-independent
+/// while still rejecting genuinely missing references.
+fn register_graph_metrics(graph: &mut SemanticGraph, metrics: &[Metric]) -> Result<()> {
+    for metric in metrics.iter().cloned() {
+        if graph.get_metric(&metric.name).is_none() {
+            graph.add_metric_unvalidated(metric)?;
+        }
+    }
+    for metric in metrics {
+        graph.validate_metric_dependencies(metric)?;
+    }
+    Ok(())
 }
 
 fn collect_unique_models(models: Vec<Model>) -> Result<HashMap<String, Model>> {
@@ -1310,6 +1319,47 @@ semantic_model:
             loaded.model_sources["orders"].source_format,
             "OSI".to_string()
         );
+    }
+
+    #[test]
+    fn test_load_osi_graph_metrics_independent_of_declaration_order() {
+        // `revenue_per_order` references `total_revenue`/`order_count` but is
+        // declared before them; loading must not fail on declaration order.
+        let yaml = r#"
+semantic_model:
+  - name: m
+    datasets:
+      - name: orders
+        source: public.orders
+        primary_key: [order_id]
+        fields:
+          - name: amount
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: amount
+    metrics:
+      - name: revenue_per_order
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: total_revenue / order_count
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(amount)
+      - name: order_count
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: COUNT(*)
+"#;
+
+        let graph = load_from_string(yaml).unwrap();
+        assert!(graph.get_metric("revenue_per_order").is_some());
+        assert!(graph.get_metric("total_revenue").is_some());
+        assert!(graph.get_metric("order_count").is_some());
     }
 
     #[test]

--- a/sidemantic-rs/src/config/loader.rs
+++ b/sidemantic-rs/src/config/loader.rs
@@ -7,23 +7,31 @@ use std::path::Path;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+use crate::adapters::{Adapter, CubeAdapter, OsiAdapter};
 use crate::core::{
     extract_dependencies, resolve_model_inheritance, Metric, Model, Parameter, Relationship,
     RelationshipType, SemanticGraph,
 };
 use crate::error::{Result, SidemanticError};
 
-use super::schema::{CubeConfig, SidemanticConfig, NATIVE_FORMAT_VERSION};
+use super::schema::{SidemanticConfig, NATIVE_FORMAT_VERSION};
 use super::sql_parser::{
     parse_sql_definitions, parse_sql_graph_definitions_extended, parse_sql_models,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct ParsedConfig {
     models: Vec<Model>,
     extends_map: HashMap<String, String>,
+    /// Top-level metrics assigned to an owning model (native format).
     top_level_metrics: Vec<Metric>,
     top_level_parameters: Vec<Parameter>,
+    /// Graph-level metrics added directly to the graph (OSI), never reassigned.
+    graph_metrics: Vec<Metric>,
+    /// Graph-level metadata payload (OSI import state).
+    graph_metadata: Option<serde_json::Value>,
+    /// When true, relationships are declared explicitly; skip FK inference.
+    explicit_relationships: bool,
 }
 
 #[derive(Debug)]
@@ -48,6 +56,18 @@ pub enum ConfigFormat {
     Sidemantic,
     /// Cube.js format (cubes: key)
     Cube,
+    /// OSI (Open Semantic Interchange) format (semantic_model: / ontology_mappings: key)
+    Osi,
+}
+
+impl ConfigFormat {
+    fn source_label(self) -> &'static str {
+        match self {
+            ConfigFormat::Sidemantic => "Sidemantic",
+            ConfigFormat::Cube => "Cube",
+            ConfigFormat::Osi => "OSI",
+        }
+    }
 }
 
 /// Load a semantic graph from a single YAML file
@@ -89,6 +109,9 @@ pub fn load_from_string_with_metadata(content: &str) -> Result<LoadedGraphMetada
         extends_map,
         top_level_metrics,
         top_level_parameters,
+        graph_metrics,
+        graph_metadata,
+        ..
     } = parsed;
     let model_order: Vec<String> = models.iter().map(|model| model.name.clone()).collect();
     let original_model_metrics: HashMap<String, Vec<String>> = models
@@ -119,9 +142,20 @@ pub fn load_from_string_with_metadata(content: &str) -> Result<LoadedGraphMetada
             graph.add_metric(metric)?;
         }
     }
+    for metric in graph_metrics.iter().cloned() {
+        if graph.get_metric(&metric.name).is_none() {
+            graph.add_metric(metric)?;
+        }
+    }
     for parameter in top_level_parameters {
         graph.add_parameter(parameter)?;
     }
+    if let Some(metadata) = graph_metadata {
+        graph.set_metadata(metadata);
+    }
+
+    let mut reported_metrics = top_level_metrics;
+    reported_metrics.extend(graph_metrics);
 
     let model_sources = model_order
         .iter()
@@ -129,10 +163,7 @@ pub fn load_from_string_with_metadata(content: &str) -> Result<LoadedGraphMetada
             (
                 model_name.clone(),
                 LoadedModelSource {
-                    source_format: match format {
-                        ConfigFormat::Sidemantic => "Sidemantic".to_string(),
-                        ConfigFormat::Cube => "Cube".to_string(),
-                    },
+                    source_format: format.source_label().to_string(),
                     source_file: None,
                 },
             )
@@ -142,7 +173,7 @@ pub fn load_from_string_with_metadata(content: &str) -> Result<LoadedGraphMetada
     Ok(LoadedGraphMetadata {
         graph,
         model_order,
-        top_level_metrics,
+        top_level_metrics: reported_metrics,
         original_model_metrics,
         model_sources,
     })
@@ -305,6 +336,7 @@ fn parse_sql_content(content: &str) -> Result<ParsedConfig> {
         extends_map: HashMap::new(),
         top_level_metrics,
         top_level_parameters,
+        ..Default::default()
     })
 }
 
@@ -316,6 +348,7 @@ pub fn load_from_sql_string_with_metadata(content: &str) -> Result<LoadedGraphMe
         extends_map,
         top_level_metrics,
         top_level_parameters,
+        ..
     } = parsed;
     let model_order: Vec<String> = models.iter().map(|model| model.name.clone()).collect();
     let original_model_metrics: HashMap<String, Vec<String>> = models
@@ -402,8 +435,13 @@ pub fn load_from_directory_with_metadata(dir: impl AsRef<Path>) -> Result<Loaded
     let mut all_extends_map: HashMap<String, String> = HashMap::new();
     let mut all_top_level_metrics: Vec<Metric> = Vec::new();
     let mut all_top_level_parameters: Vec<Parameter> = Vec::new();
+    let mut all_graph_metrics: Vec<Metric> = Vec::new();
     let mut model_order: Vec<String> = Vec::new();
     let mut model_sources: HashMap<String, LoadedModelSource> = HashMap::new();
+    // Models whose format declares relationships explicitly (e.g. OSI); these
+    // are excluded from foreign-key relationship inference.
+    let mut explicit_rel_models: HashSet<String> = HashSet::new();
+    let mut merged_graph_metadata: Option<serde_json::Value> = None;
 
     // Recursively find and parse model files.
     for entry in walkdir(dir)? {
@@ -421,10 +459,7 @@ pub fn load_from_directory_with_metadata(dir: impl AsRef<Path>) -> Result<Loaded
 
                 let format = detect_format(&content);
                 let parsed = parse_content(&content, format)?;
-                let source_format = match format {
-                    ConfigFormat::Sidemantic => "Sidemantic",
-                    ConfigFormat::Cube => "Cube",
-                };
+                let source_format = format.source_label();
                 let source_file = path
                     .strip_prefix(dir)
                     .ok()
@@ -434,6 +469,9 @@ pub fn load_from_directory_with_metadata(dir: impl AsRef<Path>) -> Result<Loaded
                     extends_map,
                     top_level_metrics,
                     top_level_parameters,
+                    graph_metrics,
+                    graph_metadata,
+                    explicit_relationships,
                 } = parsed;
 
                 for model in models {
@@ -442,6 +480,9 @@ pub fn load_from_directory_with_metadata(dir: impl AsRef<Path>) -> Result<Loaded
                             "Duplicate model '{}' found while loading directory",
                             model.name
                         )));
+                    }
+                    if explicit_relationships {
+                        explicit_rel_models.insert(model.name.clone());
                     }
                     model_order.push(model.name.clone());
                     model_sources.insert(
@@ -456,6 +497,8 @@ pub fn load_from_directory_with_metadata(dir: impl AsRef<Path>) -> Result<Loaded
                 all_extends_map.extend(extends_map);
                 all_top_level_metrics.extend(top_level_metrics);
                 all_top_level_parameters.extend(top_level_parameters);
+                all_graph_metrics.extend(graph_metrics);
+                merge_osi_metadata(&mut merged_graph_metadata, graph_metadata);
             }
             Some("sql") => {
                 let content = fs::read_to_string(&path).map_err(|e| {
@@ -471,6 +514,7 @@ pub fn load_from_directory_with_metadata(dir: impl AsRef<Path>) -> Result<Loaded
                     extends_map,
                     top_level_metrics,
                     top_level_parameters,
+                    ..
                 } = parsed;
 
                 for model in models {
@@ -512,8 +556,9 @@ pub fn load_from_directory_with_metadata(dir: impl AsRef<Path>) -> Result<Loaded
         })
         .collect();
 
-    // Infer relationships from FK naming conventions
-    infer_relationships(&mut all_models);
+    // Infer relationships from FK naming conventions (skip formats that
+    // declare relationships explicitly, e.g. OSI).
+    infer_relationships(&mut all_models, &explicit_rel_models);
     let mut resolved_models = resolve_model_inheritance(all_models, &all_extends_map)?;
     if !resolved_models.is_empty() && !all_top_level_metrics.is_empty() {
         assign_top_level_metrics(&mut resolved_models, all_top_level_metrics.clone())?;
@@ -527,17 +572,66 @@ pub fn load_from_directory_with_metadata(dir: impl AsRef<Path>) -> Result<Loaded
             graph.add_metric(metric)?;
         }
     }
+    for metric in all_graph_metrics.iter().cloned() {
+        if graph.get_metric(&metric.name).is_none() {
+            graph.add_metric(metric)?;
+        }
+    }
     for parameter in all_top_level_parameters {
         graph.add_parameter(parameter)?;
     }
+    if let Some(metadata) = merged_graph_metadata {
+        graph.set_metadata(metadata);
+    }
+
+    let mut reported_metrics = all_top_level_metrics;
+    reported_metrics.extend(all_graph_metrics);
 
     Ok(LoadedGraphMetadata {
         graph,
         model_order,
-        top_level_metrics: all_top_level_metrics,
+        top_level_metrics: reported_metrics,
         original_model_metrics,
         model_sources,
     })
+}
+
+/// Merge an OSI `{ "osi": { ... } }` metadata payload into the accumulator,
+/// concatenating `semantic_models` and keeping the first `version`/`ontology`.
+fn merge_osi_metadata(acc: &mut Option<serde_json::Value>, incoming: Option<serde_json::Value>) {
+    let Some(incoming) = incoming else {
+        return;
+    };
+    let Some(incoming_osi) = incoming.get("osi").and_then(|v| v.as_object()).cloned() else {
+        return;
+    };
+
+    let acc_value =
+        acc.get_or_insert_with(|| serde_json::json!({ "osi": { "semantic_models": [] } }));
+    let Some(acc_osi) = acc_value
+        .as_object_mut()
+        .and_then(|m| m.get_mut("osi"))
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+
+    if let Some(serde_json::Value::Array(incoming_models)) = incoming_osi.get("semantic_models") {
+        let entry = acc_osi
+            .entry("semantic_models")
+            .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+        if let serde_json::Value::Array(acc_models) = entry {
+            acc_models.extend(incoming_models.iter().cloned());
+        }
+    }
+
+    for key in ["version", "ontology"] {
+        if !acc_osi.contains_key(key) {
+            if let Some(value) = incoming_osi.get(key) {
+                acc_osi.insert(key.to_string(), value.clone());
+            }
+        }
+    }
 }
 
 /// Detect the config format from content
@@ -545,6 +639,11 @@ fn detect_format(content: &str) -> ConfigFormat {
     // Check for Cube.js format markers
     if content.contains("cubes:") {
         return ConfigFormat::Cube;
+    }
+
+    // Check for OSI format markers
+    if content.contains("semantic_model:") || content.contains("ontology_mappings:") {
+        return ConfigFormat::Osi;
     }
 
     // Default to Sidemantic format
@@ -670,6 +769,7 @@ fn parse_content_with_extends(content: &str, format: ConfigFormat) -> Result<Par
                 .iter()
                 .filter_map(|m| m.extends.as_ref().map(|e| (m.name.clone(), e.clone())))
                 .collect();
+            let graph_metadata = config.metadata.clone();
             let (mut models, mut top_level_metrics, top_level_parameters) = config.into_parts()?;
             apply_embedded_sql_definitions(&content, &mut models, &mut top_level_metrics)?;
 
@@ -678,17 +778,26 @@ fn parse_content_with_extends(content: &str, format: ConfigFormat) -> Result<Par
                 extends_map,
                 top_level_metrics,
                 top_level_parameters,
+                graph_metadata,
+                ..Default::default()
             })
         }
         ConfigFormat::Cube => {
-            let config: CubeConfig = serde_yaml::from_str(&content)
-                .map_err(|e| SidemanticError::Validation(format!("YAML parse error: {e}")))?;
             // Cube.js doesn't support extends in the same way
             Ok(ParsedConfig {
-                models: config.into_models(),
-                extends_map: HashMap::new(),
-                top_level_metrics: Vec::new(),
-                top_level_parameters: Vec::new(),
+                models: CubeAdapter::new().parse_models(&content)?,
+                ..Default::default()
+            })
+        }
+        ConfigFormat::Osi => {
+            let doc = OsiAdapter::new().parse_document(&content)?;
+            Ok(ParsedConfig {
+                models: doc.models,
+                top_level_parameters: doc.parameters,
+                graph_metrics: doc.graph_metrics,
+                graph_metadata: doc.metadata,
+                explicit_relationships: doc.explicit_relationships,
+                ..Default::default()
             })
         }
     }
@@ -968,7 +1077,7 @@ fn assign_top_level_metrics(
 ///
 /// Looks for columns ending with `_id` and tries to match them to existing models.
 /// For example: `customer_id` -> `customer` or `customers` model
-fn infer_relationships(models: &mut HashMap<String, Model>) {
+fn infer_relationships(models: &mut HashMap<String, Model>, skip: &HashSet<String>) {
     // Collect model names for lookup
     let mut model_names: Vec<String> = models.keys().cloned().collect();
     model_names.sort();
@@ -977,6 +1086,10 @@ fn infer_relationships(models: &mut HashMap<String, Model>) {
     let mut relationships_to_add: Vec<(String, Relationship)> = Vec::new();
 
     for model_name in &model_names {
+        // Skip models whose format declares relationships explicitly.
+        if skip.contains(model_name) {
+            continue;
+        }
         let Some(model) = models.get(model_name) else {
             continue;
         };
@@ -1019,6 +1132,10 @@ fn infer_relationships(models: &mut HashMap<String, Model>) {
                         .find(|n| n.to_lowercase() == target)
                         .unwrap()
                         .clone();
+                    // Don't infer relationships into models that declare them explicitly.
+                    if skip.contains(&actual_target) {
+                        continue;
+                    }
                     let target_primary_keys = models
                         .get(&actual_target)
                         .map(Model::primary_keys)
@@ -1129,6 +1246,74 @@ mod tests {
     fn test_detect_format_cube() {
         let content = "cubes:\n  - name: orders";
         assert_eq!(detect_format(content), ConfigFormat::Cube);
+    }
+
+    #[test]
+    fn test_detect_format_osi() {
+        assert_eq!(
+            detect_format("semantic_model:\n  - name: m"),
+            ConfigFormat::Osi
+        );
+        assert_eq!(
+            detect_format("ontology_mappings:\n  - name: m"),
+            ConfigFormat::Osi
+        );
+    }
+
+    #[test]
+    fn test_load_from_string_auto_detects_osi() {
+        let yaml = r#"
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        source: public.orders
+        primary_key: [order_id]
+        fields:
+          - name: customer_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: customer_id
+      - name: customers
+        source: public.customers
+        primary_key: [customer_id]
+        fields:
+          - name: customer_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: customer_id
+    relationships:
+      - name: orders_to_customers
+        from: orders
+        to: customers
+        from_columns: [customer_id]
+        to_columns: [customer_id]
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.amount)
+"#;
+
+        let loaded = load_from_string_with_metadata(yaml).unwrap();
+        let graph = &loaded.graph;
+        assert!(graph.get_model("orders").is_some());
+        assert!(graph.get_model("customers").is_some());
+        // OSI relationship is explicit; FK inference must not add a reverse edge.
+        let orders = graph.get_model("orders").unwrap();
+        assert_eq!(orders.relationships.len(), 1);
+        let customers = graph.get_model("customers").unwrap();
+        assert!(customers.get_relationship("orders").is_none());
+        // Graph-level metric and metadata preserved.
+        assert!(graph.get_metric("total_revenue").is_some());
+        assert!(graph.metadata().is_some());
+        assert_eq!(
+            loaded.model_sources["orders"].source_format,
+            "OSI".to_string()
+        );
     }
 
     #[test]
@@ -1694,7 +1879,7 @@ sql_metrics: |
         models.insert("orders".to_string(), orders);
         models.insert("customers".to_string(), customers);
 
-        infer_relationships(&mut models);
+        infer_relationships(&mut models, &HashSet::new());
 
         // Check orders now has relationship to customers
         let orders = models.get("orders").unwrap();
@@ -1720,7 +1905,7 @@ sql_metrics: |
         models.insert("orders".to_string(), orders);
         models.insert("customers".to_string(), customers);
 
-        infer_relationships(&mut models);
+        infer_relationships(&mut models, &HashSet::new());
 
         let orders = models.get("orders").unwrap();
         assert_eq!(orders.relationships.len(), 1);
@@ -1744,7 +1929,7 @@ sql_metrics: |
         models.insert("orders".to_string(), orders);
         models.insert("customers".to_string(), customers);
 
-        infer_relationships(&mut models);
+        infer_relationships(&mut models, &HashSet::new());
 
         let orders = models.get("orders").unwrap();
         let relationship = orders.get_relationship("customers").unwrap();

--- a/sidemantic-rs/src/config/loader.rs
+++ b/sidemantic-rs/src/config/loader.rs
@@ -1132,10 +1132,6 @@ fn infer_relationships(models: &mut HashMap<String, Model>, skip: &HashSet<Strin
                         .find(|n| n.to_lowercase() == target)
                         .unwrap()
                         .clone();
-                    // Don't infer relationships into models that declare them explicitly.
-                    if skip.contains(&actual_target) {
-                        continue;
-                    }
                     let target_primary_keys = models
                         .get(&actual_target)
                         .map(Model::primary_keys)
@@ -1314,6 +1310,62 @@ semantic_model:
             loaded.model_sources["orders"].source_format,
             "OSI".to_string()
         );
+    }
+
+    #[test]
+    fn test_directory_infers_native_fk_into_osi_target() {
+        // A native source model should still infer its many_to_one even when
+        // the matched target model came from OSI (which is excluded only as an
+        // inference *source*, not as a target).
+        let dir = std::env::temp_dir().join(format!(
+            "sidemantic-rs-loader-mixed-osi-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("orders.yml"),
+            r#"
+models:
+  - name: orders
+    table: orders
+    primary_key: order_id
+    dimensions:
+      - name: customer_id
+        type: categorical
+"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join("customers.yaml"),
+            r#"
+semantic_model:
+  - name: crm
+    datasets:
+      - name: customers
+        source: public.customers
+        primary_key: [id]
+        fields:
+          - name: id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: id
+"#,
+        )
+        .unwrap();
+
+        let graph = load_from_directory(&dir).unwrap();
+        fs::remove_dir_all(&dir).unwrap();
+
+        let orders = graph.get_model("orders").unwrap();
+        let rel = orders.get_relationship("customers").unwrap();
+        assert_eq!(rel.r#type, RelationshipType::ManyToOne);
+        assert_eq!(rel.foreign_key_columns(), vec!["customer_id".to_string()]);
+        assert_eq!(rel.primary_key_columns(), vec!["id".to_string()]);
     }
 
     #[test]

--- a/sidemantic-rs/src/config/mod.rs
+++ b/sidemantic-rs/src/config/mod.rs
@@ -1,18 +1,19 @@
 //! Configuration loading for semantic layer definitions
 //!
-//! Supports loading from YAML files in both native Sidemantic format
-//! and Cube.js format, as well as SQL-based definitions.
+//! Supports loading from YAML files in native Sidemantic, Cube.js, and OSI
+//! formats, as well as SQL-based definitions.
 
 mod loader;
-mod schema;
+pub(crate) mod schema;
 mod sql_parser;
 
+pub use crate::adapters::cube::CubeConfig;
 pub use loader::{
     load_from_directory, load_from_directory_with_metadata, load_from_file,
     load_from_file_with_metadata, load_from_sql_string_with_metadata, load_from_string,
     load_from_string_with_metadata, ConfigFormat, LoadedGraphMetadata, LoadedModelSource,
 };
-pub use schema::{CubeConfig, ModelConfig, SidemanticConfig};
+pub use schema::{ModelConfig, SidemanticConfig};
 pub use sql_parser::{
     parse_sql_definitions, parse_sql_graph_definitions, parse_sql_graph_definitions_extended,
     parse_sql_model, parse_sql_models, parse_sql_statement_blocks,

--- a/sidemantic-rs/src/config/schema.rs
+++ b/sidemantic-rs/src/config/schema.rs
@@ -33,6 +33,9 @@ pub struct SidemanticConfig {
     pub sql_metrics: Option<String>,
     #[serde(default)]
     pub sql_segments: Option<String>,
+    /// Graph-level metadata payload (round-trips format-specific state such as OSI).
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -137,7 +140,7 @@ pub struct DimensionConfig {
     pub public: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetricConfig {
     pub name: String,
@@ -313,65 +316,6 @@ pub struct ParameterConfig {
     pub allowed_values: Option<Vec<serde_json::Value>>,
     #[serde(default)]
     pub default_to_today: bool,
-}
-
-// =============================================================================
-// Cube.js Format
-// =============================================================================
-
-/// Root schema for Cube.js YAML files
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct CubeConfig {
-    #[serde(default)]
-    pub cubes: Vec<CubeDefinition>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CubeDefinition {
-    pub name: String,
-    pub sql_table: Option<String>,
-    pub sql: Option<String>,
-    pub description: Option<String>,
-    #[serde(default)]
-    pub dimensions: Vec<CubeDimension>,
-    #[serde(default)]
-    pub measures: Vec<CubeMeasure>,
-    #[serde(default)]
-    pub segments: Vec<CubeSegment>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CubeDimension {
-    pub name: String,
-    #[serde(rename = "type")]
-    pub dim_type: Option<String>,
-    pub sql: Option<String>,
-    pub description: Option<String>,
-    pub title: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CubeMeasure {
-    pub name: String,
-    #[serde(rename = "type")]
-    pub measure_type: Option<String>,
-    pub sql: Option<String>,
-    pub description: Option<String>,
-    pub title: Option<String>,
-    #[serde(default)]
-    pub filters: Vec<CubeFilter>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CubeFilter {
-    pub sql: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CubeSegment {
-    pub name: String,
-    pub sql: String,
-    pub description: Option<String>,
 }
 
 // =============================================================================
@@ -863,170 +807,36 @@ impl ParameterConfig {
     }
 }
 
-// Cube.js conversions
-
-impl CubeConfig {
-    /// Convert to list of core Model types
-    pub fn into_models(self) -> Vec<Model> {
-        self.cubes.into_iter().map(|c| c.into_model()).collect()
+/// Build a [`Metric`] from a raw SQL expression, applying the same inline
+/// aggregation detection and metric-type inference as the native YAML loader.
+///
+/// Used by importers (e.g. OSI) whose metric definitions carry full aggregate
+/// expressions like `SUM(orders.amount)` or `COUNT(DISTINCT customers.id)`.
+pub(crate) fn metric_from_sql_expression(
+    name: String,
+    sql: Option<String>,
+    description: Option<String>,
+    meta: Option<serde_json::Value>,
+) -> Metric {
+    MetricConfig {
+        name,
+        sql,
+        description,
+        meta,
+        public: true,
+        ..MetricConfig::default()
     }
+    .into_metric()
 }
 
-impl CubeDefinition {
-    fn into_model(self) -> Model {
-        // Infer primary key from name (cube_name -> cube_name_id or id)
-        let primary_key = "id".to_string();
-
-        Model {
-            name: self.name,
-            table: self.sql_table,
-            sql: self.sql,
-            source_uri: None,
-            extends: None,
-            primary_key: primary_key.clone(),
-            primary_key_columns: vec![primary_key],
-            unique_keys: None,
-            dimensions: self
-                .dimensions
-                .into_iter()
-                .map(|d| d.into_dimension())
-                .collect(),
-            metrics: self.measures.into_iter().map(|m| m.into_metric()).collect(),
-            relationships: Vec::new(), // Cube.js uses joins differently
-            segments: self
-                .segments
-                .into_iter()
-                .map(|s| s.into_segment())
-                .collect(),
-            pre_aggregations: Vec::new(),
-            default_time_dimension: None,
-            default_grain: None,
-            label: None,
-            description: self.description,
-            metadata: None,
-            meta: None,
-        }
-    }
-}
-
-impl CubeDimension {
-    fn into_dimension(self) -> Dimension {
-        let dim_type = match self.dim_type.as_deref() {
-            Some("time") => DimensionType::Time,
-            Some("boolean") => DimensionType::Boolean,
-            Some("number") => DimensionType::Numeric,
-            _ => DimensionType::Categorical, // string, etc.
-        };
-
-        // Strip ${CUBE}. prefix from SQL
-        let sql = self.sql.map(|s| strip_cube_placeholder(&s));
-
-        Dimension {
-            name: self.name,
-            r#type: dim_type,
-            sql,
-            granularity: None,
-            supported_granularities: None,
-            label: self.title,
-            description: self.description,
-            metadata: None,
-            meta: None,
-            format: None,
-            value_format_name: None,
-            parent: None,
-            window: None,
-            public: true,
-        }
-    }
-}
-
-impl CubeMeasure {
-    fn into_metric(self) -> Metric {
-        // Map Cube.js measure types to aggregations
-        let (metric_type, agg) = match self.measure_type.as_deref() {
-            Some("count") => (MetricType::Simple, Some(Aggregation::Count)),
-            Some("countDistinct") | Some("count_distinct") => {
-                (MetricType::Simple, Some(Aggregation::CountDistinct))
-            }
-            Some("sum") => (MetricType::Simple, Some(Aggregation::Sum)),
-            Some("avg") => (MetricType::Simple, Some(Aggregation::Avg)),
-            Some("min") => (MetricType::Simple, Some(Aggregation::Min)),
-            Some("max") => (MetricType::Simple, Some(Aggregation::Max)),
-            Some("stddev") => (MetricType::Simple, Some(Aggregation::Stddev)),
-            Some("stddev_pop") => (MetricType::Simple, Some(Aggregation::StddevPop)),
-            Some("variance") => (MetricType::Simple, Some(Aggregation::Variance)),
-            Some("variance_pop") => (MetricType::Simple, Some(Aggregation::VariancePop)),
-            Some("number") => (MetricType::Derived, None), // derived/calculated
-            _ => (MetricType::Simple, Some(Aggregation::Sum)),
-        };
-
-        // Strip ${CUBE}. prefix from SQL
-        let sql = self.sql.map(|s| strip_cube_placeholder(&s));
-
-        // Convert filters
-        let filters = self
-            .filters
-            .into_iter()
-            .map(|f| strip_cube_placeholder(&f.sql))
-            .collect();
-
-        Metric {
-            name: self.name,
-            extends: None,
-            r#type: metric_type,
-            agg,
-            sql,
-            numerator: None,
-            denominator: None,
-            offset_window: None,
-            filters,
-            label: self.title,
-            description: self.description,
-            metadata: None,
-            meta: None,
-            window: None,
-            grain_to_date: None,
-            window_expression: None,
-            window_frame: None,
-            window_order: None,
-            base_metric: None,
-            comparison_type: None,
-            time_offset: None,
-            calculation: None,
-            entity: None,
-            base_event: None,
-            conversion_event: None,
-            conversion_window: None,
-            steps: None,
-            cohort_event: None,
-            activity_event: None,
-            periods: None,
-            retention_granularity: None,
-            inner_metrics: None,
-            entity_dimensions: None,
-            having: None,
-            fill_nulls_with: None,
-            format: None,
-            value_format_name: None,
-            drill_fields: None,
-            non_additive_dimension: None,
-            public: true,
-        }
-    }
-}
-
-impl CubeSegment {
-    fn into_segment(self) -> Segment {
-        // Convert ${CUBE} to {model} for our segment format
-        let sql = self.sql.replace("${CUBE}", "{model}");
-
-        Segment {
-            name: self.name,
-            sql,
-            description: self.description,
-            public: true,
-        }
-    }
+/// Parse a YAML list of metric configs into core [`Metric`]s, applying the same
+/// inline-aggregation and type inference as the native loader. Used to ferry
+/// graph-level metrics through the bridge without imposing model ownership.
+pub(crate) fn metrics_from_config_yaml(yaml: &str) -> crate::error::Result<Vec<Metric>> {
+    let configs: Vec<MetricConfig> = serde_yaml::from_str(yaml).map_err(|e| {
+        crate::error::SidemanticError::Validation(format!("failed to parse metrics: {e}"))
+    })?;
+    Ok(configs.into_iter().map(MetricConfig::into_metric).collect())
 }
 
 // =============================================================================
@@ -1302,11 +1112,6 @@ fn parse_comparison_calculation(s: &str) -> Option<ComparisonCalculation> {
         "ratio" => Some(ComparisonCalculation::Ratio),
         _ => None,
     }
-}
-
-/// Strip ${CUBE}. prefix from SQL expressions
-fn strip_cube_placeholder(sql: &str) -> String {
-    sql.replace("${CUBE}.", "").replace("${CUBE}", "")
 }
 
 #[cfg(test)]
@@ -1688,50 +1493,6 @@ models:
     }
 
     #[test]
-    fn test_parse_cube_yaml() {
-        let yaml = r#"
-cubes:
-  - name: orders
-    sql_table: orders
-
-    dimensions:
-      - name: status
-        sql: "${CUBE}.status"
-        type: string
-      - name: created_at
-        sql: "${CUBE}.created_at"
-        type: time
-
-    measures:
-      - name: count
-        type: count
-      - name: revenue
-        sql: "${CUBE}.amount"
-        type: sum
-
-    segments:
-      - name: completed
-        sql: "${CUBE}.status = 'completed'"
-"#;
-
-        let config: CubeConfig = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(config.cubes.len(), 1);
-
-        let models = config.into_models();
-        let orders = &models[0];
-        assert_eq!(orders.name, "orders");
-        assert_eq!(orders.dimensions.len(), 2);
-        assert_eq!(orders.metrics.len(), 2);
-        assert_eq!(orders.segments.len(), 1);
-
-        // Check ${CUBE} was stripped from dimension SQL
-        assert_eq!(orders.dimensions[0].sql, Some("status".to_string()));
-
-        // Check ${CUBE} was converted to {model} in segment
-        assert_eq!(orders.segments[0].sql, "{model}.status = 'completed'");
-    }
-
-    #[test]
     fn test_parse_many_to_many_relationship_fields() {
         let yaml = r#"
 models:
@@ -1929,15 +1690,6 @@ models:
         assert_eq!(
             explicit_derived_revenue.sql.as_deref(),
             Some("SUM(orders.amount)")
-        );
-    }
-
-    #[test]
-    fn test_strip_cube_placeholder() {
-        assert_eq!(strip_cube_placeholder("${CUBE}.status"), "status");
-        assert_eq!(
-            strip_cube_placeholder("${CUBE}.amount > 100"),
-            "amount > 100"
         );
     }
 }

--- a/sidemantic-rs/src/core/graph.rs
+++ b/sidemantic-rs/src/core/graph.rs
@@ -87,6 +87,8 @@ pub struct SemanticGraph {
     parameters: HashMap<String, Parameter>,
     /// Adjacency list: model -> edges
     adjacency: HashMap<String, Vec<AdjacencyEdge>>,
+    /// Graph-level metadata payload (e.g. format-specific import/export state).
+    metadata: Option<serde_json::Value>,
 }
 
 impl SemanticGraph {
@@ -456,6 +458,21 @@ impl SemanticGraph {
     /// Get all parameters
     pub fn parameters(&self) -> impl Iterator<Item = &Parameter> {
         self.parameters.values()
+    }
+
+    /// Get the graph-level metadata payload, if any.
+    pub fn metadata(&self) -> Option<&serde_json::Value> {
+        self.metadata.as_ref()
+    }
+
+    /// Replace the graph-level metadata payload.
+    pub fn set_metadata(&mut self, metadata: serde_json::Value) {
+        self.metadata = Some(metadata);
+    }
+
+    /// Mutable access to the graph-level metadata payload.
+    pub fn metadata_mut(&mut self) -> &mut Option<serde_json::Value> {
+        &mut self.metadata
     }
 
     /// Rebuild the adjacency list from model relationships

--- a/sidemantic-rs/src/core/graph.rs
+++ b/sidemantic-rs/src/core/graph.rs
@@ -284,6 +284,22 @@ impl SemanticGraph {
         self.models.values()
     }
 
+    /// Add a graph-level metric without validating its dependencies.
+    ///
+    /// Use when reconstructing a graph whose metrics were already validated
+    /// elsewhere (e.g. re-exporting a graph built by the Python layer), where
+    /// insertion order may not match dependency order.
+    pub fn add_metric_unvalidated(&mut self, metric: Metric) -> Result<()> {
+        if self.get_metric(&metric.name).is_some() {
+            return Err(SidemanticError::Validation(format!(
+                "Measure '{}' already exists",
+                metric.name
+            )));
+        }
+        self.metrics.insert(metric.name.clone(), metric);
+        Ok(())
+    }
+
     /// Add a graph-level metric.
     pub fn add_metric(&mut self, metric: Metric) -> Result<()> {
         if self.get_metric(&metric.name).is_some() {

--- a/sidemantic-rs/src/core/graph.rs
+++ b/sidemantic-rs/src/core/graph.rs
@@ -313,7 +313,12 @@ impl SemanticGraph {
         Ok(())
     }
 
-    fn validate_metric_dependencies(&self, metric: &Metric) -> Result<()> {
+    /// Validate that a metric's dependencies resolve against the current graph.
+    ///
+    /// Exposed so callers that register a batch of interdependent metrics out of
+    /// dependency order (e.g. OSI import) can insert them all first, then
+    /// validate once everything is present.
+    pub fn validate_metric_dependencies(&self, metric: &Metric) -> Result<()> {
         for dependency in extract_dependencies(metric, Some(self)) {
             let dependency_name = dependency
                 .rsplit_once('.')

--- a/sidemantic-rs/src/lib.rs
+++ b/sidemantic-rs/src/lib.rs
@@ -34,6 +34,7 @@
 //! println!("{}", sql);
 //! ```
 
+pub mod adapters;
 pub mod config;
 pub mod core;
 pub mod db;
@@ -47,6 +48,7 @@ pub mod sql;
 pub mod wasm;
 
 // Re-export commonly used types
+pub use adapters::{Adapter, CubeAdapter, OsiAdapter, ParsedDocument};
 pub use config::{
     load_from_directory, load_from_directory_with_metadata, load_from_file, load_from_string,
 };

--- a/sidemantic-rs/src/main.rs
+++ b/sidemantic-rs/src/main.rs
@@ -24,7 +24,8 @@ use serde_json::Value as JsonValue;
 use sidemantic::{
     build_preaggregation_refresh_statements, extract_preaggregation_patterns,
     generate_preaggregation_definition, recommend_preaggregation_patterns,
-    summarize_preaggregation_patterns, SemanticQuery, SidemanticError, SidemanticRuntime,
+    summarize_preaggregation_patterns, Adapter, OsiAdapter, SemanticQuery, SidemanticError,
+    SidemanticRuntime,
 };
 #[cfg(feature = "adbc-exec")]
 use sidemantic::{execute_with_adbc, AdbcExecutionRequest, AdbcValue};
@@ -130,6 +131,7 @@ fn run() -> CliResult<()> {
         "validate" => validate_command(rest),
         "migrator" => migrator_command(rest),
         "info" => info_command(rest),
+        "convert" => convert_command(rest),
         "query" => query_command(rest),
         "run" => run_command(rest),
         "preagg" => preagg_command(rest),
@@ -156,6 +158,7 @@ fn print_help() {
            validate  Validate model/query references\n\
            migrator  Analyze SQL coverage and bootstrap model files\n\
            info      Show semantic layer model summary\n\
+           convert   Export a semantic graph to OSI YAML\n\
            query     Rewrite SQL and optionally execute via ADBC\n\
            run       Compile and execute query via ADBC\n\
            preagg    Pre-aggregation helpers (materialize/recommend/refresh)\n\
@@ -174,7 +177,7 @@ fn print_help() {
            sidemantic preagg refresh --models ./models --model orders --name daily_revenue --mode full\n\
           sidemantic serve --models ./models --bind 127.0.0.1:5544\n\
          \n\
-         Model loading: Rust --models accepts native Sidemantic YAML/SQL and Cube YAML only.\n\
+         Model loading: Rust --models accepts native Sidemantic YAML/SQL, Cube YAML, and OSI YAML.\n\
          Convert LookML, MetricFlow, Hex, Rill, Malloy, and other external formats with the Python CLI/API first.\n\
          \n\
          Use '<command> --help' for command-specific usage."
@@ -951,6 +954,51 @@ fn info_command(args: &[String]) -> CliResult<()> {
             println!("  Connected to: {connected}");
         }
         println!();
+    }
+
+    Ok(())
+}
+
+fn convert_command(args: &[String]) -> CliResult<()> {
+    if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+        println!(
+            "Usage: sidemantic convert --models <path> [--to osi] [--output <file>] [--dialects ANSI_SQL,SNOWFLAKE,DATABRICKS]"
+        );
+        return Ok(());
+    }
+
+    let (options, positionals) = parse_options(args)?;
+    expect_no_positionals(&positionals, "convert")?;
+
+    let models = require_option(&options, "--models")?;
+    let to = option_value(&options, "--to").unwrap_or_else(|| "osi".to_string());
+    if !to.eq_ignore_ascii_case("osi") {
+        return Err(format!(
+            "unsupported --to format '{to}'; supported formats: osi"
+        ));
+    }
+
+    let dialects: Vec<String> = match option_value(&options, "--dialects") {
+        Some(value) => value
+            .split(',')
+            .map(|item| item.trim().to_string())
+            .filter(|item| !item.is_empty())
+            .collect(),
+        None => vec!["ANSI_SQL".to_string()],
+    };
+
+    let runtime = load_runtime(&models)?;
+    let adapter = OsiAdapter::new().with_dialects(dialects);
+    let yaml = adapter
+        .export_string(runtime.graph())
+        .map_err(|e| format!("OSI export failed: {e}"))?;
+
+    match option_value(&options, "--output") {
+        Some(path) => {
+            fs::write(&path, yaml).map_err(|e| format!("failed to write '{path}': {e}"))?;
+            println!("Wrote OSI semantic model to {path}");
+        }
+        None => print!("{yaml}"),
     }
 
     Ok(())

--- a/sidemantic-rs/src/python.rs
+++ b/sidemantic-rs/src/python.rs
@@ -16,6 +16,7 @@ use crate::runtime::{
     dimension_sql_expr_with_yaml as dimension_sql_expr_with_yaml_native,
     dimension_with_granularity_with_yaml as dimension_with_granularity_with_yaml_native,
     evaluate_table_calculation_expression as evaluate_table_calculation_expression_native,
+    export_osi_yaml as export_osi_yaml_native,
     extract_column_references as extract_column_references_native,
     extract_metric_dependencies_from_yaml as extract_metric_dependencies_from_yaml_native,
     extract_preaggregation_patterns as extract_preaggregation_patterns_native,
@@ -298,6 +299,25 @@ fn load_graph_with_sql(sql_content: &str) -> PyResult<String> {
 #[pyfunction]
 fn load_graph_from_directory(path: &str) -> PyResult<String> {
     load_graph_from_directory_native(path).map_err(|e| match e {
+        SidemanticError::Validation(_)
+        | SidemanticError::YamlParse(_)
+        | SidemanticError::InvalidConfig(_)
+        | SidemanticError::FileNotFound(_)
+        | SidemanticError::Io(_) => PyValueError::new_err(e.to_string()),
+        _ => PyRuntimeError::new_err(e.to_string()),
+    })
+}
+
+/// Export a native-YAML graph (plus optional graph-level metrics and top-level
+/// `metadata`) to OSI YAML.
+#[pyfunction]
+#[pyo3(signature = (models_yaml, graph_metrics_yaml, dialects))]
+fn export_osi(
+    models_yaml: &str,
+    graph_metrics_yaml: &str,
+    dialects: Vec<String>,
+) -> PyResult<String> {
+    export_osi_yaml_native(models_yaml, graph_metrics_yaml, dialects).map_err(|e| match e {
         SidemanticError::Validation(_)
         | SidemanticError::YamlParse(_)
         | SidemanticError::InvalidConfig(_)
@@ -1304,6 +1324,7 @@ fn sidemantic_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(load_graph_with_yaml, m)?)?;
     m.add_function(wrap_pyfunction!(load_graph_with_sql, m)?)?;
     m.add_function(wrap_pyfunction!(load_graph_from_directory, m)?)?;
+    m.add_function(wrap_pyfunction!(export_osi, m)?)?;
     m.add_function(wrap_pyfunction!(parse_sql_definitions_payload, m)?)?;
     m.add_function(wrap_pyfunction!(parse_sql_graph_definitions_payload, m)?)?;
     m.add_function(wrap_pyfunction!(parse_sql_model_payload, m)?)?;

--- a/sidemantic-rs/src/runtime.rs
+++ b/sidemantic-rs/src/runtime.rs
@@ -91,6 +91,9 @@ pub struct LoadedGraphPayload {
     pub model_order: Vec<String>,
     pub original_model_metrics: HashMap<String, Vec<String>>,
     pub model_sources: HashMap<String, LoadedModelSource>,
+    /// Graph-level metadata payload (e.g. OSI import state). Omitted when empty.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
 }
 
 /// Tuple shape returned to Python bridge for graph path steps.
@@ -1093,6 +1096,34 @@ pub fn load_graph_from_directory(path: &str) -> Result<String> {
     })?;
     serde_json::to_string(&runtime.loaded_graph_payload())
         .map_err(|e| SidemanticError::Validation(format!("failed to serialize graph payload: {e}")))
+}
+
+/// Export a graph to OSI YAML using the requested dialects.
+///
+/// `models_yaml` is native Sidemantic YAML (models + their owned metrics +
+/// optional top-level `metadata`). `graph_metrics_yaml` is an optional YAML list
+/// of metric configs that stay graph-level (not assigned to an owning model),
+/// matching how OSI represents metrics.
+pub fn export_osi_yaml(
+    models_yaml: &str,
+    graph_metrics_yaml: &str,
+    dialects: Vec<String>,
+) -> Result<String> {
+    use crate::adapters::Adapter;
+    let runtime = SidemanticRuntime::from_yaml(models_yaml)
+        .map_err(|e| SidemanticError::Validation(format!("failed to load YAML models: {e}")))?;
+    let mut graph = runtime.graph().clone();
+
+    if !graph_metrics_yaml.trim().is_empty() {
+        for metric in crate::config::schema::metrics_from_config_yaml(graph_metrics_yaml)? {
+            if graph.get_metric(&metric.name).is_none() {
+                graph.add_metric(metric)?;
+            }
+        }
+    }
+
+    let adapter = crate::adapters::OsiAdapter::new().with_dialects(dialects);
+    adapter.export_string(&graph)
 }
 
 fn build_runtime_with_metadata(
@@ -4930,6 +4961,7 @@ impl SidemanticRuntime {
             model_order: self.model_order.clone(),
             original_model_metrics: self.original_model_metrics.clone(),
             model_sources: self.model_sources.clone(),
+            metadata: self.graph.metadata().cloned(),
         }
     }
 

--- a/sidemantic-rs/src/runtime.rs
+++ b/sidemantic-rs/src/runtime.rs
@@ -1115,9 +1115,13 @@ pub fn export_osi_yaml(
     let mut graph = runtime.graph().clone();
 
     if !graph_metrics_yaml.trim().is_empty() {
+        // These metrics came from an already-valid graph; register them without
+        // dependency validation so export does not depend on the order metrics
+        // happen to appear in (e.g. a ratio listed before the metrics it
+        // references).
         for metric in crate::config::schema::metrics_from_config_yaml(graph_metrics_yaml)? {
             if graph.get_metric(&metric.name).is_none() {
-                graph.add_metric(metric)?;
+                graph.add_metric_unvalidated(metric)?;
             }
         }
     }
@@ -5796,6 +5800,43 @@ pub fn validate_query_references(
 mod tests {
     use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn test_export_osi_yaml_accepts_out_of_order_graph_metrics() {
+        // A ratio metric listed before the graph metrics it references must not
+        // fail export: these come from an already-valid graph and graph.metrics
+        // is insertion-ordered, not dependency-ordered.
+        let models_yaml = r#"
+models:
+  - name: orders
+    table: orders
+    primary_key: order_id
+    dimensions:
+      - name: amount
+        type: numeric
+"#;
+        let graph_metrics_yaml = r#"
+- name: revenue_per_order
+  type: ratio
+  numerator: total_revenue
+  denominator: order_count
+- name: total_revenue
+  agg: sum
+  sql: amount
+- name: order_count
+  agg: count
+"#;
+
+        let osi = export_osi_yaml(
+            models_yaml,
+            graph_metrics_yaml,
+            vec!["ANSI_SQL".to_string()],
+        )
+        .expect("out-of-order graph metrics should export");
+        assert!(osi.contains("revenue_per_order"));
+        assert!(osi.contains("total_revenue"));
+        assert!(osi.contains("order_count"));
+    }
 
     #[test]
     fn test_runtime_compile_and_rewrite() {

--- a/sidemantic/rust_bridge.py
+++ b/sidemantic/rust_bridge.py
@@ -27,11 +27,13 @@ def get_rust_module() -> object:
 def graph_to_rust_yaml(graph: SemanticGraph) -> str:
     """Serialize semantic graph to sidemantic-rs YAML schema."""
     extra_metrics_by_model, remaining_top_level_metrics = _assign_top_level_metrics_for_rust(graph)
+    graph_metadata = dict(graph.metadata) if getattr(graph, "metadata", None) else None
     return models_to_rust_yaml(
         list(graph.models.values()),
         extra_metrics_by_model=extra_metrics_by_model,
         top_level_metrics=remaining_top_level_metrics,
         top_level_parameters=list(graph.parameters.values()),
+        graph_metadata=graph_metadata,
     )
 
 
@@ -214,6 +216,32 @@ def load_graph_from_directory_with_rust(directory: str | Path) -> SemanticGraph:
     return _graph_from_loaded_payload(payload)
 
 
+def _restore_composite_keys(model_data: dict) -> None:
+    """Restore list-valued composite keys that sidemantic-rs collapses to a string.
+
+    Rust stores a single ``primary_key``/``foreign_key`` string plus the full
+    ``*_columns`` list. Python represents composite keys as the list itself, so
+    promote the list back when there is more than one column.
+    """
+    pk_cols = model_data.get("primary_key_columns")
+    if isinstance(pk_cols, list) and len(pk_cols) > 1:
+        model_data["primary_key"] = list(pk_cols)
+
+    relationships = model_data.get("relationships")
+    if isinstance(relationships, list):
+        restored = []
+        for relationship in relationships:
+            relationship = dict(relationship)
+            fk_cols = relationship.get("foreign_key_columns")
+            if isinstance(fk_cols, list) and len(fk_cols) > 1:
+                relationship["foreign_key"] = list(fk_cols)
+            rel_pk_cols = relationship.get("primary_key_columns")
+            if isinstance(rel_pk_cols, list) and len(rel_pk_cols) > 1:
+                relationship["primary_key"] = list(rel_pk_cols)
+            restored.append(relationship)
+        model_data["relationships"] = restored
+
+
 def _graph_from_loaded_payload(payload: dict) -> SemanticGraph:
     """Build a Python graph from sidemantic-rs loaded graph payload JSON."""
 
@@ -228,6 +256,7 @@ def _graph_from_loaded_payload(payload: dict) -> SemanticGraph:
 
     for model_data in payload.get("models") or []:
         normalized_model = dict(model_data)
+        _restore_composite_keys(normalized_model)
         original_metric_names = set(original_model_metrics.get(normalized_model.get("name"), []))
         normalized_metrics = []
         for metric_data in normalized_model.get("metrics") or []:
@@ -255,7 +284,50 @@ def _graph_from_loaded_payload(payload: dict) -> SemanticGraph:
         parameter = Parameter(**parameter_data)
         graph.add_parameter(parameter)
 
+    metadata = payload.get("metadata")
+    if metadata:
+        graph.metadata = metadata
+
     return graph
+
+
+def load_osi_graph_with_rust(source: str | Path) -> SemanticGraph:
+    """Parse OSI YAML (file or directory) via sidemantic-rs into a Python graph."""
+    rust_module = get_rust_module()
+    path = Path(source)
+    if path.is_dir():
+        payload = json.loads(rust_module.load_graph_from_directory(str(path)))
+    else:
+        payload = json.loads(rust_module.load_graph_with_yaml(path.read_text()))
+    return _graph_from_loaded_payload(payload)
+
+
+def export_osi_with_rust(graph: SemanticGraph, dialects: list[str] | None = None) -> str:
+    """Export a Python graph to OSI YAML via sidemantic-rs.
+
+    Model-owned metrics travel with the models; graph-level metrics are sent
+    separately so they stay graph-level (OSI has no single-owner requirement).
+    """
+    rust_module = get_rust_module()
+    graph_metadata = dict(graph.metadata) if getattr(graph, "metadata", None) else None
+    models_yaml = models_to_rust_yaml(
+        list(graph.models.values()),
+        top_level_parameters=list(graph.parameters.values()),
+        graph_metadata=graph_metadata,
+    )
+    graph_metrics = list(graph.metrics.values())
+    if graph_metrics:
+        graph_metrics_yaml = yaml.safe_dump(
+            [_serialize_metric(metric, primary_key_columns=None) for metric in graph_metrics],
+            sort_keys=False,
+        )
+    else:
+        graph_metrics_yaml = ""
+    return rust_module.export_osi(
+        models_yaml,
+        graph_metrics_yaml,
+        list(dialects) if dialects else ["ANSI_SQL"],
+    )
 
 
 def parse_sql_definitions_with_rust(sql: str) -> tuple[list, list]:
@@ -343,6 +415,7 @@ def models_to_rust_yaml(
     top_level_metrics: list | None = None,
     top_level_parameters: list | None = None,
     include_extends: bool = False,
+    graph_metadata: dict | None = None,
 ) -> str:
     """Serialize model list to sidemantic-rs YAML schema."""
     serialized_models = []
@@ -431,6 +504,8 @@ def models_to_rust_yaml(
         payload["metrics"] = [_serialize_metric(metric, primary_key_columns=None) for metric in top_level_metrics]
     if top_level_parameters:
         payload["parameters"] = [_serialize_parameter(parameter) for parameter in top_level_parameters]
+    if graph_metadata:
+        payload["metadata"] = graph_metadata
 
     return yaml.safe_dump(payload, sort_keys=False)
 

--- a/sidemantic/rust_bridge.py
+++ b/sidemantic/rust_bridge.py
@@ -308,10 +308,16 @@ def export_osi_with_rust(graph: SemanticGraph, dialects: list[str] | None = None
     Model-owned metrics travel with the models; graph-level metrics are sent
     separately so they stay graph-level (OSI has no single-owner requirement).
     """
+    from sidemantic.core.inheritance import resolve_model_inheritance
+
     rust_module = get_rust_module()
     graph_metadata = dict(graph.metadata) if getattr(graph, "metadata", None) else None
+    # Resolve model inheritance first (matching OSIAdapter.export); otherwise a
+    # child still carrying `extends` would be serialized standalone and lose its
+    # inherited table/dimensions/metrics.
+    resolved_models = resolve_model_inheritance(graph.models)
     models_yaml = models_to_rust_yaml(
-        list(graph.models.values()),
+        list(resolved_models.values()),
         top_level_parameters=list(graph.parameters.values()),
         graph_metadata=graph_metadata,
     )

--- a/tests/adapters/osi/conftest.py
+++ b/tests/adapters/osi/conftest.py
@@ -1,0 +1,68 @@
+"""OSI adapter test configuration.
+
+By default these tests exercise the pure-Python ``OSIAdapter``. Set the
+environment variable ``SIDEMANTIC_OSI_BACKEND=rust`` to transparently run the
+same tests against the sidemantic-rs implementation via a drop-in shim:
+
+    SIDEMANTIC_OSI_BACKEND=rust uv run pytest tests/adapters/osi
+
+The shim requires the ``sidemantic_rs`` extension to be built
+(``maturin develop --manifest-path sidemantic-rs/Cargo.toml --features python``).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from sidemantic.adapters.osi import OSIAdapter as _PythonOSIAdapter
+from sidemantic.core.semantic_graph import SemanticGraph
+
+
+class RustOSIAdapter:
+    """Drop-in ``OSIAdapter`` replacement backed by sidemantic-rs."""
+
+    OSI_VERSION = _PythonOSIAdapter.OSI_VERSION
+    SUPPORTED_EXPORT_DIALECTS = _PythonOSIAdapter.SUPPORTED_EXPORT_DIALECTS
+    DIALECT_PREFERENCE = _PythonOSIAdapter.DIALECT_PREFERENCE
+
+    def parse(self, source) -> SemanticGraph:
+        from sidemantic.rust_bridge import load_osi_graph_with_rust
+
+        source_path = Path(source)
+        if not source_path.exists():
+            raise FileNotFoundError(f"Path does not exist: {source_path}")
+        return load_osi_graph_with_rust(source_path)
+
+    def export(self, graph, output_path, dialects=None) -> None:
+        from sidemantic.rust_bridge import export_osi_with_rust
+
+        if not dialects:
+            dialects = ["ANSI_SQL"]
+        unsupported = [d for d in dialects if d not in self.SUPPORTED_EXPORT_DIALECTS]
+        if unsupported:
+            supported = ", ".join(self.SUPPORTED_EXPORT_DIALECTS)
+            raise ValueError(f"Unsupported OSI export dialect(s): {', '.join(unsupported)}. Supported: {supported}")
+        text = export_osi_with_rust(graph, dialects)
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(text)
+
+
+def _backend_is_rust() -> bool:
+    return os.environ.get("SIDEMANTIC_OSI_BACKEND", "python").lower() == "rust"
+
+
+@pytest.fixture(autouse=True)
+def _osi_backend(request, monkeypatch):
+    """Swap ``OSIAdapter`` for the Rust-backed shim when the backend is rust."""
+    if not _backend_is_rust():
+        return
+    pytest.importorskip("sidemantic_rs")
+    module = request.module
+    # Only patch modules that import the symbol under its canonical name. The
+    # differential parity test imports it as ``PyOSIAdapter`` and is left alone.
+    if getattr(module, "OSIAdapter", None) is not None:
+        monkeypatch.setattr(module, "OSIAdapter", RustOSIAdapter, raising=False)

--- a/tests/adapters/osi/test_rust_parity.py
+++ b/tests/adapters/osi/test_rust_parity.py
@@ -141,3 +141,33 @@ def test_osi_roundtrip_parity(fixture, tmp_path):
     python_graph = PyOSIAdapter().parse(str(out))
     rust_graph = load_osi_graph_with_rust(str(out))
     assert _canonical_graph(rust_graph) == _canonical_graph(python_graph)
+
+
+def test_osi_export_resolves_model_inheritance(tmp_path):
+    """A graph with unresolved Model.extends exports identically via both adapters."""
+    from sidemantic.core.dimension import Dimension
+    from sidemantic.core.model import Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    base = Model(
+        name="base_orders",
+        table="orders",
+        primary_key="order_id",
+        dimensions=[Dimension(name="status", type="categorical", sql="status")],
+    )
+    child = Model(name="orders", extends="base_orders", primary_key="order_id")
+    graph = SemanticGraph()
+    graph.add_model(base)
+    graph.add_model(child)
+    assert graph.models["orders"].table is None  # unresolved before export
+
+    python_path = tmp_path / "python.yaml"
+    PyOSIAdapter().export(graph, python_path)
+    python_doc = yaml.safe_load(python_path.read_text())
+    rust_doc = yaml.safe_load(export_osi_with_rust(graph))
+
+    assert _canonical_osi_doc(rust_doc) == _canonical_osi_doc(python_doc)
+    # The child dataset must carry the inherited source and field.
+    orders = {d["name"]: d for d in rust_doc["semantic_model"][0]["datasets"]}["orders"]
+    assert orders["source"] == "orders"
+    assert [field["name"] for field in orders["fields"]] == ["status"]

--- a/tests/adapters/osi/test_rust_parity.py
+++ b/tests/adapters/osi/test_rust_parity.py
@@ -1,0 +1,143 @@
+"""Differential parity: pure-Python OSIAdapter vs sidemantic-rs.
+
+Runs every OSI fixture through both implementations and asserts the resulting
+semantic graphs (and re-exported OSI documents) are equivalent. Skipped when the
+``sidemantic_rs`` extension is not built.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytest.importorskip("sidemantic_rs")
+
+from sidemantic.adapters.osi import OSIAdapter as PyOSIAdapter
+from sidemantic.rust_bridge import export_osi_with_rust, load_osi_graph_with_rust
+
+FIXTURE_DIR = Path("tests/fixtures/osi")
+FIXTURES = sorted(FIXTURE_DIR.glob("*.yaml"))
+
+
+def _cols(single, columns) -> list[str]:
+    if columns:
+        return list(columns)
+    if single is None:
+        return []
+    return [single] if isinstance(single, str) else list(single)
+
+
+def _eff_type(metric) -> str:
+    """Effective metric type.
+
+    Python's OSIAdapter leaves derived/simple metrics' ``type`` as ``None`` and
+    relies on ``agg``/``sql`` to disambiguate; sidemantic-rs records the explicit
+    type. Normalize both to compare semantics rather than representation.
+    """
+    if metric.type:
+        return metric.type
+    return "simple" if metric.agg else "derived"
+
+
+def _canonical_graph(graph) -> dict:
+    models = {}
+    for name, model in graph.models.items():
+        models[name] = {
+            "table": model.table,
+            "primary_key": list(model.primary_key_columns),
+            "unique_keys": model.unique_keys,
+            "default_time_dimension": model.default_time_dimension,
+            "description": model.description,
+            "meta": model.meta,
+            "dimensions": {
+                dim.name: {
+                    "type": dim.type,
+                    "sql": dim.sql,
+                    "granularity": dim.granularity,
+                    "label": dim.label,
+                    "meta": dim.meta,
+                }
+                for dim in model.dimensions
+            },
+            "relationships": {
+                rel.name: {
+                    "type": rel.type,
+                    "foreign_key": _cols(rel.foreign_key, getattr(rel, "foreign_key_columns", None)),
+                    "primary_key": _cols(rel.primary_key, getattr(rel, "primary_key_columns", None)),
+                    "metadata": rel.metadata,
+                }
+                for rel in model.relationships
+            },
+            "metrics": {
+                metric.name: {"agg": metric.agg, "sql": metric.sql, "type": _eff_type(metric)}
+                for metric in model.metrics
+            },
+        }
+    metrics = {
+        name: {
+            "agg": metric.agg,
+            "sql": metric.sql,
+            "type": _eff_type(metric),
+            "meta": metric.meta,
+            "description": metric.description,
+        }
+        for name, metric in graph.metrics.items()
+    }
+    return {"models": models, "metrics": metrics, "metadata": graph.metadata or {}}
+
+
+@pytest.mark.parametrize("fixture", FIXTURES, ids=lambda p: p.name)
+def test_osi_import_parity(fixture):
+    """Rust import of each fixture matches the Python adapter."""
+    python_graph = PyOSIAdapter().parse(str(fixture))
+    rust_graph = load_osi_graph_with_rust(str(fixture))
+    assert _canonical_graph(rust_graph) == _canonical_graph(python_graph)
+
+
+def _by_name(items) -> dict:
+    return {item.get("name"): item for item in (items or [])}
+
+
+def _canonical_osi_doc(data: dict) -> dict:
+    semantic_model = (data.get("semantic_model") or [{}])[0]
+    datasets = {}
+    for dataset in semantic_model.get("datasets") or []:
+        entry = dict(dataset)
+        entry["fields"] = _by_name(dataset.get("fields"))
+        datasets[dataset.get("name")] = entry
+    return {
+        "version": data.get("version"),
+        "name": semantic_model.get("name"),
+        "description": semantic_model.get("description"),
+        "datasets": datasets,
+        "relationships": _by_name(semantic_model.get("relationships")),
+        "metrics": _by_name(semantic_model.get("metrics")),
+    }
+
+
+@pytest.mark.parametrize("fixture", FIXTURES, ids=lambda p: p.name)
+def test_osi_export_parity(fixture, tmp_path):
+    """Rust export of a Python-parsed graph matches the Python adapter's export."""
+    graph = PyOSIAdapter().parse(str(fixture))
+
+    python_path = tmp_path / "python.yaml"
+    PyOSIAdapter().export(graph, python_path)
+    python_doc = yaml.safe_load(python_path.read_text())
+    rust_doc = yaml.safe_load(export_osi_with_rust(graph))
+
+    assert _canonical_osi_doc(rust_doc) == _canonical_osi_doc(python_doc)
+
+
+@pytest.mark.parametrize("fixture", FIXTURES, ids=lambda p: p.name)
+def test_osi_roundtrip_parity(fixture, tmp_path):
+    """Export via Rust, re-import via both adapters; graphs stay equivalent."""
+    graph = PyOSIAdapter().parse(str(fixture))
+    rust_yaml = export_osi_with_rust(graph)
+    out = tmp_path / "rust.yaml"
+    out.write_text(rust_yaml)
+
+    python_graph = PyOSIAdapter().parse(str(out))
+    rust_graph = load_osi_graph_with_rust(str(out))
+    assert _canonical_graph(rust_graph) == _canonical_graph(python_graph)


### PR DESCRIPTION
## What

Adds a reusable adapter layer to `sidemantic-rs`, implements **OSI (Open Semantic Interchange)** import + export on it at parity with the Python adapter, and converts **Cube** onto the same trait.

### Rust core
- **New `src/adapters/` module** — an `Adapter` trait + `ParsedDocument`:
  - `cube.rs` — `CubeAdapter`; Cube parsing/conversion moved off `schema.rs`/`loader.rs` onto the trait.
  - `osi.rs` — `OsiAdapter`: import + export, dialect transpilation (ANSI → Snowflake/Databricks via `polyglot-sql`), `custom_extensions`/`ai_context`, ontology mappings, composite keys.
- `SemanticGraph` gains a `metadata` payload so OSI semantic-model-level state round-trips losslessly.
- Loader auto-detects OSI YAML (`semantic_model:`/`ontology_mappings:`) and skips FK inference for formats that declare relationships explicitly; native YAML gains an optional top-level `metadata:` key.
- New `sidemantic convert --models … --to osi [--dialects …]` CLI command.

### Running the Python OSI suite against Rust
- `rust_bridge.py`: `load_osi_graph_with_rust` / `export_osi_with_rust`, graph metadata in the payload, and composite-key restoration across the bridge.
- `tests/adapters/osi/conftest.py`: `SIDEMANTIC_OSI_BACKEND=rust` swaps in a Rust-backed `OSIAdapter` so the existing suite runs unmodified against Rust.
- `tests/adapters/osi/test_rust_parity.py`: differential import/export/round-trip parity across all OSI fixtures.

## Verification

| Check | Result |
|---|---|
| Rust lib tests | 314 passed |
| Rust fmt / clippy | clean |
| Existing OSI suite vs Rust backend (`SIDEMANTIC_OSI_BACKEND=rust`) | 156 passed |
| Differential parity (Python ≡ Rust, 8 fixtures) | 24 passed |
| OSI suite, default Python backend (regression) | 182 passed |
| rust-engine Python tests (`rust_bridge` regression) | 278 passed, 52 xfailed |
| global ruff check / format | clean |

The only normalization needed is cosmetic: Python leaves derived metrics' `type` as `None` while Rust records explicit `"derived"` (identical `agg`/`sql`).

## Notes
- The Cube schema structs moved from `config/schema.rs` to `adapters/cube.rs`; `config::CubeConfig` is re-exported for API compatibility.
- Build the extension for the Rust-backed parity run with `maturin build --features python` and run pytest under `uv run --no-sync` (plain `uv run` re-syncs and reverts a manually-installed extension).