### PR TITLE
Import metric reference entries in Holistics datasets

### DIFF
--- a/sidemantic/adapters/holistics.py
+++ b/sidemantic/adapters/holistics.py
@@ -1377,9 +1377,12 @@ def _resolve_standalone_metric_reference(
     else:
         return None
 
-    # Try the name as written, then qualified against the referencing file's
-    # module prefix / `use` aliases, matching how standalone metrics are keyed.
-    candidates = [name, _qualify_name(name, context)]
+    # Prefer the name qualified against the referencing file's module prefix /
+    # `use` aliases before the bare name, matching how standalone metrics are
+    # keyed and how other resolver paths qualify in context first. This lets a
+    # local same-named metric (e.g. finance.revenue) win over a root metric of
+    # the same name instead of silently resolving to the global one.
+    candidates = [_qualify_name(name, context), name]
     for candidate in candidates:
         referenced = standalone_metrics.get(candidate)
         if referenced is not None:

--- a/sidemantic/adapters/holistics.py
+++ b/sidemantic/adapters/holistics.py
@@ -683,6 +683,17 @@ def _stamp_block_context(block: AmlBlock, context: _FileContext) -> AmlBlock:
 
 
 _FIELD_KEYWORDS = {"metric", "measure", "dimension"}
+_METRIC_MARKER_KEYWORDS = {"metric", "measure"}
+
+
+def _is_metric_marker(item: AmlItem | None) -> bool:
+    """True if `item` is the bare `metric`/`measure` keyword that the grammar emits
+    just before a reusable-reference shorthand property (`metric name: ref`)."""
+    return (
+        isinstance(item, ExpressionStatement)
+        and isinstance(item.value, Identifier)
+        and item.value.name in _METRIC_MARKER_KEYWORDS
+    )
 
 
 def _field_units(items: list[AmlItem]) -> list[tuple[tuple[str, str] | None, list[AmlItem]]]:
@@ -1472,19 +1483,26 @@ def _parse_dataset_block(
     dimensions: list[Dimension] = []
     metrics: list[Metric] = []
 
+    prev_item: AmlItem | None = None
     for item in block.items:
         # Reusable-metric-store shorthand: `metric name: standalone_metric`
-        # parses to a property whose value names a top-level Metric. Resolve the
-        # referenced standalone metric onto the dataset (renamed to the local
-        # key) instead of dropping it, so a dataset that only references
-        # standalone metrics still produces a model.
+        # parses to a bare `metric` keyword marker (an ExpressionStatement)
+        # immediately followed by a property naming a top-level Metric. Resolve the
+        # referenced standalone metric onto the dataset (renamed to the local key)
+        # only when that marker is present, so an ordinary metadata property such
+        # as `label: some_identifier` is never misread as a metric reference even
+        # if its value coincidentally matches a standalone metric name.
         if isinstance(item, AmlProperty):
-            referenced = _resolve_standalone_metric_reference(item, standalone_metrics, item.context or context)
-            if referenced is not None:
-                metrics.append(referenced)
+            if _is_metric_marker(prev_item):
+                referenced = _resolve_standalone_metric_reference(item, standalone_metrics, item.context or context)
+                if referenced is not None:
+                    metrics.append(referenced)
+            prev_item = item
             continue
         if not isinstance(item, AmlBlock):
+            prev_item = item
             continue
+        prev_item = item
         # A child field carries its own defining context when the dataset was
         # composed across modules (Dataset extending a PartialDataset from another
         # file); resolve its constants/`use` aliases against that file.

--- a/sidemantic/adapters/holistics.py
+++ b/sidemantic/adapters/holistics.py
@@ -268,6 +268,15 @@ class HolisticsAdapter(BaseAdapter):
         dataset_models, standalone_metrics, assignment_dataset_blocks = _resolve_dataset_artifacts(
             documents, constants, resolved_models
         )
+        # Register standalone metrics before dataset metrics so a genuine
+        # top-level Metric keeps its bare graph key. A dataset can carry a copy of
+        # a standalone metric renamed to a local alias (the
+        # `metric name: standalone_metric` shorthand); registering datasets first
+        # would let that alias occupy a root metric's key and silently drop the
+        # real standalone metric via the `not in graph.metrics` guard below.
+        for metric in standalone_metrics.values():
+            if metric.name not in graph.metrics:
+                graph.add_metric(metric)
         for model in dataset_models.values():
             if model.name not in graph.models:
                 graph.add_model(model)
@@ -277,9 +286,6 @@ class HolisticsAdapter(BaseAdapter):
                 for metric in model.metrics:
                     if metric.name not in graph.metrics:
                         graph.add_metric(metric)
-        for metric in standalone_metrics.values():
-            if metric.name not in graph.metrics:
-                graph.add_metric(metric)
 
         pending_relationships: list[_AmlRelationship] = []
         pending_relationship_refs: list[_RelationshipRef] = []

--- a/sidemantic/adapters/holistics.py
+++ b/sidemantic/adapters/holistics.py
@@ -1313,10 +1313,21 @@ def _resolve_dataset_artifacts(
                 return resolved_blocks[name]
         return None
 
+    # Standalone Metric blocks become graph-level metrics. Resolved before
+    # datasets so a dataset/partial that references one via the reusable
+    # "metric name: standalone_metric" shorthand can pull it onto the dataset.
+    standalone_metrics: dict[str, Metric] = {}
+    for name, (block, context) in metric_blocks.items():
+        metric_block = AmlBlock(kind="metric", name=block.name, items=block.items)
+        metric = _parse_measure_block(metric_block, constants, context)
+        if metric:
+            metric.name = name
+            standalone_metrics[name] = metric
+
     dataset_models: dict[str, Model] = {}
 
     for name, (block, context) in dataset_blocks.items():
-        model = _parse_dataset_block(block, constants, context)
+        model = _parse_dataset_block(block, constants, context, standalone_metrics)
         if model and model.name not in existing_models:
             dataset_models[model.name] = model
 
@@ -1335,31 +1346,69 @@ def _resolve_dataset_artifacts(
             continue
         block_with_name = AmlBlock(kind="Dataset", name=name, items=block.items)
         assignment_dataset_blocks.append((block_with_name, context))
-        model = _parse_dataset_block(block_with_name, constants, context)
+        model = _parse_dataset_block(block_with_name, constants, context, standalone_metrics)
         if model and model.name not in existing_models:
             dataset_models[model.name] = model
-
-    # Standalone Metric blocks become graph-level metrics.
-    standalone_metrics: dict[str, Metric] = {}
-    for name, (block, context) in metric_blocks.items():
-        metric_block = AmlBlock(kind="metric", name=block.name, items=block.items)
-        metric = _parse_measure_block(metric_block, constants, context)
-        if metric:
-            metric.name = name
-            standalone_metrics[name] = metric
 
     return dataset_models, standalone_metrics, assignment_dataset_blocks
 
 
-def _parse_dataset_block(block: AmlBlock, constants: dict[str, AmlValue], context: _FileContext) -> Model | None:
+def _resolve_standalone_metric_reference(
+    item: AmlProperty,
+    standalone_metrics: dict[str, Metric],
+    context: _FileContext,
+) -> Metric | None:
+    """Resolve a `metric name: standalone_metric` shorthand reference.
+
+    The reusable-metric-store shorthand parses to a property whose value is a
+    bare identifier/reference naming a top-level Metric. When it resolves to a
+    known standalone metric, return a copy renamed to the property key (the
+    dataset-local name); otherwise return None so genuine properties such as
+    `label`/`description`/`models` are left untouched.
+    """
+    if not standalone_metrics:
+        return None
+
+    value = item.value
+    if isinstance(value, Identifier):
+        name = value.name
+    elif isinstance(value, Reference):
+        name = ".".join(value.parts)
+    else:
+        return None
+
+    # Try the name as written, then qualified against the referencing file's
+    # module prefix / `use` aliases, matching how standalone metrics are keyed.
+    candidates = [name, _qualify_name(name, context)]
+    for candidate in candidates:
+        referenced = standalone_metrics.get(candidate)
+        if referenced is not None:
+            resolved = referenced.model_copy(deep=True)
+            resolved.name = item.key
+            return resolved
+    return None
+
+
+def _parse_dataset_block(
+    block: AmlBlock,
+    constants: dict[str, AmlValue],
+    context: _FileContext,
+    standalone_metrics: dict[str, Metric] | None = None,
+) -> Model | None:
     """Parse a Dataset block's dataset-level dimension/metric blocks into a Model.
 
     Dataset dimensions and metrics use cross-model AQL definitions (the only
     style Holistics allows in datasets). They are surfaced on a synthetic model
     named after the dataset so they are not silently dropped.
+
+    `standalone_metrics` lets the reusable-metric-store shorthand
+    (`metric name: standalone_metric`) resolve the referenced top-level Metric
+    onto the dataset instead of dropping the reference.
     """
     if not block.name:
         return None
+
+    standalone_metrics = standalone_metrics or {}
 
     properties = _properties_from_items(block.items)
     label = _value_as_string(properties.get("label"), constants, context)
@@ -1369,6 +1418,16 @@ def _parse_dataset_block(block: AmlBlock, constants: dict[str, AmlValue], contex
     metrics: list[Metric] = []
 
     for item in block.items:
+        # Reusable-metric-store shorthand: `metric name: standalone_metric`
+        # parses to a property whose value names a top-level Metric. Resolve the
+        # referenced standalone metric onto the dataset (renamed to the local
+        # key) instead of dropping it, so a dataset that only references
+        # standalone metrics still produces a model.
+        if isinstance(item, AmlProperty):
+            referenced = _resolve_standalone_metric_reference(item, standalone_metrics, item.context or context)
+            if referenced is not None:
+                metrics.append(referenced)
+            continue
         if not isinstance(item, AmlBlock):
             continue
         # A child field carries its own defining context when the dataset was

--- a/sidemantic/adapters/holistics.py
+++ b/sidemantic/adapters/holistics.py
@@ -682,41 +682,87 @@ def _stamp_block_context(block: AmlBlock, context: _FileContext) -> AmlBlock:
     return AmlBlock(kind=block.kind, name=block.name, items=stamped_items, context=block.context or context)
 
 
+_FIELD_KEYWORDS = {"metric", "measure", "dimension"}
+
+
+def _field_units(items: list[AmlItem]) -> list[tuple[tuple[str, str] | None, list[AmlItem]]]:
+    """Group items into mergeable field units.
+
+    A field unit is `(field_key, [items])`. Named `metric`/`measure`/`dimension`
+    blocks and the reusable-reference shorthand (`metric name: ref`, which the
+    grammar emits as a bare `metric` keyword ExpressionStatement immediately
+    followed by an `AmlProperty(name, ref)`) both map to the same
+    `(keyword, name)` field key, so an override authored in either form replaces
+    the base field instead of producing a duplicate. Every other item gets a
+    `None` key and is carried through unchanged.
+    """
+    units: list[tuple[tuple[str, str] | None, list[AmlItem]]] = []
+    idx = 0
+    n = len(items)
+    while idx < n:
+        item = items[idx]
+        if (
+            isinstance(item, ExpressionStatement)
+            and isinstance(item.value, Identifier)
+            and item.value.name in _FIELD_KEYWORDS
+            and idx + 1 < n
+            and isinstance(items[idx + 1], AmlProperty)
+        ):
+            # Reference shorthand: keyword marker + `name: ref` property.
+            prop = items[idx + 1]
+            units.append(((item.value.name, prop.key), [item, items[idx + 1]]))
+            idx += 2
+            continue
+        if isinstance(item, AmlBlock) and item.kind in _FIELD_KEYWORDS and item.name is not None:
+            units.append(((item.kind, item.name), [item]))
+            idx += 1
+            continue
+        units.append((None, [item]))
+        idx += 1
+    return units
+
+
 def _merge_blocks(base: AmlBlock, extension: AmlBlock) -> AmlBlock:
-    merged_items = list(base.items)
+    merged_units = _field_units(base.items)
     prop_index: dict[str, int] = {}
-    block_index: dict[tuple[str, str | None], int] = {}
+    field_index: dict[tuple[str, str], int] = {}
 
-    for idx, item in enumerate(merged_items):
-        if isinstance(item, AmlProperty):
-            prop_index[item.key] = idx
-        elif isinstance(item, AmlBlock):
-            key = (item.kind, item.name)
-            block_index[key] = idx
+    for unit_idx, (field_key, unit_items) in enumerate(merged_units):
+        if field_key is not None:
+            field_index[field_key] = unit_idx
+        elif len(unit_items) == 1 and isinstance(unit_items[0], AmlProperty):
+            prop_index[unit_items[0].key] = unit_idx
 
-    for item in extension.items:
+    for field_key, unit_items in _field_units(extension.items):
+        if field_key is not None:
+            if field_key in field_index:
+                base_unit = merged_units[field_index[field_key]][1]
+                # Two named blocks deep-merge their child fields; any pairing that
+                # involves the shorthand reference form replaces wholesale (a
+                # reference has no inner fields to merge into).
+                if len(base_unit) == 1 and isinstance(base_unit[0], AmlBlock) and isinstance(unit_items[0], AmlBlock):
+                    merged_units[field_index[field_key]] = (field_key, [_merge_blocks(base_unit[0], unit_items[0])])
+                else:
+                    merged_units[field_index[field_key]] = (field_key, unit_items)
+            else:
+                field_index[field_key] = len(merged_units)
+                merged_units.append((field_key, unit_items))
+            continue
+
+        item = unit_items[0]
         if isinstance(item, AmlProperty):
             if item.key in prop_index:
-                merged_items[prop_index[item.key]] = item
+                merged_units[prop_index[item.key]] = (None, [item])
             else:
-                prop_index[item.key] = len(merged_items)
-                merged_items.append(item)
+                prop_index[item.key] = len(merged_units)
+                merged_units.append((None, [item]))
             continue
 
-        if isinstance(item, AmlBlock):
-            key = (item.kind, item.name)
-            if item.name is not None and key in block_index:
-                base_item = merged_items[block_index[key]]
-                if isinstance(base_item, AmlBlock):
-                    merged_items[block_index[key]] = _merge_blocks(base_item, item)
-                else:
-                    merged_items[block_index[key]] = item
-            else:
-                block_index[key] = len(merged_items)
-                merged_items.append(item)
-            continue
+        merged_units.append((None, [item]))
 
-        merged_items.append(item)
+    merged_items: list[AmlItem] = []
+    for _, unit_items in merged_units:
+        merged_items.extend(unit_items)
 
     # Preserve the defining context so child fields composed across modules keep
     # resolving constants/`use` aliases against their authoring file. The

--- a/tests/adapters/holistics/test_parsing.py
+++ b/tests/adapters/holistics/test_parsing.py
@@ -417,6 +417,59 @@ Dataset combined = base_ds.extend(reusable)
         temp_path.unlink()
 
 
+def test_holistics_partial_dataset_metric_reference_shorthand():
+    """The reusable-metric-store shorthand `metric name: standalone_metric`
+    references a top-level Metric by name rather than redefining it inline. The
+    parser represents that reference as a property (not a block), so a Dataset
+    that extends a PartialDataset whose only contribution is such a reference
+    must still surface as a model carrying the resolved standalone metric,
+    instead of producing no model at all."""
+    aml_content = """
+Model base_orders {
+  type: 'table'
+  table_name: 'orders'
+  dimension order_id { type: 'number' }
+  measure order_count { type: 'number' aggregation_type: 'count' }
+}
+
+Metric total_orders {
+  label: 'Total Orders'
+  type: 'number'
+  definition: @aql count(base_orders.order_id) ;;
+}
+
+PartialDataset partial_metrics = PartialDataset {
+  metric total_orders: total_orders
+}
+
+Dataset base_ds {
+  label: 'Base DS'
+  models: [base_orders]
+}
+
+Dataset d = base_ds.extend(partial_metrics)
+"""
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".aml", delete=False) as f:
+        f.write(aml_content)
+        temp_path = Path(f.name)
+
+    try:
+        graph = HolisticsAdapter().parse(temp_path)
+
+        # The standalone metric registers at graph scope.
+        assert "total_orders" in graph.metrics
+
+        # The extending dataset must surface as a model even though its only
+        # field is a reference to a standalone metric.
+        assert "d" in graph.models
+        d_model = graph.models["d"]
+        # The referenced standalone metric is resolved onto the dataset.
+        assert d_model.get_metric("total_orders").sql == "COUNT(base_orders.order_id)"
+    finally:
+        temp_path.unlink()
+
+
 def test_holistics_extend_partial_preserves_defining_context(tmp_path):
     """A Dataset that extends a PartialDataset declared in another module must
     resolve the partial's field definitions against the partial's own file. A

--- a/tests/adapters/holistics/test_parsing.py
+++ b/tests/adapters/holistics/test_parsing.py
@@ -470,6 +470,67 @@ Dataset d = base_ds.extend(partial_metrics)
         temp_path.unlink()
 
 
+def test_holistics_metric_reference_shorthand_prefers_local_metric(tmp_path):
+    """The reusable-metric-store shorthand `metric name: standalone_metric` must
+    resolve the reference against the referencing file's module context before
+    falling back to a bare global name. When both a root `Metric revenue` and a
+    `modules/finance` `Metric revenue` exist, a finance PartialDataset that
+    references `revenue` must pull in the local `finance.revenue`, not the
+    same-named root metric."""
+    finance_dir = tmp_path / "modules" / "finance"
+    finance_dir.mkdir(parents=True)
+
+    # Both modules define a standalone `revenue` metric with different SQL, and the
+    # finance partial references the bare name `revenue` via the shorthand.
+    (finance_dir / "rev.aml").write_text(
+        """
+Metric revenue {
+  label: 'Finance Revenue'
+  type: 'number'
+  definition: @aql sum(base_orders.amount) ;;
+}
+
+PartialDataset finance_part = PartialDataset {
+  metric revenue: revenue
+}
+"""
+    )
+
+    # The root file declares its own same-named standalone `revenue` and builds
+    # the consuming dataset by extending the finance partial.
+    (tmp_path / "root.aml").write_text(
+        """
+use finance { finance_part }
+
+Model base_orders {
+  type: 'table'
+  table_name: 'orders'
+  dimension order_id { type: 'number' }
+  dimension amount { type: 'number' }
+}
+
+Metric revenue {
+  label: 'Root Revenue'
+  type: 'number'
+  definition: @aql count(base_orders.order_id) ;;
+}
+
+Dataset base_ds {
+  label: 'Base DS'
+  models: [base_orders]
+}
+
+Dataset combined = base_ds.extend(finance_part)
+"""
+    )
+
+    graph = HolisticsAdapter().parse(tmp_path)
+
+    assert "combined" in graph.models
+    # The local finance metric wins over the root metric of the same name.
+    assert graph.models["combined"].get_metric("revenue").sql == "SUM(base_orders.amount)"
+
+
 def test_holistics_extend_partial_preserves_defining_context(tmp_path):
     """A Dataset that extends a PartialDataset declared in another module must
     resolve the partial's field definitions against the partial's own file. A

--- a/tests/adapters/holistics/test_parsing.py
+++ b/tests/adapters/holistics/test_parsing.py
@@ -470,6 +470,45 @@ Dataset d = base_ds.extend(partial_metrics)
         temp_path.unlink()
 
 
+def test_holistics_metadata_property_matching_metric_name_is_not_a_reference(tmp_path):
+    """An ordinary dataset property whose value is a bare identifier that happens to
+    match a standalone metric name (e.g. `label: revenue`) must NOT be treated as
+    the `metric name: standalone_metric` shorthand. The shorthand is only the
+    bare `metric` keyword marker followed by a property; without gating on that
+    marker, a metadata-only dataset would gain a bogus metric (named after the
+    property key) and wrongly surface as a model."""
+    (tmp_path / "root.aml").write_text(
+        """
+Model base_orders {
+  type: 'table'
+  table_name: 'orders'
+  dimension order_id { type: 'number' }
+  dimension amount { type: 'number' }
+}
+
+Metric revenue {
+  label: 'Revenue'
+  type: 'number'
+  definition: @aql sum(base_orders.amount) ;;
+}
+
+Dataset meta_only {
+  label: revenue
+  models: [base_orders]
+}
+"""
+    )
+
+    graph = HolisticsAdapter().parse(tmp_path)
+
+    # The standalone metric still registers at graph scope.
+    assert "revenue" in graph.metrics
+    # The metadata-only dataset has no dataset-level fields, so it does not surface
+    # as a model and never gains a bogus `label` metric.
+    if "meta_only" in graph.models:
+        assert "label" not in {m.name for m in graph.models["meta_only"].metrics}
+
+
 def test_holistics_metric_reference_shorthand_prefers_local_metric(tmp_path):
     """The reusable-metric-store shorthand `metric name: standalone_metric` must
     resolve the reference against the referencing file's module context before

--- a/tests/adapters/holistics/test_parsing.py
+++ b/tests/adapters/holistics/test_parsing.py
@@ -708,6 +708,59 @@ Dataset combined = base_part.extend(override)
     assert graph.models["combined"].get_metric("revenue").sql == "SUM(base_orders.amount)"
 
 
+def test_holistics_extend_override_across_block_and_reference_forms(tmp_path):
+    """An override authored with the reusable-reference shorthand
+    (`metric revenue: some_metric`) must replace a base `metric revenue { ... }`
+    block of the same name, not be appended as a duplicate. The grammar emits the
+    shorthand as a bare `metric` keyword followed by a property, which is keyed
+    differently from a named block; without merging them under a shared field key
+    the composed model ends up with two `revenue` metrics and `Model.get_metric`
+    returns the first (base) one, so the override silently loses."""
+    (tmp_path / "root.aml").write_text(
+        """
+Model base_orders {
+  type: 'table'
+  table_name: 'orders'
+  dimension order_id { type: 'number' }
+  dimension amount { type: 'number' }
+}
+
+Metric ext_revenue {
+  label: 'External Revenue'
+  type: 'number'
+  definition: @aql sum(base_orders.amount) ;;
+}
+
+Dataset base_ds {
+  label: 'Base DS'
+  models: [base_orders]
+}
+
+PartialDataset base_part = PartialDataset {
+  metric revenue {
+    type: 'number'
+    definition: @aql count(base_orders.order_id) ;;
+  }
+}
+
+PartialDataset override_part = PartialDataset {
+  metric revenue: ext_revenue
+}
+
+Dataset combined = base_ds.extend(base_part).extend(override_part)
+"""
+    )
+
+    graph = HolisticsAdapter().parse(tmp_path)
+
+    combined = graph.models["combined"]
+    # The override replaces the base field instead of duplicating it.
+    revenue_metrics = [m for m in combined.metrics if m.name == "revenue"]
+    assert len(revenue_metrics) == 1
+    # The shorthand override wins over the base block.
+    assert combined.get_metric("revenue").sql == "SUM(base_orders.amount)"
+
+
 def test_holistics_merge_preserves_per_property_context(tmp_path):
     """When a partial from another module defines a field whose `definition`
     references a const from that module, and a consuming partial overrides only a

--- a/tests/adapters/holistics/test_parsing.py
+++ b/tests/adapters/holistics/test_parsing.py
@@ -531,6 +531,69 @@ Dataset combined = base_ds.extend(finance_part)
     assert graph.models["combined"].get_metric("revenue").sql == "SUM(base_orders.amount)"
 
 
+def test_holistics_metric_reference_shorthand_does_not_clobber_root_metric(tmp_path):
+    """A dataset-local alias produced by the `metric name: standalone_metric`
+    shorthand must not occupy a same-named root standalone metric's graph key.
+    A finance PartialDataset that references `revenue` copies `finance.revenue`
+    renamed to the local alias `revenue`; registering that copy at graph scope
+    before the genuine root `Metric revenue` would let the alias claim
+    `graph.metrics["revenue"]` and silently drop the real root metric. The
+    bare graph key must still resolve to the root standalone metric, while the
+    extending dataset keeps the finance SQL on its own field."""
+    finance_dir = tmp_path / "modules" / "finance"
+    finance_dir.mkdir(parents=True)
+
+    (finance_dir / "rev.aml").write_text(
+        """
+Metric revenue {
+  label: 'Finance Revenue'
+  type: 'number'
+  definition: @aql sum(base_orders.amount) ;;
+}
+
+PartialDataset finance_part = PartialDataset {
+  metric revenue: revenue
+}
+"""
+    )
+
+    (tmp_path / "root.aml").write_text(
+        """
+use finance { finance_part }
+
+Model base_orders {
+  type: 'table'
+  table_name: 'orders'
+  dimension order_id { type: 'number' }
+  dimension amount { type: 'number' }
+}
+
+Metric revenue {
+  label: 'Root Revenue'
+  type: 'number'
+  definition: @aql count(base_orders.order_id) ;;
+}
+
+Dataset base_ds {
+  label: 'Base DS'
+  models: [base_orders]
+}
+
+Dataset combined = base_ds.extend(finance_part)
+"""
+    )
+
+    graph = HolisticsAdapter().parse(tmp_path)
+
+    # The bare graph key resolves to the genuine root standalone metric, not the
+    # finance-derived dataset alias copied onto `combined`.
+    assert graph.metrics["revenue"].sql == "COUNT(base_orders.order_id)"
+    # The module metric is still reachable under its qualified key.
+    assert graph.metrics["finance.revenue"].sql == "SUM(base_orders.amount)"
+    # The extending dataset keeps the local finance SQL on its own field.
+    assert graph.models["combined"].get_metric("revenue").sql == "SUM(base_orders.amount)"
+
+
 def test_holistics_extend_partial_preserves_defining_context(tmp_path):
     """A Dataset that extends a PartialDataset declared in another module must
     resolve the partial's field definitions against the partial's own file. A


### PR DESCRIPTION
Follow-up to #204.

## What & why

The Holistics reusable-metric-store shorthand `metric name: standalone_metric` references a top-level `Metric` by name instead of redefining it inline. The parser represents that reference as a property (not a block), so the dataset-block item loop in `sidemantic/adapters/holistics.py` dropped it via `continue`.

As a result, a `Dataset d = base.extend(partial_metrics)` whose partial only contributes such metric references produced **no `d` model at all**, even though the referenced standalone `Metric` existed. `PartialDataset.extend` only worked when every reusable metric was rewritten as a full inline block.

This change resolves metric-reference property entries against the standalone `Metric` registry (copied and renamed to the dataset-local key) so the dataset still surfaces as a model carrying the referenced metric. Standalone metrics are now resolved before datasets so the reference can be resolved at dataset-parse time. Genuine dataset properties (`label`, `description`, `models`, `relationships`) are untouched because only values that resolve to a known standalone metric are pulled in.

## Known limitations

- Resolution matches the referenced name as written and qualified against the referencing file's module prefix / `use` aliases; a reference that cannot be matched to a known standalone metric is left as before (no spurious metric created).