### PR TITLE
Fix LookML ${view.field} reference resolution and cycle handling

### DIFF
--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -1109,7 +1109,7 @@ class LookMLAdapter(BaseAdapter):
 
         # Parse dimension_group (time dimensions)
         for dim_group_def in view_def.get("dimension_groups") or []:
-            dims = self._parse_dimension_group(dim_group_def, resolved_dimension_sql)
+            dims = self._parse_dimension_group(dim_group_def, resolved_dimension_sql, declared_dim_names)
             dimensions.extend(dims)
 
         # Build a set of dimension names for measure reference resolution
@@ -1515,13 +1515,18 @@ class LookMLAdapter(BaseAdapter):
         )
 
     def _parse_dimension_group(
-        self, dim_group_def: dict, dimension_sql_lookup: dict[str, str] | None = None
+        self,
+        dim_group_def: dict,
+        dimension_sql_lookup: dict[str, str] | None = None,
+        dimension_names: set[str] | None = None,
     ) -> list[Dimension]:
         """Parse LookML dimension_group (time dimensions).
 
         Args:
             dim_group_def: Dimension group definition
             dimension_sql_lookup: Optional dict of dimension names to resolved SQL
+            dimension_names: All declared dimension names, so a ${ref} to a COMPACT dimension (no
+                explicit sql) resolves to its default column instead of leaking the literal
 
         Returns:
             List of time dimensions with different granularities
@@ -1534,7 +1539,7 @@ class LookMLAdapter(BaseAdapter):
 
         # Handle duration type separately
         if group_type == "duration":
-            return self._parse_duration_group(group_name, dim_group_def, dimension_sql_lookup)
+            return self._parse_duration_group(group_name, dim_group_def, dimension_sql_lookup, dimension_names)
 
         if group_type != "time":
             return []
@@ -1805,7 +1810,11 @@ class LookMLAdapter(BaseAdapter):
         return "\n".join(sql_parts)
 
     def _parse_duration_group(
-        self, group_name: str, dim_group_def: dict, dimension_sql_lookup: dict[str, str] | None = None
+        self,
+        group_name: str,
+        dim_group_def: dict,
+        dimension_sql_lookup: dict[str, str] | None = None,
+        dimension_names: set[str] | None = None,
     ) -> list[Dimension]:
         """Parse LookML dimension_group with type: duration.
 
@@ -1816,6 +1825,8 @@ class LookMLAdapter(BaseAdapter):
             group_name: Name of the dimension group
             dim_group_def: Dimension group definition
             dimension_sql_lookup: Resolved dimension SQL for ${ref} resolution in sql_start/sql_end
+            dimension_names: All declared dimension names, so a ${ref} to a COMPACT dimension (no
+                explicit sql) resolves to its default column rather than leaking the literal
 
         Returns:
             List of duration dimensions
@@ -1826,16 +1837,18 @@ class LookMLAdapter(BaseAdapter):
 
         # Resolve ${dimension} references (self-view refs normalized to bare ${name}) so a
         # sql_start/sql_end like ${started_at} becomes the real column instead of leaking the
-        # literal ${...} into DATE_DIFF; ${TABLE} is handled next. Without this the duration
-        # dimension carried an unresolved ${ref} and every query on it emitted invalid SQL.
+        # literal ${...} into DATE_DIFF; ${TABLE} is handled next. Pass dimension_names so a ref to
+        # a COMPACT dimension (declared with no sql) resolves to its default column, not a leak.
+        # Without this the duration dimension carried an unresolved ${ref} and any query on it
+        # emitted invalid SQL.
         if sql_start:
-            sql_start = self._resolve_dimension_references(sql_start, dimension_sql_lookup or {}).replace(
-                "${TABLE}", "{model}"
-            )
+            sql_start = self._resolve_dimension_references(
+                sql_start, dimension_sql_lookup or {}, dimension_names=dimension_names
+            ).replace("${TABLE}", "{model}")
         if sql_end:
-            sql_end = self._resolve_dimension_references(sql_end, dimension_sql_lookup or {}).replace(
-                "${TABLE}", "{model}"
-            )
+            sql_end = self._resolve_dimension_references(
+                sql_end, dimension_sql_lookup or {}, dimension_names=dimension_names
+            ).replace("${TABLE}", "{model}")
 
         # If no sql_start/sql_end, we can't create duration dimensions
         if not sql_start or not sql_end:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -332,7 +332,7 @@ class LookMLAdapter(BaseAdapter):
         unsafe_nulling = (
             tree.find(exp.Is) is not None
             or tree.find(exp.Coalesce) is not None
-            or "hash(" in sql.lower()
+            or re.search(r"\bhash\s*\(", sql, re.I) is not None
             or case_with_default
             or if_with_default
             or iff_with_default
@@ -429,7 +429,7 @@ class LookMLAdapter(BaseAdapter):
         unsafe = (
             tree.find(exp.Is) is not None
             or tree.find(exp.Coalesce) is not None
-            or "hash(" in sql.lower()
+            or re.search(r"\bhash\s*\(", sql, re.I) is not None
             or any(c.args.get("default") is not None for c in tree.find_all(exp.Case))
             or any(n.args.get("false") is not None for n in tree.find_all(exp.If))
             or any(
@@ -437,7 +437,8 @@ class LookMLAdapter(BaseAdapter):
                 for n in tree.find_all(exp.Anonymous)
             )
             or any(
-                len(d.expressions) > 1 or any(isinstance(e, exp.Tuple) and len(e.expressions) > 1 for e in d.expressions)
+                len(d.expressions) > 1
+                or any(isinstance(e, exp.Tuple) and len(e.expressions) > 1 for e in d.expressions)
                 for d in tree.find_all(exp.Distinct)
             )
         )

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -1151,6 +1151,16 @@ class LookMLAdapter(BaseAdapter):
             # dimension expression, handled/skipped by _parse_measure itself).
             if not sql_has_aggregate(expanded.replace("{model}", "x")):
                 return None
+            # Apply the SAME aggregate-safety check _parse_measure uses, so a measure IT would
+            # skip as invalid never lands in the lookup. `bad: ${total} + ${amount}` mixes an
+            # aggregate measure with a RAW dimension: _parse_measure drops it, but without this
+            # check the prepass would still cache `SUM(amount) + amount`, and a later
+            # `outer: ${bad} / NULLIF(COUNT(*), 0)` would inline that raw ungrouped column and
+            # fail on grouped queries instead of the unsupported measure being unavailable.
+            if not self._mixed_is_aggregate_safe(
+                raw, lambda rn: rn in resolved_dimension_sql or rn in declared_dim_names
+            ):
+                return None
             joined = _folded_measure_filter(m_def)
             if joined:
                 # force=True: this SQL will be INLINED into a referencing measure with no

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -434,38 +434,36 @@ class LookMLAdapter(BaseAdapter):
         except Exception:
             return False
 
-        def _in_anon_agg(c) -> bool:
-            # sqlglot parses some engine-specific aggregates (PRODUCT, ENTROPY, WEIGHTED_AVG,
-            # ...) as exp.Anonymous, not exp.AggFunc; a column inside one is still aggregate-
-            # scoped (sidemantic treats these as aggregates in aggregation_detection).
+        def _is_agg_scope(node) -> bool:
+            # A node that groups its argument columns: an aggregate function (incl. an
+            # anonymous/engine-specific aggregate), an aggregate FILTER (WHERE ...) predicate
+            # (sqlglot nests that under exp.Filter, not exp.AggFunc), an ordered-set aggregate's
+            # WITHIN GROUP (ORDER BY ...) (exp.WithinGroup, e.g. PERCENTILE_CONT(0.5) WITHIN
+            # GROUP (ORDER BY x)), or a LIST(...) collector (DuckDB's LIST -> exp.List, which
+            # aggregation_detection also counts as an aggregate, so this must agree).
+            return isinstance(node, (exp.AggFunc, exp.Filter, exp.WithinGroup, exp.List)) or (
+                isinstance(node, exp.Anonymous) and (node.name or "").lower() in _ANONYMOUS_AGGREGATE_FUNCTIONS
+            )
+
+        def _column_is_grouped(c) -> bool:
+            # Walk up from the column to the FIRST aggregate-or-window boundary.
             node = c.parent
             while node is not None:
-                if isinstance(node, exp.Anonymous) and (node.name or "").lower() in _ANONYMOUS_AGGREGATE_FUNCTIONS:
-                    return True
+                if isinstance(node, exp.Window):
+                    # Reached a window before any plain aggregate: the column is a raw per-row
+                    # argument of the window (SUM(x) OVER (), LAG(x) OVER ()) -- still ungrouped.
+                    return False
+                if _is_agg_scope(node):
+                    # A plain aggregate consumes the column and produces a grouped value. But if
+                    # that aggregate is ITSELF windowed (SUM(x) OVER ()), the column is a raw
+                    # per-row argument, so only a NON-windowed aggregate groups it. A nested
+                    # aggregate inside a window -- SUM(SUM(x)) OVER () -- is reached here at the
+                    # inner SUM, whose parent is the outer SUM (not the Window), so it is grouped.
+                    return not isinstance(node.parent, exp.Window)
                 node = node.parent
             return False
 
-        # A column is aggregate-scoped if it is inside an aggregate function (incl. an
-        # anonymous/engine-specific aggregate), inside an aggregate FILTER (WHERE ...)
-        # predicate (sqlglot nests that under exp.Filter, not exp.AggFunc), or inside an
-        # ordered-set aggregate's WITHIN GROUP (ORDER BY ...) (nested under exp.WithinGroup,
-        # e.g. PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x)), or inside a LIST(...) collector
-        # (sqlglot parses DuckDB's LIST as exp.List, and aggregation_detection counts it as an
-        # aggregate -- so this check must agree, else ARRAY_LENGTH(LIST(x)) reads as raw and a
-        # valid measure is dropped). But a column inside a WINDOW function (SUM(x) OVER ()) is
-        # NOT safe: the window runs after grouping, so a raw column there is still ungrouped
-        # and would be rejected in a grouped SELECT.
-        return all(
-            (
-                c.find_ancestor(exp.AggFunc) is not None
-                or c.find_ancestor(exp.Filter) is not None
-                or c.find_ancestor(exp.WithinGroup) is not None
-                or c.find_ancestor(exp.List) is not None
-                or _in_anon_agg(c)
-            )
-            and c.find_ancestor(exp.Window) is None
-            for c in tree.find_all(exp.Column)
-        )
+        return all(_column_is_grouped(c) for c in tree.find_all(exp.Column))
 
     # Plain decimal numeric literal: optional sign, then digits with optional fraction,
     # or a bare fraction. Deliberately excludes Python-/float()-only spellings that this

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -452,10 +452,12 @@ class LookMLAdapter(BaseAdapter):
 
     @staticmethod
     def _sql_has_list_aggregate(sql: str) -> bool:
-        """True if ``sql`` contains a ``LIST(...)`` collector (sqlglot's ``exp.List``).
+        """True if ``sql`` contains a NULL-retaining array collector -- ``LIST(...)`` (sqlglot's
+        ``exp.List``) or ``ARRAY_AGG(...)`` (``exp.ArrayAgg``).
 
-        Callers use this to refuse FILTERING such an expression: LIST keeps NULL inputs, so a
-        filter can be applied neither by column-nulling nor by a folded CASE.
+        Callers use this to refuse FILTERING such an expression: these collectors keep NULL inputs,
+        so a filter can be applied neither by column-nulling (the excluded row's NULL is still an
+        element -- ARRAY_LENGTH still counts it) nor by a folded CASE.
         """
         import sqlglot
         from sqlglot import expressions as exp
@@ -464,7 +466,7 @@ class LookMLAdapter(BaseAdapter):
             tree = sqlglot.parse_one(sql.replace("{model}", "__m__").replace("${TABLE}", "__m__"))
         except Exception:
             return False
-        return any(True for _ in tree.find_all(exp.List))
+        return any(True for _ in tree.find_all(exp.List)) or any(True for _ in tree.find_all(exp.ArrayAgg))
 
     @staticmethod
     def _has_subquery(sql: str) -> bool:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -1306,6 +1306,38 @@ class LookMLAdapter(BaseAdapter):
             if measure:
                 measures.append(measure)
 
+        # Drop measures that reference a measure which did NOT survive parsing. A row-level helper
+        # (`bad { sql: ${amount} }`) is skipped above, but a dependent (`outer { sql: ${bad} * 2 }`)
+        # still resolved ${bad} to a bare `bad` and imported as `bad * 2`, which compile cannot
+        # resolve ("Metric bad not found"). Collect each measure's UNQUALIFIED measure refs from the
+        # raw SQL, then iterate to a fixpoint so a dependent of a dependent is dropped too.
+        _measure_refs: dict[str, set[str]] = {}
+        for measure_def in view_def.get("measures") or []:
+            _mn = measure_def.get("name")
+            if not _mn:
+                continue
+            _measure_refs[_mn] = {
+                _r.group(2)
+                for _r in self._REF_RE.finditer(measure_def.get("sql") or "")
+                if _r.group(1) is None and _r.group(2) in measure_names and _r.group(2) != _mn
+            }
+        _surviving = {m.name for m in measures}
+        _changed = True
+        while _changed:
+            _changed = False
+            for _m in list(measures):
+                _dead = {r for r in _measure_refs.get(_m.name, set()) if r not in _surviving}
+                if _dead:
+                    logger.warning(
+                        "LookML measure %r references measure(s) %s that were not imported "
+                        "(e.g. a skipped row-level helper); skipping it too.",
+                        _m.name,
+                        ", ".join(sorted(_dead)),
+                    )
+                    measures.remove(_m)
+                    _surviving.discard(_m.name)
+                    _changed = True
+
         # Parse segments
         from sidemantic.core.segment import Segment
 

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -353,7 +353,15 @@ class LookMLAdapter(BaseAdapter):
             return c
 
         for a in aggs:
-            if isinstance(a.parent, exp.Window):
+            # Is `a` itself windowed? Its OVER wrapper (exp.Window) is normally the direct parent,
+            # but an aggregate FILTER clause (COUNT(*) FILTER (WHERE ...) OVER ()) nests an exp.Filter
+            # between the aggregate and the Window, so walk past any Filter wrapper. (A NESTED
+            # aggregate like the inner COUNT of SUM(COUNT(*)) OVER () has a non-Filter/-Window parent,
+            # so it is correctly NOT treated as windowed and still folds.)
+            _windowed = a.parent
+            while isinstance(_windowed, exp.Filter):
+                _windowed = _windowed.parent
+            if isinstance(_windowed, exp.Window):
                 # A WINDOWED aggregate (SUM(...) OVER ()) runs AFTER grouping, so wrapping its
                 # argument in CASE WHEN <filter> puts the filter column inside the window, ungrouped
                 # -- the engine rejects it. When the window wraps a NESTED aggregate
@@ -1367,6 +1375,18 @@ class LookMLAdapter(BaseAdapter):
                 )
                 # Replace ${TABLE} with {model} placeholder
                 segment_sql = segment_sql.replace("${TABLE}", "{model}")
+                # A cross-view reference cannot be represented inline, so an unresolved
+                # ${other_view.field} would leak into the WHERE clause when the segment is used.
+                # Drop the segment rather than import an unqueryable one, mirroring how
+                # dimensions/measures with the same leak are dropped.
+                if self._leaks_cross_view_ref(segment_sql):
+                    logger.warning(
+                        "LookML segment %r references another view inline (%s), which sidemantic "
+                        "cannot represent; dropping the segment instead of importing unqueryable SQL.",
+                        segment_name,
+                        segment_sql,
+                    )
+                    continue
                 segments.append(
                     Segment(
                         name=segment_name,

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -321,6 +321,14 @@ class LookMLAdapter(BaseAdapter):
         iff_with_default = any(
             (n.name or "").lower() in ("iff", "if") and len(n.expressions) >= 3 for n in tree.find_all(exp.Anonymous)
         )
+        # (4) a MULTI-COLUMN DISTINCT -- COUNT(DISTINCT (a, b)) or COUNT(DISTINCT a, b) -- is unsafe
+        # to null: nulling the columns of an excluded row yields the tuple (NULL, NULL), which is
+        # NOT a NULL value (only its components are), so DISTINCT counts that phantom tuple ONCE and
+        # inflates the result by one. A single-column DISTINCT is safe (its NULL is ignored).
+        multi_col_distinct = any(
+            len(d.expressions) > 1 or any(isinstance(e, exp.Tuple) and len(e.expressions) > 1 for e in d.expressions)
+            for d in tree.find_all(exp.Distinct)
+        )
         unsafe_nulling = (
             tree.find(exp.Is) is not None
             or tree.find(exp.Coalesce) is not None
@@ -328,6 +336,7 @@ class LookMLAdapter(BaseAdapter):
             or case_with_default
             or if_with_default
             or iff_with_default
+            or multi_col_distinct
         )
         # Otherwise, if every aggregate already references a column the generator can null
         # (nulling the value/ORDER-BY column filters it; aggregates ignore NULLs), the

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -170,7 +170,10 @@ class LookMLAdapter(BaseAdapter):
         def fix(value):
             return pat.sub(r"${\1}", value) if isinstance(value, str) else value
 
-        for key in ("dimensions", "dimension_groups", "measures"):
+        # `filters` are view-level segments; their `sql` can self-qualify a field the same way
+        # (`sql: ${orders.status} = 'completed' ;;`) and must be normalized too, else the leaked
+        # ${orders.status} reaches the WHERE clause and the database rejects it.
+        for key in ("dimensions", "dimension_groups", "measures", "filters"):
             for item in view_def.get(key) or []:
                 if not isinstance(item, dict):
                     continue
@@ -1123,6 +1126,12 @@ class LookMLAdapter(BaseAdapter):
             segment_name = segment_def.get("name")
             segment_sql = segment_def.get("sql")
             if segment_name and segment_sql:
+                # Resolve ${field} references (incl. self-qualified ones normalized above) through
+                # the dimension SQL, exactly like dimensions/measures -- otherwise a segment such as
+                # `${orders.status} = 'completed'` leaks an unresolved ${...} into the WHERE clause.
+                segment_sql = self._resolve_dimension_references(
+                    segment_sql, resolved_dimension_sql, dimension_names=declared_dim_names
+                )
                 # Replace ${TABLE} with {model} placeholder
                 segment_sql = segment_sql.replace("${TABLE}", "{model}")
                 segments.append(

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -344,6 +344,23 @@ class LookMLAdapter(BaseAdapter):
             return c
 
         for a in aggs:
+            if isinstance(a.parent, exp.Window):
+                # A WINDOWED aggregate (SUM(...) OVER ()) runs AFTER grouping, so wrapping its
+                # argument in CASE WHEN <filter> puts the filter column inside the window, ungrouped
+                # -- the engine rejects it. When the window wraps a NESTED aggregate
+                # (SUM(COUNT(*)) OVER ()), that inner aggregate is also in `aggs` and carries the
+                # filter, so skip only the outer one. With no inner aggregate to carry it
+                # (SUM(amount) OVER ()), the predicate cannot be applied to this term consistently
+                # with the rest -> abort the fold rather than emit inconsistent or invalid SQL.
+                inner_aggs = [n for n in a.find_all(exp.AggFunc) if n is not a]
+                inner_aggs += [
+                    n
+                    for n in a.find_all(exp.Anonymous)
+                    if n is not a and (n.name or "").lower() in _ANONYMOUS_AGGREGATE_FUNCTIONS
+                ]
+                if inner_aggs:
+                    continue
+                return None
             wg = a.find_ancestor(exp.WithinGroup)
             if wg is not None:
                 # Ordered-set aggregate: fold into the ORDER BY value(s), never the percentile

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -253,7 +253,7 @@ class LookMLAdapter(BaseAdapter):
         return resolve(sql, frozenset())
 
     @classmethod
-    def _fold_complete_sql_filters(cls, sql: str, filters: list[str]) -> str | None:
+    def _fold_complete_sql_filters(cls, sql: str, filters: list[str], force: bool = False) -> str | None:
         """Fold measure ``filters`` INTO a complete-SQL aggregate when the generator's
         column-nulling can't apply them safely.
 
@@ -308,8 +308,10 @@ class LookMLAdapter(BaseAdapter):
         unsafe_nulling = tree.find(exp.Is) is not None or tree.find(exp.Coalesce) is not None or "hash(" in sql.lower()
         # Otherwise, if every aggregate already references a column the generator can null
         # (nulling the value/ORDER-BY column filters it; aggregates ignore NULLs), the
-        # existing path is correct AND consistent -> don't rewrite.
-        if not unsafe_nulling and all(any(True for _ in _scope(a).find_all(exp.Column)) for a in aggs):
+        # existing path is correct AND consistent -> don't rewrite. `force` skips this: a caller
+        # INLINING this SQL into another measure has no generator column-nulling step, so the
+        # filter must always be baked into a CASE here.
+        if not force and not unsafe_nulling and all(any(True for _ in _scope(a).find_all(exp.Column)) for a in aggs):
             return None
 
         def _combined():
@@ -1102,6 +1104,77 @@ class LookMLAdapter(BaseAdapter):
                     if dm and dm.sql:
                         measure_full_sql_lookup[m_name] = dm.sql
 
+        # Second pass: also expand `type: number` measures into measure_full_sql_lookup so a
+        # LATER number measure that references them can go through the complete-SQL path. Covers
+        # (a) inline-aggregate "complete" measures (SUM(${amount}) with filters) and (b) pure
+        # derived metric-of-metrics (${revenue} - ${cost}). Without this, referencing them either
+        # drops the measure as unexpandable or silently loses a referenced measure's filter.
+        # Iterate to a fixpoint so chains (avg_margin -> gross_margin -> revenue/cost) resolve
+        # regardless of declaration order. filter_sensitive_measures tracks measures whose folded
+        # filter a plain derived reference would drop -- a referencing expr must INLINE them.
+        from sidemantic.sql.aggregation_detection import sql_has_aggregate
+
+        number_measure_defs = {
+            m["name"]: m
+            for m in (view_def.get("measures") or [])
+            if m.get("name") and m.get("type") == "number" and m.get("sql")
+        }
+        filter_sensitive_measures: set[str] = set()
+
+        def _expand_number_measure(m_def):
+            """Return (complete_sql, is_filter_sensitive) or None if not (yet) expandable."""
+            raw = m_def["sql"].replace("${TABLE}", "{model}")
+            refs = [(mm.group(1), mm.group(2)) for mm in self._REF_RE.finditer(raw)]
+            # Cross-view refs and subqueries have no inline complete-SQL form.
+            if any(v is not None and rn != "TABLE" for v, rn in refs) or re.search(r"(?is)\bselect\b", raw):
+                return None
+            # Every measure ref must already be resolvable (a dim, a compact dim, or already in
+            # the lookup); otherwise retry next round (it may be a later-added number measure).
+            for v, rn in refs:
+                if v is not None or rn == "TABLE" or rn in resolved_dimension_sql or rn in declared_dim_names:
+                    continue
+                if rn not in measure_full_sql_lookup:
+                    return None
+
+            def _sub(mm):
+                v, rn = mm.group(1), mm.group(2)
+                if v is None and rn == "TABLE":
+                    return mm.group(0)
+                if rn in resolved_dimension_sql:
+                    return f"({resolved_dimension_sql[rn]})"
+                if rn in declared_dim_names:
+                    return f"({{model}}.{rn})"
+                return f"({measure_full_sql_lookup[rn]})"
+
+            expanded = self._REF_RE.sub(_sub, raw)
+            # A valid measure-level expression must contain an aggregate (else it is a row-level
+            # dimension expression, handled/skipped by _parse_measure itself).
+            if not sql_has_aggregate(expanded.replace("{model}", "x")):
+                return None
+            joined = _folded_measure_filter(m_def)
+            if joined:
+                # force=True: this SQL will be INLINED into a referencing measure with no
+                # generator column-nulling, so the filter must be baked into a CASE unconditionally.
+                folded = self._fold_complete_sql_filters(expanded, [joined], force=True)
+                if folded is None:
+                    return None  # can't fold the filter safely -> leave unexpandable
+                return folded, True
+            return expanded, False
+
+        _expanding = True
+        while _expanding:
+            _expanding = False
+            for m_name, m_def in number_measure_defs.items():
+                if m_name in measure_full_sql_lookup:
+                    continue
+                result = _expand_number_measure(m_def)
+                if result is None:
+                    continue
+                measure_full_sql_lookup[m_name], _sensitive = result
+                if _sensitive:
+                    filter_sensitive_measures.add(m_name)
+                _expanding = True
+
         # Parse measures with dimension SQL lookup for reference resolution
         measures = []
         for measure_def in view_def.get("measures") or []:
@@ -1113,6 +1186,7 @@ class LookMLAdapter(BaseAdapter):
                 measure_agg_lookup,
                 measure_full_sql_lookup,
                 view_name=name.lstrip("+"),
+                filter_sensitive_measures=filter_sensitive_measures,
             )
             if measure:
                 measures.append(measure)
