### PR TITLE
Accept OSI directory as the loader root

### DIFF
--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -505,7 +505,12 @@ def _is_under_osi_tree(file_path: "Path", directory: "Path") -> bool:
     # depth (a file directly in it, or under a subfolder of it). This keeps the
     # two documented entrypoints in agreement: loading the parent project accepts
     # the same files by their leading ``OSI/`` component.
-    if directory.name.casefold() == _OSI_TREE_DIR.casefold():
+    #
+    # Resolve the loader root before reading its name so the OSI directory is
+    # recognized even when it is the current working directory: ``cd OSI &&
+    # sidemantic validate`` (or ``load_from_directory(layer, ".")`` after
+    # ``chdir``) passes ``Path(".")``, whose raw ``.name`` is empty.
+    if directory.resolve().name.casefold() == _OSI_TREE_DIR.casefold():
         return True
     # Otherwise require a top-level ``OSI/`` directory plus the file name.
     if len(relative_parts) < 2:

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -481,17 +481,30 @@ _OSI_TREE_DIR = "OSI"
 def _is_under_osi_tree(file_path: "Path", directory: "Path") -> bool:
     """Return True when ``file_path`` lives under the project-root ``OSI/`` tree.
 
-    The OSI directory must be a top-level child of the loaded project root, so
-    only the first relative path component is checked (case-insensitively, to
-    match dbt accepting ``OSI`` regardless of filesystem case-folding). A JSON
-    file sitting directly at the project root or under any non-``OSI/`` folder is
-    rejected even when it is OSI-shaped.
+    Two layouts count as "inside the OSI tree":
+
+    * A top-level ``OSI/`` child of the loaded project root (``validate .`` from
+      the project root). Only the first relative path component is checked
+      (case-insensitively, to match dbt accepting ``OSI`` regardless of
+      filesystem case-folding).
+    * The loaded ``directory`` *itself* being the ``OSI/`` directory (``validate
+      OSI/`` pointed straight at the folder dbt users are told to drop these
+      files in). Here the file sits directly in ``directory`` with no leading
+      ``OSI/`` component, so the directory name is what identifies the tree.
+
+    A JSON file sitting directly at a non-``OSI/`` project root or under any
+    non-``OSI/`` subfolder is rejected even when it is OSI-shaped.
     """
     try:
         relative_parts = file_path.relative_to(directory).parts
     except ValueError:
         return False
-    # Need at least one directory component plus the file name.
+    # ``validate OSI/`` points the loader root straight at the OSI directory, so
+    # the file sits directly inside it (relative_parts == ("model.json",)) with
+    # no leading ``OSI/`` component. Accept it when the root is itself named OSI.
+    if len(relative_parts) == 1:
+        return directory.name.casefold() == _OSI_TREE_DIR.casefold()
+    # Otherwise require a top-level ``OSI/`` directory plus the file name.
     if len(relative_parts) < 2:
         return False
     return relative_parts[0].casefold() == _OSI_TREE_DIR.casefold()

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -489,8 +489,9 @@ def _is_under_osi_tree(file_path: "Path", directory: "Path") -> bool:
       filesystem case-folding).
     * The loaded ``directory`` *itself* being the ``OSI/`` directory (``validate
       OSI/`` pointed straight at the folder dbt users are told to drop these
-      files in). Here the file sits directly in ``directory`` with no leading
-      ``OSI/`` component, so the directory name is what identifies the tree.
+      files in). The whole loaded tree is then the OSI tree, so any descendant at
+      any depth counts -- matching how ``validate <project>`` (which rglobs and
+      only checks the leading ``OSI/`` component) loads the same files.
 
     A JSON file sitting directly at a non-``OSI/`` project root or under any
     non-``OSI/`` subfolder is rejected even when it is OSI-shaped.
@@ -499,11 +500,13 @@ def _is_under_osi_tree(file_path: "Path", directory: "Path") -> bool:
         relative_parts = file_path.relative_to(directory).parts
     except ValueError:
         return False
