### PR TITLE
Import Cube joins in Python and Rust adapters

### DIFF
--- a/sidemantic-rs/src/adapters/cube.rs
+++ b/sidemantic-rs/src/adapters/cube.rs
@@ -1,9 +1,11 @@
 //! Cube.js adapter: imports Cube YAML (`cubes:`) into the semantic graph.
 
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::core::{
-    Aggregation, Dimension, DimensionType, Metric, MetricType, Model, Relationship, Segment,
+    Aggregation, Dimension, DimensionType, Metric, MetricType, Model, Relationship,
+    RelationshipType, Segment,
 };
 use crate::error::{Result, SidemanticError};
 
@@ -58,6 +60,15 @@ pub struct CubeDefinition {
     pub measures: Vec<CubeMeasure>,
     #[serde(default)]
     pub segments: Vec<CubeSegment>,
+    #[serde(default)]
+    pub joins: Vec<CubeJoin>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CubeJoin {
+    pub name: String,
+    pub sql: Option<String>,
+    pub relationship: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,6 +121,13 @@ impl CubeDefinition {
         // Infer primary key from name (cube_name -> cube_name_id or id)
         let primary_key = "id".to_string();
 
+        let self_name = self.name.clone();
+        let relationships = self
+            .joins
+            .into_iter()
+            .filter_map(|join| relationship_from_cube_join(&self_name, join))
+            .collect();
+
         Model {
             name: self.name,
             table: self.sql_table,
@@ -125,7 +143,7 @@ impl CubeDefinition {
                 .map(|d| d.into_dimension())
                 .collect(),
             metrics: self.measures.into_iter().map(|m| m.into_metric()).collect(),
-            relationships: Vec::<Relationship>::new(), // Cube.js uses joins differently
+            relationships,
             segments: self
                 .segments
                 .into_iter()
@@ -267,6 +285,154 @@ fn strip_cube_placeholder(sql: &str) -> String {
     sql.replace("${CUBE}.", "").replace("${CUBE}", "")
 }
 
+/// Split a Cube member reference into `(cube_name, column)`.
+///
+/// Handles both `${cube.col}` / `{cube.col}` (column inside the braces) and
+/// `${cube}.col` / `${CUBE}.col` (column trailing the braces).
+fn split_cube_ref(inner: &str, trailing: Option<&str>) -> (String, Option<String>) {
+    if let Some(col) = trailing {
+        return (inner.to_string(), Some(col.to_string()));
+    }
+    if let Some((head, col)) = inner.split_once('.') {
+        return (head.to_string(), Some(col.to_string()));
+    }
+    (inner.to_string(), None)
+}
+
+/// Convert a Cube join condition into Sidemantic form.
+///
+/// Cube expresses joins as a SQL equality referencing members with `${CUBE}.col`
+/// (this cube), `${target.col}` (the joined cube), and the single-brace
+/// `{cube.col}` variants. Sidemantic uses `{from}` / `{to}` placeholders.
+///
+/// Returns `(native_sql, from_col, to_col)` where `native_sql` is the condition
+/// rewritten with `{from}` / `{to}`, or `None` if it references a third cube and
+/// cannot be represented faithfully. `from_col` / `to_col` are populated only when
+/// the condition is a plain `a = b` equality.
+fn convert_cube_join(
+    join_sql: &str,
+    self_name: &str,
+    join_name: &str,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let re = Regex::new(r"\$?\{([^}]+)\}(?:\.(\w+))?").expect("valid cube member regex");
+
+    let mut untranslatable = false;
+    let mut refs: Vec<(&'static str, Option<String>)> = Vec::new();
+
+    let native = re
+        .replace_all(join_sql, |caps: &regex::Captures| {
+            let inner = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+            let trailing = caps.get(2).map(|m| m.as_str());
+            let (head, col) = split_cube_ref(inner, trailing);
+            let side = if head == "CUBE" || head == self_name {
+                "from"
+            } else if head == join_name {
+                "to"
+            } else {
+                // References a third cube: cannot be expressed with {from}/{to}.
+                untranslatable = true;
+                return caps.get(0).map(|m| m.as_str()).unwrap_or("").to_string();
+            };
+            refs.push((side, col.clone()));
+            match col {
+                Some(c) => format!("{{{side}}}.{c}"),
+                None => format!("{{{side}}}"),
+            }
+        })
+        .to_string();
+
+    if untranslatable || refs.is_empty() {
+        return (None, None, None);
+    }
+
+    // Detect a plain single-column equality: exactly two members (one per side)
+    // joined by a single '=' with nothing else around them.
+    let residual: String = re
+        .replace_all(join_sql, "@")
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let has_from = refs.iter().any(|(side, _)| *side == "from");
+    let has_to = refs.iter().any(|(side, _)| *side == "to");
+    let is_simple = residual == "@=@"
+        && refs.len() == 2
+        && has_from
+        && has_to
+        && refs.iter().all(|(_, col)| col.is_some());
+
+    if is_simple {
+        let from_col = refs
+            .iter()
+            .find(|(side, _)| *side == "from")
+            .and_then(|(_, col)| col.clone());
+        let to_col = refs
+            .iter()
+            .find(|(side, _)| *side == "to")
+            .and_then(|(_, col)| col.clone());
+        return (Some(native), from_col, to_col);
+    }
+
+    (Some(native), None, None)
+}
+
+/// Build a [`Relationship`] from a Cube `joins` entry.
+fn relationship_from_cube_join(self_name: &str, join: CubeJoin) -> Option<Relationship> {
+    let join_name = join.name;
+    if join_name.is_empty() {
+        return None;
+    }
+
+    let rel_type = match join
+        .relationship
+        .as_deref()
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("one_to_one" | "onetoone") => RelationshipType::OneToOne,
+        Some("one_to_many" | "onetomany") => RelationshipType::OneToMany,
+        Some("many_to_many" | "manytomany") => RelationshipType::ManyToMany,
+        _ => RelationshipType::ManyToOne,
+    };
+
+    let join_sql = join.sql.unwrap_or_default();
+    let (native_sql, from_col, to_col) = convert_cube_join(&join_sql, self_name, &join_name);
+
+    let mut rel = Relationship::new(join_name.clone());
+    rel.r#type = rel_type.clone();
+
+    // Plain single-column equality on many_to_one / one_to_many -> structured keys.
+    // Both engines agree on the join direction for these, so structured keys round-trip
+    // cleanly. one_to_one is deliberately excluded: the engines interpret its FK/PK
+    // direction differently, so the explicit condition is preserved instead.
+    if let (Some(from_col), Some(to_col)) = (from_col, to_col) {
+        match rel_type {
+            RelationshipType::ManyToOne => {
+                return Some(rel.with_keys(from_col, to_col));
+            }
+            RelationshipType::OneToMany => {
+                // FK lives on the related model, local key on this one.
+                return Some(rel.with_keys(to_col, from_col));
+            }
+            _ => {}
+        }
+    }
+
+    // Composite / non-equality / one_to_one condition -> preserve the full predicate.
+    if let Some(sql) = native_sql {
+        return Some(rel.with_condition(sql));
+    }
+
+    // Unparseable (references another cube, or no recognizable members): fall back to
+    // Cube's naming convention, but warn instead of silently faking a join.
+    eprintln!(
+        "warning: could not parse Cube join '{self_name}' -> '{join_name}' from SQL {join_sql:?}; \
+         falling back to foreign key '{join_name}_id'."
+    );
+    rel.foreign_key = Some(format!("{join_name}_id"));
+    rel.foreign_key_columns = Some(vec![format!("{join_name}_id")]);
+    Some(rel)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -340,5 +506,122 @@ cubes:
         assert_eq!(parsed.models[0].name, "orders");
         assert!(parsed.graph_metrics.is_empty());
         assert!(!parsed.explicit_relationships);
+    }
+
+    #[test]
+    fn test_cube_simple_many_to_one_join() {
+        let yaml = r#"
+cubes:
+  - name: orders
+    sql_table: orders
+    joins:
+      - name: customers
+        sql: "${CUBE}.customer_id = ${customers.id}"
+        relationship: many_to_one
+  - name: customers
+    sql_table: customers
+"#;
+        let config: CubeConfig = serde_yaml::from_str(yaml).unwrap();
+        let models = config.into_models();
+        let orders = models.iter().find(|m| m.name == "orders").unwrap();
+        assert_eq!(orders.relationships.len(), 1);
+        let rel = &orders.relationships[0];
+        assert_eq!(rel.name, "customers");
+        assert_eq!(rel.r#type, RelationshipType::ManyToOne);
+        assert_eq!(rel.foreign_key.as_deref(), Some("customer_id"));
+        assert_eq!(rel.primary_key.as_deref(), Some("id"));
+        assert!(rel.sql.is_none());
+    }
+
+    #[test]
+    fn test_cube_simple_one_to_many_join() {
+        let yaml = r#"
+cubes:
+  - name: orders
+    sql_table: orders
+    joins:
+      - name: line_items
+        sql: "${CUBE}.id = ${line_items.order_id}"
+        relationship: one_to_many
+  - name: line_items
+    sql_table: line_items
+"#;
+        let config: CubeConfig = serde_yaml::from_str(yaml).unwrap();
+        let models = config.into_models();
+        let orders = models.iter().find(|m| m.name == "orders").unwrap();
+        let rel = &orders.relationships[0];
+        assert_eq!(rel.r#type, RelationshipType::OneToMany);
+        // FK lives on the related model, local key on this one.
+        assert_eq!(rel.foreign_key.as_deref(), Some("order_id"));
+        assert_eq!(rel.primary_key.as_deref(), Some("id"));
+        assert!(rel.sql.is_none());
+    }
+
+    #[test]
+    fn test_cube_composite_join_preserves_condition() {
+        let yaml = r#"
+cubes:
+  - name: line_items
+    sql_table: line_items
+    joins:
+      - name: orders
+        sql: "${CUBE}.order_id = ${orders.id} AND ${CUBE}.tenant_id = ${orders.tenant_id}"
+        relationship: many_to_one
+  - name: orders
+    sql_table: orders
+"#;
+        let config: CubeConfig = serde_yaml::from_str(yaml).unwrap();
+        let models = config.into_models();
+        let line_items = models.iter().find(|m| m.name == "line_items").unwrap();
+        let rel = &line_items.relationships[0];
+        assert_eq!(rel.r#type, RelationshipType::ManyToOne);
+        assert_eq!(
+            rel.sql.as_deref(),
+            Some("{from}.order_id = {to}.id AND {from}.tenant_id = {to}.tenant_id")
+        );
+    }
+
+    #[test]
+    fn test_cube_one_to_one_single_brace_uses_condition() {
+        // Diamond-style single-brace references with the local cube named explicitly.
+        let yaml = r#"
+cubes:
+  - name: a
+    sql_table: a
+    joins:
+      - name: b
+        sql: "{a.id} = {b.id}"
+        relationship: one_to_one
+  - name: b
+    sql_table: b
+"#;
+        let config: CubeConfig = serde_yaml::from_str(yaml).unwrap();
+        let models = config.into_models();
+        let a = models.iter().find(|m| m.name == "a").unwrap();
+        let rel = &a.relationships[0];
+        assert_eq!(rel.r#type, RelationshipType::OneToOne);
+        // one_to_one is preserved as an explicit condition (engines diverge on FK/PK).
+        assert_eq!(rel.sql.as_deref(), Some("{from}.id = {to}.id"));
+    }
+
+    #[test]
+    fn test_cube_unparseable_join_falls_back_to_convention() {
+        let yaml = r#"
+cubes:
+  - name: x
+    sql_table: x
+    joins:
+      - name: y
+        sql: "${z.a} = ${w.b}"
+        relationship: many_to_one
+  - name: y
+    sql_table: y
+"#;
+        let config: CubeConfig = serde_yaml::from_str(yaml).unwrap();
+        let models = config.into_models();
+        let x = models.iter().find(|m| m.name == "x").unwrap();
+        let rel = &x.relationships[0];
+        assert_eq!(rel.foreign_key.as_deref(), Some("y_id"));
+        assert!(rel.sql.is_none());
     }
 }

--- a/sidemantic/adapters/cube.py
+++ b/sidemantic/adapters/cube.py
@@ -1,6 +1,7 @@
 """Cube adapter for importing Cube.js semantic models."""
 
 import re
+import warnings
 from pathlib import Path
 
 import yaml
@@ -45,6 +46,25 @@ def _normalize_cube_sql(sql: str | None, cube_name: str | None = None) -> str | 
         result = result.replace(f"{{{cube_name}}}", "{model}")
 
     return result
+
+
+# Matches a Cube member reference: ${cube.col}, {cube.col}, ${CUBE}.col, {cube}.col, etc.
+# group(1) = content inside braces, group(2) = optional trailing ".column".
+_CUBE_MEMBER_RE = re.compile(r"\$?\{([^}]+)\}(?:\.(\w+))?")
+
+
+def _split_cube_ref(inner: str, trailing: str | None) -> tuple[str, str | None]:
+    """Split a Cube member reference into ``(cube_name, column)``.
+
+    Handles both ``${cube.col}`` / ``{cube.col}`` (column inside the braces) and
+    ``${cube}.col`` / ``${CUBE}.col`` (column trailing the braces).
+    """
+    if trailing is not None:
+        return inner, trailing
+    if "." in inner:
+        head, col = inner.split(".", 1)
+        return head, col
+    return inner, None
 
 
 class CubeAdapter(BaseAdapter):
@@ -166,35 +186,104 @@ class CubeAdapter(BaseAdapter):
         for view_def in data.get("views") or []:
             pending_views.append(view_def)
 
-    def _extract_fk_from_join_sql(self, join_sql: str, relationship_type: str, join_name: str) -> str | None:
-        """Extract foreign key column from Cube join SQL.
+    def _convert_cube_join(
+        self, join_sql: str, self_name: str, join_name: str
+    ) -> tuple[str | None, str | None, str | None]:
+        """Convert a Cube join condition into Sidemantic form.
 
-        Parses join SQL to extract the foreign key column name based on relationship type:
-        - many_to_one: Extract from ${CUBE}.column (e.g., "${CUBE}.company_id = ${companies.id}" -> "company_id")
-        - one_to_many: Extract from ${join_name.column} (e.g., "${CUBE}.id = ${project_assignments.project_id}" -> "project_id")
+        Cube expresses joins as a SQL equality condition referencing members with
+        ``${CUBE}.col`` (this cube), ``${target.col}`` (the joined cube), and the
+        single-brace ``{cube.col}`` variants. Sidemantic represents the same thing
+        with ``{from}`` / ``{to}`` placeholders.
 
-        Args:
-            join_sql: Join SQL expression from Cube definition
-            relationship_type: Type of relationship (many_to_one or one_to_many)
-            join_name: Name of the joined model
-
-        Returns:
-            Foreign key column name, or None if parsing fails
+        Returns ``(native_sql, from_col, to_col)`` where:
+        - ``native_sql`` is the condition rewritten with ``{from}`` / ``{to}``
+          placeholders, or ``None`` if it references a cube other than this one or
+          the join target (and therefore cannot be represented faithfully).
+        - ``from_col`` / ``to_col`` are the single columns on each side when the
+          condition is a plain ``a = b`` equality, otherwise ``None``.
         """
-        if relationship_type == "one_to_many":
-            # For one_to_many, extract from ${join_name.column}
-            # Example: "${CUBE}.id = ${project_assignments.project_id}" -> "project_id"
-            match = re.search(rf"\$\{{{re.escape(join_name)}\.(\w+)\}}", join_sql)
-            if match:
-                return match.group(1)
-        else:
-            # For many_to_one (default), extract from ${CUBE}.column
-            # Example: "${CUBE}.company_id = ${companies.id}" -> "company_id"
-            match = re.search(r"\$\{CUBE\}\.(\w+)", join_sql)
-            if match:
-                return match.group(1)
+        refs: list[tuple[str, str | None]] = []  # (side, column) in order of appearance
+        untranslatable = False
 
-        return None
+        def repl(match: re.Match) -> str:
+            nonlocal untranslatable
+            head, col = _split_cube_ref(match.group(1), match.group(2))
+            if head in ("CUBE", self_name):
+                side = "from"
+            elif head == join_name:
+                side = "to"
+            else:
+                # References a third cube: cannot be expressed with {from}/{to}.
+                untranslatable = True
+                return match.group(0)
+            refs.append((side, col))
+            return f"{{{side}}}.{col}" if col else f"{{{side}}}"
+
+        native_sql = _CUBE_MEMBER_RE.sub(repl, join_sql)
+        if untranslatable or not refs:
+            return None, None, None
+
+        # Detect a plain single-column equality: exactly two members (one per side)
+        # joined by a single '=' with nothing else around them.
+        residual = re.sub(r"\s+", "", _CUBE_MEMBER_RE.sub("@", join_sql))
+        is_simple_equality = (
+            residual == "@=@"
+            and len(refs) == 2
+            and {side for side, _ in refs} == {"from", "to"}
+            and all(col for _, col in refs)
+        )
+        if is_simple_equality:
+            from_col = next(col for side, col in refs if side == "from")
+            to_col = next(col for side, col in refs if side == "to")
+            return native_sql, from_col, to_col
+        return native_sql, None, None
+
+    def _relationship_from_join(self, join_def: dict, self_name: str) -> Relationship | None:
+        """Build a Relationship from a Cube ``joins`` entry."""
+        join_name = join_def.get("name")
+        if not join_name:
+            return None
+
+        rel_type = join_def.get("relationship", "many_to_one")
+        join_sql = join_def.get("sql", "") or ""
+
+        native_sql, from_col, to_col = self._convert_cube_join(join_sql, self_name, join_name)
+
+        # Plain single-column equality on many_to_one / one_to_many -> structured keys.
+        # Both Sidemantic (Python) and the Rust engine agree on the join direction for
+        # these, so structured keys round-trip cleanly to Cube's simple join form.
+        # one_to_one is deliberately excluded: the two engines interpret its FK/PK
+        # direction differently, so we preserve the explicit condition instead.
+        if from_col and to_col and rel_type in ("many_to_one", "one_to_many"):
+            if rel_type == "many_to_one":
+                return Relationship(name=join_name, type=rel_type, foreign_key=from_col, primary_key=to_col)
+            # one_to_many: FK lives on the related model, local key on this one.
+            return Relationship(name=join_name, type=rel_type, foreign_key=to_col, primary_key=from_col)
+
+        # Composite / non-equality / one_to_one condition -> preserve the full predicate.
+        if native_sql:
+            return Relationship(name=join_name, type=rel_type, sql=native_sql)
+
+        # Unparseable (references another cube, or no recognizable members): fall back
+        # to Cube's naming convention, but warn instead of silently faking a join.
+        warnings.warn(
+            f"Could not parse Cube join '{self_name}' -> '{join_name}' from SQL {join_sql!r}; "
+            f"falling back to foreign key '{join_name}_id'.",
+            stacklevel=2,
+        )
+        return Relationship(name=join_name, type=rel_type, foreign_key=f"{join_name}_id")
+
+    @staticmethod
+    def _native_join_sql_to_cube(native_sql: str, join_name: str) -> str:
+        """Translate a ``{from}`` / ``{to}`` join condition back to Cube placeholders.
+
+        ``{from}.col`` -> ``${CUBE}.col`` and ``{to}.col`` -> ``${join_name.col}``.
+        """
+        result = re.sub(r"\{to\}\.(\w+)", rf"${{{join_name}.\1}}", native_sql)
+        result = result.replace("{to}", f"${{{join_name}}}")
+        result = result.replace("{from}", "${CUBE}")
+        return result
 
     def _parse_cube(self, cube_def: dict) -> Model | None:
         """Parse a Cube definition into a Model.
@@ -258,19 +347,9 @@ class CubeAdapter(BaseAdapter):
         # Parse joins to create relationships
         relationships = []
         for join_def in cube_def.get("joins") or []:
-            join_name = join_def.get("name")
-            if join_name:
-                # Get relationship type from join definition, default to many_to_one
-                rel_type = join_def.get("relationship", "many_to_one")
-
-                # Extract foreign key from join SQL, fallback to convention
-                join_sql = join_def.get("sql", "")
-                fk_column = self._extract_fk_from_join_sql(join_sql, rel_type, join_name)
-                if not fk_column:
-                    # Fallback to conventional naming if parsing fails
-                    fk_column = f"{join_name}_id"
-
-                relationships.append(Relationship(name=join_name, type=rel_type, foreign_key=fk_column))
+            relationship = self._relationship_from_join(join_def, name)
+            if relationship is not None:
+                relationships.append(relationship)
 
         # Parse pre-aggregations (handle None from empty YAML section)
         pre_aggregations = []
@@ -993,17 +1072,24 @@ class CubeAdapter(BaseAdapter):
             # Find target model from resolved models (inheritance-applied)
             target_model = resolved_models.get(relationship.name)
             if target_model:
-                # Use ${CUBE} for local side and ${target.col} for remote side
-                # so _extract_fk_from_join_sql can re-parse the exported SQL
-                if relationship.type in ("many_to_one", "one_to_one"):
+                if relationship.sql:
+                    # Custom predicate (composite keys, one_to_one, non-equality):
+                    # preserve it by translating {from}/{to} back to Cube placeholders.
+                    join_sql = self._native_join_sql_to_cube(relationship.sql, relationship.name)
+                elif relationship.type == "many_to_one":
+                    # ${CUBE}.fk = ${target.pk}
                     local_key = relationship.sql_expr or relationship.foreign_key
                     remote_key = relationship.primary_key or target_model.primary_key
                     if isinstance(remote_key, list):
                         remote_key = remote_key[0]
                     join_sql = f"${{CUBE}}.{local_key} = ${{{relationship.name}}}.{remote_key}"
                 else:
-                    # one_to_many: ${CUBE}.pk = ${target.fk}
-                    local_key = model.primary_key if isinstance(model.primary_key, str) else model.primary_key[0]
+                    # one_to_many / one_to_one: ${CUBE}.pk = ${target.fk}.
+                    # The local key is this model's key (relationship.primary_key when set,
+                    # else the model's primary key); the FK lives on the related model.
+                    local_key = relationship.primary_key or model.primary_key
+                    if isinstance(local_key, list):
+                        local_key = local_key[0]
                     remote_key = relationship.sql_expr or relationship.foreign_key
                     join_sql = f"${{CUBE}}.{local_key} = ${{{relationship.name}}}.{remote_key}"
 

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -1367,6 +1367,11 @@ class SQLGenerator:
 
         # Include local relationship keys if we're joining OR if they're explicitly requested as dimensions
         for relationship in model.relationships:
+            # Custom-SQL joins ({from}/{to}) supply their own key columns via
+            # _custom_join_columns_by_model; skip the default FK/PK passthrough so we
+            # don't inject a non-existent "{name}_id" column for composite/custom joins.
+            if relationship.sql and ("{from}" in relationship.sql or "{to}" in relationship.sql):
+                continue
             if relationship.type == "many_to_one":
                 # Handle multi-column foreign keys
                 for fk in relationship.foreign_key_columns:
@@ -1391,6 +1396,10 @@ class SQLGenerator:
                 if other_model_name not in all_models:
                     continue
                 for other_join in other_model.relationships:
+                    # Custom-SQL joins supply their key columns via the custom-join
+                    # column extraction; don't inject default FK/PK columns for them.
+                    if other_join.sql and ("{from}" in other_join.sql or "{to}" in other_join.sql):
+                        continue
                     if other_join.name == model_name and other_join.type in (
                         "one_to_one",
                         "one_to_many",

--- a/tests/adapters/cube/test_joins.py
+++ b/tests/adapters/cube/test_joins.py
@@ -1,0 +1,213 @@
+"""Tests for Cube adapter - join parsing, SQL generation, and round-trip.
+
+Cube expresses joins as a SQL equality condition (``${CUBE}.fk = ${target.pk}``),
+which can be composite, non-equality, or use the single-brace ``{cube.col}`` form.
+These tests cover that the adapter:
+
+- extracts structured foreign/primary keys for plain single-column equality joins,
+- preserves composite / non-equality / one_to_one conditions into Relationship.sql,
+- warns (instead of silently faking) when a join cannot be parsed,
+- generates correct, executable SQL, and round-trips through export.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from sidemantic import SemanticLayer
+from sidemantic.adapters.cube import CubeAdapter
+
+
+def _parse(yaml_text: str):
+    adapter = CubeAdapter()
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(yaml_text)
+        path = Path(f.name)
+    try:
+        return adapter.parse(path)
+    finally:
+        path.unlink()
+
+
+def test_simple_many_to_one_extracts_structured_keys():
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    joins:
+      - name: customers
+        relationship: many_to_one
+        sql: "${CUBE}.customer_id = ${customers.id}"
+  - name: customers
+    sql_table: customers
+"""
+    )
+    rel = graph.get_model("orders").relationships[0]
+    assert rel.name == "customers"
+    assert rel.type == "many_to_one"
+    assert rel.foreign_key == "customer_id"
+    assert rel.primary_key == "id"
+    assert rel.sql is None
+
+
+def test_simple_one_to_many_extracts_structured_keys():
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    joins:
+      - name: line_items
+        relationship: one_to_many
+        sql: "${CUBE}.id = ${line_items.order_id}"
+  - name: line_items
+    sql_table: line_items
+"""
+    )
+    rel = graph.get_model("orders").relationships[0]
+    assert rel.type == "one_to_many"
+    # FK lives on the related model; local key on this one.
+    assert rel.foreign_key == "order_id"
+    assert rel.primary_key == "id"
+    assert rel.sql is None
+
+
+def test_composite_key_join_preserves_full_condition():
+    graph = _parse(
+        """
+cubes:
+  - name: line_items
+    sql_table: line_items
+    joins:
+      - name: orders
+        relationship: many_to_one
+        sql: "${CUBE}.order_id = ${orders.id} AND ${CUBE}.tenant_id = ${orders.tenant_id}"
+  - name: orders
+    sql_table: orders
+"""
+    )
+    rel = graph.get_model("line_items").relationships[0]
+    assert rel.type == "many_to_one"
+    assert rel.sql == "{from}.order_id = {to}.id AND {from}.tenant_id = {to}.tenant_id"
+
+
+def test_one_to_one_preserves_condition():
+    # Single-brace diamond form, with the local cube referenced by name.
+    graph = _parse(
+        """
+cubes:
+  - name: a
+    sql_table: a
+    joins:
+      - name: b
+        relationship: one_to_one
+        sql: "{a.id} = {b.id}"
+  - name: b
+    sql_table: b
+"""
+    )
+    rel = graph.get_model("a").relationships[0]
+    assert rel.type == "one_to_one"
+    assert rel.sql == "{from}.id = {to}.id"
+
+
+def test_unparseable_join_warns_and_falls_back():
+    adapter = CubeAdapter()
+    yaml_text = """
+cubes:
+  - name: x
+    sql_table: x
+    joins:
+      - name: y
+        relationship: many_to_one
+        sql: "${z.a} = ${w.b}"
+  - name: y
+    sql_table: y
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(yaml_text)
+        path = Path(f.name)
+    try:
+        with pytest.warns(UserWarning, match="Could not parse Cube join"):
+            graph = adapter.parse(path)
+    finally:
+        path.unlink()
+    rel = graph.get_model("x").relationships[0]
+    assert rel.foreign_key == "y_id"
+    assert rel.sql is None
+
+
+def test_composite_key_join_generates_correct_sql_and_results():
+    graph = _parse(
+        """
+cubes:
+  - name: line_items
+    sql_table: line_items
+    dimensions:
+      - {name: id, sql: id, type: number, primary_key: true}
+      - {name: order_id, sql: order_id, type: number}
+      - {name: tenant_id, sql: tenant_id, type: number}
+    measures:
+      - {name: count, type: count}
+    joins:
+      - name: orders
+        relationship: many_to_one
+        sql: "${CUBE}.order_id = ${orders.id} AND ${CUBE}.tenant_id = ${orders.tenant_id}"
+  - name: orders
+    sql_table: orders
+    dimensions:
+      - {name: id, sql: id, type: number, primary_key: true}
+      - {name: tenant_id, sql: tenant_id, type: number}
+      - {name: status, sql: status, type: string}
+    measures:
+      - {name: count, type: count}
+"""
+    )
+    layer = SemanticLayer()
+    layer.graph = graph
+    layer.adapter.execute("CREATE TABLE line_items (id INT, order_id INT, tenant_id INT)")
+    layer.adapter.execute("INSERT INTO line_items VALUES (100, 1, 10), (101, 1, 10), (102, 2, 20)")
+    layer.adapter.execute("CREATE TABLE orders (id INT, tenant_id INT, status VARCHAR)")
+    layer.adapter.execute("INSERT INTO orders VALUES (1, 10, 'done'), (2, 20, 'open')")
+
+    sql = layer.compile(metrics=["line_items.count"], dimensions=["orders.status"])
+    # Both keys in the ON clause; no phantom "orders_id" column projected.
+    assert "order_id" in sql and "tenant_id" in sql
+    assert "orders_id" not in sql
+
+    rows = dict(layer.adapter.execute(sql).fetchall())
+    assert rows == {"done": 2, "open": 1}
+
+
+def test_composite_key_join_round_trips_through_export():
+    graph = _parse(
+        """
+cubes:
+  - name: line_items
+    sql_table: line_items
+    joins:
+      - name: orders
+        relationship: many_to_one
+        sql: "${CUBE}.order_id = ${orders.id} AND ${CUBE}.tenant_id = ${orders.tenant_id}"
+  - name: orders
+    sql_table: orders
+"""
+    )
+    adapter = CubeAdapter()
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        out = Path(f.name)
+    try:
+        adapter.export(graph, out)
+        exported = yaml.safe_load(out.read_text())
+        join_sql = next(c for c in exported["cubes"] if c["name"] == "line_items")["joins"][0]["sql"]
+        # Exported back to Cube placeholders.
+        assert join_sql == "${CUBE}.order_id = ${orders.id} AND ${CUBE}.tenant_id = ${orders.tenant_id}"
+
+        reimported = adapter.parse(out)
+        rel = reimported.get_model("line_items").relationships[0]
+        assert rel.sql == "{from}.order_id = {to}.id AND {from}.tenant_id = {to}.tenant_id"
+    finally:
+        out.unlink()


### PR DESCRIPTION
## Problem

Both Cube adapters discarded join definitions:

- **Rust** (`sidemantic-rs/src/adapters/cube.rs`) dropped them entirely — `relationships: Vec::new() // Cube.js uses joins differently`.
- **Python** (`sidemantic/adapters/cube.py`) regexed a single foreign-key column out of the join SQL, which mangled composite keys, non-equality conditions, and `one_to_one` joins, and silently faked a `<name>_id` foreign key when parsing failed.

## Changes

Both adapters now handle Cube `joins:` faithfully:

- **Plain single-column equality** (`many_to_one` / `one_to_many`) → structured `foreign_key` **and** `primary_key` (the related-side key is no longer assumed to be `id`).
- **Composite / non-equality / `one_to_one`** → preserved verbatim into `Relationship.sql` with `{from}`/`{to}` placeholders. Handles `${CUBE}.col`, `${cube.col}`, and the single-brace `{cube.col}` reference forms.
- **Unparseable** (references a third cube) → emits a warning instead of silently faking a `<name>_id` join.

Python export translates `Relationship.sql` back to Cube placeholders so joins round-trip, and the `one_to_many` / `one_to_one` local-key orientation is fixed.

Also fixes a latent bug in the Python SQL generator (`sidemantic/sql/generator.py`): custom-SQL joins injected a phantom `<name>_id` column into the CTE `SELECT`, which would reference a nonexistent column at execution time. Custom-join columns now come solely from the join condition. (The Rust generator uses `SELECT *` CTEs and was unaffected.)

## Tests

- New `tests/adapters/cube/test_joins.py` (7 tests): structured key extraction, composite-key preservation, `one_to_one` condition, unparseable warning, correct executed results, and export round-trip.
- 5 new Rust unit tests in `adapters/cube.rs` covering the same cases.