@@ -1586,6 +1660,7 @@ class LookMLAdapter(BaseAdapter):
         measure_agg_lookup: dict[str, str] | None = None,
         measure_full_sql_lookup: dict[str, str] | None = None,
         view_name: str | None = None,
+        filter_sensitive_measures: set[str] | None = None,
     ) -> Metric | None:
         """Parse LookML measure.
 
@@ -1595,6 +1670,8 @@ class LookMLAdapter(BaseAdapter):
             dimension_sql_lookup: Dict mapping dimension names to their resolved SQL
             measure_names: Set of measure names in this view (for base-measure resolution)
             measure_agg_lookup: Dict mapping base measure names to their SQL aggregate template
+            filter_sensitive_measures: Measures whose folded filter a plain derived reference
+                would drop, so a referencing number measure must INLINE them (complete path).
 
         Returns:
             Metric instance or None
@@ -1607,6 +1684,7 @@ class LookMLAdapter(BaseAdapter):
         dimension_sql_lookup = dimension_sql_lookup or {}
         measure_agg_lookup = measure_agg_lookup or {}
         measure_full_sql_lookup = measure_full_sql_lookup or {}
+        filter_sensitive_measures = filter_sensitive_measures or set()
 
         # Check if type is explicitly set
         has_explicit_type = "type" in measure_def
@@ -1788,7 +1866,17 @@ class LookMLAdapter(BaseAdapter):
                 # aggregates like PERCENTILE_CONT(...) WITHIN GROUP (ORDER BY ${x}). Replacing
                 # every ${...}/{model} with a plain identifier lets sqlglot see the real agg.
                 has_inline_agg = sql_has_aggregate(self._REF_RE.sub("x", sql).replace("{model}", "x"))
-                needs_complete = (referenced_measure and referenced_dimension) or has_inline_agg
+                # A reference to a FILTER-SENSITIVE measure (one whose folded filter a plain
+                # derived dependency would drop) must be inlined through the complete-SQL path,
+                # not left as a bare metric-of-metrics ref -- else e.g. `${completed_sum} * 2`
+                # silently expands to SUM(amount)*2 over ALL rows, ignoring completed_sum's filter.
+                refs_filter_sensitive = any(
+                    _m.group(1) is None and _m.group(2) != "TABLE" and _m.group(2) in filter_sensitive_measures
+                    for _m in self._REF_RE.finditer(sql)
+                )
+                needs_complete = (
+                    (referenced_measure and referenced_dimension) or has_inline_agg or refs_filter_sensitive
+                )
                 expand_measures = needs_complete and referenced_measure
                 if needs_complete:
                     if re.search(r"(?is)\bselect\b", sql):

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -346,6 +346,22 @@ class LookMLAdapter(BaseAdapter):
             return None
 
     @staticmethod
+    def _sql_has_list_aggregate(sql: str) -> bool:
+        """True if ``sql`` contains a ``LIST(...)`` collector (sqlglot's ``exp.List``).
+
+        Callers use this to refuse FILTERING such an expression: LIST keeps NULL inputs, so a
+        filter can be applied neither by column-nulling nor by a folded CASE.
+        """
+        import sqlglot
+        from sqlglot import expressions as exp
+
+        try:
+            tree = sqlglot.parse_one(sql.replace("{model}", "__m__").replace("${TABLE}", "__m__"))
+        except Exception:
+            return False
+        return any(True for _ in tree.find_all(exp.List))
+
+    @staticmethod
     def _has_subquery(sql: str) -> bool:
         """True if ``sql`` contains a SELECT outside any string literal.
 
@@ -2026,6 +2042,21 @@ class LookMLAdapter(BaseAdapter):
             meta["group_label"] = measure_def["group_label"]
         if measure_def.get("tags"):
             meta["tags"] = measure_def["tags"]
+
+        # A filtered LIST(...) aggregate has NO faithful portable form. Unlike every other
+        # aggregate, DuckDB's LIST KEEPS NULL inputs, so neither filtering strategy excludes a
+        # row: the generator's column-nulling and a folded CASE both leave one NULL element per
+        # non-matching row (LIST(CASE WHEN s='x' THEN amount END) over 3 rows -> [1, NULL, 3]),
+        # so ARRAY_LENGTH still counts them. Only a dialect-specific FILTER (WHERE ...) clause
+        # would work. Skip rather than silently import a measure that ignores its filter.
+        if number_refs_only_columns and filters and self._sql_has_list_aggregate(sql):
+            logger.warning(
+                "LookML number measure %r combines a LIST(...) aggregate with filters, which has "
+                "no faithful form (LIST keeps NULL inputs, so neither column-nulling nor a folded "
+                "CASE excludes a row); skipping on import.",
+                name,
+            )
+            return None
 
         # A COMPLETE (opaque) measure's filters are applied by the generator without
         # resolving dimension refs (it just strips {model}), so resolve {model}.<dim> to

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -1303,6 +1303,18 @@ class LookMLAdapter(BaseAdapter):
                 view_name=name.lstrip("+"),
                 filter_sensitive_measures=filter_sensitive_measures,
             )
+            if measure and self._leaks_cross_view_ref(measure.sql):
+                # Like a cross-view dimension, a measure whose SQL references another view
+                # inline (${other_view.field}) would leak that literal into the model CTE
+                # (SELECT ${customers.balance} ...). Drop it; the fixpoint below then drops any
+                # measure that depended on it.
+                logger.warning(
+                    "LookML measure %r references another view inline (%s), which sidemantic "
+                    "cannot represent; dropping the measure instead of importing unqueryable SQL.",
+                    measure.name,
+                    measure.sql,
+                )
+                measure = None
             if measure:
                 measures.append(measure)
 
@@ -1414,6 +1426,22 @@ class LookMLAdapter(BaseAdapter):
 
         return Model(**model_kwargs)
 
+    # A ${...} reference containing a dot is a cross-view reference (${other_view.field}).
+    # ${TABLE} has no dot inside the braces, and self-view qualifiers are normalized away
+    # before resolution, so any remaining dotted ${...} is an unresolvable cross-view ref
+    # that sidemantic cannot represent inline.
+    _CROSS_VIEW_REF_RE = re.compile(r"\$\{[^}]*\.[^}]*\}")
+
+    @classmethod
+    def _leaks_cross_view_ref(cls, sql: str | None) -> bool:
+        """True if ``sql`` still carries an unresolved cross-view ``${view.field}`` reference.
+
+        A resolved reference is a plain/qualified column or a parenthesized expression; a
+        remaining dotted ``${...}`` would leak the literal into generated SQL (e.g.
+        ``SELECT ${customers.name} ...``), a guaranteed syntax error.
+        """
+        return bool(sql) and bool(cls._CROSS_VIEW_REF_RE.search(sql))
+
     def _parse_dimension(self, dim_def: dict, dimension_sql_lookup: dict[str, str] | None = None) -> Dimension | None:
         """Parse LookML dimension.
 
@@ -1461,6 +1489,20 @@ class LookMLAdapter(BaseAdapter):
         if dim_def.get("can_filter") in ("no", False):
             meta["can_filter"] = False
 
+        # A queryable dimension whose SQL still references another view inline
+        # (${other_view.field}) would emit that literal into the model CTE -- e.g.
+        # SELECT ${customers.name} AS cust_name FROM orders -- so every query touching it
+        # fails with invalid SQL. Sidemantic has no inline cross-model column, so drop the
+        # dimension rather than import an unqueryable field.
+        if self._leaks_cross_view_ref(sql):
+            logger.warning(
+                "LookML dimension %r references another view inline (%s), which sidemantic "
+                "cannot represent; dropping the dimension instead of importing unqueryable SQL.",
+                name,
+                sql,
+            )
+            return None
+
         return Dimension(
             name=name,
             type=sidemantic_type,
@@ -1507,6 +1549,18 @@ class LookMLAdapter(BaseAdapter):
             base_sql = dim_group_def.get("sql")
             if base_sql:
                 base_sql = base_sql.replace("${TABLE}", "{model}")
+
+        # A dimension_group whose base SQL references another view inline (${other.ts})
+        # would leak that literal into every generated timeframe field, so drop the whole
+        # group rather than import unqueryable time dimensions (see _parse_dimension).
+        if self._leaks_cross_view_ref(base_sql):
+            logger.warning(
+                "LookML dimension_group %r references another view inline (%s), which sidemantic "
+                "cannot represent; dropping the group instead of importing unqueryable SQL.",
+                group_name,
+                base_sql,
+            )
+            return []
 
         # Create a dimension for each timeframe
         dimensions = []

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -595,15 +595,17 @@ class LookMLAdapter(BaseAdapter):
         r"week|month|year)\b"
     )
 
-    def _measure_filter_conds(self, measure_def: dict, view_name: str | None = None) -> list[str]:
-        """Convert a measure's LookML ``filters`` to a list of SQL condition strings.
+    def _measure_filter_conds(self, measure_def: dict, view_name: str | None = None) -> tuple[list[str], bool]:
+        """Convert a measure's LookML ``filters`` to SQL condition strings.
 
         Handles both the shorthand list-of-dicts (``filters: [status: "x"]``) and the
         block (``filter: { field: ...  value: ... }``) syntaxes that ``lkml`` collapses
         into ``filters__all``. A SELF-view qualifier (``<this_view>.status``) is stripped
-        so the converter builds ``{model}.status``; a CROSS-view qualifier
-        (``other_view.field``) is left intact -- collapsing it to a same-named local field
-        would silently retarget the filter (e.g. GA360's ``hits.isInteraction``).
+        so the converter builds ``{model}.status``.
+
+        Returns ``(conds, has_cross_view)``: a CROSS-view qualifier (``other_view.field``) cannot be
+        represented in the single-table model CTE, so its condition is omitted and the flag is set
+        for the caller to drop the whole measure rather than import a broken filter.
         """
 
         def _bare(field: str) -> str:
@@ -613,23 +615,36 @@ class LookMLAdapter(BaseAdapter):
                     return rest
             return field
 
+        # A filter field that still carries a dot after stripping the self-view qualifier is a
+        # CROSS-view reference (customers.active): the converter would build {model}.customers.active,
+        # and the model CTE (single base table) has no `customers` alias, so the measure fails to
+        # query. Flag it so the caller drops the whole measure, matching how a cross-view inline sql
+        # ref is dropped -- rather than importing a measure with a broken filter.
+        has_cross_view = False
+
+        def _add(field, value):
+            nonlocal has_cross_view
+            bare = _bare(field)
+            if isinstance(bare, str) and re.search(r"[^\W]+\.[^\W]", bare) and "${" not in bare:
+                has_cross_view = True
+                return
+            fs = self._convert_lookml_filter_to_sql(bare, value)
+            if fs:
+                conds.append(fs)
+
         conds: list[str] = []
         for item in measure_def.get("filters__all") or []:
             if isinstance(item, list):
                 for filter_dict in item:
                     if isinstance(filter_dict, dict):
                         for field, value in filter_dict.items():
-                            fs = self._convert_lookml_filter_to_sql(_bare(field), value)
-                            if fs:
-                                conds.append(fs)
+                            _add(field, value)
             elif isinstance(item, dict):
                 field = item.get("field")
                 value = item.get("value")
                 if field and value:
-                    fs = self._convert_lookml_filter_to_sql(_bare(field), value)
-                    if fs:
-                        conds.append(fs)
-        return conds
+                    _add(field, value)
+        return conds, has_cross_view
 
     def _convert_lookml_filter_to_sql(self, field: str, value: str) -> str:
         """Convert a LookML filter value to a SQL condition.
@@ -1139,7 +1154,7 @@ class LookMLAdapter(BaseAdapter):
             # AND-joined predicate for a base measure's OWN filters, with each filter field
             # resolved through the dimension SQL ({model}.state -> ({model}.status) when the
             # dimension renames the column) so the folded aggregate hits the real column.
-            conds = self._measure_filter_conds(m_def, name.lstrip("+"))
+            conds, _ = self._measure_filter_conds(m_def, name.lstrip("+"))
             if not conds:
                 return None
             resolved = []
@@ -1203,7 +1218,7 @@ class LookMLAdapter(BaseAdapter):
                 # foldable predicate slot, so a filtered distinct can't be expanded faithfully
                 # -- leave it out so the referencing expr is skipped with a warning rather than
                 # silently producing an UNfiltered distinct.
-                if not self._measure_filter_conds(m, name.lstrip("+")):
+                if not self._measure_filter_conds(m, name.lstrip("+"))[0]:
                     dm = self._parse_distinct_measure(m_name, m_type, m, resolved_dimension_sql, declared_dim_names)
                     if dm and dm.sql:
                         measure_full_sql_lookup[m_name] = dm.sql
@@ -2075,7 +2090,17 @@ class LookMLAdapter(BaseAdapter):
         # 2. Block syntax: filters: { field: x value: y }
         #    -> lkml returns [{'field': 'flight_length', 'value': '>120'}]
         # We need to handle both formats.
-        filters = self._measure_filter_conds(measure_def, view_name)
+        filters, _filters_cross_view = self._measure_filter_conds(measure_def, view_name)
+        if _filters_cross_view:
+            # A filter references another view inline, which the model CTE cannot resolve; drop the
+            # measure rather than import one whose filter emits invalid SQL (mirrors the cross-view
+            # inline-sql drop).
+            logger.warning(
+                "LookML measure %r has a filter referencing another view inline, which sidemantic "
+                "cannot represent; dropping the measure instead of importing unqueryable SQL.",
+                measure_def.get("name"),
+            )
+            return None
 
         # Replace ${TABLE} and resolve ${dimension_ref} placeholders in SQL
         number_refs_only_columns = False

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -407,14 +407,18 @@ class LookMLAdapter(BaseAdapter):
         # anonymous/engine-specific aggregate), inside an aggregate FILTER (WHERE ...)
         # predicate (sqlglot nests that under exp.Filter, not exp.AggFunc), or inside an
         # ordered-set aggregate's WITHIN GROUP (ORDER BY ...) (nested under exp.WithinGroup,
-        # e.g. PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x)). But a column inside a WINDOW
-        # function (SUM(x) OVER ()) is NOT safe: the window runs after grouping, so a raw
-        # column there is still ungrouped and would be rejected in a grouped SELECT.
+        # e.g. PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x)), or inside a LIST(...) collector
+        # (sqlglot parses DuckDB's LIST as exp.List, and aggregation_detection counts it as an
+        # aggregate -- so this check must agree, else ARRAY_LENGTH(LIST(x)) reads as raw and a
+        # valid measure is dropped). But a column inside a WINDOW function (SUM(x) OVER ()) is
+        # NOT safe: the window runs after grouping, so a raw column there is still ungrouped
+        # and would be rejected in a grouped SELECT.
         return all(
             (
                 c.find_ancestor(exp.AggFunc) is not None
                 or c.find_ancestor(exp.Filter) is not None
                 or c.find_ancestor(exp.WithinGroup) is not None
+                or c.find_ancestor(exp.List) is not None
                 or _in_anon_agg(c)
             )
             and c.find_ancestor(exp.Window) is None

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -363,14 +363,17 @@ class LookMLAdapter(BaseAdapter):
 
     @staticmethod
     def _has_subquery(sql: str) -> bool:
-        """True if ``sql`` contains a SELECT outside any string literal.
+        """True if ``sql`` contains a SELECT outside any quoted token.
 
-        A raw ``\\bselect\\b`` scan also matches the word inside a VALUE, e.g.
-        ``SUM(CASE WHEN status = 'select' THEN amount END)``, which has no subquery and is a
-        perfectly valid inline aggregate. Blank out single-quoted literals first so only real
-        SQL keywords are seen.
+        A raw ``\\bselect\\b`` scan also matches the word inside a VALUE
+        (``SUM(CASE WHEN status = 'select' THEN amount END)``) or inside a quoted IDENTIFIER for a
+        column named after a reserved word (``SUM(${TABLE}."select")``, ``SUM(`select`)``) --
+        neither is a subquery, and both are valid inline aggregates. Blank out every quoted form
+        first -- single-quoted literals, and double-quote / backtick / bracket identifiers (the
+        same protected set the folded-filter splitter uses) -- so only real SQL keywords are seen.
         """
-        return bool(re.search(r"(?is)\bselect\b", re.sub(r"'(?:[^']|'')*'", "''", sql or "")))
+        stripped = re.sub(r"""'(?:[^']|'')*'|"(?:[^"]|"")*"|`[^`]*`|\[[^\]]*\]""", "''", sql or "")
+        return bool(re.search(r"(?is)\bselect\b", stripped))
 
     @classmethod
     def _mixed_is_aggregate_safe(cls, sql: str, is_dim_ref, dim_sql_lookup: dict[str, str] | None = None) -> bool:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -1534,7 +1534,7 @@ class LookMLAdapter(BaseAdapter):
 
         # Handle duration type separately
         if group_type == "duration":
-            return self._parse_duration_group(group_name, dim_group_def)
+            return self._parse_duration_group(group_name, dim_group_def, dimension_sql_lookup)
 
         if group_type != "time":
             return []
@@ -1804,7 +1804,9 @@ class LookMLAdapter(BaseAdapter):
 
         return "\n".join(sql_parts)
 
-    def _parse_duration_group(self, group_name: str, dim_group_def: dict) -> list[Dimension]:
+    def _parse_duration_group(
+        self, group_name: str, dim_group_def: dict, dimension_sql_lookup: dict[str, str] | None = None
+    ) -> list[Dimension]:
         """Parse LookML dimension_group with type: duration.
 
         Duration dimension groups calculate the difference between two timestamps
@@ -1813,6 +1815,7 @@ class LookMLAdapter(BaseAdapter):
         Args:
             group_name: Name of the dimension group
             dim_group_def: Dimension group definition
+            dimension_sql_lookup: Resolved dimension SQL for ${ref} resolution in sql_start/sql_end
 
         Returns:
             List of duration dimensions
@@ -1821,13 +1824,34 @@ class LookMLAdapter(BaseAdapter):
         sql_start = dim_group_def.get("sql_start", "")
         sql_end = dim_group_def.get("sql_end", "")
 
+        # Resolve ${dimension} references (self-view refs normalized to bare ${name}) so a
+        # sql_start/sql_end like ${started_at} becomes the real column instead of leaking the
+        # literal ${...} into DATE_DIFF; ${TABLE} is handled next. Without this the duration
+        # dimension carried an unresolved ${ref} and every query on it emitted invalid SQL.
         if sql_start:
-            sql_start = sql_start.replace("${TABLE}", "{model}")
+            sql_start = self._resolve_dimension_references(sql_start, dimension_sql_lookup or {}).replace(
+                "${TABLE}", "{model}"
+            )
         if sql_end:
-            sql_end = sql_end.replace("${TABLE}", "{model}")
+            sql_end = self._resolve_dimension_references(sql_end, dimension_sql_lookup or {}).replace(
+                "${TABLE}", "{model}"
+            )
 
         # If no sql_start/sql_end, we can't create duration dimensions
         if not sql_start or not sql_end:
+            return []
+
+        # A cross-view reference cannot be represented inline, so an unresolved ${other.field} would
+        # still leak. Drop the whole group rather than import unqueryable duration dimensions
+        # (mirrors _parse_dimension / _parse_dimension_group).
+        if self._leaks_cross_view_ref(sql_start) or self._leaks_cross_view_ref(sql_end):
+            logger.warning(
+                "LookML duration group %r references another view inline (sql_start=%r sql_end=%r), which "
+                "sidemantic cannot represent; dropping the group instead of importing unqueryable SQL.",
+                group_name,
+                sql_start,
+                sql_end,
+            )
             return []
 
         dimensions = []

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -345,21 +345,40 @@ class LookMLAdapter(BaseAdapter):
         except Exception:
             return None
 
+    @staticmethod
+    def _has_subquery(sql: str) -> bool:
+        """True if ``sql`` contains a SELECT outside any string literal.
+
+        A raw ``\\bselect\\b`` scan also matches the word inside a VALUE, e.g.
+        ``SUM(CASE WHEN status = 'select' THEN amount END)``, which has no subquery and is a
+        perfectly valid inline aggregate. Blank out single-quoted literals first so only real
+        SQL keywords are seen.
+        """
+        return bool(re.search(r"(?is)\bselect\b", re.sub(r"'(?:[^']|'')*'", "''", sql or "")))
+
     @classmethod
-    def _mixed_is_aggregate_safe(cls, sql: str, is_dim_ref) -> bool:
+    def _mixed_is_aggregate_safe(cls, sql: str, is_dim_ref, dim_sql_lookup: dict[str, str] | None = None) -> bool:
         """For a ``type: number`` measure that mixes measure refs with dimension refs,
         return True iff every dimension column ends up INSIDE an aggregate (no raw,
         ungrouped column -- which would be a GROUP BY error).
 