-    # ``validate OSI/`` points the loader root straight at the OSI directory, so
-    # the file sits directly inside it (relative_parts == ("model.json",)) with
-    # no leading ``OSI/`` component. Accept it when the root is itself named OSI.
-    if len(relative_parts) == 1:
-        return directory.name.casefold() == _OSI_TREE_DIR.casefold()
+    # ``validate OSI/`` points the loader root straight at the OSI directory. The
+    # whole loaded tree is then the OSI tree, so accept every descendant at any
+    # depth (a file directly in it, or under a subfolder of it). This keeps the
+    # two documented entrypoints in agreement: loading the parent project accepts
+    # the same files by their leading ``OSI/`` component.
+    if directory.name.casefold() == _OSI_TREE_DIR.casefold():
+        return True
     # Otherwise require a top-level ``OSI/`` directory plus the file name.
     if len(relative_parts) < 2:
         return False

--- a/tests/core/test_directory_loaders.py
+++ b/tests/core/test_directory_loaders.py
@@ -498,6 +498,59 @@ def test_load_from_directory_detects_released_osi_json(tmp_path):
     assert "order_count" in layer.graph.metrics
 
 
+def test_load_from_directory_accepts_osi_dir_as_loader_root(tmp_path):
+    """Pointing the loader straight at the ``OSI/`` directory routes its JSON to OSI.
+
+    dbt users are told to drop released-spec OSI documents in ``<project>/OSI/``,
+    so ``sidemantic validate OSI/`` points the loader root at that folder itself.
+    The file then sits directly in the root (relative_parts == ("model.json",)),
+    and it must still be detected as OSI rather than reporting "No models found".
+    """
+    osi_dir = tmp_path / "OSI"
+    osi_dir.mkdir()
+    (osi_dir / "model.json").write_text(
+        """
+{
+  "version": "0.1.1",
+  "semantic_model": [
+    {
+      "name": "released_analytics",
+      "datasets": [
+        {
+          "name": "orders",
+          "source": "db.schema.fct_orders",
+          "primary_key": ["order_id"],
+          "fields": [
+            {
+              "name": "order_id",
+              "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "order_id"}]}
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "name": "order_count",
+          "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "COUNT(*)"}]}
+        }
+      ]
+    }
+  ]
+}
+"""
+    )
+
+    layer = SemanticLayer()
+    # Load the OSI directory directly, not its parent project root.
+    load_from_directory(layer, osi_dir)
+
+    assert "orders" in layer.graph.models
+    orders = layer.graph.models["orders"]
+    assert orders.table.endswith("fct_orders")
+    assert getattr(orders, "_source_format", None) == "OSI"
+    assert "order_count" in layer.graph.metrics
+
+
 def test_load_from_directory_skips_generated_osi_json(tmp_path):
     """A dbt-generated target/ OSI document must not be loaded as a source model."""
 

--- a/tests/core/test_directory_loaders.py
+++ b/tests/core/test_directory_loaders.py
@@ -551,6 +551,53 @@ def test_load_from_directory_accepts_osi_dir_as_loader_root(tmp_path):
     assert "order_count" in layer.graph.metrics
 
 
+def test_load_from_directory_accepts_osi_dir_root_subdirectory(tmp_path):
+    """When the loader root IS the ``OSI/`` directory, a document in a SUBDIRECTORY
+    of it must also load. ``validate OSI/`` and ``validate <project>`` (which rglobs
+    and only checks the leading ``OSI/`` component) must accept the same nested file.
+    """
+    sub = tmp_path / "OSI" / "models"
+    sub.mkdir(parents=True)
+    (sub / "model.json").write_text(
+        """
+{
+  "version": "0.1.1",
+  "semantic_model": [
+    {
+      "name": "released_analytics",
+      "datasets": [
+        {
+          "name": "orders",
+          "source": "db.schema.fct_orders",
+          "primary_key": ["order_id"],
+          "fields": [
+            {
+              "name": "order_id",
+              "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "order_id"}]}
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "name": "order_count",
+          "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "COUNT(*)"}]}
+        }
+      ]
+    }
+  ]
+}
+"""
+    )
+
+    layer = SemanticLayer()
+    # Load the OSI directory directly; the document lives one level deeper.
+    load_from_directory(layer, tmp_path / "OSI")
+
+    assert "orders" in layer.graph.models
+    assert "order_count" in layer.graph.metrics
+
+
 def test_load_from_directory_skips_generated_osi_json(tmp_path):
     """A dbt-generated target/ OSI document must not be loaded as a source model."""
 