-        Probes with measure refs as aggregate-valued constants (``1``) and dimension
-        refs as raw columns (``t.<name>``), then checks via sqlglot that no column sits
-        outside an aggregate. Returns False on any parse failure (treat as unsafe).
+        Probes with measure refs as aggregate-valued constants (``1``) and dimension refs
+        as their RESOLVED SQL (falling back to a raw column ``t.<name>`` for a compact
+        dimension with no explicit sql), then checks via sqlglot that no column sits
+        outside an aggregate. Using the resolved SQL matters for a CONSTANT-valued
+        dimension (``sql: 0.07 ;;``): probing it as ``t.<name>`` would look like a raw
+        ungrouped column and wrongly drop a valid measure such as
+        ``${total} * ${tax_rate}`` (really ``SUM(amount) * 0.07``).
+        Returns False on any parse failure (treat as unsafe).
         """
 
         def _probe(m):
             v, rn = m.group(1), m.group(2)
             if v is None and rn != "TABLE" and is_dim_ref(rn):
-                return f"t.{rn}"
+                # Parenthesized so the substituted expression keeps its precedence; the
+                # caller's {model} -> t replacement below rewrites any table qualifier.
+                dim_sql = (dim_sql_lookup or {}).get(rn)
+                return f"({dim_sql})" if dim_sql else f"t.{rn}"
             return "1"
 
         probe = cls._REF_RE.sub(_probe, sql).replace("{model}", "t")
@@ -1126,7 +1145,7 @@ class LookMLAdapter(BaseAdapter):
             raw = m_def["sql"].replace("${TABLE}", "{model}")
             refs = [(mm.group(1), mm.group(2)) for mm in self._REF_RE.finditer(raw)]
             # Cross-view refs and subqueries have no inline complete-SQL form.
-            if any(v is not None and rn != "TABLE" for v, rn in refs) or re.search(r"(?is)\bselect\b", raw):
+            if any(v is not None and rn != "TABLE" for v, rn in refs) or self._has_subquery(raw):
                 return None
             # Every measure ref must already be resolvable (a dim, a compact dim, or already in
             # the lookup); otherwise retry next round (it may be a later-added number measure).
@@ -1158,7 +1177,9 @@ class LookMLAdapter(BaseAdapter):
             # `outer: ${bad} / NULLIF(COUNT(*), 0)` would inline that raw ungrouped column and
             # fail on grouped queries instead of the unsupported measure being unavailable.
             if not self._mixed_is_aggregate_safe(
-                raw, lambda rn: rn in resolved_dimension_sql or rn in declared_dim_names
+                raw,
+                lambda rn: rn in resolved_dimension_sql or rn in declared_dim_names,
+                resolved_dimension_sql,
             ):
                 return None
             joined = _folded_measure_filter(m_def)
@@ -1889,7 +1910,7 @@ class LookMLAdapter(BaseAdapter):
                 )
                 expand_measures = needs_complete and referenced_measure
                 if needs_complete:
-                    if re.search(r"(?is)\bselect\b", sql):
+                    if self._has_subquery(sql):
                         # A scalar subquery in the expr can't go through the complete-SQL
                         # path: its builder rewrites EVERY parsed column -- including columns
                         # INSIDE the subquery -- to this measure's CTE raw alias, producing a
@@ -1911,7 +1932,11 @@ class LookMLAdapter(BaseAdapter):
                         and m.group(2) not in measure_full_sql_lookup
                         for m in self._REF_RE.finditer(sql)
                     )
-                    if cross_view or unexpandable or not self._mixed_is_aggregate_safe(sql, _is_dim_ref):
+                    if (
+                        cross_view
+                        or unexpandable
+                        or not self._mixed_is_aggregate_safe(sql, _is_dim_ref, dimension_sql_lookup)
+                    ):
                         logger.warning(
                             "LookML number measure %r combines a measure/dimension reference with "
                             "a raw ungrouped column or an unsupported reference, which has no valid "

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -2373,6 +2373,17 @@ class LookMLAdapter(BaseAdapter):
                 )
                 for f in filters
             ]
+            # A filter field that is a local alias for a DROPPED cross-view dimension expands to its
+            # leaked ${other_view.field} SQL above, which the generator would emit into the model
+            # CTE. The measure.sql leak check does not see filters, so reject the measure here.
+            if any(self._leaks_cross_view_ref(f) for f in filters):
+                logger.warning(
+                    "LookML measure %r has a filter that expands to a cross-view reference, which "
+                    "sidemantic cannot represent; dropping the measure instead of importing "
+                    "unqueryable SQL.",
+                    name,
+                )
+                return None
             # The generator filters a complete-SQL measure by nulling the raw columns its SQL
             # references; that drops the filter for a zero-column aggregate (COUNT(*)) and
             # corrupts a NULL-test predicate (status IS NULL). Fold into the aggregate instead.

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -407,12 +407,18 @@ class LookMLAdapter(BaseAdapter):
 
         A raw ``\\bselect\\b`` scan also matches the word inside a VALUE
         (``SUM(CASE WHEN status = 'select' THEN amount END)``) or inside a quoted IDENTIFIER for a
-        column named after a reserved word (``SUM(${TABLE}."select")``, ``SUM(`select`)``) --
-        neither is a subquery, and both are valid inline aggregates. Blank out every quoted form
-        first -- single-quoted literals, and double-quote / backtick / bracket identifiers (the
-        same protected set the folded-filter splitter uses) -- so only real SQL keywords are seen.
+        column named after a reserved word (``SUM(${TABLE}."select")``, ``SUM(`select`)``), or
+        inside a SQL COMMENT (``/* select paid rows */ SUM(amount)``) -- none is a subquery, and all
+        are valid inline aggregates. Blank out every quoted form AND every comment first -- single-
+        quoted literals, double-quote / backtick / bracket identifiers, and ``--``/``/* */``
+        comments -- in one left-to-right pass so a comment inside a string (or a quote inside a
+        comment) is consumed by whichever opens first, leaving only real SQL keywords.
         """
-        stripped = re.sub(r"""'(?:[^']|'')*'|"(?:[^"]|"")*"|`[^`]*`|\[[^\]]*\]""", "''", sql or "")
+        stripped = re.sub(
+            r"""'(?:[^']|'')*'|"(?:[^"]|"")*"|`[^`]*`|\[[^\]]*\]|--[^\n]*|/\*[\s\S]*?\*/""",
+            " ",
+            sql or "",
+        )
         return bool(re.search(r"(?is)\bselect\b", stripped))
 
     @classmethod

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -305,16 +305,29 @@ class LookMLAdapter(BaseAdapter):
         # to true and counts the row; (2) a keyed symmetric-distinct aggregate hashes the key
         # (`HASH(col)`), and HASH(NULL) is a non-NULL constant, so the row still contributes
         # (garbage). In those cases fold the filter into the aggregate predicate instead.
-        # (3) a CASE with an ELSE default also survives nulling: nulling the predicate's column
-        # only makes the WHEN false, and ELSE still yields a non-NULL value, so the aggregate
-        # keeps counting the excluded row -- e.g. COUNT(CASE WHEN status='completed' THEN 1
-        # ELSE 0 END) returns EVERY row rather than the filtered ones.
+        # (3) a conditional with a non-NULL DEFAULT branch also survives nulling: nulling the
+        # predicate's column only makes the condition false, and the default still yields a
+        # non-NULL value, so the aggregate keeps counting the excluded row -- e.g.
+        # COUNT(CASE WHEN status='completed' THEN 1 ELSE 0 END) or its IF/IFF spellings return
+        # EVERY row rather than the filtered ones. Covers:
+        #   - CASE ... ELSE <x>            -> exp.Case with a `default`
+        #   - IF(cond, a, b)               -> exp.If with a non-None `false` branch. A CASE's own
+        #                                     WHEN clauses are exp.If with false=None, so a plain
+        #                                     CASE (no ELSE) is NOT matched here.
+        #   - IFF(cond, a, b) (Snowflake)  -> parsed as exp.Anonymous with 3 args
+        # (NVL / IFNULL already parse as exp.Coalesce, covered above.)
         case_with_default = any(c.args.get("default") is not None for c in tree.find_all(exp.Case))
+        if_with_default = any(n.args.get("false") is not None for n in tree.find_all(exp.If))
+        iff_with_default = any(
+            (n.name or "").lower() in ("iff", "if") and len(n.expressions) >= 3 for n in tree.find_all(exp.Anonymous)
+        )
         unsafe_nulling = (
             tree.find(exp.Is) is not None
             or tree.find(exp.Coalesce) is not None
             or "hash(" in sql.lower()
             or case_with_default
+            or if_with_default
+            or iff_with_default
         )
         # Otherwise, if every aggregate already references a column the generator can null
         # (nulling the value/ORDER-BY column filters it; aggregates ignore NULLs), the

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -153,48 +153,249 @@ class LookMLAdapter(BaseAdapter):
         for explore_def in parsed.get("explores") or []:
             self._parse_explore(explore_def, graph)
 
-    def _resolve_dimension_references(self, sql: str, dimension_sql_lookup: dict[str, str], max_depth: int = 10) -> str:
-        """Resolve ${dimension_name} references in SQL expressions.
+    # Matches ${field} and ${view.field}. ${TABLE} is handled specially.
+    _REF_RE = re.compile(r"\$\{(?:([a-zA-Z_]\w*)\.)?([a-zA-Z_]\w*)\}")
 
-        This handles LookML's dimension reference syntax where measures and dimensions
-        can reference other dimensions using ${dimension_name}. It handles recursive
-        resolution when a dimension references another dimension.
+    @staticmethod
+    def _strip_self_view_qualifiers(view_def: dict, view_name: str) -> dict:
+        """Rewrite ``${view_name.field}`` -> ``${field}`` in this view's SQL.
+
+        In LookML a self-qualified reference (``${this_view.field}``) is identical
+        to the bare ``${field}``. Normalizing it here (in place) lets the
+        bare-reference resolver handle it instead of leaking the literal ``${...}``
+        into generated SQL (which the database rejects).
+        """
+        pat = re.compile(r"\$\{" + re.escape(view_name) + r"\.([a-zA-Z_]\w*)\}")
+
+        def fix(value):
+            return pat.sub(r"${\1}", value) if isinstance(value, str) else value
+
+        for key in ("dimensions", "dimension_groups", "measures"):
+            for item in view_def.get(key) or []:
+                if not isinstance(item, dict):
+                    continue
+                for sql_key in ("sql", "sql_start", "sql_end", "sql_distinct_key"):
+                    if sql_key in item:
+                        item[sql_key] = fix(item[sql_key])
+        derived = view_def.get("derived_table")
+        if isinstance(derived, dict) and "sql" in derived:
+            derived["sql"] = fix(derived["sql"])
+        return view_def
+
+    def _resolve_dimension_references(
+        self,
+        sql: str,
+        dimension_sql_lookup: dict[str, str],
+        max_depth: int = 10,
+        dimension_names: set[str] | None = None,
+    ) -> str:
+        """Resolve ``${dimension}`` references in a SQL expression.
+
+        Handles LookML's reference syntax where dimensions/measures reference other
+        dimensions via ``${name}``. Resolution is recursive (a dimension may
+        reference another dimension) with cycle detection, so acyclic chains of any
+        depth resolve fully and circular references terminate instead of either
+        looping forever or silently truncating at a fixed depth.
+
+        ``${TABLE}`` is left untouched (handled separately). Self-view qualifiers
+        are expected to have been normalized away already (see
+        ``_strip_self_view_qualifiers``); any remaining ``${view.field}`` is a
+        cross-view reference, which sidemantic cannot represent inline, so it is
+        emitted as a qualified column ``view.field`` with a warning rather than
+        leaking the literal ``${...}`` (a guaranteed SQL syntax error).
 
         Args:
-            sql: SQL expression that may contain ${dimension_name} references
-            dimension_sql_lookup: Dict mapping dimension names to their SQL expressions
-            max_depth: Maximum recursion depth to prevent infinite loops
+            sql: SQL expression that may contain ``${...}`` references.
+            dimension_sql_lookup: Map of dimension name -> its SQL expression.
+            max_depth: Retained for compatibility; cycle detection is authoritative.
 
         Returns:
-            SQL with all dimension references resolved
+            SQL with references resolved.
         """
-        if not sql or max_depth <= 0:
+        if not sql:
             return sql
 
-        # Pattern to match ${name} but NOT ${TABLE} or ${model.field}
-        pattern = r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}"
-
-        def replace_ref(match: re.Match) -> str:
-            ref_name = match.group(1)
-            if ref_name == "TABLE":
-                # Keep ${TABLE} as-is, it's handled separately
+        def resolve(text: str, path: frozenset) -> str:
+            def replace_ref(match: re.Match) -> str:
+                view, name = match.group(1), match.group(2)
+                if view is None and name == "TABLE":
+                    return match.group(0)
+                if view is not None:
+                    # Cross-view reference (self-view already normalized away).
+                    # Sidemantic cannot represent an inline cross-model column, so
+                    # leave the ${view.field} literal and warn rather than emitting a
+                    # qualified column that the generator can't join (which would
+                    # produce wrong SQL or fail with "no join path").
+                    logger.warning(
+                        "LookML cross-view reference ${%s.%s} is not supported (sidemantic "
+                        "has no inline cross-model column); left unresolved.",
+                        view,
+                        name,
+                    )
+                    return match.group(0)
+                if name in dimension_sql_lookup:
+                    if name in path:
+                        # Circular reference: stop expanding to avoid infinite loop.
+                        return match.group(0)
+                    return f"({resolve(dimension_sql_lookup[name], path | {name})})"
+                if dimension_names and name in dimension_names:
+                    # Compact dimension (declared with no explicit sql) -> its default
+                    # column. Without this the literal ${name} would leak into SQL.
+                    return f"({{model}}.{name})"
+                # Unknown bare reference: leave as-is.
                 return match.group(0)
-            if ref_name in dimension_sql_lookup:
-                # Return the dimension's SQL, wrapped in parentheses for safety
-                return f"({dimension_sql_lookup[ref_name]})"
-            # Unknown reference, keep as-is
-            return match.group(0)
 
-        resolved = re.sub(pattern, replace_ref, sql)
+            return self._REF_RE.sub(replace_ref, text)
 
-        # If we made changes and there are still references, recurse
-        if resolved != sql and re.search(pattern, resolved):
-            # Check if remaining refs are just ${TABLE} or unknown
-            remaining_refs = re.findall(pattern, resolved)
-            if any(ref != "TABLE" and ref in dimension_sql_lookup for ref in remaining_refs):
-                return self._resolve_dimension_references(resolved, dimension_sql_lookup, max_depth - 1)
+        return resolve(sql, frozenset())
 
-        return resolved
+    @classmethod
+    def _fold_complete_sql_filters(cls, sql: str, filters: list[str]) -> str | None:
+        """Fold measure ``filters`` INTO a complete-SQL aggregate when the generator's
+        column-nulling can't apply them safely.
+
+        The generator filters an opaque complete-SQL measure by projecting each column the
+        SQL references wrapped in ``CASE WHEN <filter> THEN col ELSE NULL END``; the outer
+        aggregate then ignores the NULLs. That works for ``SUM(amount)`` but is WRONG in two
+        cases: (1) a ZERO-column aggregate like ``COUNT(*)`` has no column to null so the
+        filter is silently dropped (and a mix like ``COUNT(*) / COUNT(DISTINCT id)`` filters
+        inconsistently); (2) the SQL tests a filter-affected column for NULL (``col IS NULL``
+        / ``COALESCE(col, ...)``) -- nulling the column to EXCLUDE a row instead makes
+        ``col IS NULL`` true, COUNTING the excluded row. In either case rewrite EVERY
+        aggregate to carry the filter via a portable ``CASE WHEN`` inside its argument and
+        return the new SQL (caller then clears ``filters``). Returns None to leave the SQL
+        and filters untouched -- the common all-columns/no-null-test case (generator handles
+        it) or any parse failure (fall back to the existing path).
+        """
+        import sqlglot
+        from sqlglot import expressions as exp
+
+        from sidemantic.sql.aggregation_detection import _ANONYMOUS_AGGREGATE_FUNCTIONS
+
+        def _case(cond, then):
+            return exp.Case(ifs=[exp.If(this=cond, true=then)])
+
+        try:
+            tree = sqlglot.parse_one(sql.replace("{model}", "__MODEL__"))
+            parsed_conds = [sqlglot.parse_one(f.replace("{model}", "__MODEL__")) for f in filters]
+        except Exception:
+            return None
+        # Include recognized ANONYMOUS aggregates (PRODUCT/ENTROPY/WEIGHTED_AVG/... which
+        # sqlglot parses as exp.Anonymous, not exp.AggFunc) so a filter is folded into them
+        # too -- otherwise a mix like PRODUCT(amount) / COUNT(*) would fold only the COUNT,
+        # clear the filters, and leave PRODUCT computed over ALL rows.
+        aggs = list(tree.find_all(exp.AggFunc))
+        aggs += [n for n in tree.find_all(exp.Anonymous) if (n.name or "").lower() in _ANONYMOUS_AGGREGATE_FUNCTIONS]
+        if not aggs or not parsed_conds:
+            return None
+
+        # An ordered-set aggregate (PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x)) keeps its
+        # value column in the enclosing WithinGroup's ORDER BY, NOT inside the AggFunc (whose
+        # only arg is the percentile constant). Its "aggregate scope" for the column check and
+        # for folding is therefore the WithinGroup.
+        def _scope(a):
+            wg = a.find_ancestor(exp.WithinGroup)
+            return wg if wg is not None else a
+
+        # Column-nulling is UNSAFE when nulling a filter-affected column to EXCLUDE a row does
+        # NOT actually exclude it: (1) a NULL-test (`col IS NULL` / `COALESCE(col, ...)`) flips
+        # to true and counts the row; (2) a keyed symmetric-distinct aggregate hashes the key
+        # (`HASH(col)`), and HASH(NULL) is a non-NULL constant, so the row still contributes
+        # (garbage). In those cases fold the filter into the aggregate predicate instead.
+        unsafe_nulling = tree.find(exp.Is) is not None or tree.find(exp.Coalesce) is not None or "hash(" in sql.lower()
+        # Otherwise, if every aggregate already references a column the generator can null
+        # (nulling the value/ORDER-BY column filters it; aggregates ignore NULLs), the
+        # existing path is correct AND consistent -> don't rewrite.
+        if not unsafe_nulling and all(any(True for _ in _scope(a).find_all(exp.Column)) for a in aggs):
+            return None
+
+        def _combined():
+            c = parsed_conds[0].copy()
+            for p in parsed_conds[1:]:
+                c = exp.And(this=c, expression=p.copy())
+            return c
+
+        for a in aggs:
+            wg = a.find_ancestor(exp.WithinGroup)
+            if wg is not None:
+                # Ordered-set aggregate: fold into the ORDER BY value(s), never the percentile
+                # constant (PERCENTILE_CONT(CASE ...) would be a non-constant parameter).
+                for ordered in wg.find_all(exp.Ordered):
+                    ordered.set("this", _case(_combined(), ordered.this.copy()))
+                continue
+            if isinstance(a, exp.Anonymous):
+                # Anonymous aggregate: its arguments live in .expressions (not .this, which is
+                # the function name), so wrap each argument to carry the filter.
+                a.set("expressions", [_case(_combined(), e.copy()) for e in a.expressions])
+                continue
+            arg = a.this
+            if isinstance(arg, exp.Distinct):
+                arg.set("expressions", [_case(_combined(), e.copy()) for e in arg.expressions])
+            elif arg is None or isinstance(arg, exp.Star):
+                a.set("this", _case(_combined(), exp.Literal.number(1)))
+            else:
+                a.set("this", _case(_combined(), arg.copy()))
+        try:
+            return tree.sql().replace("__MODEL__", "{model}")
+        except Exception:
+            return None
+
+    @classmethod
+    def _mixed_is_aggregate_safe(cls, sql: str, is_dim_ref) -> bool:
+        """For a ``type: number`` measure that mixes measure refs with dimension refs,
+        return True iff every dimension column ends up INSIDE an aggregate (no raw,
+        ungrouped column -- which would be a GROUP BY error).
+
+        Probes with measure refs as aggregate-valued constants (``1``) and dimension
+        refs as raw columns (``t.<name>``), then checks via sqlglot that no column sits
+        outside an aggregate. Returns False on any parse failure (treat as unsafe).
+        """
+
+        def _probe(m):
+            v, rn = m.group(1), m.group(2)
+            if v is None and rn != "TABLE" and is_dim_ref(rn):
+                return f"t.{rn}"
+            return "1"
+
+        probe = cls._REF_RE.sub(_probe, sql).replace("{model}", "t")
+        try:
+            import sqlglot
+            from sqlglot import expressions as exp
+
+            from sidemantic.sql.aggregation_detection import _ANONYMOUS_AGGREGATE_FUNCTIONS
+
+            tree = sqlglot.parse_one(probe)
+        except Exception:
+            return False
+
+        def _in_anon_agg(c) -> bool:
+            # sqlglot parses some engine-specific aggregates (PRODUCT, ENTROPY, WEIGHTED_AVG,
+            # ...) as exp.Anonymous, not exp.AggFunc; a column inside one is still aggregate-
+            # scoped (sidemantic treats these as aggregates in aggregation_detection).
+            node = c.parent
+            while node is not None:
+                if isinstance(node, exp.Anonymous) and (node.name or "").lower() in _ANONYMOUS_AGGREGATE_FUNCTIONS:
+                    return True
+                node = node.parent
+            return False
+
+        # A column is aggregate-scoped if it is inside an aggregate function (incl. an
+        # anonymous/engine-specific aggregate), inside an aggregate FILTER (WHERE ...)
+        # predicate (sqlglot nests that under exp.Filter, not exp.AggFunc), or inside an
+        # ordered-set aggregate's WITHIN GROUP (ORDER BY ...) (nested under exp.WithinGroup,
+        # e.g. PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x)). But a column inside a WINDOW
+        # function (SUM(x) OVER ()) is NOT safe: the window runs after grouping, so a raw
+        # column there is still ungrouped and would be rejected in a grouped SELECT.
+        return all(
+            (
+                c.find_ancestor(exp.AggFunc) is not None
+                or c.find_ancestor(exp.Filter) is not None
+                or c.find_ancestor(exp.WithinGroup) is not None
+                or _in_anon_agg(c)
+            )
+            and c.find_ancestor(exp.Window) is None
+            for c in tree.find_all(exp.Column)
+        )
 
     # Plain decimal numeric literal: optional sign, then digits with optional fraction,
     # or a bare fraction. Deliberately excludes Python-/float()-only spellings that this
@@ -284,6 +485,42 @@ class LookMLAdapter(BaseAdapter):
         r"monday|tuesday|wednesday|thursday|friday|saturday|sunday|"
         r"week|month|year)\b"
     )
+
+    def _measure_filter_conds(self, measure_def: dict, view_name: str | None = None) -> list[str]:
+        """Convert a measure's LookML ``filters`` to a list of SQL condition strings.
+
+        Handles both the shorthand list-of-dicts (``filters: [status: "x"]``) and the
+        block (``filter: { field: ...  value: ... }``) syntaxes that ``lkml`` collapses
+        into ``filters__all``. A SELF-view qualifier (``<this_view>.status``) is stripped
+        so the converter builds ``{model}.status``; a CROSS-view qualifier
+        (``other_view.field``) is left intact -- collapsing it to a same-named local field
+        would silently retarget the filter (e.g. GA360's ``hits.isInteraction``).
+        """
+
+        def _bare(field: str) -> str:
+            if isinstance(field, str) and view_name and field.startswith(f"{view_name}."):
+                rest = field[len(view_name) + 1 :]
+                if re.fullmatch(r"\w+", rest):
+                    return rest
+            return field
+
+        conds: list[str] = []
+        for item in measure_def.get("filters__all") or []:
+            if isinstance(item, list):
+                for filter_dict in item:
+                    if isinstance(filter_dict, dict):
+                        for field, value in filter_dict.items():
+                            fs = self._convert_lookml_filter_to_sql(_bare(field), value)
+                            if fs:
+                                conds.append(fs)
+            elif isinstance(item, dict):
+                field = item.get("field")
+                value = item.get("value")
+                if field and value:
+                    fs = self._convert_lookml_filter_to_sql(_bare(field), value)
+                    if fs:
+                        conds.append(fs)
+        return conds
 
     def _convert_lookml_filter_to_sql(self, field: str, value: str) -> str:
         """Convert a LookML filter value to a SQL condition.
@@ -695,6 +932,10 @@ class LookMLAdapter(BaseAdapter):
         if not name:
             return None
 
+        # Normalize self-view-qualified references (${this_view.field} -> ${field})
+        # so they resolve like bare references instead of leaking literal ${...}.
+        view_def = self._strip_self_view_qualifiers(view_def, name.lstrip("+"))
+
         # Get table name
         table = view_def.get("sql_table_name")
 
@@ -732,11 +973,24 @@ class LookMLAdapter(BaseAdapter):
                     if timeframe != "raw":
                         dimension_sql_lookup[f"{group_name}_{timeframe}"] = group_sql
 
+        # All declared dimension names (including compact dimensions with no explicit
+        # sql), so ${ref}s to a compact dimension resolve to its default column rather
+        # than leaking the literal ${name}.
+        declared_dim_names: set[str] = {d.get("name") for d in dimension_defs if d.get("name")}
+        for dim_group_def in view_def.get("dimension_groups") or []:
+            group_name = dim_group_def.get("name")
+            if group_name:
+                for timeframe in dim_group_def.get("timeframes", ["date"]):
+                    if timeframe != "raw":
+                        declared_dim_names.add(f"{group_name}_{timeframe}")
+
         # Resolve any dimension-to-dimension references in the lookup
         # (e.g., line_total references quantity, unit_price, line_discount)
         resolved_dimension_sql: dict[str, str] = {}
         for dim_name, dim_sql in dimension_sql_lookup.items():
-            resolved_sql = self._resolve_dimension_references(dim_sql, dimension_sql_lookup)
+            resolved_sql = self._resolve_dimension_references(
+                dim_sql, dimension_sql_lookup, dimension_names=declared_dim_names
+            )
             resolved_dimension_sql[dim_name] = resolved_sql
 
         # Parse dimensions with resolved SQL
@@ -767,20 +1021,95 @@ class LookMLAdapter(BaseAdapter):
         # measure's own aggregate function.
         measure_names: set[str] = set()
         measure_agg_lookup: dict[str, str] = {}
+        # Full resolved aggregate SQL per measure (e.g. total -> "SUM({model}.amount)"),
+        # used to expand a measure ref inside an aggregate-safe mixed number measure into
+        # its base aggregate over the REAL column (not a phantom {model}.<measure>).
+        measure_full_sql_lookup: dict[str, str] = {}
+
+        def _folded_measure_filter(m_def):
+            # AND-joined predicate for a base measure's OWN filters, with each filter field
+            # resolved through the dimension SQL ({model}.state -> ({model}.status) when the
+            # dimension renames the column) so the folded aggregate hits the real column.
+            conds = self._measure_filter_conds(m_def, name.lstrip("+"))
+            if not conds:
+                return None
+            resolved = []
+            for c in conds:
+                c = re.sub(
+                    r"\{model\}\.(\w+)",
+                    lambda mm: f"({resolved_dimension_sql[mm.group(1)]})"
+                    if mm.group(1) in resolved_dimension_sql
+                    else mm.group(0),
+                    c,
+                )
+                resolved.append(f"({c})")
+            return " AND ".join(resolved)
+
         for m in view_def.get("measures") or []:
             m_name = m.get("name")
             if not m_name:
                 continue
             measure_names.add(m_name)
-            agg_template = self._SQL_AGG_FUNC.get(m.get("type", "count"))
+            m_type = m.get("type", "count")
+            agg_template = self._SQL_AGG_FUNC.get(m_type)
             if agg_template:
                 measure_agg_lookup[m_name] = agg_template
+                m_sql = m.get("sql")
+                if m_sql:
+                    col = self._resolve_dimension_references(
+                        m_sql.replace("${TABLE}", "{model}"),
+                        resolved_dimension_sql,
+                        dimension_names=declared_dim_names,
+                    )
+                    # Fold the base measure's OWN LookML filters into its aggregate so a
+                    # mixed-expr expansion of a filtered measure (e.g. completed_total with
+                    # filters: [status: "completed"]) keeps the filter, not SUM(amount).
+                    joined = _folded_measure_filter(m)
+                    if m_type == "count" and col.strip() == "*":
+                        # `type: count sql: * ;;` is the row-count form; `*` can't live inside
+                        # a CASE, so route it through the no-sql count path instead of emitting
+                        # an invalid COUNT(CASE WHEN ... THEN * END).
+                        measure_full_sql_lookup[m_name] = (
+                            f"COUNT(CASE WHEN {joined} THEN 1 END)" if joined else "COUNT(*)"
+                        )
+                    else:
+                        if joined:
+                            col = f"CASE WHEN {joined} THEN {col} END"
+                        measure_full_sql_lookup[m_name] = agg_template.format(col)
+                elif m_type == "count":
+                    # type: count with no sql -> COUNT(*); fold the measure's own filters
+                    # so a filtered count (completed_count) keeps its filter in a mixed-expr
+                    # expansion instead of counting all rows.
+                    joined = _folded_measure_filter(m)
+                    if joined:
+                        measure_full_sql_lookup[m_name] = f"COUNT(CASE WHEN {joined} THEN 1 END)"
+                    else:
+                        measure_full_sql_lookup[m_name] = "COUNT(*)"
+            elif m_type in ("sum_distinct", "average_distinct", "median_distinct", "percentile_distinct"):
+                # Supported distinct aggregates: reuse _parse_distinct_measure's generated SQL
+                # so a complete `type: number` expression that references one (e.g.
+                # ${sum_distinct_total} / SUM(${amount})) can EXPAND it instead of being
+                # dropped as unexpandable. Only expand UNFILTERED distinct measures: their
+                # SQL (esp. the keyed symmetric-aggregate / quantile forms) has no single
+                # foldable predicate slot, so a filtered distinct can't be expanded faithfully
+                # -- leave it out so the referencing expr is skipped with a warning rather than
+                # silently producing an UNfiltered distinct.
+                if not self._measure_filter_conds(m, name.lstrip("+")):
+                    dm = self._parse_distinct_measure(m_name, m_type, m, resolved_dimension_sql, declared_dim_names)
+                    if dm and dm.sql:
+                        measure_full_sql_lookup[m_name] = dm.sql
 
         # Parse measures with dimension SQL lookup for reference resolution
         measures = []
         for measure_def in view_def.get("measures") or []:
             measure = self._parse_measure(
-                measure_def, dimension_names, resolved_dimension_sql, measure_names, measure_agg_lookup
+                measure_def,
+                dimension_names,
+                resolved_dimension_sql,
+                measure_names,
+                measure_agg_lookup,
+                measure_full_sql_lookup,
+                view_name=name.lstrip("+"),
             )
             if measure:
                 measures.append(measure)
@@ -1246,6 +1575,8 @@ class LookMLAdapter(BaseAdapter):
         dimension_sql_lookup: dict[str, str] | None = None,
         measure_names: set[str] | None = None,
         measure_agg_lookup: dict[str, str] | None = None,
+        measure_full_sql_lookup: dict[str, str] | None = None,
+        view_name: str | None = None,
     ) -> Metric | None:
         """Parse LookML measure.
 
@@ -1265,6 +1596,8 @@ class LookMLAdapter(BaseAdapter):
 
         dimension_names = dimension_names or set()
         dimension_sql_lookup = dimension_sql_lookup or {}
+        measure_agg_lookup = measure_agg_lookup or {}
+        measure_full_sql_lookup = measure_full_sql_lookup or {}
 
         # Check if type is explicitly set
         has_explicit_type = "type" in measure_def
@@ -1309,7 +1642,7 @@ class LookMLAdapter(BaseAdapter):
             if not sql:
                 return None  # Skip placeholder percentile measures without SQL
             sql = sql.replace("${TABLE}", "{model}")
-            sql = self._resolve_dimension_references(sql, dimension_sql_lookup or {})
+            sql = self._resolve_dimension_references(sql, dimension_sql_lookup or {}, dimension_names=dimension_names)
             percentile_value = measure_def.get("percentile", 50)
             fraction = float(percentile_value) / 100.0
             percentile_sql = f"PERCENTILE_CONT({fraction}) WITHIN GROUP (ORDER BY {sql})"
@@ -1332,7 +1665,9 @@ class LookMLAdapter(BaseAdapter):
             sql = measure_def.get("sql")
             if sql:
                 sql = sql.replace("${TABLE}", "{model}")
-                sql = self._resolve_dimension_references(sql, dimension_sql_lookup or {})
+                sql = self._resolve_dimension_references(
+                    sql, dimension_sql_lookup or {}, dimension_names=dimension_names
+                )
                 list_sql = f"STRING_AGG(DISTINCT {sql}, ', ')"
                 meta = {}
                 if measure_def.get("hidden") in ("yes", True):
@@ -1354,7 +1689,7 @@ class LookMLAdapter(BaseAdapter):
         # (e.g. caused by join fanout) using sql_distinct_key when present.
         # Looker: sum_distinct, average_distinct, median_distinct, percentile_distinct.
         if measure_type in ("sum_distinct", "average_distinct", "median_distinct", "percentile_distinct"):
-            return self._parse_distinct_measure(name, measure_type, measure_def, dimension_sql_lookup)
+            return self._parse_distinct_measure(name, measure_type, measure_def, dimension_sql_lookup, dimension_names)
 
         # Handle post-SQL / table-calculation measure types. These reference
         # another numeric measure and compute a column-wise calculation.
@@ -1395,28 +1730,10 @@ class LookMLAdapter(BaseAdapter):
         # 2. Block syntax: filters: { field: x value: y }
         #    -> lkml returns [{'field': 'flight_length', 'value': '>120'}]
         # We need to handle both formats.
-        filters = []
-        filters_all = measure_def.get("filters__all") or []
-        if filters_all:
-            for item in filters_all:
-                if isinstance(item, list):
-                    # Format 1: Shorthand syntax - list of dicts with field:value pairs
-                    for filter_dict in item:
-                        if isinstance(filter_dict, dict):
-                            for field, value in filter_dict.items():
-                                filter_sql = self._convert_lookml_filter_to_sql(field, value)
-                                if filter_sql:
-                                    filters.append(filter_sql)
-                elif isinstance(item, dict):
-                    # Format 2: Block syntax - dict with 'field' and 'value' keys
-                    field = item.get("field")
-                    value = item.get("value")
-                    if field and value:
-                        filter_sql = self._convert_lookml_filter_to_sql(field, value)
-                        if filter_sql:
-                            filters.append(filter_sql)
+        filters = self._measure_filter_conds(measure_def, view_name)
 
         # Replace ${TABLE} and resolve ${dimension_ref} placeholders in SQL
+        number_refs_only_columns = False
         sql = measure_def.get("sql")
         if sql:
             sql = sql.replace("${TABLE}", "{model}")
@@ -1427,21 +1744,128 @@ class LookMLAdapter(BaseAdapter):
                 # We need to distinguish measure references from dimension references:
                 # - ${measure_name} where measure_name is NOT a dimension -> plain measure_name
                 # - ${dimension_name} -> resolved SQL from dimension
+                # Pre-scan the refs: a derived metric is a metric-of-metrics, so it can
+                # carry measure references OR raw dimension columns. A mix is representable
+                # ONLY when every dimension column ends up inside an aggregate (so there is
+                # no raw, ungrouped column); then we expand each measure ref to its base
+                # aggregate SQL and emit opaque complete SQL. A mix with a raw ungrouped
+                # column has no valid SQL form and is skipped with a warning.
+                def _is_dim_ref(rn):
+                    return rn in dimension_sql_lookup or rn in dimension_names
+
+                referenced_measure = False
+                referenced_dimension = False
+                for _m in self._REF_RE.finditer(sql):
+                    _v, _rn = _m.group(1), _m.group(2)
+                    if _v is not None or _rn == "TABLE":
+                        continue
+                    if _is_dim_ref(_rn):
+                        referenced_dimension = True
+                    else:
+                        referenced_measure = True
+
+                from sidemantic.sql.aggregation_detection import sql_has_aggregate
+
+                # An expression needs OPAQUE/complete SQL (not a metric-of-metrics derived
+                # metric) when it mixes a measure ref with a dimension ref, OR it contains
+                # an INLINE aggregate (SUM(...)/COUNT(*)/...). In both, the derived-metric
+                # path mishandles it: a raw dimension column or an inline aggregate makes
+                # the generator skip dependency replacement, leaving bare measure tokens
+                # that reference nonexistent columns. So expand measure refs to their base
+                # aggregate SQL and mark the whole thing complete. Pure metric-of-metrics
+                # ratios (no inline aggregate, no dimension) stay derived.
+                # Detect inline aggregates on a ref-NEUTRALIZED copy: raw ${ref} placeholders
+                # break sqlglot's parser, forcing the regex fallback, which misses multi-word
+                # aggregates like PERCENTILE_CONT(...) WITHIN GROUP (ORDER BY ${x}). Replacing
+                # every ${...}/{model} with a plain identifier lets sqlglot see the real agg.
+                has_inline_agg = sql_has_aggregate(self._REF_RE.sub("x", sql).replace("{model}", "x"))
+                needs_complete = (referenced_measure and referenced_dimension) or has_inline_agg
+                expand_measures = needs_complete and referenced_measure
+                if needs_complete:
+                    if re.search(r"(?is)\bselect\b", sql):
+                        # A scalar subquery in the expr can't go through the complete-SQL
+                        # path: its builder rewrites EVERY parsed column -- including columns
+                        # INSIDE the subquery -- to this measure's CTE raw alias, producing a
+                        # wrong correlated query. No faithful form, so skip on import.
+                        logger.warning(
+                            "LookML number measure %r contains a subquery, which the complete-SQL "
+                            "path cannot represent (it would rewrite the subquery's columns); "
+                            "skipping on import.",
+                            name,
+                        )
+                        return None
+                    cross_view = any(
+                        m.group(1) is not None and m.group(2) != "TABLE" for m in self._REF_RE.finditer(sql)
+                    )
+                    unexpandable = expand_measures and any(
+                        m.group(1) is None
+                        and m.group(2) != "TABLE"
+                        and not _is_dim_ref(m.group(2))
+                        and m.group(2) not in measure_full_sql_lookup
+                        for m in self._REF_RE.finditer(sql)
+                    )
+                    if cross_view or unexpandable or not self._mixed_is_aggregate_safe(sql, _is_dim_ref):
+                        logger.warning(
+                            "LookML number measure %r combines a measure/dimension reference with "
+                            "a raw ungrouped column or an unsupported reference, which has no valid "
+                            "aggregate SQL form; skipping on import.",
+                            name,
+                        )
+                        return None
+
                 def resolve_reference(match):
-                    ref_name = match.group(1)
+                    view, ref_name = match.group(1), match.group(2)
+                    if view is None and ref_name == "TABLE":
+                        return match.group(0)
+                    if view is not None:
+                        # Cross-view ref (self-view already normalized away): sidemantic
+                        # cannot represent an inline cross-model column, so leave the
+                        # literal and warn rather than emitting a column the derived
+                        # metric builder can't resolve (it would fail with "no join path").
+                        logger.warning(
+                            "LookML cross-view reference ${%s.%s} is not supported (sidemantic "
+                            "has no inline cross-model column); left unresolved.",
+                            view,
+                            ref_name,
+                        )
+                        return match.group(0)
                     if ref_name in dimension_sql_lookup:
                         # It's a dimension reference - use the resolved SQL
                         return f"({dimension_sql_lookup[ref_name]})"
-                    else:
-                        # It's a measure reference - use plain measure_name
-                        # The dependency analyzer will resolve this
-                        return ref_name
+                    if ref_name in dimension_names:
+                        # Compact dimension (no explicit sql) -> its default column.
+                        return f"({{model}}.{ref_name})"
+                    if expand_measures:
+                        # Complete expr: expand the measure ref to its base aggregate over
+                        # the REAL column so the whole thing is valid opaque SQL (e.g.
+                        # total -> SUM({model}.amount)).
+                        return f"({measure_full_sql_lookup[ref_name]})"
+                    # It's a measure reference - use plain measure_name; the
+                    # dependency analyzer will resolve this.
+                    return ref_name
 
-                sql = re.sub(r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}", resolve_reference, sql)
+                sql = self._REF_RE.sub(resolve_reference, sql)
+
+                # A number measure that references ONLY raw dimension columns with NO
+                # aggregate (e.g. ${amount} / 2) is a row-level expression, not a valid
+                # aggregate measure: as a metric it returns one value per input row, not a
+                # scalar. It belongs as a dimension, so skip it with a warning rather than
+                # emit a measure with wrong cardinality.
+                if not needs_complete and not referenced_measure and referenced_dimension and bool(sql):
+                    logger.warning(
+                        "LookML number measure %r is a row-level dimension expression (no "
+                        "aggregate); it would return one row per input row, so it is skipped "
+                        "on import (define it as a dimension instead).",
+                        name,
+                    )
+                    return None
+                # Complete exprs (mixed or inline-aggregate, measure refs expanded above)
+                # are opaque SQL; pure metric-of-metrics ratios stay derived metrics.
+                number_refs_only_columns = needs_complete
             else:
                 # For regular aggregation measures (sum, avg, count_distinct, etc.),
                 # resolve dimension references to their SQL expressions
-                sql = self._resolve_dimension_references(sql, dimension_sql_lookup)
+                sql = self._resolve_dimension_references(sql, dimension_sql_lookup, dimension_names=dimension_names)
 
         # Determine if this is a derived/ratio metric
         metric_type = None
@@ -1467,11 +1891,35 @@ class LookMLAdapter(BaseAdapter):
         if measure_def.get("tags"):
             meta["tags"] = measure_def["tags"]
 
+        # A COMPLETE (opaque) measure's filters are applied by the generator without
+        # resolving dimension refs (it just strips {model}), so resolve {model}.<dim> to
+        # the dimension's real column SQL here -- a renamed dimension's filter must hit the
+        # actual column (status), not the dimension name (state).
+        if number_refs_only_columns and filters:
+            filters = [
+                re.sub(
+                    r"\{model\}\.(\w+)",
+                    lambda mm: f"({dimension_sql_lookup[mm.group(1)]})"
+                    if mm.group(1) in dimension_sql_lookup
+                    else mm.group(0),
+                    f,
+                )
+                for f in filters
+            ]
+            # The generator filters a complete-SQL measure by nulling the raw columns its SQL
+            # references; that drops the filter for a zero-column aggregate (COUNT(*)) and
+            # corrupts a NULL-test predicate (status IS NULL). Fold into the aggregate instead.
+            folded = self._fold_complete_sql_filters(sql, filters)
+            if folded is not None:
+                sql = folded
+                filters = None
+
         return Metric(
             name=name,
             type=metric_type,
             agg=agg_type,
             sql=sql,
+            sql_is_complete=number_refs_only_columns,
             filters=filters if filters else None,
             description=measure_def.get("description"),
             label=measure_def.get("label"),
@@ -1500,6 +1948,7 @@ class LookMLAdapter(BaseAdapter):
         measure_type: str,
         measure_def: dict,
         dimension_sql_lookup: dict[str, str],
+        dimension_names: set[str] | None = None,
     ) -> Metric | None:
         """Parse a distinct aggregate measure (sum/average/median/percentile_distinct).
 
@@ -1523,12 +1972,14 @@ class LookMLAdapter(BaseAdapter):
             # No field to aggregate -> placeholder in an abstract view, skip.
             return None
         sql = sql.replace("${TABLE}", "{model}")
-        sql = self._resolve_dimension_references(sql, dimension_sql_lookup)
+        sql = self._resolve_dimension_references(sql, dimension_sql_lookup, dimension_names=dimension_names)
 
         sql_distinct_key = measure_def.get("sql_distinct_key")
         if sql_distinct_key:
             sql_distinct_key = sql_distinct_key.replace("${TABLE}", "{model}")
-            sql_distinct_key = self._resolve_dimension_references(sql_distinct_key, dimension_sql_lookup)
+            sql_distinct_key = self._resolve_dimension_references(
+                sql_distinct_key, dimension_sql_lookup, dimension_names=dimension_names
+            )
 
         # With a sql_distinct_key, Looker dedupes by the *key entity*, not by the
         # aggregated value: two distinct orders that both have amount 10 must
@@ -1658,8 +2109,18 @@ class LookMLAdapter(BaseAdapter):
         sql = sql.replace("${TABLE}", "{model}")
 
         def _resolve(match: re.Match) -> str:
-            ref_name = match.group(1)
-            if ref_name == "TABLE":
+            view, ref_name = match.group(1), match.group(2)
+            if view is None and ref_name == "TABLE":
+                return match.group(0)
+            if view is not None:
+                # Cross-view reference (self-view already normalized away): sidemantic
+                # has no inline cross-model column, so leave the literal and warn.
+                logger.warning(
+                    "LookML cross-view reference ${%s.%s} is not supported (sidemantic "
+                    "has no inline cross-model column); left unresolved.",
+                    view,
+                    ref_name,
+                )
                 return match.group(0)
             if ref_name in dimension_sql_lookup:
                 return f"({dimension_sql_lookup[ref_name]})"
@@ -1670,7 +2131,7 @@ class LookMLAdapter(BaseAdapter):
                 return f"{{model}}.{ref_name}"
             return ref_name
 
-        return re.sub(r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}", _resolve, sql)
+        return self._REF_RE.sub(_resolve, sql)
 
     def _parse_post_sql_measure(
         self,

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -305,7 +305,17 @@ class LookMLAdapter(BaseAdapter):
         # to true and counts the row; (2) a keyed symmetric-distinct aggregate hashes the key
         # (`HASH(col)`), and HASH(NULL) is a non-NULL constant, so the row still contributes
         # (garbage). In those cases fold the filter into the aggregate predicate instead.
-        unsafe_nulling = tree.find(exp.Is) is not None or tree.find(exp.Coalesce) is not None or "hash(" in sql.lower()
+        # (3) a CASE with an ELSE default also survives nulling: nulling the predicate's column
+        # only makes the WHEN false, and ELSE still yields a non-NULL value, so the aggregate
+        # keeps counting the excluded row -- e.g. COUNT(CASE WHEN status='completed' THEN 1
+        # ELSE 0 END) returns EVERY row rather than the filtered ones.
+        case_with_default = any(c.args.get("default") is not None for c in tree.find_all(exp.Case))
+        unsafe_nulling = (
+            tree.find(exp.Is) is not None
+            or tree.find(exp.Coalesce) is not None
+            or "hash(" in sql.lower()
+            or case_with_default
+        )
         # Otherwise, if every aggregate already references a column the generator can null
         # (nulling the value/ORDER-BY column filters it; aggregates ignore NULLs), the
         # existing path is correct AND consistent -> don't rewrite. `force` skips this: a caller

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -407,15 +407,16 @@ class LookMLAdapter(BaseAdapter):
 
         A raw ``\\bselect\\b`` scan also matches the word inside a VALUE
         (``SUM(CASE WHEN status = 'select' THEN amount END)``) or inside a quoted IDENTIFIER for a
-        column named after a reserved word (``SUM(${TABLE}."select")``, ``SUM(`select`)``), or
-        inside a SQL COMMENT (``/* select paid rows */ SUM(amount)``) -- none is a subquery, and all
-        are valid inline aggregates. Blank out every quoted form AND every comment first -- single-
-        quoted literals, double-quote / backtick / bracket identifiers, and ``--``/``/* */``
-        comments -- in one left-to-right pass so a comment inside a string (or a quote inside a
-        comment) is consumed by whichever opens first, leaving only real SQL keywords.
+        column named after a reserved word (``SUM(${TABLE}."select")``, ``SUM(`select`)``), inside a
+        SQL COMMENT (``/* select paid rows */ SUM(amount)``), or inside a LookML ``${...}`` field
+        reference to a column named ``select`` (``SUM(${select})``) -- none is a subquery, and all
+        are valid inline aggregates. This runs on the RAW SQL before refs are resolved, so blank out
+        every quoted form, every comment, AND every ``${...}`` placeholder first -- in one left-to-
+        right pass so a comment inside a string (or a quote inside a comment) is consumed by
+        whichever opens first, leaving only real SQL keywords.
         """
         stripped = re.sub(
-            r"""'(?:[^']|'')*'|"(?:[^"]|"")*"|`[^`]*`|\[[^\]]*\]|--[^\n]*|/\*[\s\S]*?\*/""",
+            r"""'(?:[^']|'')*'|"(?:[^"]|"")*"|`[^`]*`|\[[^\]]*\]|--[^\n]*|/\*[\s\S]*?\*/|\$\{[^}]*\}""",
             " ",
             sql or "",
         )

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -402,6 +402,54 @@ class LookMLAdapter(BaseAdapter):
         except Exception:
             return None
 