--- a/tests/core/test_directory_loaders.py
+++ b/tests/core/test_directory_loaders.py
@@ -551,6 +551,60 @@ def test_load_from_directory_accepts_osi_dir_as_loader_root(tmp_path):
     assert "order_count" in layer.graph.metrics
 
 
+def test_load_from_directory_accepts_osi_dir_as_cwd_loader_root(tmp_path, monkeypatch):
+    """Running from inside ``OSI/`` with the default ``.`` path still routes to OSI.
+
+    ``cd project/OSI && sidemantic validate`` (or ``load_from_directory(layer, ".")``
+    after ``chdir``) passes ``Path(".")``, whose raw ``.name`` is empty. The loader
+    must resolve the root before checking for the ``OSI/`` name so the document is
+    not skipped as "No models found".
+    """
+    osi_dir = tmp_path / "OSI"
+    osi_dir.mkdir()
+    (osi_dir / "model.json").write_text(
+        """
+{
+  "version": "0.1.1",
+  "semantic_model": [
+    {
+      "name": "released_analytics",
+      "datasets": [
+        {
+          "name": "orders",
+          "source": "db.schema.fct_orders",
+          "primary_key": ["order_id"],
+          "fields": [
+            {
+              "name": "order_id",
+              "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "order_id"}]}
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "name": "order_count",
+          "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "COUNT(*)"}]}
+        }
+      ]
+    }
+  ]
+}
+"""
+    )
+
+    layer = SemanticLayer()
+    # Emulate ``cd project/OSI && sidemantic validate`` (default path ".").
+    monkeypatch.chdir(osi_dir)
+    load_from_directory(layer, ".")
+
+    assert "orders" in layer.graph.models
+    orders = layer.graph.models["orders"]
+    assert orders.table.endswith("fct_orders")
+    assert getattr(orders, "_source_format", None) == "OSI"
+    assert "order_count" in layer.graph.metrics
+
+
 def test_load_from_directory_accepts_osi_dir_root_subdirectory(tmp_path):
     """When the loader root IS the ``OSI/`` directory, a document in a SUBDIRECTORY
     of it must also load. ``validate OSI/`` and ``validate <project>`` (which rglobs


### PR DESCRIPTION
Follow-up to #206: when a CLI user points `sidemantic validate` or `load_from_directory` straight at the `OSI/` directory itself (the folder dbt users are told to drop released-spec OSI documents in), the JSON file sits directly at the loader root with no leading `OSI/` path component. `relative_parts` was only `('model.json',)`, so the OSI-tree guard returned False, the JSON was never routed to `OSIAdapter`, and validation reported "No models found".

`_is_under_osi_tree` now also accepts an OSI-shaped JSON sitting directly in a loader root whose own directory name is `OSI` (case per the existing `_OSI_TREE_DIR` constant), in addition to the existing top-level `OSI/` subtree case. The generated-artifact exclusion (`target/`, `dbt_packages/`) and the OSI-shape check are unchanged, so an archived/scratch OSI document under a non-OSI folder is still ignored.

Known limitation: this only matches when the loaded directory itself is literally named `OSI`; an OSI document at a differently-named root (e.g. `validate .` from a project root with the document at top level) is still rejected, matching dbt's `<project_root>/OSI/` scope.