+    @classmethod
+    def _generator_column_nulling_suffices(cls, sql: str) -> bool:
+        """True if the generator's column-nulling can faithfully apply a filter to this complete SQL.
+
+        Mirrors the early-return in ``_fold_complete_sql_filters``: nulling the columns each
+        aggregate references filters it only when EVERY aggregate has a column to null and no
+        unsafe-nulling construct (NULL-test, COALESCE, HASH, CASE/IF/IFF-with-default, multi-column
+        DISTINCT) is present. When this is False AND folding also aborts, the filter cannot be
+        applied at all -- a zero-column aggregate like ``COUNT(*) FILTER (WHERE ...) OVER ()`` has no
+        column to null, so the imported filter would silently count every row.
+        """
+        import sqlglot
+        from sqlglot import expressions as exp
+
+        from sidemantic.sql.aggregation_detection import _ANONYMOUS_AGGREGATE_FUNCTIONS
+
+        try:
+            tree = sqlglot.parse_one(sql.replace("{model}", "__M__"))
+        except Exception:
+            return False
+        aggs = list(tree.find_all(exp.AggFunc))
+        aggs += [n for n in tree.find_all(exp.Anonymous) if (n.name or "").lower() in _ANONYMOUS_AGGREGATE_FUNCTIONS]
+        if not aggs:
+            return False
+        unsafe = (
+            tree.find(exp.Is) is not None
+            or tree.find(exp.Coalesce) is not None
+            or "hash(" in sql.lower()
+            or any(c.args.get("default") is not None for c in tree.find_all(exp.Case))
+            or any(n.args.get("false") is not None for n in tree.find_all(exp.If))
+            or any(
+                (n.name or "").lower() in ("iff", "if") and len(n.expressions) >= 3
+                for n in tree.find_all(exp.Anonymous)
+            )
+            or any(
+                len(d.expressions) > 1 or any(isinstance(e, exp.Tuple) and len(e.expressions) > 1 for e in d.expressions)
+                for d in tree.find_all(exp.Distinct)
+            )
+        )
+        if unsafe:
+            return False
+
+        def _scope(a):
+            wg = a.find_ancestor(exp.WithinGroup)
+            return wg if wg is not None else a
+
+        return all(any(True for _ in _scope(a).find_all(exp.Column)) for a in aggs)
+
     @staticmethod
     def _sql_has_list_aggregate(sql: str) -> bool:
         """True if ``sql`` contains a ``LIST(...)`` collector (sqlglot's ``exp.List``).
@@ -500,7 +548,13 @@ class LookMLAdapter(BaseAdapter):
                     # per-row argument, so only a NON-windowed aggregate groups it. A nested
                     # aggregate inside a window -- SUM(SUM(x)) OVER () -- is reached here at the
                     # inner SUM, whose parent is the outer SUM (not the Window), so it is grouped.
-                    return not isinstance(node.parent, exp.Window)
+                    # An aggregate FILTER clause nests exp.Filter between the aggregate and its OVER
+                    # window (SUM(x) FILTER (WHERE ...) OVER ()), so walk past Filter wrappers to see
+                    # the window -- otherwise a raw windowed aggregate reads as grouped.
+                    _p = node.parent
+                    while isinstance(_p, exp.Filter):
+                        _p = _p.parent
+                    return not isinstance(_p, exp.Window)
                 node = node.parent
             return False
 
@@ -2324,6 +2378,16 @@ class LookMLAdapter(BaseAdapter):
             if folded is not None:
                 sql = folded
                 filters = None
+            elif not self._generator_column_nulling_suffices(sql):
+                # Folding aborted AND column-nulling cannot apply the filter (a zero-column /
+                # windowed aggregate has no column to null), so keeping the filter would silently
+                # count every row. Drop the measure rather than import ineffective filters.
+                logger.warning(
+                    "LookML measure %r has filters that can be applied neither by folding nor by "
+                    "generator column-nulling (e.g. a zero-column windowed aggregate); dropping it.",
+                    name,
+                )
+                return None
 
         return Metric(
             name=name,

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -1217,6 +1217,13 @@ class LookMLAdapter(BaseAdapter):
                 return None
             joined = _folded_measure_filter(m_def)
             if joined:
+                # A filtered LIST(...) has no faithful form -- LIST keeps NULL inputs, so no
+                # filtering strategy excludes a row (see _parse_measure, which skips these).
+                # Without this the prepass would fold only the OTHER aggregates and cache a
+                # PARTIALLY filtered SQL, so a later measure referencing it would inline an
+                # unfiltered LIST over a filtered denominator. Keep prepass and parser in step.
+                if self._sql_has_list_aggregate(expanded):
+                    return None
                 # force=True: this SQL will be INLINED into a referencing measure with no
                 # generator column-nulling, so the filter must be baked into a CASE unconditionally.
                 folded = self._fold_complete_sql_filters(expanded, [joined], force=True)

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -2062,6 +2062,18 @@ class LookMLAdapter(BaseAdapter):
 
                 sql = self._REF_RE.sub(resolve_reference, sql)
 
+                # Re-check the RESOLVED expression for a SUBQUERY: a dimension ref may have EXPANDED
+                # into one, and the pre-resolution guard above only saw the raw ${refs}. The
+                # complete-SQL builder rewrites EVERY column -- including those INSIDE the subquery --
+                # to this measure's CTE raw aliases, producing wrong correlated SQL, so skip it.
+                if needs_complete and self._has_subquery(sql):
+                    logger.warning(
+                        "LookML number measure %r resolves to a scalar subquery (via a dimension "
+                        "reference), which the complete-SQL path cannot represent; skipping on import.",
+                        name,
+                    )
+                    return None
+
                 # A number measure that references ONLY raw dimension columns with NO
                 # aggregate (e.g. ${amount} / 2) is a row-level expression, not a valid
                 # aggregate measure: as a metric it returns one value per input row, not a

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -613,6 +613,16 @@ class SQLGenerator:
         """
         return _quote_identifier_cached(name, self.dialect, self._is_simple_identifier(name))
 
+    def _raw_column_ref(self, col_name: str, quoted: bool) -> str:
+        """A raw column reference for a CTE projection, mirroring the SOURCE's quoting.
+
+        A column QUOTED in the source (a reserved word like ``"group"``, or a case-sensitive name)
+        is re-quoted; an unquoted one is left bare. This is exact where sqlglot's default is not:
+        ``exp.column("group").sql()`` leaves ``group`` unquoted (DuckDB then rejects it), yet
+        force-quoting every column would fold-break a case-sensitive unquoted column on Postgres.
+        """
+        return exp.column(exp.to_identifier(col_name, quoted=quoted)).sql(dialect=self.dialect)
+
     def _dimension_base_expr(self, dimension, *, window: bool = False) -> str:
         """Row-level SQL expression for a dimension, with bare column names quoted.
 
@@ -2091,6 +2101,10 @@ class SQLGenerator:
         # Collect all measures needed for metrics
         measures_needed = set()
         extra_metric_sql_columns: set[str] = set()
+        # Raw columns whose name was QUOTED in the source SQL (e.g. a reserved word `"group"`).
+        # They must be re-quoted in the CTE projection; sqlglot's default quoting misses some
+        # reserved words, and force-quoting every column would break case-folded unquoted columns.
+        quoted_raw_columns: set[str] = set()
         # Opaque complete-sql measures (Cube/Tesseract number_agg/time/string/boolean):
         # each is projected into the CTE under dedicated raw aliases so the preserved
         # expression sees raw column values (never dimension-transformed) and honors
@@ -2107,6 +2121,8 @@ class SQLGenerator:
                     if col.table and col.table.replace("_cte", "") != model_name:
                         continue
                     extra_metric_sql_columns.add(col.name)
+                    if isinstance(col.this, exp.Identifier) and col.this.args.get("quoted"):
+                        quoted_raw_columns.add(col.name)
             except Exception:
                 logging.debug("Failed to parse metric SQL for columns: %s", sql_expr, exc_info=True)
 
@@ -2213,6 +2229,14 @@ class SQLGenerator:
 
         all_metric_columns = set(metric_filter_columns or set()) | extra_metric_sql_columns
 
+        # A complete measure's columns also reach all_metric_columns via metric-filter extraction,
+        # which drops the quoted flag. Recover it from the complete measures (already parsed) so a
+        # reserved column projected on THIS path is quoted too, not just on the dedicated-alias path.
+        for measure in complete_sql_measures.values():
+            for _cn, _cq in self._complete_sql_columns(measure):
+                if _cq:
+                    quoted_raw_columns.add(_cn)
+
         # Add raw columns referenced by inline aggregate SQL (if they are not dimensions/measures)
         for col_name in all_metric_columns:
             if col_name in columns_added:
@@ -2226,10 +2250,10 @@ class SQLGenerator:
                 continue
             if model.get_metric(col_name):
                 continue
-            # Quote the raw column for the dialect so a reserved-word / special column is emitted
-            # as e.g. `"select"`, not the bare `select` the engine rejects.
-            quoted_col = exp.column(col_name).sql(dialect=self.dialect)
-            raw_expr = f"{model_table_alias}.{quoted_col}" if model_table_alias else quoted_col
+            # Mirror the source's quoting so a reserved-word column (`"group"`) is emitted quoted,
+            # not the bare `group` the engine rejects, without force-quoting ordinary columns.
+            raw_col = self._raw_column_ref(col_name, col_name in quoted_raw_columns)
+            raw_expr = f"{model_table_alias}.{raw_col}" if model_table_alias else raw_col
             select_cols.append(f"{raw_expr} AS {self._quote_alias(col_name)}")
             columns_added.add(col_name)
 
@@ -2297,15 +2321,15 @@ class SQLGenerator:
             for filter_str in measure.filters or []:
                 filter_conditions.append(filter_str.replace("{model}.", "").replace("{model}", ""))
             filter_sql = " AND ".join(filter_conditions) if filter_conditions else None
-            for col_name in self._complete_sql_columns(measure):
+            for col_name, col_quoted in self._complete_sql_columns(measure):
                 raw_alias = self._complete_sql_raw_alias(measure.name, col_name)
                 if raw_alias in columns_added:
                     continue
-                # Quote the column for the dialect so a reserved-word / special column (e.g. a
-                # LookML `${TABLE}."select"`) is emitted as `"select"`, not the bare `select` the
-                # engine rejects. sqlglot leaves ordinary identifiers unquoted.
-                quoted_col = exp.column(col_name).sql(dialect=self.dialect)
-                raw_expr = f"{model_table_alias}.{quoted_col}" if model_table_alias else quoted_col
+                # Mirror the source's quoting so a reserved-word column (e.g. a LookML
+                # `${TABLE}."group"`) is emitted as `"group"`, not the bare `group` the engine
+                # rejects, without force-quoting ordinary columns.
+                raw_col = self._raw_column_ref(col_name, col_quoted)
+                raw_expr = f"{model_table_alias}.{raw_col}" if model_table_alias else raw_col
                 if filter_sql:
                     raw_expr = f"CASE WHEN {filter_sql} THEN {raw_expr} ELSE NULL END"
                 select_cols.append(f"{raw_expr} AS {self._quote_alias(raw_alias)}")
@@ -3421,10 +3445,14 @@ class SQLGenerator:
         """
         return f"{measure_name}__{column}__cmpl"
 
-    def _complete_sql_columns(self, measure) -> list[str]:
-        """Model-local column names referenced by an opaque complete-sql measure."""
+    def _complete_sql_columns(self, measure) -> list[tuple[str, bool]]:
+        """(column name, was_quoted) pairs referenced by an opaque complete-sql measure.
+
+        ``was_quoted`` records whether the name was a quoted identifier in the source, so the CTE
+        projection can re-quote a reserved column (``"group"``) without force-quoting all columns.
+        """
         sql_expr = (measure.sql or "").replace("{model}.", "").replace("{model}", "")
-        columns: list[str] = []
+        columns: list[tuple[str, bool]] = []
         seen: set[str] = set()
         try:
             parsed = _parse_fragment(sql_expr, self.dialect)
@@ -3432,7 +3460,8 @@ class SQLGenerator:
                 if col.name in seen:
                     continue
                 seen.add(col.name)
-                columns.append(col.name)
+                quoted = isinstance(col.this, exp.Identifier) and bool(col.this.args.get("quoted"))
+                columns.append((col.name, quoted))
         except Exception:
             logging.debug("Failed to parse complete-sql measure for columns: %s", sql_expr, exc_info=True)
         return columns

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -2226,7 +2226,10 @@ class SQLGenerator:
                 continue
             if model.get_metric(col_name):
                 continue
-            raw_expr = f"{model_table_alias}.{col_name}" if model_table_alias else col_name
+            # Quote the raw column for the dialect so a reserved-word / special column is emitted
+            # as e.g. `"select"`, not the bare `select` the engine rejects.
+            quoted_col = exp.column(col_name).sql(dialect=self.dialect)
+            raw_expr = f"{model_table_alias}.{quoted_col}" if model_table_alias else quoted_col
             select_cols.append(f"{raw_expr} AS {self._quote_alias(col_name)}")
             columns_added.add(col_name)
 
@@ -2298,7 +2301,11 @@ class SQLGenerator:
                 raw_alias = self._complete_sql_raw_alias(measure.name, col_name)
                 if raw_alias in columns_added:
                     continue
-                raw_expr = f"{model_table_alias}.{col_name}" if model_table_alias else col_name
+                # Quote the column for the dialect so a reserved-word / special column (e.g. a
+                # LookML `${TABLE}."select"`) is emitted as `"select"`, not the bare `select` the
+                # engine rejects. sqlglot leaves ordinary identifiers unquoted.
+                quoted_col = exp.column(col_name).sql(dialect=self.dialect)
+                raw_expr = f"{model_table_alias}.{quoted_col}" if model_table_alias else quoted_col
                 if filter_sql:
                     raw_expr = f"CASE WHEN {filter_sql} THEN {raw_expr} ELSE NULL END"
                 select_cols.append(f"{raw_expr} AS {self._quote_alias(raw_alias)}")

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2513,6 +2513,30 @@ view: customers { sql_table_name: customers ;; dimension: active { type: yesno  
     assert model.get_metric("self_filtered").filters == ["{model}.status = 'done'"]
 
 
+def test_lookml_complete_measure_filter_alias_for_cross_view_dimension_dropped():
+    """A complete measure filtered by a LOCAL dimension that is a dropped cross-view alias is dropped.
+
+    filters: [customer_active: "yes"] where customer_active { sql: ${customers.active} } expands to
+    the leaked ${customers.active} in the filter; the measure.sql leak check doesn't see filters, so
+    the measure must be rejected after the filter rewrite. An unfiltered measure is kept.
+    """
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: customer_active { type: yesno  sql: ${customers.active} ;; }
+  measure: n { type: number  sql: COUNT(${TABLE}.id) ;; filters: [customer_active: "yes"] }
+  measure: plain { type: number  sql: COUNT(${TABLE}.id) ;; }
+}
+view: customers { sql_table_name: customers ;; dimension: active { type: yesno  sql: ${TABLE}.active ;; } }
+"""
+    )
+    names = {m.name for m in graph.get_model("orders").metrics}
+    assert "n" not in names  # filter expands to a cross-view ref -> dropped
+    assert "plain" in names
+
+
 def test_lookml_number_measure_row_level_dimension_expr_skipped():
     """A type: number measure that is a ROW-LEVEL dimension expression (no aggregate) is skipped.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2508,6 +2508,46 @@ view: orders {
     assert con.execute(layer.compile(metrics=["orders.triple_sum"])).fetchall() == [(390,)]  # 260 + 130
 
 
+def test_lookml_number_measure_case_with_else_folds_filter():
+    """A CASE with an ELSE default survives column-nulling, so its filter must be FOLDED.
+
+    The generator filters a complete measure by nulling the columns its SQL reads, relying on the
+    aggregate ignoring NULLs. That fails for COUNT(CASE WHEN status='completed' THEN 1 ELSE 0 END):
+    nulling `status` only makes the WHEN false, and ELSE 0 is still non-NULL, so COUNT returns
+    EVERY row. A CASE with an ELSE must be treated as unsafe-to-null and folded instead.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  dimension: country { type: string  sql: ${TABLE}.country ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: n_else { type: number  sql: COUNT(CASE WHEN ${status} = 'completed' THEN 1 ELSE 0 END) ;; filters: [country: "US"] }
+  measure: n_no_else { type: number  sql: COUNT(CASE WHEN ${status} = 'completed' THEN 1 END) ;; filters: [country: "US"] }
+  measure: total { type: number  sql: SUM(${amount}) ;; filters: [country: "US"] }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table orders(id int, status text, country text, amount int)")
+    con.execute("insert into orders values (1,'completed','US',10),(2,'pending','US',20),(3,'completed','CA',30)")
+    # ELSE 0 counts every row unless the filter is folded: 2 US rows, not 3.
+    assert con.execute(layer.compile(metrics=["orders.n_else"])).fetchall() == [(2,)]
+    # A CASE with no ELSE nulls out naturally: only the US+completed row.
+    assert con.execute(layer.compile(metrics=["orders.n_no_else"])).fetchall() == [(1,)]
+    # A plain aggregate still filters correctly via the generator's column-nulling.
+    assert con.execute(layer.compile(metrics=["orders.total"])).fetchall() == [(30,)]
+
+
 def test_lookml_number_measure_filtered_list_aggregate_skipped():
     """A FILTERED LIST(...) measure has no faithful form and must be skipped, not silently wrong.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2749,6 +2749,44 @@ view: orders {
     assert con.execute(sql).fetchall() == [(20,)]  # SUM of the quoted `select` column
 
 
+def test_lookml_complete_measure_reserved_column_sqlglot_misses_is_quoted():
+    """A reserved column sqlglot does NOT auto-quote (e.g. `group`) must still round-trip.
+
+    sqlglot's DuckDB dialect leaves `group` bare as a column, but DuckDB rejects `group AS ...`. The
+    CTE projection mirrors the SOURCE quoting instead: a column quoted in the source stays quoted on
+    BOTH projection paths (the dedicated __cmpl alias and the metric-filter raw column), while an
+    ordinary column is NOT over-quoted (over-quoting would fold-break case-sensitive Postgres names).
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: grp { type: number  sql: ${TABLE}."group" ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: total { type: sum  sql: ${amount} ;; }
+  measure: m { type: number  sql: SUM(${grp}) / NULLIF(${total}, 0) ;; }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    sql = layer.compile(metrics=["orders.m"])
+
+    assert "group AS group" not in sql  # the reserved column is not projected bare
+    assert '"amount" AS' not in sql  # an ordinary column is NOT over-quoted
+
+    con = duckdb.connect()
+    con.execute('create table orders as select 1 id, 5 "group", 10 amount union all select 2, 15, 20')
+    # SUM("group") = 20, SUM(amount) = 30 -> 20/30.
+    assert con.execute(sql).fetchall() == [(20 / 30,)]
+
+
 def test_lookml_number_measure_dimension_ref_expanding_to_subquery_is_skipped():
     """A dimension ref that EXPANDS to a subquery must be caught after resolution, not just raw.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2616,6 +2616,36 @@ view: orders {
     assert float(tax_value) == pytest.approx(180 * 0.07)  # SUM(amount) * 0.07
 
 
+def test_lookml_number_measure_quoted_select_identifier_is_not_a_subquery():
+    """A quoted IDENTIFIER named after a reserved word must not read as a subquery.
+
+    A column named `select` is written quoted -- ${TABLE}."select", `select`, [select] -- and has
+    no subquery, but a bare \\bselect\\b scan matched it and dropped the measure. Every quoted form
+    is blanked before scanning; a REAL subquery is still detected.
+    """
+    conv = LookMLAdapter._has_subquery
+    assert not conv('SUM({model}."select")')  # double-quoted (standard / Postgres / DuckDB)
+    assert not conv("SUM(`select`)")  # backtick (BigQuery / MySQL)
+    assert not conv("SUM([select])")  # bracket (SQL Server)
+    assert not conv("SUM(CASE WHEN {model}.s = 'select' THEN {model}.a END)")  # string VALUE
+    assert conv("SUM({model}.a) / (SELECT SUM(x) FROM t)")  # real subquery
+    assert conv('SUM({model}."col") / (SELECT 1)')  # quoted id AND a real subquery
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  measure: s { type: number  sql: SUM(${TABLE}."select") ;; }
+  measure: subq { type: number  sql: SUM(${TABLE}.a) / NULLIF((SELECT SUM(x) FROM t), 0) ;; }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    assert model.get_metric("s") is not None  # was dropped as a phantom subquery
+    assert model.get_metric("subq") is None  # a real subquery is still skipped
+
+
 def test_lookml_number_measure_select_in_string_literal_is_not_a_subquery():
     """The word `select` inside a string VALUE must not be mistaken for a subquery.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -1440,7 +1440,11 @@ view: percentile_test {
 
 
 def test_lookml_cross_view_reference():
-    """Test parsing cross-view field references (${other_view.field})."""
+    """A cross-view field reference (${other_view.field}) is unqueryable, so it is dropped.
+
+    Sidemantic has no inline cross-model column; keeping the dimension would leak the literal
+    ${customers.name} into the model CTE, so every query touching it fails. Drop the field.
+    """
     import tempfile
 
     lkml_content = """
@@ -1463,10 +1467,10 @@ view: orders {
         graph = adapter.parse(Path(f.name))
         orders = graph.get_model("orders")
 
-        # Cross-view references should be preserved
-        customer_name = orders.get_dimension("customer_name")
-        assert customer_name is not None
-        assert "customers.name" in customer_name.sql
+        # The cross-view dimension is dropped rather than imported with a leaked literal.
+        assert orders.get_dimension("customer_name") is None
+        # The ordinary dimension is unaffected.
+        assert orders.get_dimension("id") is not None
 
 
 def test_lookml_recursive_dimension_references():
@@ -2292,12 +2296,11 @@ view: orders {
     assert "{model}.amount" in total.sql
 
 
-def test_lookml_self_view_resolved_cross_view_left_unsupported(caplog):
-    """Self-view refs resolve; cross-view refs are unsupported -> left literal + warned.
+def test_lookml_self_view_resolved_cross_view_dropped(caplog):
+    """Self-view refs resolve; a cross-view ref is unqueryable, so the field is dropped + warned.
 
-    Sidemantic has no inline cross-model column, so emitting a qualified column would
-    crash the generator ("no join path"); the honest behavior is to leave the literal
-    and warn rather than produce something that looks valid but fails.
+    Sidemantic has no inline cross-model column. Leaving the literal ${customers.name} would leak
+    it into the model CTE, so any query on the field fails; drop the dimension entirely instead.
     """
     import logging
 
@@ -2319,13 +2322,13 @@ view: customers {
     orders = graph.get_model("orders")
     # self-view ref resolves to the model column (no literal left)
     assert orders.get_dimension("self_x2").sql == "({model}.id) * 2"
-    # cross-view ref is left as the literal and a warning is emitted
-    assert orders.get_dimension("cust_name").sql == "${customers.name}"
-    assert any("cross-view reference" in rec.getMessage() for rec in caplog.records)
+    # cross-view ref field is dropped (not importable), with a warning
+    assert orders.get_dimension("cust_name") is None
+    assert any("references another view inline" in rec.getMessage() for rec in caplog.records)
 
 
-def test_lookml_number_measure_cross_view_left_unsupported():
-    """type: number measures resolve self-view refs but leave cross-view refs literal (no crash)."""
+def test_lookml_number_measure_cross_view_dropped():
+    """type: number measures resolve self-view refs; a measure with a cross-view ref is dropped."""
     graph = _parse_lkml(
         """
 view: orders {
@@ -2342,10 +2345,43 @@ view: customers {
 """
     )
     orders = graph.get_model("orders")
-    # self-view measure ref resolves (no literal)
+    # self-view measure ref resolves (no literal) and is kept
     assert "${" not in orders.get_metric("self_ratio").sql
-    # cross-view ref is left literal (unsupported) rather than emitting a crashing column
-    assert "${customers.total}" in orders.get_metric("margin_pct").sql
+    # a measure that references another view inline is dropped, not imported with a leaked literal
+    assert orders.get_metric("margin_pct") is None
+
+
+def test_lookml_cross_view_dimension_group_dropped_and_no_leak_on_compile():
+    """A dimension_group with a cross-view base SQL is dropped; surviving fields compile cleanly."""
+    from sidemantic.core.semantic_layer import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension_group: cust_created {
+    type: time
+    timeframes: [date, month]
+    sql: ${customers.created_at} ;;
+  }
+}
+view: customers {
+  sql_table_name: customers ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: created_at { type: time  sql: ${TABLE}.created_at ;; }
+}
+"""
+    )
+    orders = graph.get_model("orders")
+    # every timeframe field of the cross-view group is dropped
+    assert not any(d.name.startswith("cust_created") for d in orders.dimensions)
+    # a surviving field still compiles without a leaked ${...}
+    layer = SemanticLayer()
+    layer.graph = graph
+    sql = layer.compile(dimensions=["orders.amount"])
+    assert "${" not in sql
 
 
 def test_lookml_number_measure_row_level_dimension_expr_skipped():

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2795,6 +2795,33 @@ view: orders {
     assert graph.get_model("orders").get_metric("commented") is not None  # comment is not a subquery
 
 
+def test_lookml_number_measure_ref_named_select_is_not_a_subquery():
+    """A `${...}` reference to a field named `select` must not look like a subquery.
+
+    The subquery scan runs on the RAW SQL before refs are resolved, so `SUM(${select})` matched
+    `select` inside the placeholder and dropped a valid inline aggregate. Placeholders are blanked
+    with quotes/comments; a real subquery alongside a ref is still detected.
+    """
+    conv = LookMLAdapter._has_subquery
+    assert conv("SUM(${select})") is False
+    assert conv("SUM(${orders.select})") is False
+    assert conv("SUM(${select}) / (SELECT COUNT(*) FROM t)") is True  # real subquery still detected
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: select { type: number  sql: ${TABLE}."select" ;; }
+  measure: m { type: number  sql: SUM(${select}) / NULLIF(COUNT(*), 0) ;; }
+}
+"""
+    )
+    metric = graph.get_model("orders").get_metric("m")
+    assert metric is not None  # ${select} ref is not a subquery
+    assert '"select"' in metric.sql  # resolved to the quoted column
+
+
 def test_lookml_number_measure_unsafe_intermediate_not_expandable():
     """A number measure _parse_measure skips as unsafe must not be inlined into a later measure.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -1354,6 +1354,34 @@ view: orders {
     assert "${" not in layer.compile(dimensions=["orders.elapsed_days"])
 
 
+def test_lookml_duration_group_resolves_compact_dimension_references():
+    """A ref to a COMPACT dimension (declared with no sql) resolves to its default column.
+
+    The resolver needs the declared dimension set to use its compact-dimension fallback; without
+    it a bare ${started_at} for a `dimension: started_at { type: time }` leaked into DATE_DIFF.
+    """
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: started_at { type: time }
+  dimension: ended_at { type: time }
+  dimension_group: elapsed {
+    type: duration
+    intervals: [day]
+    sql_start: ${started_at} ;;
+    sql_end: ${ended_at} ;;
+  }
+}
+"""
+    )
+    elapsed = graph.get_model("orders").get_dimension("elapsed_days")
+    assert elapsed is not None
+    assert "${" not in elapsed.sql  # compact refs resolved to their default columns
+    assert "started_at" in elapsed.sql and "ended_at" in elapsed.sql
+
+
 def test_lookml_duration_group_cross_view_ref_dropped():
     """A duration group whose sql_start/sql_end references another view inline is dropped."""
     graph = _parse_lkml(

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2508,6 +2508,39 @@ view: orders {
     assert con.execute(layer.compile(metrics=["orders.triple_sum"])).fetchall() == [(390,)]  # 260 + 130
 
 
+def test_lookml_number_measure_list_aggregate_is_scope_safe():
+    """A column inside DuckDB's LIST(...) collector is aggregate-scoped, not raw.
+
+    aggregation_detection counts exp.List as an aggregate, so ARRAY_LENGTH(LIST(${amount}))
+    takes the complete-SQL path; the safety check must agree or the column reads as raw and the
+    valid measure is dropped. A raw column OUTSIDE the LIST must still be rejected.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: n_amounts { type: number  sql: ARRAY_LENGTH(LIST(${amount})) ;; }
+  measure: raw_bad { type: number  sql: ARRAY_LENGTH(LIST(${amount})) + ${amount} ;; }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    assert model.get_metric("n_amounts") is not None  # was dropped as a raw ungrouped column
+    assert model.get_metric("raw_bad") is None  # raw column outside the LIST is still unsafe
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table orders(id int, amount int)")
+    con.execute("insert into orders values (1,100),(2,50),(3,30)")
+    assert con.execute(layer.compile(metrics=["orders.n_amounts"])).fetchall() == [(3,)]
+
+
 def test_lookml_number_measure_constant_dimension_is_aggregate_safe():
     """A CONSTANT-valued dimension in a mixed number measure must not read as a raw column.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2367,6 +2367,55 @@ view: orders {
     assert graph.get_model("orders").get_metric("half_amount") is None  # row-level -> skipped
 
 
+def test_lookml_measure_referencing_skipped_measure_is_dropped():
+    """A measure that references a measure which did NOT survive parsing must be dropped too.
+
+    A row-level helper `bad { sql: ${amount} }` is skipped, but a dependent `outer { sql: ${bad}*2 }`
+    still resolved ${bad} to a bare `bad` and imported as `bad * 2` -- compile then failed with
+    "Metric bad not found". Drop such dependents (iterating so a dependent of a dependent goes too);
+    a dependent of a SURVIVING measure is kept and works.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    dropped = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: bad { type: number  sql: ${amount} ;; }
+  measure: outer { type: number  sql: ${bad} * 2 ;; }
+  measure: outer2 { type: number  sql: ${outer} + 1 ;; }
+}
+"""
+    ).get_model("orders")
+    # bad (row-level) is skipped, and its transitive dependents go with it.
+    assert dropped.get_metric("bad") is None
+    assert dropped.get_metric("outer") is None
+    assert dropped.get_metric("outer2") is None
+
+    # A dependent of a SURVIVING measure is kept and compiles.
+    kept = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: total { type: sum  sql: ${amount} ;; }
+  measure: dbl { type: number  sql: ${total} * 2 ;; }
+}
+"""
+    ).get_model("orders")
+    assert kept.get_metric("dbl") is not None
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(kept)
+    con = duckdb.connect()
+    con.execute("create table orders as select 1 id, 10 amount union all select 2, 20")
+    assert con.execute(layer.compile(metrics=["orders.dbl"])).fetchall() == [(60,)]
+
+
 def test_lookml_number_measure_compact_dimension_row_level_skipped():
     """A number measure over a COMPACT dimension with no aggregate is also a row-level expr -> skipped."""
     graph = _parse_lkml(

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2766,6 +2766,47 @@ view: orders {
     assert con.execute(layer.compile(metrics=["orders.outer_ok"])).fetchall() == [(2.0,)]
 
 
+def test_lookml_filter_wrapped_windowed_aggregate_is_not_grouped():
+    """A FILTER clause between an aggregate and its OVER window must not read as grouped.
+
+    SUM(x) FILTER (WHERE ...) OVER () nests exp.Filter between the SUM and its window, so a
+    direct-parent check saw a non-Window parent and treated the raw windowed aggregate as grouped.
+    Walk past Filter so it is correctly rejected as ungrouped (aggregate-unsafe).
+    """
+    is_safe = LookMLAdapter._mixed_is_aggregate_safe
+    assert is_safe("SUM({model}.amount) FILTER (WHERE TRUE) OVER ()", lambda rn: False) is False
+    assert is_safe("SUM({model}.amount) OVER ()", lambda rn: False) is False
+    # A nested aggregate inside a window still groups its column; a plain aggregate is safe.
+    assert is_safe("SUM(COUNT({model}.x)) OVER ()", lambda rn: False) is True
+    assert is_safe("SUM({model}.a) / COUNT(*)", lambda rn: False) is True
+
+
+def test_lookml_zero_column_windowed_filtered_measure_dropped():
+    """A filtered complete measure whose filter can be applied neither by folding nor column-nulling
+    (a zero-column windowed aggregate) is dropped, not imported with ineffective filters."""
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: winct {
+    type: number
+    sql: COUNT(*) FILTER (WHERE TRUE) OVER () ;;
+    filters: [status: "x"]
+  }
+  measure: colnull { type: number  sql: STDDEV(${TABLE}.amount) ;; filters: [status: "x"] }
+}
+"""
+    )
+    names = {m.name for m in graph.get_model("orders").metrics}
+    assert "winct" not in names  # filter cannot be applied any way -> dropped
+    assert "colnull" in names  # a column-nullable filtered aggregate is kept
+    # The helper distinguishes the two.
+    assert LookMLAdapter._generator_column_nulling_suffices("COUNT(*) FILTER (WHERE TRUE) OVER ()") is False
+    assert LookMLAdapter._generator_column_nulling_suffices("STDDEV({model}.amount)") is True
+
+
 def test_lookml_number_measure_case_with_else_folds_filter():
     """A CASE with an ELSE default survives column-nulling, so its filter must be FOLDED.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -745,6 +745,45 @@ def test_lookml_segments():
     assert "successful_transactions" in segment_names
 
 
+def test_lookml_segment_resolves_self_qualified_and_bare_field_refs():
+    """A `filter:` segment's ${...} field refs must resolve, not leak into the WHERE clause.
+
+    A self-qualified ${orders.status} (and a bare ${status}) reference a dimension; like
+    dimensions and measures, they must resolve through the dimension SQL. Otherwise the literal
+    ${...} reaches the generated WHERE clause and the database rejects it.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+
+    src = """view: orders {
+      sql_table_name: raw_orders ;;
+      dimension: id { primary_key: yes sql: ${TABLE}.id ;; }
+      dimension: status { sql: ${TABLE}.order_status ;; }
+      filter: completed_seg { sql: ${orders.status} = 'completed' ;; }
+      filter: bare_seg { sql: ${status} = 'x' ;; }
+      measure: total { type: sum sql: ${TABLE}.amount ;; }
+    }
+    """
+    path = tempfile.mktemp(suffix=".lkml")
+    with open(path, "w") as f:
+        f.write(src)
+    graph = LookMLAdapter().parse(Path(path))
+    model = graph.get_model("orders")
+    by_name = {s.name: s.sql for s in model.segments}
+    # The self-qualified reference resolves to the real column (order_status), no leaked ${...}.
+    assert by_name["completed_seg"] == "({model}.order_status) = 'completed'", by_name
+    assert by_name["bare_seg"] == "({model}.order_status) = 'x'", by_name
+
+    # End-to-end: querying with the segment must produce valid SQL (no ${...}).
+    layer = SemanticLayer()
+    for mdl in graph.models.values():
+        layer.add_model(mdl)
+    sql = layer.compile(metrics=["orders.total"], segments=["orders.completed_seg"])
+    assert "${" not in sql
+    assert "order_status" in sql and "completed" in sql
+
+
 # =============================================================================
 # COMPLEX SQL TESTS
 # =============================================================================

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2487,6 +2487,32 @@ view: customers { sql_table_name: customers ;; dimension: active { type: yesno  
     assert "big" in names  # ordinary segment kept
 
 
+def test_lookml_measure_cross_view_filter_dropped():
+    """A measure whose `filters` reference another view inline is dropped, not imported broken.
+
+    filters: [customers.active: "yes"] would become {model}.customers.active in the single-table
+    model CTE (no `customers` alias) and fail to query. A self-view filter still imports.
+    """
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: cross_filtered { type: sum  sql: ${TABLE}.amount ;; filters: [customers.active: "yes"] }
+  measure: self_filtered { type: sum  sql: ${TABLE}.amount ;; filters: [orders.status: "done"] }
+  measure: plain { type: sum  sql: ${TABLE}.amount ;; }
+}
+view: customers { sql_table_name: customers ;; dimension: active { type: yesno  sql: ${TABLE}.active ;; } }
+"""
+    )
+    model = graph.get_model("orders")
+    names = {m.name for m in model.metrics}
+    assert "cross_filtered" not in names  # cross-view filter -> measure dropped
+    assert {"self_filtered", "plain"} <= names  # self-view filter and unfiltered measure kept
+    assert model.get_metric("self_filtered").filters == ["{model}.status = 'done'"]
+
+
 def test_lookml_number_measure_row_level_dimension_expr_skipped():
     """A type: number measure that is a ROW-LEVEL dimension expression (no aggregate) is skipped.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2875,12 +2875,15 @@ view: orders {
   dimension: status { type: string  sql: ${TABLE}.status ;; }
   measure: n_completed { type: number  sql: ARRAY_LENGTH(LIST(${amount})) ;; filters: [status: "completed"] }
   measure: n_all { type: number  sql: ARRAY_LENGTH(LIST(${amount})) ;; }
+  measure: arr_completed { type: number  sql: ARRAY_LENGTH(ARRAY_AGG(${amount})) ;; filters: [status: "completed"] }
   measure: sum_completed { type: number  sql: SUM(${amount}) ;; filters: [status: "completed"] }
 }
 """
     )
     model = graph.get_model("orders")
     assert model.get_metric("n_completed") is None  # would have silently ignored its filter
+    # ARRAY_AGG retains NULLs just like LIST, so a filtered ARRAY_AGG measure is dropped too.
+    assert model.get_metric("arr_completed") is None
     assert model.get_metric("n_all") is not None  # unfiltered LIST is fine
     assert model.get_metric("sum_completed") is not None  # a foldable filtered aggregate is fine
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2574,6 +2574,8 @@ view: orders {
   dimension: amount { type: number  sql: ${TABLE}.amount ;; }
   measure: n_else { type: number  sql: COUNT(CASE WHEN ${status} = 'completed' THEN 1 ELSE 0 END) ;; filters: [country: "US"] }
   measure: n_no_else { type: number  sql: COUNT(CASE WHEN ${status} = 'completed' THEN 1 END) ;; filters: [country: "US"] }
+  measure: n_if { type: number  sql: COUNT(IF(${status} = 'completed', 1, 0)) ;; filters: [country: "US"] }
+  measure: n_if_no_default { type: number  sql: COUNT(IF(${status} = 'completed', 1)) ;; filters: [country: "US"] }
   measure: total { type: number  sql: SUM(${amount}) ;; filters: [country: "US"] }
 }
 """
@@ -2588,6 +2590,10 @@ view: orders {
     assert con.execute(layer.compile(metrics=["orders.n_else"])).fetchall() == [(2,)]
     # A CASE with no ELSE nulls out naturally: only the US+completed row.
     assert con.execute(layer.compile(metrics=["orders.n_no_else"])).fetchall() == [(1,)]
+    # IF(cond, 1, 0) is the same trap: IF(NULL, 1, 0) is 0, so it must fold too.
+    assert con.execute(layer.compile(metrics=["orders.n_if"])).fetchall() == [(2,)]
+    # IF with no false branch has no default -> nulls out naturally, must NOT over-fold.
+    assert con.execute(layer.compile(metrics=["orders.n_if_no_default"])).fetchall() == [(1,)]
     # A plain aggregate still filters correctly via the generator's column-nulling.
     assert con.execute(layer.compile(metrics=["orders.total"])).fetchall() == [(30,)]
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -1321,6 +1321,59 @@ view: duration_test {
         assert "SECOND" in seconds_dim.sql.upper()
 
 
+def test_lookml_duration_group_resolves_field_references():
+    """sql_start/sql_end ${field} references resolve to real columns, not leaked ${...} literals.
+
+    The duration path only replaced ${TABLE}, so a self-view ref (${started_at}) leaked into
+    DATE_DIFF and every query on the duration dimension emitted invalid SQL. Resolve them.
+    """
+    from sidemantic.core.semantic_layer import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: started_at { type: time  sql: ${TABLE}.started_at ;; }
+  dimension: ended_at { type: time  sql: ${TABLE}.ended_at ;; }
+  dimension_group: elapsed {
+    type: duration
+    intervals: [day, hour]
+    sql_start: ${started_at} ;;
+    sql_end: ${ended_at} ;;
+  }
+}
+"""
+    )
+    elapsed = graph.get_model("orders").get_dimension("elapsed_days")
+    assert elapsed is not None
+    assert "${" not in elapsed.sql  # refs resolved, not leaked
+    assert "started_at" in elapsed.sql and "ended_at" in elapsed.sql
+    layer = SemanticLayer()
+    layer.graph = graph
+    assert "${" not in layer.compile(dimensions=["orders.elapsed_days"])
+
+
+def test_lookml_duration_group_cross_view_ref_dropped():
+    """A duration group whose sql_start/sql_end references another view inline is dropped."""
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension_group: elapsed {
+    type: duration
+    intervals: [day]
+    sql_start: ${other.a} ;;
+    sql_end: ${TABLE}.ended_at ;;
+  }
+}
+view: other { sql_table_name: other ;; dimension: a { type: time  sql: ${TABLE}.a ;; } }
+"""
+    )
+    assert not any(d.name.startswith("elapsed") for d in graph.get_model("orders").dimensions)
+
+
 # =============================================================================
 # NATIVE DERIVED TABLE (EXPLORE_SOURCE) TESTS
 # =============================================================================

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2220,5 +2220,817 @@ def test_lookml_filter_date_expression_warns(caplog):
     assert sum("not translated" in rec.getMessage() for rec in caplog.records) >= 2
 
 
+def _parse_lkml(text):
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".lkml", delete=False) as f:
+        f.write(text)
+        f.flush()
+        return LookMLAdapter().parse(Path(f.name))
+
+
+def test_lookml_self_view_qualified_refs_resolve():
+    """${this_view.field} must resolve like ${field}, not leak literal ${...}."""
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: public.orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: amount_x2 { type: number  sql: ${orders.amount} * 2 ;; }
+  measure: total { type: sum  sql: ${orders.amount} ;; }
+}
+"""
+    )
+    orders = graph.get_model("orders")
+    amount_x2 = orders.get_dimension("amount_x2")
+    assert "${" not in amount_x2.sql
+    assert "{model}.amount" in amount_x2.sql
+
+    total = orders.get_metric("total")
+    assert total.agg == "sum"
+    assert "${" not in total.sql
+    assert "{model}.amount" in total.sql
+
+
+def test_lookml_self_view_resolved_cross_view_left_unsupported(caplog):
+    """Self-view refs resolve; cross-view refs are unsupported -> left literal + warned.
+
+    Sidemantic has no inline cross-model column, so emitting a qualified column would
+    crash the generator ("no join path"); the honest behavior is to leave the literal
+    and warn rather than produce something that looks valid but fails.
+    """
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        graph = _parse_lkml(
+            """
+view: orders {
+  sql_table_name: public.orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: self_x2 { type: number  sql: ${orders.id} * 2 ;; }
+  dimension: cust_name { type: string  sql: ${customers.name} ;; }
+}
+view: customers {
+  sql_table_name: public.customers ;;
+  dimension: name { type: string  sql: ${TABLE}.name ;; }
+}
+"""
+        )
+    orders = graph.get_model("orders")
+    # self-view ref resolves to the model column (no literal left)
+    assert orders.get_dimension("self_x2").sql == "({model}.id) * 2"
+    # cross-view ref is left as the literal and a warning is emitted
+    assert orders.get_dimension("cust_name").sql == "${customers.name}"
+    assert any("cross-view reference" in rec.getMessage() for rec in caplog.records)
+
+
+def test_lookml_number_measure_cross_view_left_unsupported():
+    """type: number measures resolve self-view refs but leave cross-view refs literal (no crash)."""
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  measure: total { type: sum  sql: ${TABLE}.amount ;; }
+  measure: self_ratio { type: number  sql: ${orders.total} / 2 ;; }
+  measure: margin_pct { type: number  sql: ${customers.total} / ${orders.total} ;; }
+}
+view: customers {
+  sql_table_name: c ;;
+  dimension: total { type: number  sql: ${TABLE}.total ;; }
+}
+"""
+    )
+    orders = graph.get_model("orders")
+    # self-view measure ref resolves (no literal)
+    assert "${" not in orders.get_metric("self_ratio").sql
+    # cross-view ref is left literal (unsupported) rather than emitting a crashing column
+    assert "${customers.total}" in orders.get_metric("margin_pct").sql
+
+
+def test_lookml_number_measure_row_level_dimension_expr_skipped():
+    """A type: number measure that is a ROW-LEVEL dimension expression (no aggregate) is skipped.
+
+    `${amount} / 2` is not a valid aggregate measure -- as a metric it would return one row
+    per input row, not a scalar -- so it is dropped on import (belongs as a dimension).
+    """
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: half_amount { type: number  sql: ${orders.amount} / 2 ;; }
+}
+"""
+    )
+    assert graph.get_model("orders").get_metric("half_amount") is None  # row-level -> skipped
+
+
+def test_lookml_number_measure_compact_dimension_row_level_skipped():
+    """A number measure over a COMPACT dimension with no aggregate is also a row-level expr -> skipped."""
+    graph = _parse_lkml(
+        """
+view: inventory_items {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: cost {}
+  measure: half_cost { type: number  sql: ${inventory_items.cost} / 2 ;; }
+}
+"""
+    )
+    assert graph.get_model("inventory_items").get_metric("half_cost") is None
+
+
+def test_lookml_number_measure_mixed_with_raw_dimension_skipped():
+    """A number measure dividing an aggregate measure by a RAW dimension column is skipped.
+
+    `${total} / NULLIF(${amount}, 0)` has no valid SQL form (amount is neither grouped
+    nor aggregated), so it is dropped on import rather than emitting invalid SQL.
+    """
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: total { type: sum  sql: ${TABLE}.amount ;; }
+  measure: m { type: number  sql: ${orders.total} / NULLIF(${orders.amount}, 0) ;; }
+}
+"""
+    )
+    names = {mt.name for mt in graph.get_model("orders").metrics}
+    assert "total" in names  # the clean measure is kept
+    assert "m" not in names  # the raw-column mixed measure is dropped
+
+
+def test_lookml_number_measure_mixed_aggregate_safe_kept_and_executes():
+    """A mix where the dimension ref is INSIDE an aggregate is valid and must round-trip.
+
+    `${total} / NULLIF(SUM(${amount}), 0)` has no raw ungrouped column, so the measure
+    ref is expanded to its base aggregate over the real column and the whole expression
+    is kept as opaque complete SQL that actually executes.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: total { type: sum  sql: ${TABLE}.amount ;; }
+  measure: m { type: number  sql: ${orders.total} / NULLIF(SUM(${orders.amount}), 0) ;; }
+}
+"""
+    )
+    m = graph.get_model("orders").get_metric("m")
+    assert m is not None and m.sql_is_complete is True
+    assert "${" not in m.sql  # measure ref expanded to base aggregate, dim ref resolved
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(graph.get_model("orders"))
+    sql = layer.compile(metrics=["orders.m"])
+    con = duckdb.connect()
+    con.execute("create table orders as select 1 id, 10 amount union all select 2, 20")
+    assert con.execute(sql).fetchall() == [(1.0,)]  # SUM(amount)/SUM(amount) = 1.0
+
+
+def test_lookml_number_measure_mixed_filtered_base_measure_keeps_filter():
+    """Expanding a FILTERED base measure in a mixed expr must keep the filter, not drop it.
+
+    `completed_total` (sum filtered to status='completed') used in
+    `${completed_total} / NULLIF(SUM(${amount}), 0)` must compile to a filtered numerator
+    (10/40 = 0.25), not an unfiltered SUM(amount)/SUM(amount) = 1.0.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: completed_total { type: sum  sql: ${TABLE}.amount ;; filters: [status: "completed"] }
+  measure: m { type: number  sql: ${orders.completed_total} / NULLIF(SUM(${orders.amount}), 0) ;; }
+}
+"""
+    )
+    m = graph.get_model("orders").get_metric("m")
+    assert m is not None and "completed" in m.sql  # base-measure filter folded in
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(graph.get_model("orders"))
+    sql = layer.compile(metrics=["orders.m"])
+    con = duckdb.connect()
+    con.execute("create table orders(id int, amount int, status text)")
+    con.execute("insert into orders values (1,10,'completed'),(2,30,'pending')")
+    assert con.execute(sql).fetchall() == [(0.25,)]  # 10 / (10+30)
+
+
+def test_lookml_number_measure_mixed_filter_clause_kept():
+    """A mixed expr using an aggregate FILTER (WHERE ...) clause is aggregate-safe and kept."""
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: total { type: sum  sql: ${TABLE}.amount ;; }
+  measure: m { type: number  sql: ${o.total} / NULLIF(SUM(${o.amount}) FILTER (WHERE ${o.status} = 'completed'), 0) ;; }
+}
+"""
+    )
+    m = graph.get_model("o").get_metric("m")
+    assert m is not None and m.sql_is_complete is True  # FILTER predicate cols are aggregate-safe
+
+
+def test_lookml_number_measure_inline_aggregate_cases_execute():
+    """A number measure with an INLINE aggregate is opaque/complete and executes correctly.
+
+    Covers a measure ref divided by an inline aggregate (${count}/COUNT(*)) and an
+    inline-aggregate-over-dimension measure with filters (SUM(${amount}) filters: ...) --
+    both previously mis-routed to the derived path (bare-token / unfiltered SQL).
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: completed_count { type: count  filters: [status: "completed"] }
+  measure: rate { type: number  sql: ${o.completed_count} / NULLIF(COUNT(*), 0) ;; }
+  measure: completed_amt { type: number  sql: SUM(${o.amount}) ;; filters: [status: "completed"] }
+}
+"""
+    )
+    model = graph.get_model("o")
+    assert model.get_metric("rate").sql_is_complete is True
+    assert model.get_metric("completed_amt").sql_is_complete is True
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table o(id int, amount int, status text)")
+    con.execute("insert into o values (1,10,'completed'),(2,30,'pending')")
+    assert con.execute(layer.compile(metrics=["o.rate"])).fetchall() == [(0.5,)]  # 1 completed / 2 rows
+    assert con.execute(layer.compile(metrics=["o.completed_amt"])).fetchall() == [(10,)]  # filtered SUM
+
+
+def test_lookml_number_measure_zero_column_aggregate_filter_applied():
+    """A complete number measure whose aggregate has NO foldable column still honors filters.
+
+    The generator filters a complete-SQL measure by nulling the raw columns it references,
+    but COUNT(*) has none to null, so the filter would be silently dropped (and a mix like
+    COUNT(*)/COUNT(DISTINCT id) would filter inconsistently). The adapter folds the filter
+    into every aggregate via CASE WHEN so the result is correct.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: completed_num { type: number  sql: COUNT(*) ;; filters: [status: "completed"] }
+  measure: completed_ratio { type: number  sql: COUNT(*) / NULLIF(COUNT(DISTINCT ${id}), 0) ;; filters: [status: "completed"] }
+}
+"""
+    )
+    model = graph.get_model("o")
+    completed_num = model.get_metric("completed_num")
+    # Filter folded INTO the aggregate (not left as a separate, ignored filter).
+    assert "CASE WHEN" in completed_num.sql
+    assert not completed_num.filters
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table o(id int, status text)")
+    con.execute("insert into o values (1,'completed'),(2,'pending'),(3,'completed'),(4,'cancelled')")
+    assert con.execute(layer.compile(metrics=["o.completed_num"])).fetchall() == [(2,)]  # 2 of 4
+    assert con.execute(layer.compile(metrics=["o.completed_ratio"])).fetchall() == [(1.0,)]  # 2 completed / 2 distinct
+
+
+def test_lookml_number_measure_expands_distinct_base_measure():
+    """A complete number expr referencing a supported distinct measure must EXPAND it, not drop.
+
+    sum_distinct/average_distinct/etc. are not in _SQL_AGG_FUNC, so they were missing from
+    measure_full_sql_lookup and the unexpandable check dropped the whole metric. They now
+    expand via _parse_distinct_measure's generated SQL.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: sd_total { type: sum_distinct  sql: ${amount} ;;  sql_distinct_key: ${id} ;; }
+  measure: rate { type: number  sql: ${sd_total} / NULLIF(SUM(${amount}), 0) ;; }
+}
+"""
+    )
+    model = graph.get_model("o")
+    rate = model.get_metric("rate")
+    assert rate is not None and rate.sql_is_complete is True  # not dropped as unexpandable
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table o(id int, amount int)")
+    con.execute("insert into o values (1,10),(2,20)")
+    # distinct-by-key sum = 30; SUM(amount) = 30 -> 1.0
+    assert con.execute(layer.compile(metrics=["o.rate"])).fetchall() == [(1.0,)]
+
+
+def test_lookml_number_measure_keyed_distinct_ref_with_own_filter_executes():
+    """A complete measure's own filter over an expanded KEYED distinct must fold (HASH-safe).
+
+    The keyed symmetric-distinct aggregate hashes the key; nulling the key for excluded rows
+    gives HASH(NULL) (a non-NULL constant), so column-nulling leaves garbage. The filter must
+    fold into the aggregate args instead.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: country { type: string  sql: ${TABLE}.country ;; }
+  measure: sd_total { type: sum_distinct  sql: ${amount} ;;  sql_distinct_key: ${id} ;; }
+  measure: us_rate { type: number  sql: ${sd_total} / NULLIF(SUM(${amount}), 0) ;;  filters: [country: "US"] }
+}
+"""
+    )
+    model = graph.get_model("o")
+    us_rate = model.get_metric("us_rate")
+    assert us_rate is not None and not us_rate.filters  # folded into the HASH aggregate, not column-nulled
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table o(id int, amount int, country text)")
+    con.execute("insert into o values (1,10,'US'),(2,20,'US'),(3,1000,'CA')")
+    # US distinct-by-key sum = 30; US SUM(amount) = 30 -> 1.0 (the CA 1000 excluded, not garbage)
+    assert con.execute(layer.compile(metrics=["o.us_rate"])).fetchall() == [(1.0,)]
+
+
+def test_lookml_number_measure_count_star_sql_with_filter_expands_validly():
+    """A referenced `type: count sql: * ;;` with filters must expand as COUNT(CASE..THEN 1), not THEN *."""
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: completed_ct { type: count  sql: * ;;  filters: [status: "completed"] }
+  measure: rate { type: number  sql: ${completed_ct} / NULLIF(COUNT(*), 0) ;; }
+}
+"""
+    )
+    model = graph.get_model("o")
+    rate = model.get_metric("rate")
+    assert rate is not None and "THEN * END" not in (rate.sql or "")  # no invalid star-in-CASE
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table o(id int, status text)")
+    con.execute("insert into o values (1,'completed'),(2,'pending'),(3,'completed'),(4,'x')")
+    assert con.execute(layer.compile(metrics=["o.rate"])).fetchall() == [(0.5,)]  # 2 of 4
+
+
+def test_lookml_number_measure_filtered_distinct_ref_not_silently_unfiltered():
+    """A FILTERED distinct base measure can't expand faithfully -> the referencing expr is dropped.
+
+    _parse_distinct_measure doesn't fold the measure's own filters (the keyed symmetric /
+    quantile forms have no single predicate slot), so expanding a filtered distinct would
+    silently produce an UNfiltered result. Skip it (drop the ref) rather than mislead; an
+    UNfiltered distinct still expands.
+    """
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: completed_sd { type: sum_distinct  sql: ${amount} ;;  sql_distinct_key: ${id} ;;  filters: [status: "completed"] }
+  measure: rate { type: number  sql: ${completed_sd} / NULLIF(SUM(${amount}), 0) ;; }
+  measure: sd_plain { type: sum_distinct  sql: ${amount} ;;  sql_distinct_key: ${id} ;; }
+  measure: rate_plain { type: number  sql: ${sd_plain} / NULLIF(SUM(${amount}), 0) ;; }
+}
+"""
+    )
+    model = graph.get_model("o")
+    assert model.get_metric("rate") is None  # filtered distinct ref dropped (not unfiltered)
+    assert model.get_metric("rate_plain") is not None  # unfiltered distinct still expands
+
+
+def test_lookml_number_measure_own_filter_with_null_predicate_folds():
+    """A complete measure's own filter must fold (not null columns) when SQL tests col IS NULL.
+
+    null_status_ct expands to COUNT(CASE WHEN status IS NULL THEN 1 END); applying the
+    measure's own country='US' filter by NULLING status would make status IS NULL true for
+    non-US rows, inflating the count. The filter must fold into the aggregate predicate.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  dimension: country { type: string  sql: ${TABLE}.country ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: null_status_ct { type: count  filters: [status: "NULL"] }
+  measure: us_rate { type: number  sql: ${null_status_ct} / NULLIF(SUM(${amount}), 0) ;;  filters: [country: "US"] }
+}
+"""
+    )
+    model = graph.get_model("o")
+    us_rate = model.get_metric("us_rate")
+    assert us_rate is not None and not us_rate.filters  # own filter folded into the SQL
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table o(id int, status text, country text, amount int)")
+    con.execute("insert into o values (1,NULL,'US',10),(2,'x','US',10),(3,NULL,'CA',10)")
+    # numerator = US rows with status NULL = 1 (id1, NOT id3/CA); denom = SUM US amount = 20
+    assert con.execute(layer.compile(metrics=["o.us_rate"])).fetchall() == [(0.05,)]
+
+
+def test_lookml_number_measure_ordered_set_aggregate_kept_and_executes():
+    """A number measure using an ordered-set aggregate (WITHIN GROUP) is a valid aggregate.
+
+    sqlglot nests the ORDER BY column under exp.WithinGroup (not exp.AggFunc), so the
+    aggregate-safety check must accept it; otherwise the measure is wrongly dropped as a
+    'raw ungrouped column'.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: median_amt { type: number  sql: PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ${amount}) ;; }
+}
+"""
+    )
+    model = graph.get_model("o")
+    median = model.get_metric("median_amt")
+    assert median is not None  # not dropped
+    assert median.sql_is_complete is True
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table o(id int, amount int)")
+    con.execute("insert into o values (1,10),(2,20),(3,30)")
+    assert con.execute(layer.compile(metrics=["o.median_amt"])).fetchall() == [(20,)]
+
+
+def test_lookml_number_measure_anonymous_aggregate_filter_folded():
+    """A filter over a mix of anonymous aggregate + zero-column aggregate must fold into BOTH.
+
+    PRODUCT(amount) / COUNT(*) with filters: the COUNT(*) forces the fold path; PRODUCT is an
+    exp.Anonymous, so without including it the fold would leave PRODUCT over ALL rows while
+    COUNT is filtered -> wrong. Both must carry the filter.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: country { type: string  sql: ${TABLE}.country ;; }
+  measure: prod_rate { type: number  sql: PRODUCT(${amount}) / NULLIF(COUNT(*), 0) ;;  filters: [country: "US"] }
+}
+"""
+    )
+    model = graph.get_model("o")
+    prod_rate = model.get_metric("prod_rate")
+    assert prod_rate is not None and not prod_rate.filters  # folded into both aggregates
+    assert "PRODUCT(CASE WHEN" in prod_rate.sql  # PRODUCT arg wrapped, not left unfiltered
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table o(id int, amount int, country text)")
+    con.execute("insert into o values (1,2,'US'),(2,3,'US'),(3,100,'CA')")
+    # US: PRODUCT(2,3)=6 / COUNT(US)=2 -> 3.0 (the CA 100 excluded from BOTH, not just COUNT)
+    assert con.execute(layer.compile(metrics=["o.prod_rate"])).fetchall() == [(3.0,)]
+
+
+def test_lookml_number_measure_anonymous_aggregate_kept_and_executes():
+    """A number measure using an anonymous/engine-specific aggregate (PRODUCT) is valid.
+
+    sqlglot parses PRODUCT/ENTROPY/WEIGHTED_AVG etc. as exp.Anonymous (not exp.AggFunc), but
+    sidemantic recognizes them as aggregates; the aggregate-safety check must accept their
+    column args so the measure imports as complete SQL instead of being dropped as raw.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: prod_amt { type: number  sql: PRODUCT(${amount}) ;; }
+}
+"""
+    )
+    model = graph.get_model("o")
+    prod = model.get_metric("prod_amt")
+    assert prod is not None and prod.sql_is_complete is True
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table o(id int, amount int)")
+    con.execute("insert into o values (1,2),(2,3),(3,4)")
+    assert con.execute(layer.compile(metrics=["o.prod_amt"])).fetchall() == [(24,)]  # 2*3*4
+
+
+def test_lookml_number_measure_ordered_set_aggregate_with_filter_executes():
+    """A FILTERED ordered-set aggregate must filter the ORDER BY values, not the constant.
+
+    The zero-column fold must NOT wrap the percentile fraction (PERCENTILE_CONT(CASE ...) is
+    a non-constant parameter DuckDB rejects). The ORDER-BY column has a column, so the filter
+    is applied by the generator's column-nulling (NULLs are ignored by the percentile).
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: median_done { type: number  sql: PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ${amount}) ;; filters: [status: "completed"] }
+}
+"""
+    )
+    model = graph.get_model("o")
+    median = model.get_metric("median_done")
+    assert median is not None
+    assert "PERCENTILE_CONT(CASE" not in (median.sql or "")  # constant param not wrapped
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table o(id int, amount int, status text)")
+    con.execute("insert into o values (1,10,'completed'),(2,30,'completed'),(3,50,'completed'),(4,1000,'pending')")
+    # median of {10,30,50} = 30; the pending 1000 must be excluded
+    assert con.execute(layer.compile(metrics=["o.median_done"])).fetchall() == [(30.0,)]
+
+
+def test_lookml_number_measure_with_subquery_skipped():
+    """A number measure containing a scalar subquery is skipped (complete-SQL can't represent it).
+
+    The complete-SQL builder rewrites every parsed column to the measure's CTE raw alias,
+    including columns INSIDE the subquery, producing a wrong correlated query -- so skip.
+    """
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: pct_target { type: number  sql: SUM(${amount}) / NULLIF((SELECT SUM(amount) FROM targets), 0) ;; }
+  measure: ok_ratio { type: number  sql: SUM(${amount}) / NULLIF(COUNT(*), 0) ;; }
+}
+"""
+    )
+    model = graph.get_model("o")
+    assert model.get_metric("pct_target") is None  # subquery -> skipped
+    assert model.get_metric("ok_ratio") is not None  # ordinary inline-aggregate still kept
+
+
+def test_lookml_number_measure_mixed_windowed_aggregate_skipped():
+    """A mixed expr with a WINDOW aggregate over a raw column is NOT safe -> skipped.
+
+    SUM(x) OVER () runs after grouping, so a raw column there is still ungrouped and would
+    be rejected in a grouped SELECT; the measure must be dropped, not imported as invalid.
+    """
+    graph = _parse_lkml(
+        """
+view: o {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: total { type: sum  sql: ${TABLE}.amount ;; }
+  measure: m { type: number  sql: ${o.total} / NULLIF(SUM(${o.amount}) OVER (), 0) ;; }
+}
+"""
+    )
+    assert graph.get_model("o").get_metric("m") is None  # windowed raw column -> skipped
+
+
+def test_lookml_complete_measure_own_filter_resolves_renamed_dimension():
+    """A COMPLETE (mixed) measure's OWN filter on a renamed dimension resolves to the real column."""
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: state { type: string  sql: ${TABLE}.status ;; }
+  measure: total { type: sum  sql: ${TABLE}.amount ;; }
+  measure: m { type: number  sql: ${orders.total} / NULLIF(SUM(${orders.amount}), 0) ;; filters: [state: "completed"] }
+}
+"""
+    )
+    m = graph.get_model("orders").get_metric("m")
+    assert m is not None and m.sql_is_complete is True
+    assert any("status" in f for f in (m.filters or []))  # renamed dim resolved to its column
+    assert not any("{model}.state" in f for f in (m.filters or []))  # not the bare dim name
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(graph.get_model("orders"))
+    sql = layer.compile(metrics=["orders.m"])
+    con = duckdb.connect()
+    con.execute("create table orders(id int, amount int, status text)")
+    con.execute("insert into orders values (1,10,'completed'),(2,30,'pending')")
+    assert con.execute(sql).fetchall()  # executes (no raw `state` column error)
+
+
+def test_lookml_measure_filter_strips_self_view_qualifier():
+    """A measure filter with a view-qualified field (orders.status) must not double-qualify."""
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: completed_total { type: sum  sql: ${TABLE}.amount ;; filters: [orders.status: "completed"] }
+  measure: m { type: number  sql: ${orders.completed_total} / NULLIF(SUM(${orders.amount}), 0) ;; }
+}
+"""
+    )
+    m = graph.get_model("orders").get_metric("m")
+    assert m is not None and "{model}.status" in m.sql and "orders.status" not in m.sql
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(graph.get_model("orders"))
+    sql = layer.compile(metrics=["orders.m"])
+    con = duckdb.connect()
+    con.execute("create table orders(id int, amount int, status text)")
+    con.execute("insert into orders values (1,10,'completed'),(2,30,'pending')")
+    assert con.execute(sql).fetchall() == [(0.25,)]
+
+
+def test_lookml_number_measure_mixed_filtered_base_measure_resolves_renamed_dimension():
+    """Folding a base measure's filter must resolve the filter field through its dimension SQL."""
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: state { type: string  sql: ${TABLE}.status ;; }
+  measure: completed_total { type: sum  sql: ${TABLE}.amount ;; filters: [state: "completed"] }
+  measure: m { type: number  sql: ${orders.completed_total} / NULLIF(SUM(${orders.amount}), 0) ;; }
+}
+"""
+    )
+    m = graph.get_model("orders").get_metric("m")
+    assert m is not None and "status" in m.sql and "{model}.state" not in m.sql  # renamed col resolved
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(graph.get_model("orders"))
+    sql = layer.compile(metrics=["orders.m"])
+    con = duckdb.connect()
+    con.execute("create table orders(id int, amount int, status text)")
+    con.execute("insert into orders values (1,10,'completed'),(2,30,'pending')")
+    assert con.execute(sql).fetchall() == [(0.25,)]  # 10 / (10+30)
+
+
+def test_lookml_number_measure_mixed_filtered_count_ref_keeps_filter():
+    """A filtered `type: count` (no sql) base measure expanded in a mixed expr keeps its filter."""
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: completed_count { type: count  filters: [status: "completed"] }
+  measure: rate { type: number  sql: ${orders.completed_count} / NULLIF(COUNT(${orders.id}), 0) ;; }
+}
+"""
+    )
+    rate = graph.get_model("orders").get_metric("rate")
+    assert rate is not None and "CASE WHEN" in rate.sql  # count filter folded, not bare COUNT(*)
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(graph.get_model("orders"))
+    sql = layer.compile(metrics=["orders.rate"])
+    con = duckdb.connect()
+    con.execute("create table orders(id int, status text)")
+    con.execute("insert into orders values (1,'completed'),(2,'pending'),(3,'completed'),(4,'pending')")
+    assert con.execute(sql).fetchall() == [(0.5,)]  # 2 completed / 4 total
+
+
+def test_lookml_number_measure_bare_column_dimension_row_level_skipped():
+    """A number measure over a bare-column dimension with no aggregate is row-level -> skipped."""
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: o ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: bare { sql: amount ;; }
+  measure: m { type: number  sql: ${orders.bare} / 2 ;; }
+}
+"""
+    )
+    assert graph.get_model("orders").get_metric("m") is None  # no aggregate -> not a valid measure
+
+
+def test_lookml_dimension_referencing_compact_dimension_resolves():
+    """A dimension whose sql references a COMPACT dimension must resolve, not leak ${name}."""
+    graph = _parse_lkml(
+        """
+view: inventory_items {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: cost {}
+  dimension: cost_x2 { sql: ${inventory_items.cost} * 2 ;; }
+}
+"""
+    )
+    cost_x2 = graph.get_model("inventory_items").get_dimension("cost_x2")
+    assert "${" not in cost_x2.sql
+    assert "{model}.cost" in cost_x2.sql
+
+
+def test_lookml_deep_reference_chain_resolves_fully():
+    """Reference chains longer than 10 must resolve fully (no fixed-depth truncation)."""
+    dims = "\n".join(f"  dimension: d{i} {{ type: number  sql: ${{d{i - 1}}} + 1 ;; }}" for i in range(1, 13))
+    graph = _parse_lkml(
+        f"view: v {{\n  sql_table_name: t ;;\n"
+        f"  dimension: d0 {{ primary_key: yes  type: number  sql: ${{TABLE}}.x ;; }}\n{dims}\n}}"
+    )
+    d12 = graph.get_model("v").get_dimension("d12")
+    assert "${" not in d12.sql
+
+
+def test_lookml_self_referential_dimension_terminates():
+    """A self-referential dimension must terminate (no infinite loop / runaway expansion)."""
+    graph = _parse_lkml(
+        "view: v { sql_table_name: t ;; "
+        "dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+        "dimension: selfd { type: number  sql: ${selfd} + 1 ;; } }"
+    )
+    selfd = graph.get_model("v").get_dimension("selfd")
+    # Resolution stops at the cycle rather than expanding many levels deep.
+    assert selfd.sql.count("+ 1") <= 2
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2471,6 +2471,80 @@ view: orders {
     assert con.execute(sql).fetchall() == [(0.25,)]  # 10 / (10+30)
 
 
+def test_lookml_number_measure_ref_to_filtered_complete_measure_keeps_filter():
+    """Referencing a FILTERED complete number measure must inline its filter, not drop it.
+
+    `completed_sum` is a type: number inline-aggregate measure filtered to status='completed'.
+    `double_sum = ${completed_sum} * 2` must inline the FILTERED aggregate (completed=130, *2 =
+    260), not expand to an unfiltered SUM(amount)*2 over all rows (360). A chained reference
+    (triple_sum = double_sum + completed_sum) must also stay filtered.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: completed_sum { type: number  sql: SUM(${amount}) ;; filters: [status: "completed"] }
+  measure: double_sum { type: number  sql: ${completed_sum} * 2 ;; }
+  measure: triple_sum { type: number  sql: ${double_sum} + ${completed_sum} ;; }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    assert model.get_metric("double_sum") is not None  # not dropped
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table orders(id int, amount int, status text)")
+    con.execute("insert into orders values (1,100,'completed'),(2,50,'pending'),(3,30,'completed')")
+    assert con.execute(layer.compile(metrics=["orders.completed_sum"])).fetchall() == [(130,)]
+    assert con.execute(layer.compile(metrics=["orders.double_sum"])).fetchall() == [(260,)]  # not 360
+    assert con.execute(layer.compile(metrics=["orders.triple_sum"])).fetchall() == [(390,)]  # 260 + 130
+
+
+def test_lookml_number_measure_expands_chained_derived_ref():
+    """A number measure referencing another DERIVED number measure must be kept, not dropped.
+
+    `gross_margin = ${revenue} - ${cost_total}` is itself derived; `avg_margin =
+    ${gross_margin} / NULLIF(COUNT(*), 0)` has an inline aggregate, so it needs the complete-SQL
+    path. gross_margin must be recursively expandable (else avg_margin is dropped as unexpandable).
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: cost { type: number  sql: ${TABLE}.cost ;; }
+  measure: revenue { type: sum  sql: ${amount} ;; }
+  measure: cost_total { type: sum  sql: ${cost} ;; }
+  measure: gross_margin { type: number  sql: ${revenue} - ${cost_total} ;; }
+  measure: avg_margin { type: number  sql: ${gross_margin} / NULLIF(COUNT(*), 0) ;; }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    assert model.get_metric("avg_margin") is not None  # was dropped as unexpandable before
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table orders(id int, amount int, cost int)")
+    con.execute("insert into orders values (1,100,10),(2,50,20),(3,30,5)")
+    # gross_margin = (100+50+30) - (10+20+5) = 180 - 35 = 145; avg_margin = 145 / 3
+    assert con.execute(layer.compile(metrics=["orders.gross_margin"])).fetchall() == [(145,)]
+    assert con.execute(layer.compile(metrics=["orders.avg_margin"])).fetchall() == [(145 / 3,)]
+
+
 def test_lookml_number_measure_mixed_filter_clause_kept():
     """A mixed expr using an aggregate FILTER (WHERE ...) clause is aggregate-safe and kept."""
     graph = _parse_lkml(

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2770,6 +2770,31 @@ view: orders {
     assert con.execute(layer.compile(metrics=["orders.sel"])).fetchall() == [(50,)]
 
 
+def test_lookml_number_measure_select_in_comment_is_not_a_subquery():
+    """The word `select` inside a SQL COMMENT must not be mistaken for a subquery.
+
+    A comment like `/* select paid rows */ SUM(amount)` has no subquery; leaving the comment text
+    in the scan matched `select` and dropped a valid inline aggregate. Comments are blanked with
+    quoted tokens, and a real subquery is still skipped.
+    """
+    conv = LookMLAdapter._has_subquery
+    assert conv("/* select paid rows */ SUM(amount)") is False
+    assert conv("-- select paid rows\nSUM(amount)") is False
+    assert conv("SUM(amount) / (SELECT COUNT(*) FROM t)") is True  # real subquery still detected
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: commented { type: number  sql: /* select paid rows */ SUM(${amount}) / NULLIF(COUNT(*), 0) ;; }
+}
+"""
+    )
+    assert graph.get_model("orders").get_metric("commented") is not None  # comment is not a subquery
+
+
 def test_lookml_number_measure_unsafe_intermediate_not_expandable():
     """A number measure _parse_measure skips as unsafe must not be inlined into a later measure.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2465,6 +2465,28 @@ view: customers {
     assert "${" not in sql
 
 
+def test_lookml_cross_view_segment_dropped():
+    """A view-level filter (segment) with a cross-view ref is dropped, not imported unqueryable.
+
+    Otherwise the unresolved ${customers.active} leaks into the WHERE clause when the segment is
+    used, while dimensions/measures with the same leak are dropped. A normal segment is kept.
+    """
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  filter: active_customers { type: yesno  sql: ${customers.active} ;; }
+  filter: big { type: number  sql: ${TABLE}.amount > 100 ;; }
+}
+view: customers { sql_table_name: customers ;; dimension: active { type: yesno  sql: ${TABLE}.active ;; } }
+"""
+    )
+    names = {s.name for s in graph.get_model("orders").segments}
+    assert "active_customers" not in names  # cross-view segment dropped
+    assert "big" in names  # ordinary segment kept
+
+
 def test_lookml_number_measure_row_level_dimension_expr_skipped():
     """A type: number measure that is a ROW-LEVEL dimension expression (no aggregate) is skipped.
 
@@ -3627,6 +3649,15 @@ def test_lookml_filtered_windowed_aggregate_folds_into_inner_aggregate():
     )
     # No inner aggregate to carry the filter -> the fold aborts (returns None).
     assert LookMLAdapter._fold_complete_sql_filters("SUM(amount) OVER ()", ["{model}.status = 'x'"]) is None
+    # A FILTER clause nests exp.Filter between the aggregate and its OVER window; the windowed
+    # check must still see the window (via the Filter) and abort rather than fold the arg into the
+    # window -- COUNT(CASE ...) OVER () would put the filter column ungrouped inside the window.
+    assert (
+        LookMLAdapter._fold_complete_sql_filters(
+            "COUNT(*) FILTER (WHERE TRUE) OVER ()", ["{model}.status = 'x'"], force=True
+        )
+        is None
+    )
 
     graph = _parse_lkml(
         """

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2508,6 +2508,46 @@ view: orders {
     assert con.execute(layer.compile(metrics=["orders.triple_sum"])).fetchall() == [(390,)]  # 260 + 130
 
 
+def test_lookml_number_measure_filtered_list_aggregate_skipped():
+    """A FILTERED LIST(...) measure has no faithful form and must be skipped, not silently wrong.
+
+    LIST keeps NULL inputs, so neither the generator's column-nulling nor a folded CASE excludes
+    a row: LIST(CASE WHEN status='completed' THEN amount END) over 3 rows yields [100, NULL, 30],
+    so ARRAY_LENGTH still returns 3 and the filter is ignored. Only a dialect-specific
+    FILTER (WHERE ...) clause would work. An UNFILTERED LIST, and a filtered NON-list aggregate,
+    must both still import.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: n_completed { type: number  sql: ARRAY_LENGTH(LIST(${amount})) ;; filters: [status: "completed"] }
+  measure: n_all { type: number  sql: ARRAY_LENGTH(LIST(${amount})) ;; }
+  measure: sum_completed { type: number  sql: SUM(${amount}) ;; filters: [status: "completed"] }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    assert model.get_metric("n_completed") is None  # would have silently ignored its filter
+    assert model.get_metric("n_all") is not None  # unfiltered LIST is fine
+    assert model.get_metric("sum_completed") is not None  # a foldable filtered aggregate is fine
+
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table orders(id int, amount int, status text)")
+    con.execute("insert into orders values (1,100,'completed'),(2,50,'pending'),(3,30,'completed')")
+    assert con.execute(layer.compile(metrics=["orders.n_all"])).fetchall() == [(3,)]
+    assert con.execute(layer.compile(metrics=["orders.sum_completed"])).fetchall() == [(130,)]
+
+
 def test_lookml_number_measure_list_aggregate_is_scope_safe():
     """A column inside DuckDB's LIST(...) collector is aggregate-scoped, not raw.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -3395,6 +3395,53 @@ view: orders {
     assert con.execute(sql).fetchall() == [(1.0,)]
 
 
+def test_lookml_filtered_multi_column_distinct_folds_around_the_tuple():
+    """A filtered multi-column DISTINCT must fold the predicate, not rely on column-nulling.
+
+    Nulling the columns of an excluded row yields the tuple (NULL, NULL), which is NOT a NULL value,
+    so COUNT(DISTINCT (a, b)) counts that phantom tuple once and inflates the result by one. Fold
+    the predicate around the tuple instead; a single-column distinct stays on the safe nulling path.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    # Multi-column distinct (tuple and comma forms) folds; single-column stays on the nulling path.
+    assert (
+        LookMLAdapter._fold_complete_sql_filters("COUNT(DISTINCT ({model}.uid, {model}.oid))", ["{model}.s = 'x'"])
+        == "COUNT(DISTINCT CASE WHEN {model}.s = 'x' THEN ({model}.uid, {model}.oid) END)"
+    )
+    assert (
+        LookMLAdapter._fold_complete_sql_filters("COUNT(DISTINCT {model}.uid, {model}.oid)", ["{model}.s = 'x'"])
+        is not None
+    )
+    assert LookMLAdapter._fold_complete_sql_filters("COUNT(DISTINCT {model}.uid)", ["{model}.s = 'x'"]) is None
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: uid { type: number  sql: ${TABLE}.uid ;; }
+  dimension: oid { type: number  sql: ${TABLE}.oid ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: pairs { type: number  sql: COUNT(DISTINCT (${uid}, ${oid})) ;; filters: [status: "completed"] }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    sql = layer.compile(metrics=["orders.pairs"])
+    con = duckdb.connect()
+    con.execute(
+        "create table orders as select 1 id, 1 uid, 10 oid, 'completed' status "
+        "union all select 2, 2, 20, 'pending' union all select 3, 1, 10, 'completed'"
+    )
+    # Only the two 'completed' rows, both (1, 10) -> one distinct pair. Nulling would give 2.
+    assert con.execute(sql).fetchall() == [(1,)]
+
+
 def test_lookml_complete_measure_own_filter_resolves_renamed_dimension():
     """A COMPLETE (mixed) measure's OWN filter on a renamed dimension resolves to the real column."""
     import duckdb

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2508,6 +2508,50 @@ view: orders {
     assert con.execute(layer.compile(metrics=["orders.triple_sum"])).fetchall() == [(390,)]  # 260 + 130
 
 
+def test_lookml_filtered_list_measure_not_cached_for_expansion():
+    """A filtered LIST measure the parser skips must not be cached for later expansion.
+
+    ARRAY_LENGTH(LIST(${amount})) / NULLIF(COUNT(*), 0) with filters is unrepresentable (LIST
+    keeps NULLs), so _parse_measure skips it. The expansion prepass must apply the same guard: it
+    would otherwise fold only the COUNT(*), cache a PARTIALLY filtered SQL, and let a referencing
+    measure inline an UNFILTERED LIST numerator over a filtered denominator -- silently wrong.
+    An UNFILTERED LIST measure, and its referencer, must still work.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: ratio { type: number  sql: ARRAY_LENGTH(LIST(${amount})) / NULLIF(COUNT(*), 0) ;; filters: [status: "completed"] }
+  measure: outer_m { type: number  sql: ${ratio} * 2 ;; }
+  measure: unfiltered_ratio { type: number  sql: ARRAY_LENGTH(LIST(${amount})) / NULLIF(COUNT(*), 0) ;; }
+  measure: outer_ok { type: number  sql: ${unfiltered_ratio} * 2 ;; }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    assert model.get_metric("ratio") is None  # filtered LIST is unrepresentable
+    # The referencer must NOT carry an inlined, partially-filtered copy. It stays a plain derived
+    # ref to the skipped measure, which fails LOUDLY rather than returning a wrong number.
+    outer = model.get_metric("outer_m")
+    assert outer is None or "LIST" not in (outer.sql or ""), outer.sql if outer else None
+
+    # The unfiltered LIST path is unaffected and still executes.
+    assert model.get_metric("unfiltered_ratio") is not None
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table orders(id int, amount int, status text)")
+    con.execute("insert into orders values (1,100,'completed'),(2,50,'pending'),(3,30,'completed')")
+    assert con.execute(layer.compile(metrics=["orders.outer_ok"])).fetchall() == [(2.0,)]
+
+
 def test_lookml_number_measure_case_with_else_folds_filter():
     """A CASE with an ELSE default survives column-nulling, so its filter must be FOLDED.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -3301,6 +3301,48 @@ view: orders {
     assert dict(con.execute(sql).fetchall()) == {"e": 0.1, "w": 0.9}
 
 
+def test_lookml_filtered_windowed_aggregate_folds_into_inner_aggregate():
+    """A filter on a windowed aggregate must fold into its INNER aggregate, not the window arg.
+
+    For COUNT(*) / NULLIF(SUM(COUNT(*)) OVER (), 0) with a filter, wrapping the outer windowed
+    SUM's argument put the filter column inside the window, ungrouped -- DuckDB rejected it. The
+    inner COUNT(*) is a grouped aggregate that can carry the filter, so fold there; a windowed
+    aggregate over a RAW column has nothing to carry it and is dropped rather than mis-filtered.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    # The predicate folds into the inner COUNT, never the outer windowed SUM's argument.
+    assert LookMLAdapter._fold_complete_sql_filters(
+        "COUNT(*) / NULLIF(SUM(COUNT(*)) OVER (), 0)", ["{model}.status = 'x'"]
+    ) == (
+        "COUNT(CASE WHEN {model}.status = 'x' THEN 1 END) / "
+        "NULLIF(SUM(COUNT(CASE WHEN {model}.status = 'x' THEN 1 END)) OVER (), 0)"
+    )
+    # No inner aggregate to carry the filter -> the fold aborts (returns None).
+    assert LookMLAdapter._fold_complete_sql_filters("SUM(amount) OVER ()", ["{model}.status = 'x'"]) is None
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: pct { type: number  sql: COUNT(*) / NULLIF(SUM(COUNT(*)) OVER (), 0) ;; filters: [status: "x"] }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    sql = layer.compile(metrics=["orders.pct"])
+    con = duckdb.connect()
+    con.execute("create table orders as select 1 id, 'x' status union all select 2, 'x' union all select 3, 'y'")
+    # 2 rows match the filter; each is its own group, summed over the window = 2, so 2/2 rows -> 1.0.
+    assert con.execute(sql).fetchall() == [(1.0,)]
+
+
 def test_lookml_complete_measure_own_filter_resolves_renamed_dimension():
     """A COMPLETE (mixed) measure's OWN filter on a renamed dimension resolves to the real column."""
     import duckdb

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -3262,6 +3262,45 @@ view: o {
     assert graph.get_model("o").get_metric("m") is None  # windowed raw column -> skipped
 
 
+def test_lookml_number_measure_aggregate_nested_in_window_is_kept():
+    """A window OVER an already-aggregated column is safe and must be imported.
+
+    In SUM(SUM(x)) OVER () the inner SUM groups the raw column before the window runs, so the
+    outer window aggregates a grouped value -- valid in a grouped SELECT. The blanket "any column
+    under a window is unsafe" check wrongly dropped this percent-of-total-style measure; only a
+    RAW window argument (SUM(x) OVER ()) is unsafe.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: region { type: string  sql: ${TABLE}.region ;; }
+  measure: total { type: sum  sql: ${amount} ;; }
+  measure: pct_of_total { type: number  sql: ${total} / NULLIF(SUM(SUM(${amount})) OVER (), 0) ;; }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    assert model.get_metric("pct_of_total") is not None  # nested-agg window kept, not dropped
+
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    sql = layer.compile(metrics=["orders.pct_of_total"], dimensions=["orders.region"])
+    con = duckdb.connect()
+    con.execute(
+        "create table orders as select 1 id, 10.0 amount, 'e' region "
+        "union all select 2, 30, 'w' union all select 3, 60, 'w'"
+    )
+    # region totals 10 and 90 out of 100 overall.
+    assert dict(con.execute(sql).fetchall()) == {"e": 0.1, "w": 0.9}
+
+
 def test_lookml_complete_measure_own_filter_resolves_renamed_dimension():
     """A COMPLETE (mixed) measure's OWN filter on a renamed dimension resolves to the real column."""
     import duckdb

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2831,6 +2831,23 @@ view: orders {
     assert LookMLAdapter._generator_column_nulling_suffices("STDDEV({model}.amount)") is True
 
 
+def test_lookml_hash_with_space_classified_unsafe_like_no_space():
+    """`HASH (col)` (space before the paren) must be classified unsafe just like `HASH(col)`.
+
+    A keyed symmetric-distinct aggregate hashes the key; HASH(NULL) is a non-NULL constant, so
+    nulling the key does NOT exclude the row -- column-nulling produces garbage. The unsafe check
+    must be whitespace-tolerant, otherwise a `HASH (id)` spelling slips through and the filtered
+    measure is silently imported with ineffective column-nulling."""
+    no_space = "SUM(DISTINCT HASH({model}.id) * 100 + {model}.amount)"
+    with_space = "SUM(DISTINCT HASH ({model}.id) * 100 + {model}.amount)"
+    # column-nulling is NOT sufficient for either spelling
+    assert LookMLAdapter._generator_column_nulling_suffices(no_space) is False
+    assert LookMLAdapter._generator_column_nulling_suffices(with_space) is False
+    # ...and both are treated as unsafe-to-null, so folding proceeds rather than early-returning None
+    assert LookMLAdapter._fold_complete_sql_filters(no_space, ["{model}.status = 'x'"]) is not None
+    assert LookMLAdapter._fold_complete_sql_filters(with_space, ["{model}.status = 'x'"]) is not None
+
+
 def test_lookml_number_measure_case_with_else_folds_filter():
     """A CASE with an ELSE default survives column-nulling, so its filter must be FOLDED.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2508,6 +2508,33 @@ view: orders {
     assert con.execute(layer.compile(metrics=["orders.triple_sum"])).fetchall() == [(390,)]  # 260 + 130
 
 
+def test_lookml_number_measure_unsafe_intermediate_not_expandable():
+    """A number measure _parse_measure skips as unsafe must not be inlined into a later measure.
+
+    `bad = ${total} + ${amount}` mixes an aggregate measure with a RAW dimension, so it is dropped
+    on import. The expansion prepass must apply the same aggregate-safety check, otherwise it
+    caches `SUM(amount) + amount` and a later `outer = ${bad} / NULLIF(COUNT(*), 0)` inlines that
+    raw ungrouped column and fails on grouped queries -- instead of `outer` being unavailable too.
+    """
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: total { type: sum  sql: ${amount} ;; }
+  measure: bad { type: number  sql: ${total} + ${amount} ;; }
+  measure: outer_m { type: number  sql: ${bad} / NULLIF(COUNT(*), 0) ;; }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    names = {m.name for m in model.metrics}
+    assert "bad" not in names  # mixed aggregate + raw ungrouped column -> unsupported
+    assert "outer_m" not in names  # must NOT inline the unsafe intermediate
+    assert "total" in names  # the valid base measure is unaffected
+
+
 def test_lookml_number_measure_expands_chained_derived_ref():
     """A number measure referencing another DERIVED number measure must be kept, not dropped.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2508,6 +2508,75 @@ view: orders {
     assert con.execute(layer.compile(metrics=["orders.triple_sum"])).fetchall() == [(390,)]  # 260 + 130
 
 
+def test_lookml_number_measure_constant_dimension_is_aggregate_safe():
+    """A CONSTANT-valued dimension in a mixed number measure must not read as a raw column.
+
+    `dimension: tax_rate { sql: 0.07 ;; }` plus `tax = ${total} * ${tax_rate}` resolves to
+    `SUM(amount) * 0.07` -- valid aggregate SQL with no ungrouped column. Probing the ref as a
+    synthetic `t.tax_rate` column wrongly flagged it as raw and dropped the measure.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: tax_rate { type: number  sql: 0.07 ;; }
+  measure: total { type: sum  sql: ${amount} ;; }
+  measure: tax { type: number  sql: ${total} * ${tax_rate} ;; }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    assert model.get_metric("tax") is not None  # was dropped as an ungrouped column
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table orders(id int, amount int)")
+    con.execute("insert into orders values (1,100),(2,50),(3,30)")
+    # DuckDB returns a Decimal for the constant-scaled product; compare numerically.
+    (tax_value,) = con.execute(layer.compile(metrics=["orders.tax"])).fetchone()
+    assert float(tax_value) == pytest.approx(180 * 0.07)  # SUM(amount) * 0.07
+
+
+def test_lookml_number_measure_select_in_string_literal_is_not_a_subquery():
+    """The word `select` inside a string VALUE must not be mistaken for a subquery.
+
+    `SUM(CASE WHEN ${status} = 'select' THEN ${amount} END)` has no subquery and is a valid
+    inline aggregate; a raw \\bselect\\b scan matched the literal and dropped it. A REAL subquery
+    must still be skipped.
+    """
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: status { type: string  sql: ${TABLE}.status ;; }
+  measure: sel { type: number  sql: SUM(CASE WHEN ${status} = 'select' THEN ${amount} END) ;; }
+  measure: subq { type: number  sql: SUM(${amount}) / NULLIF((SELECT SUM(amount) FROM orders), 0) ;; }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    assert model.get_metric("sel") is not None  # literal 'select' is not a subquery
+    assert model.get_metric("subq") is None  # a real subquery is still skipped
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    con = duckdb.connect()
+    con.execute("create table orders(id int, amount int, status text)")
+    con.execute("insert into orders values (1,100,'completed'),(2,50,'select'),(3,30,'completed')")
+    assert con.execute(layer.compile(metrics=["orders.sel"])).fetchall() == [(50,)]
+
+
 def test_lookml_number_measure_unsafe_intermediate_not_expandable():
     """A number measure _parse_measure skips as unsafe must not be inlined into a later measure.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2735,6 +2735,55 @@ view: orders {
     assert model.get_metric("s") is not None  # was dropped as a phantom subquery
     assert model.get_metric("subq") is None  # a real subquery is still skipped
 
+    # The quoted column must round-trip all the way to a WORKING query -- the complete-SQL CTE
+    # projection has to keep the quoting (`"select" AS s__select__cmpl`), not emit a bare `select`.
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    sql = layer.compile(metrics=["orders.s"])
+    con = duckdb.connect()
+    con.execute('create table orders as select 1 id, 5 "select" union all select 2, 15')
+    assert con.execute(sql).fetchall() == [(20,)]  # SUM of the quoted `select` column
+
+
+def test_lookml_number_measure_dimension_ref_expanding_to_subquery_is_skipped():
+    """A dimension ref that EXPANDS to a subquery must be caught after resolution, not just raw.
+
+    The pre-resolution guard only sees `SUM(${target})`; once `target` expands to a scalar subquery
+    the complete-SQL builder would rewrite the subquery's OWN columns to this measure's CTE aliases,
+    producing wrong correlated SQL. Re-checking the resolved expression skips it; a normal complete
+    measure over the same shape is still imported.
+    """
+    skipped = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  dimension: target { type: number  sql: (SELECT target FROM targets WHERE targets.id = ${TABLE}.id) ;; }
+  measure: total { type: sum  sql: ${amount} ;; }
+  measure: m { type: number  sql: SUM(${target}) / NULLIF(${total}, 0) ;; }
+}
+"""
+    ).get_model("orders")
+    assert skipped.get_metric("m") is None  # dim ref expanded to a subquery -> skipped
+
+    kept = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  measure: total { type: sum  sql: ${amount} ;; }
+  measure: m { type: number  sql: SUM(${amount}) / NULLIF(${total}, 0) ;; }
+}
+"""
+    ).get_model("orders")
+    assert kept.get_metric("m") is not None  # ordinary complete measure still imported
+
 
 def test_lookml_number_measure_select_in_string_literal_is_not_a_subquery():
     """The word `select` inside a string VALUE must not be mistaken for a subquery.


### PR DESCRIPTION
## Summary
Part of the LookML adapter correctness series. **Stacked on #241** (base = `fix/lookml-filters`).

The reference resolver's regex `\${name}` never matched dotted references, so any `${view.field}` leaked the literal `${...}` into generated SQL — a guaranteed database syntax error. Confirmed firsthand: the canonical GA360 block fixture left **26 fields** unresolved.

## Changes
- **Self-view refs** (`${this_view.field}`) are normalized to `${field}` before resolution, so they resolve like bare refs (common in machine-generated LookML).
- **Cross-view refs** (`${other_view.field}`) now emit a qualified column `view.field` plus a warning, instead of leaking `${...}`.
- **Cycle-safe resolution**: replaced the fixed depth-10 cap (which silently truncated long chains and let self-refs expand 10x) with path-based cycle detection — acyclic chains of any depth resolve fully; circular refs terminate.
- Regression tests for each case.

## Known limitation
Cross-view *field* references are a deeper modeling gap: sidemantic cannot represent an inline cross-model column (the generator emits `customers.name` against `FROM orders` with no join). This PR stops the silent invalid-SQL leak and surfaces a warning; full support is a separate effort.