### PR TITLE
Default LookML view table to the view name when unspecified

### DIFF
--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -509,19 +509,10 @@ class LookMLAdapter(BaseAdapter):
         if not parsed:
             return
 
-        # Parse explores
+        # Parse explores. The scope check lives in _parse_explore, which owns the from:/fallback
+        # resolution of the base view -- duplicating that resolution here would drift from it.
         for explore_def in parsed.get("explores") or []:
-            if allowed_views is not None:
-                base_view = explore_def.get("from", explore_def.get("name"))
-                if base_view not in allowed_views:
-                    logger.debug(
-                        "Ignoring LookML explore %s in %s: view %s is not in the model's scope.",
-                        explore_def.get("name"),
-                        file_path,
-                        base_view,
-                    )
-                    continue
-            self._parse_explore(explore_def, graph)
+            self._parse_explore(explore_def, graph, allowed_views=allowed_views)
 
     # Matches ${field} and ${view.field}. ${TABLE} is handled specially.
     _REF_RE = re.compile(r"\$\{(?:([a-zA-Z_]\w*)\.)?([a-zA-Z_]\w*)\}")
@@ -3782,12 +3773,13 @@ class LookMLAdapter(BaseAdapter):
             **common,
         )
 
-    def _parse_explore(self, explore_def: dict, graph: SemanticGraph) -> None:
+    def _parse_explore(self, explore_def: dict, graph: SemanticGraph, allowed_views: set[str] | None = None) -> None:
         """Parse LookML explore and add relationships to models.
 
         Args:
             explore_def: Explore definition from parsed LookML
             graph: Semantic graph to add relationships to
+            allowed_views: Views this explore's model file may reference, or None to allow any.
         """
         explore_name = explore_def.get("name")
         if not explore_name:
@@ -3800,6 +3792,16 @@ class LookMLAdapter(BaseAdapter):
             if explore_name not in graph.models:
                 return
             base_model_name = explore_name
+
+        # Scope-check the RESOLVED base: an explore on a view this model file neither defines nor
+        # includes is not part of this model, and applying it would mutate the live view.
+        if allowed_views is not None and base_model_name not in allowed_views:
+            logger.debug(
+                "Ignoring LookML explore %s: view %s is not in the model's scope.",
+                explore_name,
+                base_model_name,
+            )
+            return
 
         base_model = graph.models[base_model_name]
 
@@ -3875,6 +3877,23 @@ class LookMLAdapter(BaseAdapter):
 
         # Parse joins
         for join_def in explore_def.get("joins") or []:
+            # Scope join targets like the base view: unique un-included views are still installed,
+            # so without this a model that includes only orders.view.lkml could wire `join:
+            # customers` to an archived customers.view.lkml Looker would not have in scope. Check
+            # the `from:` target, which is the view a join alias actually reads.
+            #
+            # Only skip a target that EXISTS but is out of scope. A join to a never-defined view
+            # is left intact: that dangling relationship is a real error `validate` must surface
+            # (see _drop_non_registerable_models), and silently dropping it would hide the typo.
+            join_target = join_def.get("from", join_def.get("name"))
+            if allowed_views is not None and join_target in graph.models and join_target not in allowed_views:
+                logger.debug(
+                    "Ignoring LookML join %s in explore %s: view %s is not in the model's scope.",
+                    join_def.get("name"),
+                    explore_name,
+                    join_target,
+                )
+                continue
             relationship = self._parse_join(join_def, base_model_name, explore_name)
             if relationship:
                 # Add relationship to the base model

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -2942,29 +2942,18 @@ class LookMLAdapter(BaseAdapter):
         label = dim_group_def.get("label")
         description = dim_group_def.get("description")
 
-        # minute15 / minute30 are N-minute BUCKETS, not a plain DATE_TRUNC grain -- the coarse
-        # `minute` granularity would truncate to the minute and silently re-bucket the data. Bake
-        # the N-minute bucket into the SQL and keep MINUTE granularity: the generator's later
-        # DATE_TRUNC('minute', ...) is then a no-op on the already-minute-aligned bucket, preserving
-        # the 15/30-minute grouping. `meta` still round-trips the exact timeframe on export.
-        bucket_n = self._MINUTE_BUCKET_TF.get(timeframe)
-        if bucket_n is not None:
-            base_expr = base_sql if base_sql is not None else "{model}"
-            return Dimension(
-                name=name,
-                type="time",
-                sql=self._minute_bucket_sql(base_expr, bucket_n),
-                granularity="minute",
-                label=label,
-                description=description,
-                meta={"lookml_timeframe": timeframe},
-            )
-
-        # millisecond / microsecond are FINER than the finest supported granularity (`second`), so a
-        # time dimension would truncate to the second and silently drop the sub-second precision the
-        # field name promises. The granularity enum cannot express them, so leave them unsupported
-        # rather than expose a wrong-grain field.
-        if timeframe in self._SUBSECOND_TF:
+        # Timeframes sidemantic cannot represent as a portable time dimension, so leave them
+        # unsupported rather than expose a field that queries at the wrong grain or emits SQL that
+        # only runs on some engines:
+        #   - minute15 / minute30 are N-minute BUCKETS, not a DATE_TRUNC grain. The coarse `minute`
+        #     granularity truncates to the minute (dropping the bucket), and baking the bucket
+        #     expression stores DIALECT-SPECIFIC SQL (DuckDB/Postgres DATE_TRUNC + INTERVAL) into
+        #     Dimension.sql, which the generator does not transpile -- so it fails on BigQuery,
+        #     Snowflake, etc. Generating it dialect-aware needs the query dialect, which the import
+        #     adapter does not have.
+        #   - millisecond / microsecond are FINER than the finest granularity the enum supports
+        #     (`second`), so a time dimension truncates to the second and silently drops precision.
+        if timeframe in self._MINUTE_BUCKET_TF or timeframe in self._SUBSECOND_TF:
             return None
 
         # Time-truncation timeframes -> time dimension with granularity. Remember the

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -92,10 +92,16 @@ class LookMLAdapter(BaseAdapter):
         else:
             lkml_files = [source_path]
 
-        # First pass: parse all views, collecting refinements separately
+        # First pass: parse all views, collecting refinements separately. Remember which file
+        # defined each view so a whole-project (directory) load still reports per-file
+        # provenance instead of just the project root.
         refinements: list[Model] = []
+        view_source_files: dict[str, str] = {}
         for lkml_file in lkml_files:
+            _before = set(graph.models)
             self._parse_views_from_file(lkml_file, graph, refinements)
+            for _new in set(graph.models) - _before:
+                view_source_files[_new] = str(lkml_file)
 
         # Snapshot abstract / unsupported-derived_table flags BEFORE refinement merge:
         # merge_model REPLACES a base view's meta when the refinement carries metadata,
@@ -245,6 +251,14 @@ class LookMLAdapter(BaseAdapter):
 
         # Rebuild adjacency graph now that relationships have been added
         graph.build_adjacency()
+
+        # Stamp per-file provenance LAST: refinement/extends resolution can REPLACE a model
+        # object, which would drop an earlier stamp. Loaders only fills _source_file when it is
+        # unset, so this keeps per-file attribution for a whole-project load.
+        for _name, _model in graph.models.items():
+            _src = view_source_files.get(_name)
+            if _src and not hasattr(_model, "_source_file"):
+                _model._source_file = _src
 
         return graph
 
@@ -4058,7 +4072,9 @@ class LookMLAdapter(BaseAdapter):
         ``_parse_dimension``). If the source SQL is already a DATE_TRUNC at this grain it
         is reused verbatim, keeping repeated round-trips stable (no nested truncation).
         """
-        src = (group_sql if group_sql is not None else dim.sql) or ""
+        # Fall back to the dimension's DEFAULT column expression (sql_expr == sql or name) when it
+        # has no explicit sql -- an empty string would emit `sql: DATE_TRUNC('hour', ) ;;`.
+        src = (group_sql if group_sql is not None else dim.sql) or dim.sql_expr
         src = src.replace("{model}", "${TABLE}")
         grain = (dim.granularity or "").lower()
         tf = (dim.meta or {}).get("lookml_timeframe")

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -553,6 +553,22 @@ class LookMLAdapter(BaseAdapter):
         resolvable = {n: m for n, m in graph.models.items() if _chain_resolvable(n)}
         unresolvable = {n: m for n, m in graph.models.items() if n not in resolvable}
 
+        # Clear the extends link on a model whose parent was INTENTIONALLY rejected -- it exists but
+        # is out of the child's include scope, or is an unsupported derived table. The scoped parse
+        # omitted its inherited fields on purpose, but leaving `extends` set lets a downstream
+        # re-resolution WITHOUT the include scope (e.g. LookMLAdapter.export or a serialization
+        # helper) merge the rejected parent back in, reintroducing the removed fields. A parent that
+        # is genuinely MISSING (or a circular chain) is a real error, so keep its extends so
+        # validation still surfaces it.
+        for _name, _m in unresolvable.items():
+            _parent = _m.extends
+            if (
+                _parent
+                and _parent in graph.models
+                and (not _parent_in_scope(_name, _parent) or _parent in unsupported_dt_views)
+            ):
+                _m.extends = None
+
         if resolvable:
             resolved = resolve_model_inheritance(resolvable)
             resolved.update(unresolvable)

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -2943,8 +2943,16 @@ class LookMLAdapter(BaseAdapter):
         # `sql: ${TABLE}.created ;;` and re-emit the group without inventing a sql.
         implicit_sql = not dim_group_def.get("sql")
 
-        # Get SQL from the resolved lookup if available
-        first_timeframe_name = f"{group_name}_{timeframes[0]}" if timeframes else None
+        # Get SQL from the resolved lookup if available. Key off the first SUPPORTED timeframe,
+        # not timeframes[0]: an unsupported leading timeframe (minute15, sub-second) is never
+        # seeded in the resolved lookup, so keying off it would miss and fall back to the RAW
+        # dim_group `sql` below -- leaving a ${ref} to another dimension (sql: ${ts_src}) literally
+        # unresolved, so a surviving timeframe compiled DATE_TRUNC('day', ${ts_src}).
+        lookup_timeframe = next(
+            (tf for tf in timeframes if tf != "raw" and not self._is_unsupported_timeframe(tf)),
+            timeframes[0] if timeframes else None,
+        )
+        first_timeframe_name = f"{group_name}_{lookup_timeframe}" if lookup_timeframe else None
         if dimension_sql_lookup and first_timeframe_name and first_timeframe_name in dimension_sql_lookup:
             base_sql = dimension_sql_lookup[first_timeframe_name]
         else:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -2942,6 +2942,31 @@ class LookMLAdapter(BaseAdapter):
         label = dim_group_def.get("label")
         description = dim_group_def.get("description")
 
+        # minute15 / minute30 are N-minute BUCKETS, not a plain DATE_TRUNC grain -- the coarse
+        # `minute` granularity would truncate to the minute and silently re-bucket the data. Bake
+        # the N-minute bucket into the SQL and keep MINUTE granularity: the generator's later
+        # DATE_TRUNC('minute', ...) is then a no-op on the already-minute-aligned bucket, preserving
+        # the 15/30-minute grouping. `meta` still round-trips the exact timeframe on export.
+        bucket_n = self._MINUTE_BUCKET_TF.get(timeframe)
+        if bucket_n is not None:
+            base_expr = base_sql if base_sql is not None else "{model}"
+            return Dimension(
+                name=name,
+                type="time",
+                sql=self._minute_bucket_sql(base_expr, bucket_n),
+                granularity="minute",
+                label=label,
+                description=description,
+                meta={"lookml_timeframe": timeframe},
+            )
+
+        # millisecond / microsecond are FINER than the finest supported granularity (`second`), so a
+        # time dimension would truncate to the second and silently drop the sub-second precision the
+        # field name promises. The granularity enum cannot express them, so leave them unsupported
+        # rather than expose a wrong-grain field.
+        if timeframe in self._SUBSECOND_TF:
+            return None
+
         # Time-truncation timeframes -> time dimension with granularity. Remember the
         # original LookML timeframe so export can round-trip it exactly: several
         # timeframes (e.g. "time" and "second") map to the same sidemantic granularity

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -263,11 +263,49 @@ class LookMLAdapter(BaseAdapter):
         # must let a_ref win even though the walk parsed a_ref first. Files no model reaches keep
         # their sorted-walk position (last); with no include scope at all the sorted order stands,
         # which is what keeps a plain directory load deterministic.
+        _ordered_closures: dict[Path, list[Path]] = {}
         _include_order: dict[Path, int] = {}
         if _scoping_active:
             for _model_file in _model_files:
-                for _reached in _ordered_include_closure(_model_file):
+                _ordered_closures[_model_file] = _ordered_include_closure(_model_file)
+                for _reached in _ordered_closures[_model_file]:
                     _include_order.setdefault(_reached, len(_include_order))
+
+        # Models can disagree: one includes z_ref then a_ref, another the reverse. Looker resolves
+        # each model separately; one model per view name can only be merged in ONE order, and the
+        # first model file's order wins. Report the disagreement rather than silently serving the
+        # other model the wrong overrides. Compares each PAIR of a view's refinement files, so a
+        # model that merely includes MORE of them is not mistaken for a conflict.
+        if _ordered_closures:
+            _ref_files_by_base: dict[str, set[Path]] = {}
+            for _i, _refinement in enumerate(refinements):
+                if _i < len(refinement_source_files):
+                    _ref_files_by_base.setdefault(_refinement.name.lstrip("+"), set()).add(
+                        refinement_source_files[_i].resolve()
+                    )
+            for _base, _ref_files in _ref_files_by_base.items():
+                if len(_ref_files) < 2:
+                    continue
+                _pair_orders: dict[tuple[Path, Path], set[bool]] = {}
+                for _closure in _ordered_closures.values():
+                    _seq = [f for f in _closure if f in _ref_files]
+                    for _first in range(len(_seq)):
+                        for _second in range(_first + 1, len(_seq)):
+                            _a, _b = _seq[_first], _seq[_second]
+                            _key = (_a, _b) if _a < _b else (_b, _a)
+                            _pair_orders.setdefault(_key, set()).add(_a == _key[0])
+                _conflicts = [pair for pair, seen in _pair_orders.items() if len(seen) > 1]
+                if _conflicts:
+                    logger.warning(
+                        "LookML models disagree on the include order of refinements for view %r: %s. Looker "
+                        "applies refinements in each model's own include order, but one model per view name "
+                        "can hold only one result, so the first model file's order is used and the others see "
+                        "overrides Looker would not give them. Align the include order across models, or give "
+                        "the models separate views.",
+                        _base,
+                        "; ".join(sorted(f"{a.name} vs {b.name}" for a, b in _conflicts)),
+                    )
+
         if _include_order and refinement_source_files:
             _unordered = len(_include_order)
             # Stable: refinements from the SAME file keep their in-file order.
@@ -2737,12 +2775,21 @@ class LookMLAdapter(BaseAdapter):
 
         # Get SQL from the resolved lookup if available
         first_timeframe_name = f"{group_name}_{timeframes[0]}" if timeframes else None
+        implicit_sql = False
         if dimension_sql_lookup and first_timeframe_name and first_timeframe_name in dimension_sql_lookup:
             base_sql = dimension_sql_lookup[first_timeframe_name]
         else:
             base_sql = dim_group_def.get("sql")
             if base_sql:
                 base_sql = base_sql.replace("${TABLE}", "{model}")
+            else:
+                # A group that omits `sql` reads Looker's implicit `<group>` column -- ONE column
+                # shared by every timeframe. Leaving sql unset made each generated field fall back
+                # to its OWN name, compiling DATE_TRUNC('day', created_date) against a column that
+                # does not exist. Mark them so export can tell this from an explicit
+                # `sql: ${TABLE}.created ;;` and re-emit the group without inventing a sql.
+                base_sql = "{model}." + group_name
+                implicit_sql = True
 
         # A dimension_group whose base SQL references another view inline (${other.ts})
         # would leak that literal into every generated timeframe field, so drop the whole
@@ -2764,6 +2811,8 @@ class LookMLAdapter(BaseAdapter):
 
             dim = self._build_timeframe_dimension(group_name, timeframe, base_sql, dim_group_def)
             if dim is not None:
+                if implicit_sql:
+                    dim.meta = {**(dim.meta or {}), "_lookml_implicit_group": True}
                 dimensions.append(dim)
 
         return dimensions
@@ -4660,7 +4709,9 @@ class LookMLAdapter(BaseAdapter):
                     base_name = dim.name[: -(len(stored_tf) + 1)]
                     # An imported `dimension_group` that omits `sql` reads ONE implicit column
                     # named after the GROUP (`created`), shared by every timeframe it generates.
-                    implicit_group = dim.sql is None
+                    # The parser resolves those dims to that column and marks them, so this is the
+                    # marker rather than `sql is None`.
+                    implicit_group = bool((dim.meta or {}).get("_lookml_implicit_group"))
                 else:
                     # Native dims (no stored timeframe): strip any known LookML truncation
                     # timeframe suffix, LONGEST first so e.g. `_minute15`/`_time_of_day`/

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -720,7 +720,10 @@ class LookMLAdapter(BaseAdapter):
             elif (
                 model.table is None
                 and model.sql is None
-                and (_extends_chain_has(model_name, unsupported_dt_views) or (model.meta or {}).get("unsupported_derived_table"))
+                and (
+                    _extends_chain_has(model_name, unsupported_dt_views)
+                    or (model.meta or {}).get("unsupported_derived_table")
+                )
             ):
                 model.meta = {**(model.meta or {}), "unsupported_derived_table": True, "lookml_template": True}
                 is_template = True
@@ -2896,6 +2899,11 @@ class LookMLAdapter(BaseAdapter):
         if unsupported_derived_table:
             model_meta["unsupported_derived_table"] = True
             model_meta["_unsupported_derived_table_raw"] = view_def["derived_table"]
+            # A refinement can add a `derived_table` to a view that already had `sql_table_name`,
+            # leaving both keys. The view is now derived (not a physical table), so drop the stale
+            # sql_table_name -- otherwise the template stamping (which only marks tableless
+            # unsupported PDTs) leaves it registerable and the loader queries the stale table.
+            table = None
 
         # Build kwargs conditionally so that unset scalars don't appear in
         # model_fields_set. This matters for refinements: merge_model treats

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -146,24 +146,34 @@ class LookMLAdapter(BaseAdapter):
         # includes -- a view with no rival is kept regardless, so an imperfectly-resolved include
         # can never silently drop a view.
         chosen: dict[str, tuple[Path, dict, Model]] = {}
+        duplicates: list[tuple[Path, dict, Model]] = []
         for _file, _view_def, _model in view_candidates:
             previous = chosen.get(_model.name)
             if previous is None:
                 chosen[_model.name] = (_file, _view_def, _model)
                 continue
-            if included_paths and _file.resolve() in included_paths and previous[0].resolve() not in included_paths:
+            current_included = bool(included_paths) and _file.resolve() in included_paths
+            previous_included = bool(included_paths) and previous[0].resolve() in included_paths
+            if current_included and not previous_included:
                 chosen[_model.name] = (_file, _view_def, _model)  # the included copy wins
-            else:
+            elif previous_included and not current_included:
                 logger.debug(
-                    "Ignoring duplicate LookML view %r from %s (already defined by %s).",
+                    "Ignoring duplicate LookML view %r from %s: %s is the included copy.",
                     _model.name,
                     _file,
                     previous[0],
                 )
+            else:
+                # Neither or BOTH are included, so nothing distinguishes them -- this is a real
+                # duplicate in the active project, not an archived copy. Install both and let
+                # add_model surface the conflict rather than silently loading one at random.
+                duplicates.append((_file, _view_def, _model))
         for _name, (_file, _view_def, _model) in chosen.items():
             raw_view_defs[_name] = _view_def
             view_source_files[_name] = str(_file)
             graph.add_model(_model)
+        for _file, _view_def, _model in duplicates:
+            graph.add_model(_model)  # raises: an unresolvable duplicate must not pass silently
 
         # Snapshot abstract / unsupported-derived_table flags BEFORE refinement merge:
         # merge_model REPLACES a base view's meta when the refinement carries metadata,
@@ -293,8 +303,15 @@ class LookMLAdapter(BaseAdapter):
 
         _apply_default_tables()
 
-        # Second pass: parse explores and add relationships
+        # Second pass: parse explores and add relationships. Scope them the same way refinements
+        # are: an explore in a model file no include reaches -- an archived or alternate model --
+        # would otherwise mutate the LIVE model by adding its joins/segments. A file DECLARING
+        # includes is part of the project (that is where explores normally live), so the active
+        # model file is unaffected; with no includes declared nothing is filtered.
         for lkml_file in lkml_files:
+            if included_paths and lkml_file.resolve() not in included_paths:
+                logger.debug("Ignoring LookML explores in %s: not reached by any include.", lkml_file)
+                continue
             self._parse_explores_from_file(lkml_file, graph)
 
         # Re-apply the default: explores can add segments (sql_always_where /

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -35,7 +35,12 @@ class LookMLAdapter(BaseAdapter):
     """
 
     def parse(self, source: str | Path) -> SemanticGraph:
-        """Parse LookML files into semantic graph.
+        """Parse LookML files into a semantic graph.
+
+        Auto-registration to an active SemanticLayer is suppressed while the graph is
+        built, so a tableless view that only gets its default table after refinements/
+        extends are resolved is not validated mid-parse (which would raise inside a
+        ``with SemanticLayer():`` block). The finalized models are registered once.
 
         Args:
             source: Path to .lkml file or directory
@@ -43,6 +48,40 @@ class LookMLAdapter(BaseAdapter):
         Returns:
             Semantic graph with imported models
         """
+        from sidemantic.core.registry import get_current_layer, set_current_layer
+
+        prev_layer = get_current_layer()
+        set_current_layer(None)
+        try:
+            graph = self._build_graph(source)
+        finally:
+            set_current_layer(prev_layer)
+        # Defer auto-registration until models are complete (tables defaulted). Skip ONLY
+        # intentional non-queryable templates -- abstract extension:required bases and
+        # unsupported derived tables, marked in meta -- which add_model's validation would
+        # reject; mirrors loaders._is_registerable_model. A merely-broken tableless view
+        # (e.g. extends:[missing], left unresolved) is NOT skipped, so add_model still
+        # surfaces the real "no table/sql" error instead of silently dropping it. Strip
+        # survivors' relationships pointing at a skipped template (e.g. an explore join to
+        # it) so the active layer is not left with a dangling relationship validation flags.
+        if prev_layer is not None:
+            skipped = {
+                name
+                for name, m in graph.models.items()
+                if not (m.table or m.sql or getattr(m, "dax", None) or getattr(m, "source_uri", None))
+                and (m.meta or {}).get("lookml_template")
+            }
+            for model in graph.models.values():
+                if model.name in skipped or model.name in prev_layer.graph.models:
+                    continue
+                rels = getattr(model, "relationships", None)
+                if rels:
+                    model.relationships = [r for r in rels if r.name not in skipped]
+                prev_layer.add_model(model)
+        return graph
+
+    def _build_graph(self, source: str | Path) -> SemanticGraph:
+        """Build the semantic graph from LookML files (see :meth:`parse`)."""
         graph = SemanticGraph()
         source_path = Path(source)
 
@@ -58,16 +97,49 @@ class LookMLAdapter(BaseAdapter):
         for lkml_file in lkml_files:
             self._parse_views_from_file(lkml_file, graph, refinements)
 
+        # Snapshot abstract / unsupported-derived_table flags BEFORE refinement merge:
+        # merge_model REPLACES a base view's meta when the refinement carries metadata,
+        # which would otherwise drop these markers.
+        abstract_pre = {n for n, m in graph.models.items() if (m.meta or {}).get("extension_required")}
+        unsupported_pre = {n for n, m in graph.models.items() if (m.meta or {}).get("unsupported_derived_table")}
+
         # Apply refinements: merge each refinement into its base view
         from sidemantic.core.inheritance import merge_model, resolve_model_inheritance
 
+        refinement_abstract: set[str] = set()
+        refinement_unsupported_dt: set[str] = set()
         for refinement in refinements:
             base_name = refinement.name.lstrip("+")
+            # Record flags from EACH refinement's own meta: a later refinement's merge
+            # can replace the base meta and drop a flag an earlier refinement added.
+            rmeta = refinement.meta or {}
+            if rmeta.get("extension_required"):
+                refinement_abstract.add(base_name)
+            if rmeta.get("unsupported_derived_table"):
+                refinement_unsupported_dt.add(base_name)
             if base_name in graph.models:
                 # Create a copy with the base name for merging
                 refinement_for_merge = refinement.model_copy(update={"name": base_name})
                 merged = merge_model(refinement_for_merge, graph.models[base_name])
                 graph.models[base_name] = merged
+
+        # Union the pre-merge snapshot, every refinement's own flags, and the post-merge
+        # state (so a flag added by ANY refinement is caught even if a later refinement
+        # replaced the meta). Resolve this BEFORE extends so a concrete child that only
+        # INHERITS abstractness is not treated as abstract. Record extends parents too,
+        # so descendants of an unsupported derived table are detectable after resolution
+        # clears `extends`.
+        abstract_views = (
+            abstract_pre
+            | refinement_abstract
+            | {n for n, m in graph.models.items() if (m.meta or {}).get("extension_required")}
+        )
+        unsupported_dt_views = (
+            unsupported_pre
+            | refinement_unsupported_dt
+            | {n for n, m in graph.models.items() if (m.meta or {}).get("unsupported_derived_table")}
+        )
+        extends_parent = {n: m.extends for n, m in graph.models.items() if m.extends}
 
         # Resolve extends chains. Pre-filter to models whose full chain
         # is present so one broken/missing parent doesn't block valid ones.
@@ -92,9 +164,67 @@ class LookMLAdapter(BaseAdapter):
             resolved.update(unresolvable)
             graph.models = resolved
 
+        def _extends_chain_has(name: str, flagset: set[str]) -> bool:
+            """True if name or any of its extends-ancestors is in flagset."""
+            seen: set[str] = set()
+            cur: str | None = name
+            while cur is not None and cur not in seen:
+                if cur in flagset:
+                    return True
+                seen.add(cur)
+                cur = extends_parent.get(cur)
+            return False
+
+        # Apply the implicit "table = view name" default AFTER refinements and extends
+        # are resolved, so a view whose fields/name come from a refinement or whose
+        # parent was tableless still gets its OWN name as the table (Looker's behavior).
+        # Skip abstract views, still-unresolved-extends, and views that are (or extend) an
+        # unsupported derived table. Do NOT require parsed fields: Looker defaults the table
+        # for an ordinary fieldless view (`view: orders {}`, or one with only adapter-ignored
+        # fields) too, so leaving it tableless would wrongly fail CLI validation/registration.
+        # Abstractness is NOT inherited through extends (a concrete child of an abstract base
+        # gets its own table), but an unsupported derived table IS inherited by descendants.
+        def _apply_default_tables():
+            for model_name, model in graph.models.items():
+                if (
+                    model.table is None
+                    and model.sql is None
+                    and not model.extends
+                    and model_name not in abstract_views
+                    and not _extends_chain_has(model_name, unsupported_dt_views)
+                    and not (model.meta or {}).get("unsupported_derived_table")
+                ):
+                    model.table = model_name
+
+        _apply_default_tables()
+
         # Second pass: parse explores and add relationships
         for lkml_file in lkml_files:
             self._parse_explores_from_file(lkml_file, graph)
+
+        # Re-apply the default: explores can add segments (sql_always_where /
+        # always_filter) to an otherwise-fieldless view, which only now makes it
+        # eligible for the implicit table default.
+        _apply_default_tables()
+
+        # Re-assert non-queryable markers on models intentionally left tableless. A
+        # refinement can OVERWRITE a view's meta (dropping an `extension_required` flag an
+        # earlier refinement added) even though abstractness is tracked in side-sets, so
+        # without this the loader (which keys off final meta) would try to register and
+        # reject them. Set the flag definitively now, after all merges. Also stamp a
+        # PARSER-OWNED `lookml_template` marker so registration skips (here and in the
+        # loader) key off a sidemantic-internal flag, not the public `extension_required`/
+        # `unsupported_derived_table` keys -- a native/other-format model that happens to
+        # carry those user-facing keys must still surface its missing-source error.
+        for model_name, model in graph.models.items():
+            if model.table is not None or model.sql is not None:
+                continue
+            if model_name in abstract_views:
+                model.meta = {**(model.meta or {}), "extension_required": True, "lookml_template": True}
+            elif _extends_chain_has(model_name, unsupported_dt_views) or (model.meta or {}).get(
+                "unsupported_derived_table"
+            ):
+                model.meta = {**(model.meta or {}), "unsupported_derived_table": True, "lookml_template": True}
 
         # Rebuild adjacency graph now that relationships have been added
         graph.build_adjacency()
@@ -1955,6 +2085,14 @@ class LookMLAdapter(BaseAdapter):
                 extends = flat[0] if flat else None
             elif isinstance(extends_list, str):
                 extends = extends_list
+
+        # A LookML view with no sql_table_name/derived_table implicitly uses a table
+        # named after the view (Looker's default). A view with a derived_table the
+        # adapter cannot turn into SQL must NOT get such a default; mark it so the
+        # post-merge pass skips it (the raw derived_table dict is not retained).
+        unsupported_derived_table = bool(view_def.get("derived_table")) and sql is None
+        if unsupported_derived_table:
+            model_meta["unsupported_derived_table"] = True
 
         # Build kwargs conditionally so that unset scalars don't appear in
         # model_fields_set. This matters for refinements: merge_model treats

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -2199,12 +2199,20 @@ class LookMLAdapter(BaseAdapter):
         for dim_group_def in view_def.get("dimension_groups") or []:
             group_name = dim_group_def.get("name")
             group_sql = dim_group_def.get("sql")
-            if group_name and group_sql:
+            if not group_name:
+                continue
+            if group_sql:
                 group_sql = group_sql.replace("${TABLE}", "{model}")
-                timeframes = dim_group_def.get("timeframes", ["date"])
-                for timeframe in timeframes:
-                    if timeframe != "raw":
-                        dimension_sql_lookup[f"{group_name}_{timeframe}"] = group_sql
+            else:
+                # A group that omits `sql` reads Looker's implicit `<group>` column. Seed it HERE,
+                # not just on the generated dimensions: this lookup is what expands a ${created_date}
+                # reference in another field, and an unseeded timeframe falls back to the generated
+                # field name -- so a measure over it queried a column that does not exist.
+                group_sql = "{model}." + group_name
+            timeframes = dim_group_def.get("timeframes", ["date"])
+            for timeframe in timeframes:
+                if timeframe != "raw":
+                    dimension_sql_lookup[f"{group_name}_{timeframe}"] = group_sql
 
         # All declared dimension names (including compact dimensions with no explicit
         # sql), so ${ref}s to a compact dimension resolve to its default column rather
@@ -2783,9 +2791,17 @@ class LookMLAdapter(BaseAdapter):
 
         timeframes = dim_group_def.get("timeframes", ["date"])
 
+        # A group that omits `sql` reads Looker's implicit `<group>` column -- ONE column shared by
+        # every timeframe. Leaving sql unset made each generated field fall back to its OWN name,
+        # compiling DATE_TRUNC('day', created_date) against a column that does not exist. Marked
+        # from the DEFINITION, not from whichever branch below supplies the SQL: the resolved
+        # lookup seeds implicit groups too, so inferring the mark from an unset sql would silently
+        # stop marking them. Export needs the mark to tell this from an explicit
+        # `sql: ${TABLE}.created ;;` and re-emit the group without inventing a sql.
+        implicit_sql = not dim_group_def.get("sql")
+
         # Get SQL from the resolved lookup if available
         first_timeframe_name = f"{group_name}_{timeframes[0]}" if timeframes else None
-        implicit_sql = False
         if dimension_sql_lookup and first_timeframe_name and first_timeframe_name in dimension_sql_lookup:
             base_sql = dimension_sql_lookup[first_timeframe_name]
         else:
@@ -2793,13 +2809,7 @@ class LookMLAdapter(BaseAdapter):
             if base_sql:
                 base_sql = base_sql.replace("${TABLE}", "{model}")
             else:
-                # A group that omits `sql` reads Looker's implicit `<group>` column -- ONE column
-                # shared by every timeframe. Leaving sql unset made each generated field fall back
-                # to its OWN name, compiling DATE_TRUNC('day', created_date) against a column that
-                # does not exist. Mark them so export can tell this from an explicit
-                # `sql: ${TABLE}.created ;;` and re-emit the group without inventing a sql.
                 base_sql = "{model}." + group_name
-                implicit_sql = True
 
         # A dimension_group whose base SQL references another view inline (${other.ts})
         # would leak that literal into every generated timeframe field, so drop the whole

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -131,14 +131,26 @@ class LookMLAdapter(BaseAdapter):
         # REFINEMENT merge is scoped: views themselves still all parse, so a project whose
         # includes do not enumerate every view keeps loading them. With no includes declared
         # (the common single-directory case) nothing is filtered.
-        included_paths: set[Path] = set()
+        # Resolve the project's include graph as a TRANSITIVE CLOSURE seeded from MODEL files.
+        # Seeding only from models means a stray view file's helper include cannot switch scoping
+        # on for a directory no model selects; following the closure means a refinement reachable
+        # THROUGH a selected view (model -> orders.view -> refine.view) is still included.
+        _include_root = source_path if source_path.is_dir() else source_path.parent
+        includes_by_file: dict[Path, list[str]] = {}
         for _including_file, _pattern in include_specs:
-            included_paths |= self._resolve_include(
-                source_path if source_path.is_dir() else source_path.parent, _including_file, _pattern
-            )
-        if included_paths:
-            # A file declaring includes is part of the project itself.
-            included_paths |= {f.resolve() for f, _ in include_specs}
+            includes_by_file.setdefault(_including_file.resolve(), []).append(_pattern)
+        _model_files = [f for f in includes_by_file if f.name.endswith(".model.lkml")]
+        included_paths: set[Path] = set()
+        if _model_files:
+            included_paths |= set(_model_files)  # a model file is part of its own project
+            _queue = list(_model_files)
+            while _queue:
+                _current = _queue.pop()
+                for _pattern in includes_by_file.get(_current, []):
+                    for _hit in self._resolve_include(_include_root, _current, _pattern):
+                        if _hit not in included_paths:
+                            included_paths.add(_hit)
+                            _queue.append(_hit)
 
         # Install base views, resolving a SAME-NAME collision between files by include: an
         # archived copy of a view alongside the live one would otherwise make add_model raise
@@ -407,10 +419,10 @@ class LookMLAdapter(BaseAdapter):
 
         # Record this file's `include:` declarations (LookML model files list the view files the
         # model actually uses) so refinements from un-included files can be ignored.
-        # ONLY a model file's includes activate scoping. A view file may include a helper, which
-        # says nothing about which files the project selects -- letting it populate the included
-        # set would make unrelated sibling refinements/explores look un-included and drop them.
-        if include_specs is not None and file_path.name.endswith(".model.lkml"):
+        # Record every file's includes. Only a MODEL file's includes SEED the scoping (see the
+        # closure in _build_graph) -- but a selected view file's own includes must be followed
+        # from there, so they have to be recorded here too.
+        if include_specs is not None:
             for pattern in parsed.get("includes") or []:
                 if isinstance(pattern, str):
                     include_specs.append((file_path, pattern))

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -59,21 +59,24 @@ class LookMLAdapter(BaseAdapter):
             set_current_layer(prev_layer)
         # Defer auto-registration until models are complete (tables defaulted). Skip ONLY
         # intentional non-queryable templates -- abstract extension:required bases and
-        # unsupported derived tables, marked in meta -- which add_model's validation would
-        # reject; mirrors loaders._is_registerable_model. A merely-broken tableless view
-        # (e.g. extends:[missing], left unresolved) is NOT skipped, so add_model still
-        # surfaces the real "no table/sql" error instead of silently dropping it. Strip
-        # survivors' relationships pointing at a skipped template (e.g. an explore join to
-        # it) so the active layer is not left with a dangling relationship validation flags.
-        # A name the layer ALREADY defines is NOT skipped: that is a genuine duplicate-model
-        # conflict, and add_model must surface it (as auto-registration did before this
-        # deferral) rather than silently leaving the pre-existing definition in place.
+        # unsupported derived tables, flagged with the parser-owned `lookml_template` meta
+        # marker -- which add_model's validation would reject; mirrors
+        # loaders._is_registerable_model. The marker (not tablelessness) is decisive: an
+        # `extension: required` base that declares or inherits a sql_table_name is STILL a
+        # template Looker only uses through extends, so it must be skipped even though it has
+        # a source. A merely-broken tableless view (e.g. extends:[missing], left unresolved)
+        # never carries the marker, so it is NOT skipped and add_model still surfaces the real
+        # "no table/sql" error instead of silently dropping it. Strip survivors' relationships
+        # pointing at a skipped template (e.g. an explore join to it) so the active layer is
+        # not left with a dangling relationship validation flags. A name the layer ALREADY
+        # defines is NOT skipped: that is a genuine duplicate-model conflict, and add_model must
+        # surface it (as auto-registration did before this deferral) rather than silently
+        # leaving the pre-existing definition in place.
         if prev_layer is not None:
             skipped = {
                 name
                 for name, m in graph.models.items()
-                if not (m.table or m.sql or getattr(m, "dax", None) or getattr(m, "source_uri", None))
-                and (m.meta or {}).get("lookml_template")
+                if (m.meta or {}).get("lookml_template")
                 # ...but a name the layer ALREADY defines is a duplicate-model conflict, not a
                 # skippable template: let add_model raise it rather than silently keeping the
                 # pre-existing model. (Mirrors the non-template case below.)

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -5089,6 +5089,12 @@ class LookMLAdapter(BaseAdapter):
                     # Prefer the original LookML timeframe captured at import (so
                     # "time"/"second"/etc. round-trip distinctly).
                     timeframe = (dim.meta or {}).get("lookml_timeframe")
+                    if timeframe is not None and self._is_unsupported_timeframe(timeframe):
+                        # An unsupported bucket/sub-second timeframe (minute15, millisecond) would be
+                        # emitted in `timeframes: [...]` but dropped on re-import, losing the field.
+                        # It is exported as a standalone collision dim instead, so keep it OUT of the
+                        # group's timeframe list here (and out of the pre-seed that mirrors it).
+                        continue
                     if timeframe is None:
                         # Native (non-import) dim: derive from the field-name suffix (longest
                         # known timeframe) so the EXACT name round-trips (created_hour -> [hour])
@@ -5137,13 +5143,31 @@ class LookMLAdapter(BaseAdapter):
                         used_names.add(cdim["name"])
                         collision_dims.append(cdim)
                     continue
+                # Route dims whose preserved timeframe is unsupported through the standalone
+                # collision form: a dimension_group `timeframes: [minute15]` re-imports to nothing
+                # (_is_unsupported_timeframe drops it), losing the field. The collision form emits a
+                # plain DATE_TRUNC/bucket dimension that round-trips. Keep the rest as the group.
+                group_dims = []
+                for dim in dims:
+                    tf = (dim.meta or {}).get("lookml_timeframe")
+                    if tf is not None and self._is_unsupported_timeframe(tf):
+                        cdim = self._export_collision_time_dim(
+                            dim, base_name if group_sql is None else group_sql, used_names
+                        )
+                        used_names.add(cdim["name"])
+                        collision_dims.append(cdim)
+                    else:
+                        group_dims.append(dim)
+                if not group_dims:
+                    continue
+
                 group_name = base_name
                 assigned_names.add(group_name)
 
                 dim_group_def = {
                     "name": group_name,
                     "type": "time",
-                    "timeframes": _group_timeframes(dims),
+                    "timeframes": _group_timeframes(group_dims),
                 }
 
                 if group_sql:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -2244,13 +2244,14 @@ class LookMLAdapter(BaseAdapter):
                     if matched_tf:
                         sidemantic_type = "time"
                         granularity = grain
-                        # Only STORE the timeframe when it's an EXACT one-to-one match for the
-                        # grain. An INEXACT suffix (minute15/30, sub-second, time_of_day) on a
-                        # PLAIN DATE_TRUNC does NOT preserve that timeframe's semantics (the
-                        # explicit bucket/subsecond forms, handled above, do) -- recording it
-                        # would make the next export WIDEN a 1-minute dim into a 15-min bucket.
-                        # Recover as a plain grain time dim (no inexact meta) instead.
-                        if matched_tf not in self._INEXACT_NAME_TF:
+                        # STORE the timeframe unless it is one whose exact semantics live in a
+                        # special SQL form (minute15/30 bucket, sub-second DATE_TRUNC) that a PLAIN
+                        # DATE_TRUNC has already lost -- recording those would make the next export
+                        # WIDEN a 1-minute dim into a 15-min bucket. `time_of_day` is NOT in that
+                        # set: its canonical export IS this plain hour DATE_TRUNC named
+                        # `*_time_of_day`, so it is recoverable only by name -- record it, else the
+                        # next export loses the timeframe and renames the field to `*_hour`.
+                        if matched_tf not in self._EXACT_FORM_TF:
                             recovered_timeframe = matched_tf
 
         # Build meta dict from LookML-specific display properties
@@ -3989,6 +3990,13 @@ class LookMLAdapter(BaseAdapter):
     # data, not 15-minute buckets, so emitting `[minute15]` would silently re-bucket. They only
     # round-trip when preserved in meta['lookml_timeframe'] (the import path).
     _INEXACT_NAME_TF = frozenset(_MINUTE_BUCKET_TF) | _SUBSECOND_TF | {"time_of_day"}
+    # Inexact timeframes whose exact semantics live in a SPECIAL SQL FORM (15/30-min bucket
+    # expression, sub-second DATE_TRUNC unit). If one reaches import recovery as a PLAIN
+    # DATE_TRUNC, that exact form was lost, so its name suffix must NOT be recorded (recording
+    # `minute15` on a plain minute DATE_TRUNC would re-bucket 1-minute data). `time_of_day` is
+    # deliberately EXCLUDED: it has no finer SQL form -- its canonical collision export IS a plain
+    # hour DATE_TRUNC named `*_time_of_day`, so it is recoverable (and only recoverable) by name.
+    _EXACT_FORM_TF = frozenset(_MINUTE_BUCKET_TF) | _SUBSECOND_TF
     # Canonical EXACT LookML timeframe for each sidemantic grain (inverse of the common
     # cases in _TIME_GRANULARITY_TIMEFRAMES). Used to give a suffixless collision time dim
     # a recoverable name on export (e.g. `started` at hour grain -> `started_hour`).

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -64,6 +64,9 @@ class LookMLAdapter(BaseAdapter):
         # surfaces the real "no table/sql" error instead of silently dropping it. Strip
         # survivors' relationships pointing at a skipped template (e.g. an explore join to
         # it) so the active layer is not left with a dangling relationship validation flags.
+        # A name the layer ALREADY defines is NOT skipped: that is a genuine duplicate-model
+        # conflict, and add_model must surface it (as auto-registration did before this
+        # deferral) rather than silently leaving the pre-existing definition in place.
         if prev_layer is not None:
             skipped = {
                 name
@@ -72,7 +75,7 @@ class LookMLAdapter(BaseAdapter):
                 and (m.meta or {}).get("lookml_template")
             }
             for model in graph.models.values():
-                if model.name in skipped or model.name in prev_layer.graph.models:
+                if model.name in skipped:
                     continue
                 rels = getattr(model, "relationships", None)
                 if rels:
@@ -85,10 +88,13 @@ class LookMLAdapter(BaseAdapter):
         graph = SemanticGraph()
         source_path = Path(source)
 
-        # Collect all .lkml files
+        # Collect all .lkml files. SORT them: rglob order is filesystem-dependent, and refinements
+        # (`view: +name`) are merged in file order -- so with two refinements setting the same
+        # property (label, sql_table_name, ...) an unsorted walk would make the resulting model
+        # depend on directory traversal. Sorting makes a project load deterministic.
         lkml_files = []
         if source_path.is_dir():
-            lkml_files = list(source_path.rglob("*.lkml"))
+            lkml_files = sorted(source_path.rglob("*.lkml"))
         else:
             lkml_files = [source_path]
 

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -237,9 +237,18 @@ class LookMLAdapter(BaseAdapter):
         # The view scope of every file a model reaches: the views that model defines inline plus
         # the views its include closure reaches. Keyed on REACHABILITY, not file name -- a model's
         # explores routinely live in an included sidecar (orders.explore.lkml), which inherits the
-        # includer's scope. A file reached by several models sees the UNION of their scopes, the
-        # closest single-graph answer to Looker resolving each model separately.
+        # includer's scope.
+        #
+        # Kept BOTH per model (_scopes_by_file) and unioned (_scope_by_file), because the two
+        # consumers need different things from a file several models reach:
+        #  - An explore must be checked against ONE model's scope: the union would let it join a
+        #    base view from model A to a target only model B includes, a pair no single LookML
+        #    model can see.
+        #  - An extends is checked from the CHILD's file, and the child is in the scope of every
+        #    model reaching that file, so "parent in the union" already means "some one model sees
+        #    child and parent both" -- exactly the per-model rule.
         _view_files = {name: Path(src).resolve() for name, src in view_source_files.items()}
+        _scopes_by_file: dict[Path, list[set[str]]] = {}
         _scope_by_file: dict[Path, set[str]] = {}
         # Which model files reach each file. Used to tell a refinement that every model sharing a
         # view agrees on from one only SOME of them select.
@@ -249,6 +258,7 @@ class LookMLAdapter(BaseAdapter):
                 _closure = _include_closure(_model_file)
                 _allowed = {v for v, src in _view_files.items() if src in _closure}
                 for _reached in _closure:
+                    _scopes_by_file.setdefault(_reached, []).append(_allowed)
                     _scope_by_file.setdefault(_reached, set()).update(_allowed)
                     _models_by_file.setdefault(_reached, set()).add(_model_file)
 
@@ -501,10 +511,10 @@ class LookMLAdapter(BaseAdapter):
             if not _scoping_active:
                 self._parse_explores_from_file(lkml_file, graph)
                 continue
-            if _resolved not in _scope_by_file:
+            if _resolved not in _scopes_by_file:
                 logger.debug("Ignoring LookML explores in %s: not reached by any include.", lkml_file)
                 continue
-            self._parse_explores_from_file(lkml_file, graph, allowed_views=_scope_by_file[_resolved])
+            self._parse_explores_from_file(lkml_file, graph, model_scopes=_scopes_by_file[_resolved])
 
         # Re-apply the default: explores can add segments (sql_always_where /
         # always_filter) to an otherwise-fieldless view, which only now makes it
@@ -625,15 +635,15 @@ class LookMLAdapter(BaseAdapter):
                     graph.add_model(model)
 
     def _parse_explores_from_file(
-        self, file_path: Path, graph: SemanticGraph, allowed_views: set[str] | None = None
+        self, file_path: Path, graph: SemanticGraph, model_scopes: list[set[str]] | None = None
     ) -> None:
         """Parse explores from a single LookML file and add relationships.
 
         Args:
             file_path: Path to .lkml file
             graph: Semantic graph to add relationships to
-            allowed_views: Base views this file may explore, or None to allow any. Scopes a model
-                file's explores to the views it defines or includes, as Looker resolves them.
+            model_scopes: One view set per model that includes this file, or None to allow any.
+                Scopes each explore to the views a SINGLE model can see, as Looker resolves them.
         """
         lkml = _import_lkml()
 
@@ -648,7 +658,7 @@ class LookMLAdapter(BaseAdapter):
         # Parse explores. The scope check lives in _parse_explore, which owns the from:/fallback
         # resolution of the base view -- duplicating that resolution here would drift from it.
         for explore_def in parsed.get("explores") or []:
-            self._parse_explore(explore_def, graph, allowed_views=allowed_views)
+            self._parse_explore(explore_def, graph, model_scopes=model_scopes)
 
     # Matches ${field} and ${view.field}. ${TABLE} is handled specially.
     _REF_RE = re.compile(r"\$\{(?:([a-zA-Z_]\w*)\.)?([a-zA-Z_]\w*)\}")
@@ -3920,13 +3930,17 @@ class LookMLAdapter(BaseAdapter):
             **common,
         )
 
-    def _parse_explore(self, explore_def: dict, graph: SemanticGraph, allowed_views: set[str] | None = None) -> None:
+    def _parse_explore(
+        self, explore_def: dict, graph: SemanticGraph, model_scopes: list[set[str]] | None = None
+    ) -> None:
         """Parse LookML explore and add relationships to models.
 
         Args:
             explore_def: Explore definition from parsed LookML
             graph: Semantic graph to add relationships to
-            allowed_views: Views this explore's model file may reference, or None to allow any.
+            model_scopes: One view set per model including this explore's file, or None to allow
+                any. An explore resolves within a SINGLE model, so its base view and joins are
+                checked against the same model's scope rather than the models' combined views.
         """
         explore_name = explore_def.get("name")
         if not explore_name:
@@ -3940,15 +3954,20 @@ class LookMLAdapter(BaseAdapter):
                 return
             base_model_name = explore_name
 
-        # Scope-check the RESOLVED base: an explore on a view this model file neither defines nor
-        # includes is not part of this model, and applying it would mutate the live view.
-        if allowed_views is not None and base_model_name not in allowed_views:
-            logger.debug(
-                "Ignoring LookML explore %s: view %s is not in the model's scope.",
-                explore_name,
-                base_model_name,
-            )
-            return
+        # Scope-check the RESOLVED base: an explore on a view no model including this file defines
+        # or includes is not part of any model, and applying it would mutate the live view. The
+        # models that CAN see the base are the ones this explore could belong to, so its joins are
+        # checked against those and not against every model sharing the file.
+        base_scopes = model_scopes
+        if model_scopes is not None:
+            base_scopes = [scope for scope in model_scopes if base_model_name in scope]
+            if not base_scopes:
+                logger.debug(
+                    "Ignoring LookML explore %s: view %s is not in the scope of any model including this file.",
+                    explore_name,
+                    base_model_name,
+                )
+                return
 
         base_model = graph.models[base_model_name]
 
@@ -4033,14 +4052,33 @@ class LookMLAdapter(BaseAdapter):
             # is left intact: that dangling relationship is a real error `validate` must surface
             # (see _drop_non_registerable_models), and silently dropping it would hide the typo.
             join_target = join_def.get("from", join_def.get("name"))
-            if allowed_views is not None and join_target in graph.models and join_target not in allowed_views:
-                logger.debug(
-                    "Ignoring LookML join %s in explore %s: view %s is not in the model's scope.",
-                    join_def.get("name"),
-                    explore_name,
-                    join_target,
-                )
-                continue
+            if base_scopes is not None and join_target in graph.models:
+                joinable = [scope for scope in base_scopes if join_target in scope]
+                if not joinable:
+                    logger.debug(
+                        "Ignoring LookML join %s in explore %s: no model including this file sees both %s and %s.",
+                        join_def.get("name"),
+                        explore_name,
+                        base_model_name,
+                        join_target,
+                    )
+                    continue
+                if len(joinable) != len(base_scopes):
+                    # Some models that explore this base view do not include the join target, so
+                    # Looker would give them an explore without this join (and reject the file for
+                    # them). One model per view name cannot hold both shapes, so the join is kept
+                    # for the models that do include it and the divergence is reported.
+                    logger.warning(
+                        "LookML explore %r joins %r, which only some of the models including this explore "
+                        "have in scope. The join is applied to the single %r model, so the models missing "
+                        "%r see a join Looker would not give them. Include %r from every model with this "
+                        "explore, or give the models separate explores.",
+                        explore_name,
+                        join_target,
+                        base_model_name,
+                        join_target,
+                        join_target,
+                    )
             relationship = self._parse_join(join_def, base_model_name, explore_name)
             if relationship:
                 # Add relationship to the base model

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -1,5 +1,6 @@
 """LookML adapter for importing Looker semantic models."""
 
+import copy
 import logging
 import re
 from pathlib import Path
@@ -102,10 +103,12 @@ class LookMLAdapter(BaseAdapter):
         # defined each view so a whole-project (directory) load still reports per-file
         # provenance instead of just the project root.
         refinements: list[Model] = []
+        refinement_raw_defs: list[dict] = []
+        raw_view_defs: dict[str, dict] = {}
         view_source_files: dict[str, str] = {}
         for lkml_file in lkml_files:
             _before = set(graph.models)
-            self._parse_views_from_file(lkml_file, graph, refinements)
+            self._parse_views_from_file(lkml_file, graph, refinements, raw_view_defs, refinement_raw_defs)
             for _new in set(graph.models) - _before:
                 view_source_files[_new] = str(lkml_file)
 
@@ -120,7 +123,7 @@ class LookMLAdapter(BaseAdapter):
 
         refinement_abstract: set[str] = set()
         refinement_unsupported_dt: set[str] = set()
-        for refinement in refinements:
+        for _ridx, refinement in enumerate(refinements):
             base_name = refinement.name.lstrip("+")
             # Record flags from EACH refinement's own meta: a later refinement's merge
             # can replace the base meta and drop a flag an earlier refinement added.
@@ -130,10 +133,28 @@ class LookMLAdapter(BaseAdapter):
             if rmeta.get("unsupported_derived_table"):
                 refinement_unsupported_dt.add(base_name)
             if base_name in graph.models:
-                # Create a copy with the base name for merging
-                refinement_for_merge = refinement.model_copy(update={"name": base_name})
-                merged = merge_model(refinement_for_merge, graph.models[base_name])
-                graph.models[base_name] = merged
+                # Prefer merging the RAW LookML dicts and re-parsing: that is the only way a
+                # PARTIAL field refinement (`dimension: id { label: "ID" }`) keeps the base
+                # field's sql/type/primary_key -- merging parsed models would clobber them with
+                # the parser's defaults. Fall back to the model-level merge when the base's raw
+                # dict is unavailable (e.g. a base built by some other path).
+                base_raw = raw_view_defs.get(base_name)
+                ref_raw = refinement_raw_defs[_ridx] if _ridx < len(refinement_raw_defs) else None
+                remerged = None
+                if base_raw is not None and ref_raw is not None:
+                    merged_raw = self._merge_view_defs(base_raw, ref_raw)
+                    remerged = self._parse_view(merged_raw)
+                    if remerged is not None:
+                        # Keep the merged raw so a SECOND refinement of the same view stacks
+                        # onto this result rather than the original base.
+                        raw_view_defs[base_name] = merged_raw
+                if remerged is not None:
+                    graph.models[base_name] = remerged
+                else:
+                    # Create a copy with the base name for merging
+                    refinement_for_merge = refinement.model_copy(update={"name": base_name})
+                    merged = merge_model(refinement_for_merge, graph.models[base_name])
+                    graph.models[base_name] = merged
 
         # Union the pre-merge snapshot, every refinement's own flags, and the post-merge
         # state (so a flag added by ANY refinement is caught even if a later refinement
@@ -269,7 +290,12 @@ class LookMLAdapter(BaseAdapter):
         return graph
 
     def _parse_views_from_file(
-        self, file_path: Path, graph: SemanticGraph, refinements: list[Model] | None = None
+        self,
+        file_path: Path,
+        graph: SemanticGraph,
+        refinements: list[Model] | None = None,
+        raw_view_defs: dict[str, dict] | None = None,
+        refinement_raw_defs: list[dict] | None = None,
     ) -> None:
         """Parse views from a single LookML file.
 
@@ -277,6 +303,10 @@ class LookMLAdapter(BaseAdapter):
             file_path: Path to .lkml file
             graph: Semantic graph to add models to
             refinements: Optional list to collect refinement models into
+            raw_view_defs: Optional map to collect each base view's RAW LookML dict, keyed by
+                view name -- refinements are merged at the raw level (see _merge_view_defs).
+            refinement_raw_defs: Optional list collecting each refinement's RAW dict, appended in
+                lockstep with ``refinements``.
         """
         lkml = _import_lkml()
 
@@ -296,7 +326,11 @@ class LookMLAdapter(BaseAdapter):
                     # Refinement: collect separately for merging after all views parsed
                     if refinements is not None:
                         refinements.append(model)
+                        if refinement_raw_defs is not None:
+                            refinement_raw_defs.append(view_def)
                 else:
+                    if raw_view_defs is not None:
+                        raw_view_defs[model.name] = view_def
                     graph.add_model(model)
 
     def _parse_explores_from_file(self, file_path: Path, graph: SemanticGraph) -> None:
@@ -635,6 +669,51 @@ class LookMLAdapter(BaseAdapter):
             return wg if wg is not None else a
 
         return all(any(True for _ in _scope(a).find_all(exp.Column)) for a in aggs)
+
+    # LookML view keys holding a named-field LIST. A refinement's entry for an EXISTING field
+    # updates that field's properties; it does not replace the field.
+    _VIEW_FIELD_LIST_KEYS = ("dimensions", "dimension_groups", "measures", "filters", "parameters", "sets")
+
+    @classmethod
+    def _merge_view_defs(cls, base: dict, refinement: dict) -> dict:
+        """Merge a `view: +name` refinement's RAW LookML dict onto the base view's RAW dict.
+
+        Merging at the RAW level (then re-parsing) is what makes a PARTIAL field refinement work:
+        ``view: +base { dimension: id { label: "ID" } }`` must only set ``label`` and leave the
+        base field's ``sql``/``type``/``primary_key`` intact. Merging the PARSED models cannot do
+        this -- the parser fills defaults (a bare ``dimension:`` becomes type ``categorical`` with
+        no sql), so the refinement's field looks fully specified and clobbers the base's.
+
+        Named-field lists are merged per field by name; every other key is overridden wholesale
+        (Looker refinement semantics), and the base's name is kept.
+        """
+        merged = copy.deepcopy(base)
+        for key, value in refinement.items():
+            if key == "name":
+                continue
+            if key in cls._VIEW_FIELD_LIST_KEYS and isinstance(value, list):
+                by_name: dict[str, dict] = {}
+                extras: list = []
+                for item in merged.get(key) or []:
+                    if isinstance(item, dict) and item.get("name"):
+                        by_name[item["name"]] = copy.deepcopy(item)
+                    else:
+                        extras.append(copy.deepcopy(item))
+                for item in value:
+                    if not isinstance(item, dict) or not item.get("name"):
+                        extras.append(copy.deepcopy(item))
+                        continue
+                    fname = item["name"]
+                    if fname in by_name:
+                        # Field-level refinement: override ONLY the properties it specifies.
+                        by_name[fname].update({k: copy.deepcopy(v) for k, v in item.items() if k != "name"})
+                    else:
+                        by_name[fname] = copy.deepcopy(item)
+                merged[key] = list(by_name.values()) + extras
+            else:
+                merged[key] = copy.deepcopy(value)
+        merged["name"] = base.get("name")
+        return merged
 
     @staticmethod
     def _sql_has_list_aggregate(sql: str) -> bool:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -145,35 +145,40 @@ class LookMLAdapter(BaseAdapter):
         # "Model X already exists" and fail the whole project load. Only a collision consults the
         # includes -- a view with no rival is kept regardless, so an imperfectly-resolved include
         # can never silently drop a view.
-        chosen: dict[str, tuple[Path, dict, Model]] = {}
-        duplicates: list[tuple[Path, dict, Model]] = []
-        for _file, _view_def, _model in view_candidates:
-            previous = chosen.get(_model.name)
-            if previous is None:
-                chosen[_model.name] = (_file, _view_def, _model)
-                continue
-            current_included = bool(included_paths) and _file.resolve() in included_paths
-            previous_included = bool(included_paths) and previous[0].resolve() in included_paths
-            if current_included and not previous_included:
-                chosen[_model.name] = (_file, _view_def, _model)  # the included copy wins
-            elif previous_included and not current_included:
-                logger.debug(
-                    "Ignoring duplicate LookML view %r from %s: %s is the included copy.",
-                    _model.name,
-                    _file,
-                    previous[0],
-                )
-            else:
-                # Neither or BOTH are included, so nothing distinguishes them -- this is a real
-                # duplicate in the active project, not an archived copy. Install both and let
-                # add_model surface the conflict rather than silently loading one at random.
-                duplicates.append((_file, _view_def, _model))
-        for _name, (_file, _view_def, _model) in chosen.items():
+        by_name: dict[str, list[tuple[Path, dict, Model]]] = {}
+        for _candidate in view_candidates:
+            by_name.setdefault(_candidate[2].name, []).append(_candidate)
+
+        for _name, _candidates in by_name.items():
+            winner = _candidates[0]
+            if len(_candidates) > 1:
+                # Decide over ALL candidates for the name at once: deciding pairwise as files
+                # stream in mis-handles two archived copies followed by the included one (the
+                # first pair looks unresolvable before the winner is even seen).
+                _included = [c for c in _candidates if c[0].resolve() in included_paths] if included_paths else []
+                if len(_included) == 1:
+                    winner = _included[0]  # exactly one live copy: the rest are archived
+                    for _file, _, _ in _candidates:
+                        if _file is not winner[0]:
+                            logger.debug(
+                                "Ignoring duplicate LookML view %r from %s: %s is the included copy.",
+                                _name,
+                                _file,
+                                winner[0],
+                            )
+                else:
+                    # Zero or several included copies: nothing distinguishes them, so this is a
+                    # real duplicate in the active project. Install every copy and let add_model
+                    # surface the conflict rather than silently loading one at random.
+                    for _file, _view_def, _model in _candidates:
+                        raw_view_defs[_name] = _view_def
+                        view_source_files[_name] = str(_file)
+                        graph.add_model(_model)
+                    continue
+            _file, _view_def, _model = winner
             raw_view_defs[_name] = _view_def
             view_source_files[_name] = str(_file)
             graph.add_model(_model)
-        for _file, _view_def, _model in duplicates:
-            graph.add_model(_model)  # raises: an unresolvable duplicate must not pass silently
 
         # Snapshot abstract / unsupported-derived_table flags BEFORE refinement merge:
         # merge_model REPLACES a base view's meta when the refinement carries metadata,
@@ -402,7 +407,10 @@ class LookMLAdapter(BaseAdapter):
 
         # Record this file's `include:` declarations (LookML model files list the view files the
         # model actually uses) so refinements from un-included files can be ignored.
-        if include_specs is not None:
+        # ONLY a model file's includes activate scoping. A view file may include a helper, which
+        # says nothing about which files the project selects -- letting it populate the included
+        # set would make unrelated sibling refinements/explores look un-included and drop them.
+        if include_specs is not None and file_path.name.endswith(".model.lkml"):
             for pattern in parsed.get("includes") or []:
                 if isinstance(pattern, str):
                     include_specs.append((file_path, pattern))

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -280,6 +280,27 @@ class LookMLAdapter(BaseAdapter):
                 for _v in _allowed:
                     _view_model_count[_v] = _view_model_count.get(_v, 0) + 1
 
+        def _parent_in_scope(child: str, parent: str) -> bool:
+            """Whether `child` may INHERIT from `parent` under the project's include scoping.
+
+            A unique view is installed even when no include reaches it (an imperfectly-resolved
+            include must never silently drop a view), but being loaded is not being in a model's
+            scope: letting an included child extend an archived parent merges fields Looker would
+            not expose. Such a parent is treated as absent instead, which leaves the child's
+            extends unresolved -- the child still loads, just without the inherited fields.
+
+            The parent must be visible from the CHILD's own file, not merely included somewhere in
+            the project: with several models, a parent selected only by model B is not in scope for
+            a child selected only by model A, and inheriting it would expose another model's
+            fields. A view whose source file is unknown is left alone.
+            """
+            if not _scoping_active:
+                return True
+            child_source = view_source_files.get(child)
+            if child_source is None or parent not in view_source_files:
+                return True
+            return parent in _scope_by_file.get(Path(child_source).resolve(), set())
+
         # Snapshot abstract / unsupported-derived_table flags BEFORE refinement merge:
         # merge_model REPLACES a base view's meta when the refinement carries metadata,
         # which would otherwise drop these markers.
@@ -403,8 +424,11 @@ class LookMLAdapter(BaseAdapter):
                 remerged = None
                 if base_raw is not None and ref_raw is not None:
                     # A refinement can touch a field the base only has via `extends`; seed those from
-                    # the inherited definition so the partial refinement does not clobber it.
-                    inherited_fields = self._inherited_raw_fields(base_name, raw_view_defs)
+                    # the inherited definition so the partial refinement does not clobber it. Only
+                    # seed from parents IN the base's include scope, mirroring the extends resolution
+                    # below -- otherwise a table-backed view would expose an archived parent's field
+                    # Looker (and the resolved extends) would not include.
+                    inherited_fields = self._inherited_raw_fields(base_name, raw_view_defs, _parent_in_scope)
                     merged_raw = self._merge_view_defs(base_raw, ref_raw, inherited_fields)
                     remerged = self._parse_view(merged_raw)
                     if remerged is not None:
@@ -436,27 +460,6 @@ class LookMLAdapter(BaseAdapter):
             | {n for n, m in graph.models.items() if (m.meta or {}).get("unsupported_derived_table")}
         )
         extends_parent = {n: m.extends for n, m in graph.models.items() if m.extends}
-
-        def _parent_in_scope(child: str, parent: str) -> bool:
-            """Whether `child` may INHERIT from `parent` under the project's include scoping.
-
-            A unique view is installed even when no include reaches it (an imperfectly-resolved
-            include must never silently drop a view), but being loaded is not being in a model's
-            scope: letting an included child extend an archived parent merges fields Looker would
-            not expose. Such a parent is treated as absent instead, which leaves the child's
-            extends unresolved -- the child still loads, just without the inherited fields.
-
-            The parent must be visible from the CHILD's own file, not merely included somewhere in
-            the project: with several models, a parent selected only by model B is not in scope for
-            a child selected only by model A, and inheriting it would expose another model's
-            fields. A view whose source file is unknown is left alone.
-            """
-            if not _scoping_active:
-                return True
-            child_source = view_source_files.get(child)
-            if child_source is None or parent not in view_source_files:
-                return True
-            return parent in _scope_by_file.get(Path(child_source).resolve(), set())
 
         # Resolve extends chains. Pre-filter to models whose full chain
         # is present so one broken/missing parent doesn't block valid ones.
@@ -1100,23 +1103,32 @@ class LookMLAdapter(BaseAdapter):
         return extends_list if isinstance(extends_list, str) else None
 
     @classmethod
-    def _inherited_raw_fields(cls, base_name: str, raw_view_defs: dict) -> dict:
+    def _inherited_raw_fields(cls, base_name: str, raw_view_defs: dict, parent_in_scope=None) -> dict:
         """Fields a view inherits via ``extends``, as ``{(list_key, field_name): field_def}``.
 
         Walks the extends chain through the raw view dicts (nearest parent wins). Lets a refinement
         of an INHERITED field seed from the real definition instead of adding a bare partial field
         that re-parses to a categorical default and then overrides the inherited one.
+
+        ``parent_in_scope(child, parent)`` gates each extends LINK the same way the extends
+        resolution does: an out-of-scope parent leaves the extends unresolved, so its fields must
+        NOT be seeded either (else a table-backed view would expose an archived parent's field).
+        Walking stops at the first out-of-scope link, since nothing beyond it is inherited.
         """
         fields: dict[tuple[str, str], dict] = {}
         seen: set[str] = {base_name}
+        child = base_name
         parent = cls._raw_extends_parent(raw_view_defs.get(base_name) or {})
         while parent is not None and parent not in seen:
+            if parent_in_scope is not None and not parent_in_scope(child, parent):
+                break
             seen.add(parent)
             parent_raw = raw_view_defs.get(parent) or {}
             for key in cls._VIEW_FIELD_LIST_KEYS:
                 for item in parent_raw.get(key) or []:
                     if isinstance(item, dict) and item.get("name"):
                         fields.setdefault((key, item["name"]), copy.deepcopy(item))  # nearest wins
+            child = parent
             parent = cls._raw_extends_parent(parent_raw)
         return fields
 

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -139,18 +139,31 @@ class LookMLAdapter(BaseAdapter):
         includes_by_file: dict[Path, list[str]] = {}
         for _including_file, _pattern in include_specs:
             includes_by_file.setdefault(_including_file.resolve(), []).append(_pattern)
-        _model_files = [f for f in includes_by_file if f.name.endswith(".model.lkml")]
+
+        def _include_closure(start: Path) -> set[Path]:
+            """Files reachable from `start` through include:, including `start` itself."""
+            reached = {start}
+            queue = [start]
+            while queue:
+                current = queue.pop()
+                for pattern in includes_by_file.get(current, []):
+                    for hit in self._resolve_include(_include_root, current, pattern):
+                        if hit not in reached:
+                            reached.add(hit)
+                            queue.append(hit)
+            return reached
+
+        # EVERY model file seeds the closure, not just the ones that declare includes: a
+        # self-contained model (its own views and explores, no include:) belongs to the project
+        # just as much as an include-based sibling and must not be scoped out by one.
+        _model_files = [f.resolve() for f in lkml_files if f.name.endswith(".model.lkml")]
+        # Scoping only ACTIVATES once some model declares an include. Seeding unconditionally
+        # would scope an include-free project down to its model files alone.
+        _scoping_active = any(f in includes_by_file for f in _model_files)
         included_paths: set[Path] = set()
-        if _model_files:
-            included_paths |= set(_model_files)  # a model file is part of its own project
-            _queue = list(_model_files)
-            while _queue:
-                _current = _queue.pop()
-                for _pattern in includes_by_file.get(_current, []):
-                    for _hit in self._resolve_include(_include_root, _current, _pattern):
-                        if _hit not in included_paths:
-                            included_paths.add(_hit)
-                            _queue.append(_hit)
+        if _scoping_active:
+            for _model_file in _model_files:
+                included_paths |= _include_closure(_model_file)
 
         # Install base views, resolving a SAME-NAME collision between files by include: an
         # archived copy of a view alongside the live one would otherwise make add_model raise
@@ -320,13 +333,23 @@ class LookMLAdapter(BaseAdapter):
 
         _apply_default_tables()
 
-        # Second pass: parse explores and add relationships. Scope them the same way refinements
-        # are: an explore in a model file no include reaches -- an archived or alternate model --
-        # would otherwise mutate the LIVE model by adding its joins/segments. A file DECLARING
-        # includes is part of the project (that is where explores normally live), so the active
-        # model file is unaffected; with no includes declared nothing is filtered.
+        # Second pass: parse explores and add relationships. Once the project declares includes,
+        # an explore is scoped to the views ITS OWN model file can see -- the views that file
+        # defines inline plus the views its include closure reaches. Looker resolves a model's
+        # fields that way, and loading the tree as one project otherwise lets an archived or
+        # alternate model's joins/segments silently mutate the LIVE model. A self-contained model
+        # (inline views, no include:) still sees its own views; an archived model that includes
+        # nothing and defines nothing sees none, so its explores cannot attach anywhere.
+        _view_files = {name: Path(src).resolve() for name, src in view_source_files.items()}
         for lkml_file in lkml_files:
-            if included_paths and lkml_file.resolve() not in included_paths:
+            _resolved = lkml_file.resolve()
+            if _scoping_active and _resolved in _model_files:
+                _scope = _include_closure(_resolved)
+                self._parse_explores_from_file(
+                    lkml_file, graph, allowed_views={v for v, src in _view_files.items() if src in _scope}
+                )
+                continue
+            if included_paths and _resolved not in included_paths:
                 logger.debug("Ignoring LookML explores in %s: not reached by any include.", lkml_file)
                 continue
             self._parse_explores_from_file(lkml_file, graph)
@@ -449,12 +472,16 @@ class LookMLAdapter(BaseAdapter):
                         raw_view_defs[model.name] = view_def
                     graph.add_model(model)
 
-    def _parse_explores_from_file(self, file_path: Path, graph: SemanticGraph) -> None:
+    def _parse_explores_from_file(
+        self, file_path: Path, graph: SemanticGraph, allowed_views: set[str] | None = None
+    ) -> None:
         """Parse explores from a single LookML file and add relationships.
 
         Args:
             file_path: Path to .lkml file
             graph: Semantic graph to add relationships to
+            allowed_views: Base views this file may explore, or None to allow any. Scopes a model
+                file's explores to the views it defines or includes, as Looker resolves them.
         """
         lkml = _import_lkml()
 
@@ -468,6 +495,16 @@ class LookMLAdapter(BaseAdapter):
 
         # Parse explores
         for explore_def in parsed.get("explores") or []:
+            if allowed_views is not None:
+                base_view = explore_def.get("from", explore_def.get("name"))
+                if base_view not in allowed_views:
+                    logger.debug(
+                        "Ignoring LookML explore %s in %s: view %s is not in the model's scope.",
+                        explore_def.get("name"),
+                        file_path,
+                        base_view,
+                    )
+                    continue
             self._parse_explore(explore_def, graph)
 
     # Matches ${field} and ${view.field}. ${TABLE} is handled specially.

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -108,13 +108,38 @@ class LookMLAdapter(BaseAdapter):
         # provenance instead of just the project root.
         refinements: list[Model] = []
         refinement_raw_defs: list[dict] = []
+        refinement_source_files: list[Path] = []
+        include_specs: list[tuple[Path, str]] = []
         raw_view_defs: dict[str, dict] = {}
         view_source_files: dict[str, str] = {}
         for lkml_file in lkml_files:
             _before = set(graph.models)
-            self._parse_views_from_file(lkml_file, graph, refinements, raw_view_defs, refinement_raw_defs)
+            self._parse_views_from_file(
+                lkml_file,
+                graph,
+                refinements,
+                raw_view_defs,
+                refinement_raw_defs,
+                refinement_source_files,
+                include_specs,
+            )
             for _new in set(graph.models) - _before:
                 view_source_files[_new] = str(lkml_file)
+
+        # When the project DECLARES includes (a model file listing the view files it uses), a
+        # refinement in an un-included file must not silently override a loaded view -- e.g. a
+        # stale `view: +orders { sql_table_name: ... }` left in an archive/ directory. Only the
+        # REFINEMENT merge is scoped: views themselves still all parse, so a project whose
+        # includes do not enumerate every view keeps loading them. With no includes declared
+        # (the common single-directory case) nothing is filtered.
+        included_paths: set[Path] = set()
+        for _including_file, _pattern in include_specs:
+            included_paths |= self._resolve_include(
+                source_path if source_path.is_dir() else source_path.parent, _including_file, _pattern
+            )
+        if included_paths:
+            # A file declaring includes is part of the project itself.
+            included_paths |= {f.resolve() for f, _ in include_specs}
 
         # Snapshot abstract / unsupported-derived_table flags BEFORE refinement merge:
         # merge_model REPLACES a base view's meta when the refinement carries metadata,
@@ -129,6 +154,15 @@ class LookMLAdapter(BaseAdapter):
         refinement_unsupported_dt: set[str] = set()
         for _ridx, refinement in enumerate(refinements):
             base_name = refinement.name.lstrip("+")
+            if included_paths and _ridx < len(refinement_source_files):
+                _src = refinement_source_files[_ridx].resolve()
+                if _src not in included_paths:
+                    logger.debug(
+                        "Ignoring LookML refinement of %r from %s: not reached by any include.",
+                        base_name,
+                        _src,
+                    )
+                    continue
             # Record flags from EACH refinement's own meta: a later refinement's merge
             # can replace the base meta and drop a flag an earlier refinement added.
             rmeta = refinement.meta or {}
@@ -300,6 +334,8 @@ class LookMLAdapter(BaseAdapter):
         refinements: list[Model] | None = None,
         raw_view_defs: dict[str, dict] | None = None,
         refinement_raw_defs: list[dict] | None = None,
+        refinement_source_files: list[Path] | None = None,
+        include_specs: list[tuple[Path, str]] | None = None,
     ) -> None:
         """Parse views from a single LookML file.
 
@@ -322,6 +358,13 @@ class LookMLAdapter(BaseAdapter):
         if not parsed:
             return
 
+        # Record this file's `include:` declarations (LookML model files list the view files the
+        # model actually uses) so refinements from un-included files can be ignored.
+        if include_specs is not None:
+            for pattern in parsed.get("includes") or []:
+                if isinstance(pattern, str):
+                    include_specs.append((file_path, pattern))
+
         # Parse views
         for view_def in parsed.get("views") or []:
             model = self._parse_view(view_def)
@@ -332,6 +375,8 @@ class LookMLAdapter(BaseAdapter):
                         refinements.append(model)
                         if refinement_raw_defs is not None:
                             refinement_raw_defs.append(view_def)
+                        if refinement_source_files is not None:
+                            refinement_source_files.append(file_path)
                 else:
                     if raw_view_defs is not None:
                         raw_view_defs[model.name] = view_def
@@ -680,6 +725,21 @@ class LookMLAdapter(BaseAdapter):
 
     # Metric types SemanticGraph.add_model auto-registers at graph level (accessible unprefixed).
     _GRAPH_LEVEL_METRIC_TYPES = ("time_comparison", "conversion")
+
+    @staticmethod
+    def _resolve_include(root: Path, including_file: Path, pattern: str) -> set[Path]:
+        """Files matched by one LookML ``include:`` pattern.
+
+        A leading ``/`` is project-root relative; anything else is relative to the file declaring
+        the include. ``//other_project/...`` is a cross-project include, which has no local files.
+        """
+        if pattern.startswith("//"):
+            return set()
+        base, pat = (root, pattern[1:]) if pattern.startswith("/") else (including_file.parent, pattern)
+        try:
+            return {p.resolve() for p in base.glob(pat) if p.is_file()}
+        except (OSError, ValueError):
+            return set()
 
     @classmethod
     def _replace_model_refreshing_graph_metrics(cls, graph: SemanticGraph, name: str, model: Model) -> None:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -205,6 +205,20 @@ class LookMLAdapter(BaseAdapter):
             view_source_files[_name] = str(_file)
             graph.add_model(_model)
 
+        # The view scope of every file a model reaches: the views that model defines inline plus
+        # the views its include closure reaches. Keyed on REACHABILITY, not file name -- a model's
+        # explores routinely live in an included sidecar (orders.explore.lkml), which inherits the
+        # includer's scope. A file reached by several models sees the UNION of their scopes, the
+        # closest single-graph answer to Looker resolving each model separately.
+        _view_files = {name: Path(src).resolve() for name, src in view_source_files.items()}
+        _scope_by_file: dict[Path, set[str]] = {}
+        if _scoping_active:
+            for _model_file in _model_files:
+                _closure = _include_closure(_model_file)
+                _allowed = {v for v, src in _view_files.items() if src in _closure}
+                for _reached in _closure:
+                    _scope_by_file.setdefault(_reached, set()).update(_allowed)
+
         # Snapshot abstract / unsupported-derived_table flags BEFORE refinement merge:
         # merge_model REPLACES a base view's meta when the refinement carries metadata,
         # which would otherwise drop these markers.
@@ -276,19 +290,26 @@ class LookMLAdapter(BaseAdapter):
         )
         extends_parent = {n: m.extends for n, m in graph.models.items() if m.extends}
 
-        def _parent_in_scope(name: str) -> bool:
-            """Whether `name` may be INHERITED from under the project's include scoping.
+        def _parent_in_scope(child: str, parent: str) -> bool:
+            """Whether `child` may INHERIT from `parent` under the project's include scoping.
 
             A unique view is installed even when no include reaches it (an imperfectly-resolved
             include must never silently drop a view), but being loaded is not being in a model's
             scope: letting an included child extend an archived parent merges fields Looker would
             not expose. Such a parent is treated as absent instead, which leaves the child's
             extends unresolved -- the child still loads, just without the inherited fields.
+
+            The parent must be visible from the CHILD's own file, not merely included somewhere in
+            the project: with several models, a parent selected only by model B is not in scope for
+            a child selected only by model A, and inheriting it would expose another model's
+            fields. A view whose source file is unknown is left alone.
             """
             if not _scoping_active:
                 return True
-            source = view_source_files.get(name)
-            return source is None or Path(source).resolve() in included_paths
+            child_source = view_source_files.get(child)
+            if child_source is None or parent not in view_source_files:
+                return True
+            return parent in _scope_by_file.get(Path(child_source).resolve(), set())
 
         # Resolve extends chains. Pre-filter to models whose full chain
         # is present so one broken/missing parent doesn't block valid ones.
@@ -302,7 +323,7 @@ class LookMLAdapter(BaseAdapter):
                 return False
             if not model.extends:
                 return True
-            if not _parent_in_scope(model.extends):
+            if not _parent_in_scope(name, model.extends):
                 return False
             visited.add(name)
             return _chain_resolvable(model.extends, visited)
@@ -357,19 +378,8 @@ class LookMLAdapter(BaseAdapter):
         # include:) still sees its own views; an archived model that includes nothing and defines
         # nothing sees none, so its explores cannot attach anywhere.
         #
-        # Scope is keyed on REACHABILITY, not file name: explores routinely live in an included
-        # sidecar (orders.explore.lkml) rather than the model file, and such a file inherits the
-        # scope of the model that includes it. A file reached by several models sees the union,
-        # which is the closest single-graph answer to Looker's per-model resolution.
-        _view_files = {name: Path(src).resolve() for name, src in view_source_files.items()}
-        _scope_by_file: dict[Path, set[str]] = {}
-        if _scoping_active:
-            for _model_file in _model_files:
-                _closure = _include_closure(_model_file)
-                _allowed = {v for v, src in _view_files.items() if src in _closure}
-                for _reached in _closure:
-                    _scope_by_file.setdefault(_reached, set()).update(_allowed)
-
+        # Reuses the per-file scope built with the views above (see _scope_by_file), so an explore
+        # and an extends in the same file resolve against exactly the same set of views.
         for lkml_file in lkml_files:
             _resolved = lkml_file.resolve()
             if not _scoping_active:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -280,6 +280,8 @@ class LookMLAdapter(BaseAdapter):
                 for _v in _allowed:
                     _view_model_count[_v] = _view_model_count.get(_v, 0) + 1
 
+        _warned_ambiguous_extends: set[tuple[str, str]] = set()
+
         def _parent_in_scope(child: str, parent: str) -> bool:
             """Whether `child` may INHERIT from `parent` under the project's include scoping.
 
@@ -289,17 +291,40 @@ class LookMLAdapter(BaseAdapter):
             not expose. Such a parent is treated as absent instead, which leaves the child's
             extends unresolved -- the child still loads, just without the inherited fields.
 
-            The parent must be visible from the CHILD's own file, not merely included somewhere in
-            the project: with several models, a parent selected only by model B is not in scope for
-            a child selected only by model A, and inheriting it would expose another model's
-            fields. A view whose source file is unknown is left alone.
+            EVERY model whose scope reaches the child must include the parent, not merely one: the
+            child is a single graph model shared by all of them, so inheriting a parent that only
+            SOME models select would expose its fields to the models that do not -- fields Looker
+            would not give them. When the models disagree the parent is treated as out of scope (the
+            conservative, no-leak choice) and the ambiguity is reported. A view whose source file is
+            unknown is left alone.
             """
             if not _scoping_active:
                 return True
             child_source = view_source_files.get(child)
             if child_source is None or parent not in view_source_files:
                 return True
-            return parent in _scope_by_file.get(Path(child_source).resolve(), set())
+            scopes = _scopes_by_file.get(Path(child_source).resolve(), [])
+            if not scopes:
+                return True  # child not reached by any model -> unscoped, leave it alone
+            including = [parent in scope for scope in scopes]
+            if all(including):
+                return True
+            if any(including) and (child, parent) not in _warned_ambiguous_extends:
+                _warned_ambiguous_extends.add((child, parent))
+                logger.warning(
+                    "LookML view %r extends %r, but only some of the models using %r include %r. "
+                    "One graph model per view name cannot inherit for some and not others, so %r is "
+                    "NOT inherited (its fields would otherwise leak to the models missing it). "
+                    "Include %r from every model that uses %r, or give them separate views.",
+                    child,
+                    parent,
+                    child,
+                    parent,
+                    parent,
+                    parent,
+                    child,
+                )
+            return False
 
         # Snapshot abstract / unsupported-derived_table flags BEFORE refinement merge:
         # merge_model REPLACES a base view's meta when the refinement carries metadata,

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -525,6 +525,11 @@ class LookMLAdapter(BaseAdapter):
                 parent = graph.models.get(parent_name)
                 if parent is None or not _parent_in_scope(name, parent_name):
                     continue
+                if parent_name in unsupported_dt_views:
+                    # An unsupported derived-table parent is dropped by the loader; copying its
+                    # fields would leave the child querying a column from a table that never gets
+                    # registered. The first-parent chain already skips these -- do the same here.
+                    continue
                 have_dims = {d.name for d in model.dimensions}
                 model.dimensions.extend(d.model_copy(deep=True) for d in parent.dimensions if d.name not in have_dims)
                 have_metrics = {mm.name for mm in model.metrics}

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -190,9 +190,16 @@ class LookMLAdapter(BaseAdapter):
         # would scope an include-free project down to its model files alone.
         _scoping_active = any(f in includes_by_file for f in _model_files)
         included_paths: set[Path] = set()
+        # Per-model include closure, so a duplicate view name can be told apart: two copies each
+        # reached by a DIFFERENT model (prod model -> prod/orders, stage model -> stage/orders) is a
+        # valid multi-model layout, whereas ONE model reaching two copies is a real within-model
+        # duplicate. Union of all closures still drives the archived-vs-live single-copy decision.
+        closures_by_model_file: dict[Path, set[Path]] = {}
         if _scoping_active:
             for _model_file in _model_files:
-                included_paths |= _include_closure(_model_file)
+                _closure = _include_closure(_model_file)
+                closures_by_model_file[_model_file] = _closure
+                included_paths |= _closure
 
         # Install base views, resolving a SAME-NAME collision between files by include: an
         # archived copy of a view alongside the live one would otherwise make add_model raise
@@ -221,15 +228,33 @@ class LookMLAdapter(BaseAdapter):
                                 winner[0],
                             )
                 elif len(_included) >= 2 or not _scoping_active:
-                    # A REAL duplicate in the active project: several copies the includes reach, or
-                    # (scoping off) no include information to tell an archive from the live view.
-                    # Install every copy and let add_model surface the conflict rather than loading
-                    # one at random.
-                    for _file, _view_def, _model in _candidates:
-                        raw_view_defs[_name] = _view_def
-                        view_source_files[_name] = str(_file)
-                        graph.add_model(_model)
-                    continue
+                    # Several copies the includes reach, or (scoping off) no include information.
+                    # A genuine WITHIN-model duplicate -- ONE model's closure reaches 2+ copies -- is
+                    # a real conflict: install every copy and let add_model surface it. But when each
+                    # copy is reached by a DIFFERENT model (a valid multi-model layout where every
+                    # model namespace has its own `orders`), sidemantic's single graph can hold only
+                    # one, so keep the first included copy and warn rather than aborting the whole
+                    # directory load over a layout LookML considers valid.
+                    within_model_dup = _scoping_active and any(
+                        sum(1 for c in _included if c[0].resolve() in _closure) >= 2
+                        for _closure in closures_by_model_file.values()
+                    )
+                    if within_model_dup or not _scoping_active:
+                        for _file, _view_def, _model in _candidates:
+                            raw_view_defs[_name] = _view_def
+                            view_source_files[_name] = str(_file)
+                            graph.add_model(_model)
+                        continue
+                    winner = _included[0]
+                    for _file, _, _ in _included[1:]:
+                        logger.warning(
+                            "LookML view %r is defined by multiple models (%s and %s); sidemantic has "
+                            "a single model namespace, so keeping %s and ignoring the other copy.",
+                            _name,
+                            winner[0],
+                            _file,
+                            winner[0],
+                        )
                 else:
                     # Scoping is ON and NO copy is included: every copy is archived / unreachable
                     # from any model. Skip them all -- raising here would fail a valid project over

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -350,25 +350,35 @@ class LookMLAdapter(BaseAdapter):
         _apply_default_tables()
 
         # Second pass: parse explores and add relationships. Once the project declares includes,
-        # an explore is scoped to the views ITS OWN model file can see -- the views that file
-        # defines inline plus the views its include closure reaches. Looker resolves a model's
-        # fields that way, and loading the tree as one project otherwise lets an archived or
-        # alternate model's joins/segments silently mutate the LIVE model. A self-contained model
-        # (inline views, no include:) still sees its own views; an archived model that includes
-        # nothing and defines nothing sees none, so its explores cannot attach anywhere.
+        # an explore is scoped to the views its MODEL can see -- the views that model file defines
+        # inline plus the views its include closure reaches. Looker resolves a model's fields that
+        # way, and loading the tree as one project otherwise lets an archived or alternate model's
+        # joins/segments silently mutate the LIVE model. A self-contained model (inline views, no
+        # include:) still sees its own views; an archived model that includes nothing and defines
+        # nothing sees none, so its explores cannot attach anywhere.
+        #
+        # Scope is keyed on REACHABILITY, not file name: explores routinely live in an included
+        # sidecar (orders.explore.lkml) rather than the model file, and such a file inherits the
+        # scope of the model that includes it. A file reached by several models sees the union,
+        # which is the closest single-graph answer to Looker's per-model resolution.
         _view_files = {name: Path(src).resolve() for name, src in view_source_files.items()}
+        _scope_by_file: dict[Path, set[str]] = {}
+        if _scoping_active:
+            for _model_file in _model_files:
+                _closure = _include_closure(_model_file)
+                _allowed = {v for v, src in _view_files.items() if src in _closure}
+                for _reached in _closure:
+                    _scope_by_file.setdefault(_reached, set()).update(_allowed)
+
         for lkml_file in lkml_files:
             _resolved = lkml_file.resolve()
-            if _scoping_active and _resolved in _model_files:
-                _scope = _include_closure(_resolved)
-                self._parse_explores_from_file(
-                    lkml_file, graph, allowed_views={v for v, src in _view_files.items() if src in _scope}
-                )
+            if not _scoping_active:
+                self._parse_explores_from_file(lkml_file, graph)
                 continue
-            if included_paths and _resolved not in included_paths:
+            if _resolved not in _scope_by_file:
                 logger.debug("Ignoring LookML explores in %s: not reached by any include.", lkml_file)
                 continue
-            self._parse_explores_from_file(lkml_file, graph)
+            self._parse_explores_from_file(lkml_file, graph, allowed_views=_scope_by_file[_resolved])
 
         # Re-apply the default: explores can add segments (sql_always_where /
         # always_filter) to an otherwise-fieldless view, which only now makes it

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -606,6 +606,19 @@ class LookMLAdapter(BaseAdapter):
 
         return graph
 
+    @classmethod
+    def _flatten_include_patterns(cls, entry) -> list[str]:
+        """String include patterns from one ``includes`` entry, flattening bracketed lists.
+
+        A scalar ``include: "a"`` parses to the string ``"a"``; a bracketed ``include: ["a", "b"]``
+        parses to the nested list ``["a", "b"]``. Recurse so any nesting yields plain strings.
+        """
+        if isinstance(entry, str):
+            return [entry]
+        if isinstance(entry, list):
+            return [p for item in entry for p in cls._flatten_include_patterns(item)]
+        return []
+
     def _parse_views_from_file(
         self,
         file_path: Path,
@@ -644,8 +657,12 @@ class LookMLAdapter(BaseAdapter):
         # closure in _build_graph) -- but a selected view file's own includes must be followed
         # from there, so they have to be recorded here too.
         if include_specs is not None:
-            for pattern in parsed.get("includes") or []:
-                if isinstance(pattern, str):
+            # LookML allows a bracketed `include: ["a", "b"]`, which lkml parses as a NESTED list
+            # (`[["a", "b"]]`), while a scalar `include: "a"` parses as a plain string. Flatten so
+            # both forms yield string patterns -- otherwise a bracketed include is dropped, scoping
+            # never activates, and stale un-included refinements/explores leak back in.
+            for entry in parsed.get("includes") or []:
+                for pattern in self._flatten_include_patterns(entry):
                     include_specs.append((file_path, pattern))
 
         # Parse views

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -153,6 +153,35 @@ class LookMLAdapter(BaseAdapter):
                             queue.append(hit)
             return reached
 
+        def _ordered_include_closure(start: Path) -> list[Path]:
+            """Files reachable from `start`, in Looker's include order.
+
+            Refinements are order-sensitive -- the LAST include of a `view: +name` wins -- so a
+            model listing `z_ref` then `a_ref` must let `a_ref` win, whatever the filenames sort
+            like. Walks includes depth-first in declaration order, sorting only WITHIN a glob
+            pattern (whose on-disk match order is otherwise arbitrary) so loads stay deterministic.
+
+            A file is ordered AFTER the files it includes: `include:` brings that content in where
+            it is written, and includes sit at the top of a file, so an included refinement lands
+            before the includer's own. Looker documents that refinements follow include order but
+            not how a nested include orders against its includer, so this mirrors the plain
+            file-inclusion reading.
+            """
+            order: list[Path] = []
+            seen: set[Path] = set()
+
+            def visit(current: Path) -> None:
+                if current in seen:
+                    return
+                seen.add(current)  # before recursing: a circular include must not loop
+                for pattern in includes_by_file.get(current, []):
+                    for hit in sorted(self._resolve_include(_include_root, current, pattern)):
+                        visit(hit)
+                order.append(current)
+
+            visit(start)
+            return order
+
         # EVERY model file seeds the closure, not just the ones that declare includes: a
         # self-contained model (its own views and explores, no include:) belongs to the project
         # just as much as an include-based sibling and must not be scoped out by one.
@@ -228,6 +257,27 @@ class LookMLAdapter(BaseAdapter):
         # which would otherwise drop these markers.
         abstract_pre = {n for n, m in graph.models.items() if (m.meta or {}).get("extension_required")}
         unsupported_pre = {n for n, m in graph.models.items() if (m.meta or {}).get("unsupported_derived_table")}
+
+        # Merge refinements in the models' INCLUDE order, not the sorted tree-walk order. Looker
+        # gives the last-included `view: +orders` precedence, so a model including z_ref then a_ref
+        # must let a_ref win even though the walk parsed a_ref first. Files no model reaches keep
+        # their sorted-walk position (last); with no include scope at all the sorted order stands,
+        # which is what keeps a plain directory load deterministic.
+        _include_order: dict[Path, int] = {}
+        if _scoping_active:
+            for _model_file in _model_files:
+                for _reached in _ordered_include_closure(_model_file):
+                    _include_order.setdefault(_reached, len(_include_order))
+        if _include_order and refinement_source_files:
+            _unordered = len(_include_order)
+            # Stable: refinements from the SAME file keep their in-file order.
+            _positions = sorted(
+                range(len(refinements)),
+                key=lambda i: _include_order.get(refinement_source_files[i].resolve(), _unordered),
+            )
+            refinements = [refinements[i] for i in _positions]
+            refinement_raw_defs = [refinement_raw_defs[i] for i in _positions]
+            refinement_source_files = [refinement_source_files[i] for i in _positions]
 
         # Apply refinements: merge each refinement into its base view
         from sidemantic.core.inheritance import merge_model, resolve_model_inheritance

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -212,12 +212,16 @@ class LookMLAdapter(BaseAdapter):
         # closest single-graph answer to Looker resolving each model separately.
         _view_files = {name: Path(src).resolve() for name, src in view_source_files.items()}
         _scope_by_file: dict[Path, set[str]] = {}
+        # Which model files reach each file. Used to tell a refinement that every model sharing a
+        # view agrees on from one only SOME of them select.
+        _models_by_file: dict[Path, set[Path]] = {}
         if _scoping_active:
             for _model_file in _model_files:
                 _closure = _include_closure(_model_file)
                 _allowed = {v for v, src in _view_files.items() if src in _closure}
                 for _reached in _closure:
                     _scope_by_file.setdefault(_reached, set()).update(_allowed)
+                    _models_by_file.setdefault(_reached, set()).add(_model_file)
 
         # Snapshot abstract / unsupported-derived_table flags BEFORE refinement merge:
         # merge_model REPLACES a base view's meta when the refinement carries metadata,
@@ -241,6 +245,30 @@ class LookMLAdapter(BaseAdapter):
                         _src,
                     )
                     continue
+                # A refinement only SOME of the base view's models select is genuinely ambiguous:
+                # Looker resolves each model separately (prod sees the plain view, staging sees the
+                # refined one), while a graph holds ONE model per view name and cannot hold both.
+                # The refinement is still applied -- refusing to load a valid project, or dropping
+                # the refinement and silently mis-serving the model that DID select it, are both
+                # worse -- but the ambiguity is surfaced rather than resolved by a coin flip.
+                _base_source = view_source_files.get(base_name)
+                if _base_source is not None:
+                    _unselecting = _models_by_file.get(Path(_base_source).resolve(), set()) - _models_by_file.get(
+                        _src, set()
+                    )
+                    if _unselecting:
+                        logger.warning(
+                            "LookML refinement of view %r from %s is not included by these models, which use "
+                            "%r without it: %s. It is applied anyway, because one model per view name cannot "
+                            "hold both the refined and unrefined view -- so those models see the refined view, "
+                            "which Looker would not do. Include the refinement from every model that uses %r, "
+                            "or give the models separate views.",
+                            base_name,
+                            _src,
+                            base_name,
+                            ", ".join(sorted(f.name for f in _unselecting)),
+                            base_name,
+                        )
             # Record flags from EACH refinement's own meta: a later refinement's merge
             # can replace the base meta and drop a flag an earlier refinement added.
             rmeta = refinement.meta or {}

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -2171,8 +2171,75 @@ class LookMLAdapter(BaseAdapter):
             if sql:
                 sql = sql.replace("${TABLE}", "{model}")
 
+        # Recover the granularity of the collision-export form: a standalone time
+        # dimension we emit as `type: date_time sql: DATE_TRUNC('<grain>', ...)` whose
+        # name carries a LookML timeframe suffix for that grain (e.g. started_date with
+        # DATE_TRUNC('day', ...), started_minute with DATE_TRUNC('minute', ...) -- see
+        # _export_collision_time_dim). Guard tightly so a hand-written DATE_TRUNC dim is
+        # NOT hijacked: the grain must be one sidemantic supports, the name's trailing
+        # `_<suffix>` must be a LookML timeframe mapping to that exact grain, AND the dim
+        # must carry no other properties (the collision form emits only name/type/sql).
+        # This keeps a hand-written `created` (DATE_TRUNC('day', ...)) on the categorical
+        # path (no rename to created_date), preserves a hand-written `created_date` with
+        # `hidden`/`label`/etc. as a plain dimension (props not dropped), and never copies
+        # a dialect grain like 'isoweek' into Dimension.granularity (a validation error).
+        granularity = None
+        recovered_timeframe = None
+        if (
+            dim_type in ("date", "date_time", "datetime", "time")
+            and sql
+            and not (set(dim_def) & self._PRESERVED_DIM_PROPS)
+        ):
+            bucket = self._MINUTE_BUCKET_RE.match(sql)
+            tm = self._DATE_TRUNC_RE.match(sql)
+            if bucket:
+                # A collision-export minute15/minute30 bucket: recover minute grain + the
+                # exact timeframe. KEEP the full bucket expression as the dim's sql (do NOT
+                # reduce to the raw column) so QUERIES bucket every 15/30 minutes; the
+                # generator's DATE_TRUNC('minute', ...) wrap is idempotent on an already
+                # minute-aligned bucket. Re-export detects this bucket to avoid re-wrapping.
+                tf = f"minute{bucket.group(2)}"
+                if name.endswith("_" + tf):
+                    sidemantic_type = "time"
+                    granularity = "minute"
+                    recovered_timeframe = tf
+            elif tm:
+                grain = tm.group(1).lower()
+                if grain in self._SUBSECOND_TF and name.endswith("_" + grain):
+                    # A collision-export sub-second DATE_TRUNC (millisecond/microsecond):
+                    # sidemantic has no such grain, so store the nearest (second) + the
+                    # exact timeframe in meta, KEEPING the sub-second DATE_TRUNC sql so the
+                    # exported precision round-trips (queries run at second, sidemantic's max).
+                    sidemantic_type = "time"
+                    granularity = "second"
+                    recovered_timeframe = grain
+                # Match the LONGEST known timeframe suffix, not just text after the last
+                # underscore -- multi-word timeframes like "time_of_day" must round-trip
+                # (started_time_of_day, not a bogus "day" suffix lookup).
+                elif grain in self._SUPPORTED_GRAINS:
+                    matched_tf = None
+                    for tf, g in self._TIME_GRANULARITY_TIMEFRAMES.items():
+                        if name.endswith("_" + tf) and g == grain and (not matched_tf or len(tf) > len(matched_tf)):
+                            matched_tf = tf
+                    if matched_tf:
+                        sidemantic_type = "time"
+                        granularity = grain
+                        # Only STORE the timeframe when it's an EXACT one-to-one match for the
+                        # grain. An INEXACT suffix (minute15/30, sub-second, time_of_day) on a
+                        # PLAIN DATE_TRUNC does NOT preserve that timeframe's semantics (the
+                        # explicit bucket/subsecond forms, handled above, do) -- recording it
+                        # would make the next export WIDEN a 1-minute dim into a 15-min bucket.
+                        # Recover as a plain grain time dim (no inexact meta) instead.
+                        if matched_tf not in self._INEXACT_NAME_TF:
+                            recovered_timeframe = matched_tf
+
         # Build meta dict from LookML-specific display properties
         meta = {}
+        if recovered_timeframe:
+            # Remember the exact LookML timeframe so the NEXT export strips this suffix
+            # (e.g. _time_of_day) instead of re-deriving a wrong one and renaming the
+            # field -- keeps repeated collision round-trips stable.
+            meta["lookml_timeframe"] = recovered_timeframe
         if dim_def.get("hidden") in ("yes", True):
             meta["hidden"] = True
         if dim_def.get("group_label"):
@@ -2202,6 +2269,7 @@ class LookMLAdapter(BaseAdapter):
             name=name,
             type=sidemantic_type,
             sql=sql,
+            granularity=granularity,
             description=dim_def.get("description"),
             label=dim_def.get("label"),
             value_format_name=dim_def.get("value_format_name"),
@@ -2277,7 +2345,9 @@ class LookMLAdapter(BaseAdapter):
     # Timeframes that truncate a timestamp to a coarser time grain. These keep
     # type="time" with a Sidemantic granularity so they behave as time dimensions.
     _TIME_GRANULARITY_TIMEFRAMES = {
-        "time": "hour",
+        # Looker's "time" timeframe keeps full timestamp precision (to the second);
+        # truncating to the hour silently collapses sub-hour rows.
+        "time": "second",
         "time_of_day": "hour",
         "hour": "hour",
         "minute": "minute",
@@ -2337,7 +2407,10 @@ class LookMLAdapter(BaseAdapter):
         label = dim_group_def.get("label")
         description = dim_group_def.get("description")
 
-        # Time-truncation timeframes -> time dimension with granularity.
+        # Time-truncation timeframes -> time dimension with granularity. Remember the
+        # original LookML timeframe so export can round-trip it exactly: several
+        # timeframes (e.g. "time" and "second") map to the same sidemantic granularity
+        # and would otherwise collapse to one on export.
         granularity = self._TIME_GRANULARITY_TIMEFRAMES.get(timeframe)
         if granularity is not None:
             return Dimension(
@@ -2347,6 +2420,7 @@ class LookMLAdapter(BaseAdapter):
                 granularity=granularity,
                 label=label,
                 description=description,
+                meta={"lookml_timeframe": timeframe},
             )
 
         # Fiscal quarter/year truncations honoring fiscal_month_offset. The base
@@ -3879,6 +3953,138 @@ class LookMLAdapter(BaseAdapter):
             return None
         return f"{func}(CASE WHEN {conds} THEN {arg} END)"
 
+    # DATE_TRUNC('<grain>', <expr>) emitted for collision time dimensions, and matched
+    # on import to recover the grain. The grain is the first capture; expr is the rest.
+    _DATE_TRUNC_RE = re.compile(r"(?is)^\s*DATE_TRUNC\(\s*'(\w+)'\s*,\s*(.+)\)\s*$")
+    # minute15 / minute30 bucket every N minutes -- sidemantic has no such grain (it
+    # stores them as `minute` + meta), and DATE_TRUNC('minute', ...) loses the bucket.
+    # The collision export emits the expression below; this regex recovers (src, N).
+    _MINUTE_BUCKET_TF = {"minute15": 15, "minute30": 30}
+    # Sub-second LookML timeframes finer than sidemantic's `second` grain but valid as
+    # DATE_TRUNC units; the collision export truncates at these and import recovers them.
+    _SUBSECOND_TF = frozenset({"millisecond", "microsecond"})
+    # LookML timeframes that map MANY-to-one onto a coarser/finer sidemantic grain (15/30-min
+    # buckets -> minute, sub-second -> second, time-of-day extraction -> hour). A native dim's
+    # NAME suffix must NOT infer these on export: `created_minute15` at MINUTE grain is 1-minute
+    # data, not 15-minute buckets, so emitting `[minute15]` would silently re-bucket. They only
+    # round-trip when preserved in meta['lookml_timeframe'] (the import path).
+    _INEXACT_NAME_TF = frozenset(_MINUTE_BUCKET_TF) | _SUBSECOND_TF | {"time_of_day"}
+    # Canonical EXACT LookML timeframe for each sidemantic grain (inverse of the common
+    # cases in _TIME_GRANULARITY_TIMEFRAMES). Used to give a suffixless collision time dim
+    # a recoverable name on export (e.g. `started` at hour grain -> `started_hour`).
+    _GRAIN_TO_TIMEFRAME = {
+        "second": "second",
+        "minute": "minute",
+        "hour": "hour",
+        "day": "date",
+        "week": "week",
+        "month": "month",
+        "quarter": "quarter",
+        "year": "year",
+    }
+    _MINUTE_BUCKET_RE = re.compile(
+        r"(?is)^\s*DATE_TRUNC\('hour',\s*(.+?)\)\s*\+\s*INTERVAL '1 minute'\s*\*\s*"
+        r"CAST\(FLOOR\(EXTRACT\(MINUTE FROM .+?\)\s*/\s*(15|30)\)\s*\*\s*(?:15|30)\s*AS INTEGER\)\s*$"
+    )
+
+    @staticmethod
+    def _minute_bucket_sql(src: str, n: int) -> str:
+        """An N-minute bucket truncation of ``src`` (N = 15 or 30).
+
+        Uses portable ``FLOOR(x / n) * n`` (not DuckDB-only ``//``) so the exported SQL
+        runs on Postgres/BigQuery/Snowflake too.
+        """
+        return (
+            f"DATE_TRUNC('hour', {src}) + INTERVAL '1 minute' * "
+            f"CAST(FLOOR(EXTRACT(MINUTE FROM {src}) / {n}) * {n} AS INTEGER)"
+        )
+
+    # Grains sidemantic's Dimension.granularity accepts; used to guard DATE_TRUNC recovery.
+    _SUPPORTED_GRAINS = frozenset({"second", "minute", "hour", "day", "week", "month", "quarter", "year"})
+    # Dimension-level properties the collision-export form never emits (it writes only
+    # name/type/sql). Their presence marks a HAND-WRITTEN DATE_TRUNC dimension that must
+    # not be reclassified into a time dimension (which would drop these on round-trip).
+    _PRESERVED_DIM_PROPS = frozenset(
+        {
+            "hidden",
+            "label",
+            "group_label",
+            "description",
+            "order_by_field",
+            "value_format",
+            "value_format_name",
+            "tags",
+            "can_filter",
+            "primary_key",
+            "drill_fields",
+        }
+    )
+
+    @classmethod
+    def _export_collision_time_dim(cls, dim, group_sql: str | None, used_names: set | None = None) -> dict:
+        """Export a same-prefix time dimension (different source) as a standalone dim.
+
+        Such a dimension cannot share its base name's dimension_group, so it is written
+        as a plain ``type: date_time`` dimension preserving its exact field name, with
+        the granularity baked into ``DATE_TRUNC`` so re-import recovers it (see
+        ``_parse_dimension``). If the source SQL is already a DATE_TRUNC at this grain it
+        is reused verbatim, keeping repeated round-trips stable (no nested truncation).
+        """
+        src = (group_sql if group_sql is not None else dim.sql) or ""
+        src = src.replace("{model}", "${TABLE}")
+        grain = (dim.granularity or "").lower()
+        tf = (dim.meta or {}).get("lookml_timeframe")
+        # Compute the exported SQL for each class of timeframe:
+        n = cls._MINUTE_BUCKET_TF.get(tf)
+        if n is not None:
+            # minute15/minute30 (stored as `minute` grain + meta): emit an explicit N-minute
+            # bucket so Looker buckets correctly, not every minute. Reuse the dim's sql if it
+            # is ALREADY that bucket (recovered on a prior import) to avoid nesting.
+            bm = cls._MINUTE_BUCKET_RE.match(src)
+            sql = src if (bm and int(bm.group(2)) == n) else cls._minute_bucket_sql(src, n)
+        else:
+            # millisecond/microsecond are finer than the stored `second` grain but ARE valid
+            # DATE_TRUNC units, so truncate at the LookML timeframe to keep sub-second precision.
+            if tf in cls._SUBSECOND_TF:
+                grain = tf
+            m = cls._DATE_TRUNC_RE.match(src)
+            sql = src if (m and m.group(1).lower() == grain) else f"DATE_TRUNC('{grain}', {src})"
+
+        # A standalone dim is only recoverable as a TIME dim if its name ends in a LookML
+        # timeframe suffix that re-import maps to this grain (see _parse_dimension). Determine
+        # that trailing `_<tf>` (prefer the STORED lookml_timeframe -- e.g. minute15/millisecond
+        # -- so bucket/sub-second forms round-trip; else a name suffix matching the grain; else
+        # synthesize the grain's canonical timeframe for a suffixless name like `started`, which
+        # would otherwise re-import categorical). `stem` is the name without that suffix.
+        name = dim.name
+        tf_suffix = None
+        if tf and name.endswith("_" + tf):
+            tf_suffix = tf
+        elif grain in cls._SUBSECOND_TF and name.endswith("_" + grain):
+            tf_suffix = grain
+        else:
+            for t, g in cls._TIME_GRANULARITY_TIMEFRAMES.items():
+                if name.endswith("_" + t) and g == grain and (tf_suffix is None or len(t) > len(tf_suffix)):
+                    tf_suffix = t
+        if tf_suffix is not None:
+            stem = name[: -(len(tf_suffix) + 1)]
+        else:
+            tf_suffix = tf or (grain if grain in cls._SUBSECOND_TF else cls._GRAIN_TO_TIMEFRAME.get(grain, "date"))
+            stem = name
+            name = f"{stem}_{tf_suffix}"
+        # Guarantee uniqueness against every other emitted field (a sibling standalone, a
+        # dimension_group's generated `<base>_<tf>` field, a regular dimension/measure). This
+        # trio (`started` + `started_hour` + `started_date`, all different SQL) is otherwise
+        # unrepresentable; insert the disambiguator into the STEM (`started_2_hour`, NOT
+        # `started_hour_2`) so the trailing timeframe -- and thus time-recoverability on
+        # re-import -- is preserved. Valid + lossless.
+        if used_names is not None and name in used_names:
+            i = 2
+            while f"{stem}_{i}_{tf_suffix}" in used_names:
+                i += 1
+            name = f"{stem}_{i}_{tf_suffix}"
+        return {"name": name, "type": "date_time", "sql": sql}
+
     def _export_view(self, model: Model, graph: SemanticGraph) -> dict:
         """Export model to LookML view definition.
 
@@ -3957,55 +4163,151 @@ class LookMLAdapter(BaseAdapter):
         # Group time dimensions by base name
         time_dims = [d for d in model.dimensions if d.type == "time" and d.granularity]
         if time_dims:
-            # Group by base name and collect all timeframes
-            from collections import defaultdict
+            # Group by (base name, source SQL): same-prefix time dimensions backed by
+            # DIFFERENT columns are not one dimension_group, and merging them would
+            # rewire a field to the wrong source on round-trip.
+            from collections import Counter
 
-            base_name_groups = defaultdict(list)
+            base_name_groups: dict[tuple[str, str | None], list] = {}
 
             for dim in time_dims:
-                # Extract base name (remove _date, _week, etc suffix)
+                # Extract the base name by stripping the timeframe suffix. For imported
+                # dims, use the EXACT stored LookML timeframe (covers every mapped
+                # timeframe, e.g. millisecond/microsecond, not just the common few);
+                # for native dims fall back to the common suffix list.
                 base_name = dim.name
-                for suffix in ["_date", "_week", "_month", "_quarter", "_year", "_time", "_hour"]:
-                    if dim.name.endswith(suffix):
-                        base_name = dim.name[: -len(suffix)]
-                        break
-                base_name_groups[base_name].append(dim)
+                stored_tf = (dim.meta or {}).get("lookml_timeframe")
+                if stored_tf and dim.name.endswith("_" + stored_tf):
+                    base_name = dim.name[: -(len(stored_tf) + 1)]
+                else:
+                    # Native dims (no stored timeframe): strip any known LookML truncation
+                    # timeframe suffix, LONGEST first so e.g. `_minute15`/`_time_of_day`/
+                    # `_millisecond` win over `_minute`/`_time`/`_second` (else the field
+                    # re-imports renamed, e.g. created_minute15 -> created_minute15_minute).
+                    for tf in sorted(self._TIME_GRANULARITY_TIMEFRAMES, key=len, reverse=True):
+                        if dim.name.endswith("_" + tf):
+                            base_name = dim.name[: -(len(tf) + 1)]
+                            break
+                base_name_groups.setdefault((base_name, dim.sql), []).append(dim)
+
+            # When one base name spans multiple source SQLs, only ONE can be the
+            # dimension_group (a second `dimension_group: <base>` is illegal LookML);
+            # the rest are emitted as standalone DATE_TRUNC dimensions below so their
+            # field names round-trip exactly instead of being renamed.
+            base_name_counts = Counter(bn for (bn, _) in base_name_groups)
+            assigned_names: set[str] = set()
+
+            # Map granularity to timeframe. Used as a fallback for dimensions not
+            # imported from LookML (which carry no meta['lookml_timeframe']); a
+            # second-grain dimension maps to the LookML `second` timeframe so native
+            # `*_second` fields round-trip instead of collapsing to `time`.
+            granularity_mapping = {
+                "second": "second",
+                "minute": "minute",
+                "hour": "hour",
+                "day": "date",
+                "week": "week",
+                "month": "month",
+                "quarter": "quarter",
+                "year": "year",
+            }
 
             dimension_groups = []
-            for base_name, dims in base_name_groups.items():
-                # Map granularity to timeframe
-                granularity_mapping = {
-                    "hour": "time",
-                    "day": "date",
-                    "week": "week",
-                    "month": "month",
-                    "quarter": "quarter",
-                    "year": "year",
-                }
+            # Same-prefix time dimensions backed by a DIFFERENT source column can't all
+            # be dimension_groups: a second `dimension_group: <base>` is illegal LookML,
+            # and renaming it (started_2) would rename its fields (started_minute ->
+            # started_2_minute) and break every reference. The first source keeps the
+            # dimension_group; the rest are emitted as standalone dimensions that
+            # preserve the exact field name (granularity baked into DATE_TRUNC so the
+            # importer recovers it losslessly).
+            collision_dims = []
+            # Field names already taken by fields NOT produced by this time-dim pass (regular
+            # dimensions + measures). Time dims get their emitted names added below as each
+            # dimension_group (base + generated `<base>_<tf>` fields) and collision standalone
+            # is built, so a collision standalone never duplicates a group-generated field,
+            # another standalone, or a regular field (see _export_collision_time_dim).
+            _time_names = {d.name for d in time_dims}
+            used_names: set[str] = {d.name for d in model.dimensions if d.name not in _time_names}
+            used_names |= {m.name for m in model.metrics}
+            # Within a colliding base, let a clean (non-DATE_TRUNC) source win the
+            # dimension_group slot so the choice is stable across repeated round-trips
+            # (a DATE_TRUNC-sourced winner would otherwise nest truncations).
+            ordered_groups = sorted(
+                base_name_groups.items(),
+                key=lambda kv: (kv[0][0], 1 if self._DATE_TRUNC_RE.match(kv[0][1] or "") else 0, kv[0][1] or ""),
+            )
 
-                # Collect all timeframes for this base name
+            def _group_timeframes(dims):
+                # De-duplicated LookML timeframes for a dimension_group's dims. LookML's
+                # "time" and "second" both import to second granularity, so dedup avoids
+                # emitting [time, time] and dropping a field on re-import.
                 timeframes = []
-                sql = None
+                seen_timeframes = set()
                 for dim in dims:
-                    timeframe = granularity_mapping.get(dim.granularity, "date")
-                    timeframes.append(timeframe)
-                    if dim.sql and not sql:
-                        sql = dim.sql
+                    # Prefer the original LookML timeframe captured at import (so
+                    # "time"/"second"/etc. round-trip distinctly).
+                    timeframe = (dim.meta or {}).get("lookml_timeframe")
+                    if timeframe is None:
+                        # Native (non-import) dim: derive from the field-name suffix (longest
+                        # known timeframe) so the EXACT name round-trips (created_hour -> [hour])
+                        # -- but ONLY when that suffix is an EXACT one-to-one match for the grain.
+                        # Skip the inexact/bucketing timeframes (minute15/30, milli/microsecond,
+                        # time_of_day): their coarse mapping equals the grain, so a native
+                        # created_minute15 at MINUTE grain would wrongly export [minute15]. Also
+                        # skip a suffix that CONTRADICTS the grain. Otherwise fall back to grain.
+                        for tf in sorted(self._TIME_GRANULARITY_TIMEFRAMES, key=len, reverse=True):
+                            if (
+                                tf not in self._INEXACT_NAME_TF
+                                and dim.name.endswith("_" + tf)
+                                and self._TIME_GRANULARITY_TIMEFRAMES[tf] == dim.granularity
+                            ):
+                                timeframe = tf
+                                break
+                        if timeframe is None:
+                            timeframe = granularity_mapping.get(dim.granularity, "date")
+                    if timeframe not in seen_timeframes:
+                        seen_timeframes.add(timeframe)
+                        timeframes.append(timeframe)
+                return timeframes
+
+            # PRE-SEED used_names with every field ANY dimension_group will generate BEFORE
+            # emitting collision standalones. The group winner is the FIRST entry per base; a
+            # standalone processed earlier must not pick a disambiguated name (`started_2_hour`)
+            # that a LATER group (`started_2`) also generates. Without this pre-pass the
+            # incremental seeding misses future groups' outputs.
+            _seeded_bases: set[str] = set()
+            for (base_name, _group_sql), dims in ordered_groups:
+                if base_name in _seeded_bases:
+                    continue
+                _seeded_bases.add(base_name)
+                used_names.add(base_name)
+                used_names.update(f"{base_name}_{tf}" for tf in _group_timeframes(dims))
+
+            for (base_name, group_sql), dims in ordered_groups:
+                if base_name_counts[base_name] > 1 and base_name in assigned_names:
+                    for dim in dims:
+                        cdim = self._export_collision_time_dim(dim, group_sql, used_names)
+                        used_names.add(cdim["name"])
+                        collision_dims.append(cdim)
+                    continue
+                group_name = base_name
+                assigned_names.add(group_name)
 
                 dim_group_def = {
-                    "name": base_name,
+                    "name": group_name,
                     "type": "time",
-                    "timeframes": timeframes,
+                    "timeframes": _group_timeframes(dims),
                 }
 
-                if sql:
-                    sql = sql.replace("{model}", "${TABLE}")
-                    dim_group_def["sql"] = sql
+                if group_sql:
+                    dim_group_def["sql"] = group_sql.replace("{model}", "${TABLE}")
 
                 dimension_groups.append(dim_group_def)
 
             if dimension_groups:
                 view["dimension_groups"] = dimension_groups
+            if collision_dims:
+                view.setdefault("dimensions", []).extend(collision_dims)
 
         # Export measures
         from sidemantic.sql.aggregation_detection import sql_has_aggregate as _sql_has_aggregate

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -74,6 +74,10 @@ class LookMLAdapter(BaseAdapter):
                 for name, m in graph.models.items()
                 if not (m.table or m.sql or getattr(m, "dax", None) or getattr(m, "source_uri", None))
                 and (m.meta or {}).get("lookml_template")
+                # ...but a name the layer ALREADY defines is a duplicate-model conflict, not a
+                # skippable template: let add_model raise it rather than silently keeping the
+                # pre-existing model. (Mirrors the non-template case below.)
+                and name not in prev_layer.graph.models
             }
             for model in graph.models.values():
                 if model.name in skipped:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -2351,7 +2351,10 @@ class LookMLAdapter(BaseAdapter):
                 group_sql = "{model}." + group_name
             timeframes = dim_group_def.get("timeframes", ["date"])
             for timeframe in timeframes:
-                if timeframe != "raw":
+                # Skip UNSUPPORTED timeframes (minute buckets / sub-second): _build_timeframe_dimension
+                # drops their generated dimensions, so seeding the lookup would let a ${created_minute15}
+                # reference expand to the raw base column and run a measure on unbucketed timestamps.
+                if timeframe != "raw" and not self._is_unsupported_timeframe(timeframe):
                     dimension_sql_lookup[f"{group_name}_{timeframe}"] = group_sql
 
         # All declared dimension names (including compact dimensions with no explicit
@@ -2362,7 +2365,7 @@ class LookMLAdapter(BaseAdapter):
             group_name = dim_group_def.get("name")
             if group_name:
                 for timeframe in dim_group_def.get("timeframes", ["date"]):
-                    if timeframe != "raw":
+                    if timeframe != "raw" and not self._is_unsupported_timeframe(timeframe):
                         declared_dim_names.add(f"{group_name}_{timeframe}")
 
         # Resolve any dimension-to-dimension references in the lookup
@@ -3053,7 +3056,7 @@ class LookMLAdapter(BaseAdapter):
         #     adapter does not have.
         #   - millisecond / microsecond are FINER than the finest granularity the enum supports
         #     (`second`), so a time dimension truncates to the second and silently drops precision.
-        if timeframe in self._MINUTE_BUCKET_TF or timeframe in self._SUBSECOND_TF:
+        if self._is_unsupported_timeframe(timeframe):
             return None
 
         # Time-truncation timeframes -> time dimension with granularity. Remember the
@@ -4694,6 +4697,17 @@ class LookMLAdapter(BaseAdapter):
     # Sub-second LookML timeframes finer than sidemantic's `second` grain but valid as
     # DATE_TRUNC units; the collision export truncates at these and import recovers them.
     _SUBSECOND_TF = frozenset({"millisecond", "microsecond"})
+
+    @classmethod
+    def _is_unsupported_timeframe(cls, timeframe: str) -> bool:
+        """A timeframe sidemantic cannot represent as a portable time dimension on IMPORT.
+
+        Its generated dimension is dropped by ``_build_timeframe_dimension``, so the reference
+        lookup must skip it too -- otherwise ``${created_minute15}`` in another field would expand
+        to the raw base column and run on unbucketed timestamps.
+        """
+        return timeframe in cls._MINUTE_BUCKET_TF or timeframe in cls._SUBSECOND_TF
+
     # LookML timeframes that map MANY-to-one onto a coarser/finer sidemantic grain (15/30-min
     # buckets -> minute, sub-second -> second, time-of-day extraction -> hour). A native dim's
     # NAME suffix must NOT infer these on export: `created_minute15` at MINUTE grain is 1-minute

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -4264,12 +4264,22 @@ class LookMLAdapter(BaseAdapter):
             _time_names = {d.name for d in time_dims}
             used_names: set[str] = {d.name for d in model.dimensions if d.name not in _time_names}
             used_names |= {m.name for m in model.metrics}
-            # Within a colliding base, let a clean (non-DATE_TRUNC) source win the
-            # dimension_group slot so the choice is stable across repeated round-trips
-            # (a DATE_TRUNC-sourced winner would otherwise nest truncations).
+            # Choose the dimension_group winner within a colliding base so field names map to
+            # the RIGHT source: (1) DEPRIORITIZE a suffixless representative -- a suffixless
+            # `started` winning the group generates `started_<grain>` (e.g. started_hour) from
+            # ITS OWN sql, mis-mapping the field that an existing sibling `started_hour` should
+            # own; letting the suffixed sibling win means the group's generated `started_hour`
+            # comes from that dim's source (and the suffixless one goes standalone, renamed into
+            # its stem, e.g. started_2_hour). (2) Prefer a clean (non-DATE_TRUNC) source so
+            # repeated round-trips don't nest truncations. (3) SQL order for stability.
             ordered_groups = sorted(
                 base_name_groups.items(),
-                key=lambda kv: (kv[0][0], 1 if self._DATE_TRUNC_RE.match(kv[0][1] or "") else 0, kv[0][1] or ""),
+                key=lambda kv: (
+                    kv[0][0],
+                    1 if any(d.name == kv[0][0] for d in kv[1]) else 0,
+                    1 if self._DATE_TRUNC_RE.match(kv[0][1] or "") else 0,
+                    kv[0][1] or "",
+                ),
             )
 
             def _group_timeframes(dims):

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -276,6 +276,20 @@ class LookMLAdapter(BaseAdapter):
         )
         extends_parent = {n: m.extends for n, m in graph.models.items() if m.extends}
 
+        def _parent_in_scope(name: str) -> bool:
+            """Whether `name` may be INHERITED from under the project's include scoping.
+
+            A unique view is installed even when no include reaches it (an imperfectly-resolved
+            include must never silently drop a view), but being loaded is not being in a model's
+            scope: letting an included child extend an archived parent merges fields Looker would
+            not expose. Such a parent is treated as absent instead, which leaves the child's
+            extends unresolved -- the child still loads, just without the inherited fields.
+            """
+            if not _scoping_active:
+                return True
+            source = view_source_files.get(name)
+            return source is None or Path(source).resolve() in included_paths
+
         # Resolve extends chains. Pre-filter to models whose full chain
         # is present so one broken/missing parent doesn't block valid ones.
         def _chain_resolvable(name: str, visited: set[str] | None = None) -> bool:
@@ -288,6 +302,8 @@ class LookMLAdapter(BaseAdapter):
                 return False
             if not model.extends:
                 return True
+            if not _parent_in_scope(model.extends):
+                return False
             visited.add(name)
             return _chain_resolvable(model.extends, visited)
 

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -269,6 +269,11 @@ class LookMLAdapter(BaseAdapter):
             _file, _view_def, _model = winner
             raw_view_defs[_name] = _view_def
             view_source_files[_name] = str(_file)
+            if _scoping_active and _file.resolve() not in included_paths:
+                # Scoping is on but this view is in NO model's include closure -- Looker cannot see
+                # it. It is kept only so an imperfectly-resolved include never silently drops a view,
+                # but downstream FK inference must NOT join to it. Mark it so the loader skips it.
+                _model.meta = {**(_model.meta or {}), "_lookml_unincluded": True}
             graph.add_model(_model)
 
         # The view scope of every file a model reaches: the views that model defines inline plus

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -529,6 +529,10 @@ class LookMLAdapter(BaseAdapter):
                 model.dimensions.extend(d.model_copy(deep=True) for d in parent.dimensions if d.name not in have_dims)
                 have_metrics = {mm.name for mm in model.metrics}
                 model.metrics.extend(mm.model_copy(deep=True) for mm in parent.metrics if mm.name not in have_metrics)
+                # Also copy the parent's segments (LookML `filter:` fields); otherwise a base
+                # contributing only segments would have them silently dropped from the child.
+                have_segments = {s.name for s in model.segments}
+                model.segments.extend(s.model_copy(deep=True) for s in parent.segments if s.name not in have_segments)
 
         def _extends_chain_has(name: str, flagset: set[str]) -> bool:
             """True if name or any of its extends-ancestors is in flagset."""
@@ -1176,24 +1180,31 @@ class LookMLAdapter(BaseAdapter):
 
         ``parent_in_scope(child, parent)`` gates each extends LINK the same way the extends
         resolution does: an out-of-scope parent leaves the extends unresolved, so its fields must
-        NOT be seeded either (else a table-backed view would expose an archived parent's field).
-        Walking stops at the first out-of-scope link, since nothing beyond it is inherited.
+        NOT be seeded either (else a table-backed view would expose an archived parent's field). An
+        out-of-scope link is skipped (with its ancestors), but OTHER parents are still walked.
+
+        A view can extend SEVERAL parents (``extends: [a, b]``), so this walks EVERY parent, not
+        just the first -- otherwise a refinement of a field inherited only from a non-first parent
+        would not seed from its real definition and would re-parse to a bare categorical field.
         """
         fields: dict[tuple[str, str], dict] = {}
         seen: set[str] = {base_name}
-        child = base_name
-        parent = cls._raw_extends_parent(raw_view_defs.get(base_name) or {})
-        while parent is not None and parent not in seen:
+        # Breadth-first over all extends parents: nearer parents before their ancestors, and
+        # earlier-listed before later, so the nearest/earliest definition of a field wins (setdefault).
+        queue = [(base_name, p) for p in cls._all_extends_parents(raw_view_defs.get(base_name) or {})]
+        while queue:
+            child, parent = queue.pop(0)
+            if parent in seen:
+                continue
             if parent_in_scope is not None and not parent_in_scope(child, parent):
-                break
+                continue  # skip this link (and its ancestors); other parents still apply
             seen.add(parent)
             parent_raw = raw_view_defs.get(parent) or {}
             for key in cls._VIEW_FIELD_LIST_KEYS:
                 for item in parent_raw.get(key) or []:
                     if isinstance(item, dict) and item.get("name"):
                         fields.setdefault((key, item["name"]), copy.deepcopy(item))  # nearest wins
-            child = parent
-            parent = cls._raw_extends_parent(parent_raw)
+            queue.extend((parent, gp) for gp in cls._all_extends_parents(parent_raw))
         return fields
 
     @classmethod

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -588,14 +588,41 @@ class LookMLAdapter(BaseAdapter):
 
         # Looker allows a view to extend SEVERAL parents (`extends: [a, b]`, and additive
         # refinement extends). Model.extends is single, so core resolution above followed only the
-        # FIRST parent; merge the fields of any EXTRA in-scope parents so none are silently lost.
-        # Fields already present (the child's own and its first-parent chain) win; extra parents
-        # only fill gaps -- exact left-to-right override precedence on CONFLICTING field names is
-        # not modeled, but the common case of parents contributing disjoint fields is correct.
+        # FIRST parent; merge the fields of any EXTRA in-scope parents. Looker gives a LATER-listed
+        # parent priority for a conflicting field, so an extra parent OVERRIDES the value already
+        # present from an earlier parent -- but the child's OWN fields always win.
+        def _override_list(existing, incoming, protected_names):
+            by_name: dict = {}
+            order: list = []
+            for item in existing:
+                if item.name not in by_name:
+                    order.append(item.name)
+                by_name[item.name] = item
+            for item in incoming:
+                if item.name in protected_names:
+                    continue  # the child's own definition wins over any parent
+                if item.name not in by_name:
+                    order.append(item.name)
+                by_name[item.name] = item.model_copy(deep=True)  # later parent overrides earlier
+            return [by_name[n] for n in order]
+
         for name, model in graph.models.items():
             raw = raw_view_defs.get(name)
             if raw is None:
                 continue
+            # The child's OWN field names, so an extra parent never overrides them. Dimensions come
+            # from raw `dimensions` and the timeframe fields a raw `dimension_group` generates
+            # (matched by the `<group>_` prefix); metrics from `measures`; segments from `filters`.
+            _own_dims = {d.get("name") for d in (raw.get("dimensions") or []) if isinstance(d, dict) and d.get("name")}
+            _own_group_prefixes = tuple(
+                g["name"] + "_" for g in (raw.get("dimension_groups") or []) if isinstance(g, dict) and g.get("name")
+            )
+            _own_metrics = {m.get("name") for m in (raw.get("measures") or []) if isinstance(m, dict) and m.get("name")}
+            _own_segments = {s.get("name") for s in (raw.get("filters") or []) if isinstance(s, dict) and s.get("name")}
+
+            def _protected_dim(dname, _own_dims=_own_dims, _own_group_prefixes=_own_group_prefixes):
+                return dname in _own_dims or dname.startswith(_own_group_prefixes)
+
             for parent_name in self._all_extends_parents(raw)[1:]:
                 parent = graph.models.get(parent_name)
                 if parent is None or not _parent_in_scope(name, parent_name):
@@ -605,14 +632,11 @@ class LookMLAdapter(BaseAdapter):
                     # fields would leave the child querying a column from a table that never gets
                     # registered. The first-parent chain already skips these -- do the same here.
                     continue
-                have_dims = {d.name for d in model.dimensions}
-                model.dimensions.extend(d.model_copy(deep=True) for d in parent.dimensions if d.name not in have_dims)
-                have_metrics = {mm.name for mm in model.metrics}
-                model.metrics.extend(mm.model_copy(deep=True) for mm in parent.metrics if mm.name not in have_metrics)
-                # Also copy the parent's segments (LookML `filter:` fields); otherwise a base
-                # contributing only segments would have them silently dropped from the child.
-                have_segments = {s.name for s in model.segments}
-                model.segments.extend(s.model_copy(deep=True) for s in parent.segments if s.name not in have_segments)
+                model.dimensions = _override_list(
+                    model.dimensions, parent.dimensions, {d.name for d in model.dimensions if _protected_dim(d.name)}
+                )
+                model.metrics = _override_list(model.metrics, parent.metrics, _own_metrics)
+                model.segments = _override_list(model.segments, parent.segments, _own_segments)
 
         def _extends_chain_has(name: str, flagset: set[str]) -> bool:
             """True if name or any of its extends-ancestors is in flagset."""
@@ -5014,13 +5038,14 @@ class LookMLAdapter(BaseAdapter):
         """
         view = {"name": model.name}
 
-        # Re-emit `extension: required` for an abstract (tableless) base so a round-trip keeps
-        # it non-queryable; otherwise it re-imports as an ordinary tableless view and the
-        # implicit-table default assigns it a physical table named after the view. Only for a
-        # genuinely TABLELESS view: a concrete child INHERITS `extension_required` in meta via
-        # inheritance but has its own table, so emitting the marker would wrongly make the
-        # usable child abstract on round-trip.
-        if (model.meta or {}).get("extension_required") and not model.table and not model.sql:
+        # Re-emit `extension: required` for an abstract base so a round-trip keeps it non-queryable.
+        # Key off the PARSER-OWNED `lookml_template` marker, not `not model.table`: an
+        # extension: required base may declare a sql_table_name (valid for a reusable base), and that
+        # table is re-emitted below -- but it must still round-trip the abstract marker. A concrete
+        # child only INHERITS `extension_required` in meta (no `lookml_template` marker), so it is
+        # not made abstract on round-trip.
+        _meta = model.meta or {}
+        if _meta.get("lookml_template") and _meta.get("extension_required"):
             view["extension"] = "required"
 
         if model.sql:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -609,9 +609,47 @@ class LookMLAdapter(BaseAdapter):
                 by_name[item.name] = item.model_copy(deep=True)  # later parent overrides earlier
             return [by_name[n] for n in order]
 
-        for name, model in graph.models.items():
-            raw = raw_view_defs.get(name)
+        # The in-scope, registerable extends parents of a raw view, in declaration order. An
+        # unsupported derived-table parent is dropped by the loader, so copying its fields would
+        # leave the child querying a column from a table that never gets registered -- skip it here
+        # exactly as the first-parent chain does.
+        def _mergeable_parents(nm: str) -> list[str]:
+            raw = raw_view_defs.get(nm)
             if raw is None:
+                return []
+            return [
+                p
+                for p in self._all_extends_parents(raw)
+                if p in graph.models and _parent_in_scope(nm, p) and p not in unsupported_dt_views
+            ]
+
+        # Merge extra parents in DEPENDENCY order (a view after every parent it extends). Model.extends
+        # is single, so resolve_model_inheritance() above flattened only each view's FIRST-parent
+        # chain -- and it did so BEFORE a multi-parent intermediate received its own extra-parent
+        # fields, so a descendant that extends that intermediate would otherwise miss them. Processing
+        # bottom-up and re-pulling the first parent (add-only) propagates those fields down the chain.
+        _extends_order: list[str] = []
+        _extends_state: dict[str, int] = {}  # 1 = visiting, 2 = done
+
+        def _order_extends(nm: str) -> None:
+            if _extends_state.get(nm):
+                return  # done, or a back-edge (real cycles already rejected by resolve_model_inheritance)
+            _extends_state[nm] = 1
+            for p in _mergeable_parents(nm):
+                _order_extends(p)
+            _extends_state[nm] = 2
+            _extends_order.append(nm)
+
+        for _nm in list(graph.models):
+            _order_extends(_nm)
+
+        for name in _extends_order:
+            model = graph.models.get(name)
+            raw = raw_view_defs.get(name)
+            if model is None or raw is None:
+                continue
+            parents = _mergeable_parents(name)
+            if not parents:
                 continue
             # The child's OWN field names, so an extra parent never overrides them. Dimensions come
             # from raw `dimensions` and the timeframe fields a raw `dimension_group` generates
@@ -626,20 +664,47 @@ class LookMLAdapter(BaseAdapter):
             def _protected_dim(dname, _own_dims=_own_dims, _own_group_prefixes=_own_group_prefixes):
                 return dname in _own_dims or dname.startswith(_own_group_prefixes)
 
-            for parent_name in self._all_extends_parents(raw)[1:]:
+            for idx, parent_name in enumerate(parents):
                 parent = graph.models.get(parent_name)
-                if parent is None or not _parent_in_scope(name, parent_name):
+                if parent is None:
                     continue
-                if parent_name in unsupported_dt_views:
-                    # An unsupported derived-table parent is dropped by the loader; copying its
-                    # fields would leave the child querying a column from a table that never gets
-                    # registered. The first-parent chain already skips these -- do the same here.
-                    continue
-                model.dimensions = _override_list(
-                    model.dimensions, parent.dimensions, {d.name for d in model.dimensions if _protected_dim(d.name)}
-                )
-                model.metrics = _override_list(model.metrics, parent.metrics, _own_metrics)
-                model.segments = _override_list(model.segments, parent.segments, _own_segments)
+                if idx == 0:
+                    # First parent: resolve_model_inheritance() already flattened it into this model,
+                    # but before the parent gained its OWN extra-parent fields. Re-pull ADD-ONLY
+                    # (protect every field already present) so those fields propagate to this
+                    # descendant without clobbering the child's own or extra-parent fields. This is a
+                    # no-op for an ordinary single-parent chain (all first-parent fields already here).
+                    model.dimensions = _override_list(
+                        model.dimensions, parent.dimensions, {d.name for d in model.dimensions}
+                    )
+                    model.metrics = _override_list(model.metrics, parent.metrics, {m.name for m in model.metrics})
+                    model.segments = _override_list(model.segments, parent.segments, {s.name for s in model.segments})
+                else:
+                    # Extra parent: Looker gives a later-listed parent precedence, so it OVERRIDES an
+                    # earlier parent's conflicting field; only the child's OWN fields are protected.
+                    model.dimensions = _override_list(
+                        model.dimensions,
+                        parent.dimensions,
+                        {d.name for d in model.dimensions if _protected_dim(d.name)},
+                    )
+                    model.metrics = _override_list(model.metrics, parent.metrics, _own_metrics)
+                    model.segments = _override_list(model.segments, parent.segments, _own_segments)
+
+            # Looker applies the same later-parent precedence to the SOURCE. resolve_model_inheritance
+            # took the first parent's table/sql; if the child declares no source of its own, let the
+            # LATEST-listed parent that declares one win, so the inherited fields query the right
+            # physical table instead of the first parent's (or the view-name default).
+            if not (raw.get("sql_table_name") or raw.get("derived_table")):
+                _inherited_table = None
+                _inherited_sql = None
+                _have_source = False
+                for parent_name in parents:
+                    parent = graph.models.get(parent_name)
+                    if parent is not None and (parent.table or parent.sql):
+                        _inherited_table, _inherited_sql, _have_source = parent.table, parent.sql, True
+                if _have_source:
+                    model.table = _inherited_table
+                    model.sql = _inherited_sql
 
         def _extends_chain_has(name: str, flagset: set[str]) -> bool:
             """True if name or any of its extends-ancestors is in flagset."""
@@ -721,9 +786,7 @@ class LookMLAdapter(BaseAdapter):
                 model.meta = {**(model.meta or {}), "extension_required": True, "lookml_template": True}
                 is_template = True
             elif (model.meta or {}).get("unsupported_derived_table") or (
-                model.table is None
-                and model.sql is None
-                and _extends_chain_has(model_name, unsupported_dt_views)
+                model.table is None and model.sql is None and _extends_chain_has(model_name, unsupported_dt_views)
             ):
                 # A view that declares its OWN unsupported derived_table is non-representable even
                 # when it INHERITED a sql_table_name from a table-backed extends parent -- Looker

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -209,7 +209,7 @@ class LookMLAdapter(BaseAdapter):
                 # Decide over ALL candidates for the name at once: deciding pairwise as files
                 # stream in mis-handles two archived copies followed by the included one (the
                 # first pair looks unresolvable before the winner is even seen).
-                _included = [c for c in _candidates if c[0].resolve() in included_paths] if included_paths else []
+                _included = [c for c in _candidates if c[0].resolve() in included_paths]
                 if len(_included) == 1:
                     winner = _included[0]  # exactly one live copy: the rest are archived
                     for _file, _, _ in _candidates:
@@ -220,14 +220,26 @@ class LookMLAdapter(BaseAdapter):
                                 _file,
                                 winner[0],
                             )
-                else:
-                    # Zero or several included copies: nothing distinguishes them, so this is a
-                    # real duplicate in the active project. Install every copy and let add_model
-                    # surface the conflict rather than silently loading one at random.
+                elif len(_included) >= 2 or not _scoping_active:
+                    # A REAL duplicate in the active project: several copies the includes reach, or
+                    # (scoping off) no include information to tell an archive from the live view.
+                    # Install every copy and let add_model surface the conflict rather than loading
+                    # one at random.
                     for _file, _view_def, _model in _candidates:
                         raw_view_defs[_name] = _view_def
                         view_source_files[_name] = str(_file)
                         graph.add_model(_model)
+                    continue
+                else:
+                    # Scoping is ON and NO copy is included: every copy is archived / unreachable
+                    # from any model. Skip them all -- raising here would fail a valid project over
+                    # views it never selects, and a lone unincluded view (no rival) still loads via
+                    # the single-candidate path, so this only drops genuinely-ambiguous dead copies.
+                    logger.debug(
+                        "Ignoring %d unincluded duplicate copies of LookML view %r: no model include reaches them.",
+                        len(_candidates),
+                        _name,
+                    )
                     continue
             _file, _view_def, _model = winner
             raw_view_defs[_name] = _view_def
@@ -564,6 +576,19 @@ class LookMLAdapter(BaseAdapter):
                         gm = graph.metrics.get(mt.name)
                         if gm is not None:
                             gm.meta = {**(gm.meta or {}), "_lookml_template_metric": True}
+
+        # Stamp EVERY graph-level metric (time_comparison / conversion, auto-registered into
+        # graph.metrics by add_model) with its OWNING model. In a directory load the LookML project
+        # is parsed before the per-file scan, so a later Python/YAML file can overwrite a model name
+        # this metric depends on; the loader uses this owner to drop the metric when the surviving
+        # model no longer defines it (its base measure / time dimension would be gone). Covers the
+        # normal-view case that carries no template marker.
+        for model_name, model in graph.models.items():
+            for mt in model.metrics or []:
+                if mt.type in self._GRAPH_LEVEL_METRIC_TYPES:
+                    gm = graph.metrics.get(mt.name)
+                    if gm is not None:
+                        gm.meta = {**(gm.meta or {}), "_lookml_graph_metric_owner": model_name}
 
         # Rebuild adjacency graph now that relationships have been added
         graph.build_adjacency()

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -478,8 +478,25 @@ class LookMLAdapter(BaseAdapter):
                     # seed from parents IN the base's include scope, mirroring the extends resolution
                     # below -- otherwise a table-backed view would expose an archived parent's field
                     # Looker (and the resolved extends) would not include.
-                    inherited_fields = self._inherited_raw_fields(base_name, raw_view_defs, _parent_in_scope)
-                    merged_raw = self._merge_view_defs(base_raw, ref_raw, inherited_fields)
+                    inherited_fields = self._inherited_raw_fields(
+                        base_name, raw_view_defs, _parent_in_scope, unsupported_parents=unsupported_pre
+                    )
+                    # A refinement can touch a field that exists ONLY on an unsupported derived-table
+                    # parent (dropped by the loader). Seeding skips it above, but the refinement's
+                    # bare field would still be added as an own field querying a table that never
+                    # gets registered. Collect those keys (present via unsupported parents but not via
+                    # supported ones or the base) so the merge drops the refinement's copy entirely.
+                    all_inherited = self._inherited_raw_fields(base_name, raw_view_defs, _parent_in_scope)
+                    _base_keys = {
+                        (k, i["name"])
+                        for k in self._VIEW_FIELD_LIST_KEYS
+                        for i in (base_raw.get(k) or [])
+                        if isinstance(i, dict) and i.get("name")
+                    }
+                    unsupported_only_keys = set(all_inherited) - set(inherited_fields) - _base_keys
+                    merged_raw = self._merge_view_defs(
+                        base_raw, ref_raw, inherited_fields, drop_field_keys=unsupported_only_keys
+                    )
                     remerged = self._parse_view(merged_raw)
                     if remerged is not None:
                         # Keep the merged raw so a SECOND refinement of the same view stacks
@@ -1201,7 +1218,9 @@ class LookMLAdapter(BaseAdapter):
         return parents[0] if parents else None
 
     @classmethod
-    def _inherited_raw_fields(cls, base_name: str, raw_view_defs: dict, parent_in_scope=None) -> dict:
+    def _inherited_raw_fields(
+        cls, base_name: str, raw_view_defs: dict, parent_in_scope=None, unsupported_parents=None
+    ) -> dict:
         """Fields a view inherits via ``extends``, as ``{(list_key, field_name): field_def}``.
 
         Walks the extends chain through the raw view dicts (nearest parent wins). Lets a refinement
@@ -1213,10 +1232,15 @@ class LookMLAdapter(BaseAdapter):
         NOT be seeded either (else a table-backed view would expose an archived parent's field). An
         out-of-scope link is skipped (with its ancestors), but OTHER parents are still walked.
 
+        ``unsupported_parents`` names views backed by an unsupported derived table; they are dropped
+        by the loader, so seeding a refinement from their fields would resurrect a field querying a
+        table that never gets registered -- skip them, matching the extra-parent merge/copy guard.
+
         A view can extend SEVERAL parents (``extends: [a, b]``), so this walks EVERY parent, not
         just the first -- otherwise a refinement of a field inherited only from a non-first parent
         would not seed from its real definition and would re-parse to a bare categorical field.
         """
+        unsupported_parents = unsupported_parents or set()
         fields: dict[tuple[str, str], dict] = {}
         seen: set[str] = {base_name}
         # Breadth-first over all extends parents: nearer parents before their ancestors, and
@@ -1228,6 +1252,8 @@ class LookMLAdapter(BaseAdapter):
                 continue
             if parent_in_scope is not None and not parent_in_scope(child, parent):
                 continue  # skip this link (and its ancestors); other parents still apply
+            if parent in unsupported_parents:
+                continue  # unsupported derived-table parent: never registered, so do not seed it
             seen.add(parent)
             parent_raw = raw_view_defs.get(parent) or {}
             for key in cls._VIEW_FIELD_LIST_KEYS:
@@ -1238,7 +1264,9 @@ class LookMLAdapter(BaseAdapter):
         return fields
 
     @classmethod
-    def _merge_view_defs(cls, base: dict, refinement: dict, inherited_fields: dict | None = None) -> dict:
+    def _merge_view_defs(
+        cls, base: dict, refinement: dict, inherited_fields: dict | None = None, drop_field_keys=None
+    ) -> dict:
         """Merge a `view: +name` refinement's RAW LookML dict onto the base view's RAW dict.
 
         Merging at the RAW level (then re-parsing) is what makes a PARTIAL field refinement work:
@@ -1249,7 +1277,12 @@ class LookMLAdapter(BaseAdapter):
 
         Named-field lists are merged per field by name; every other key is overridden wholesale
         (Looker refinement semantics), and the base's name is kept.
+
+        ``drop_field_keys`` names ``(list_key, field_name)`` pairs the refinement must NOT introduce:
+        a field that exists only on an unsupported derived-table parent (never registered), so
+        refining it would resurrect a phantom own field querying a nonexistent column.
         """
+        drop_field_keys = drop_field_keys or set()
         merged = copy.deepcopy(base)
         for key, value in refinement.items():
             if key == "name":
@@ -1267,6 +1300,10 @@ class LookMLAdapter(BaseAdapter):
                         extras.append(copy.deepcopy(item))
                         continue
                     fname = item["name"]
+                    if (key, fname) in drop_field_keys and fname not in by_name:
+                        # Field exists only on an unsupported derived-table parent: refining it
+                        # would add a phantom own field querying an unregistered table, so drop it.
+                        continue
                     if fname in by_name:
                         # Field-level refinement: override ONLY the properties it specifies.
                         by_name[fname].update({k: copy.deepcopy(v) for k, v in item.items() if k != "name"})

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -720,14 +720,20 @@ class LookMLAdapter(BaseAdapter):
                 # queryable model.
                 model.meta = {**(model.meta or {}), "extension_required": True, "lookml_template": True}
                 is_template = True
-            elif (
+            elif (model.meta or {}).get("unsupported_derived_table") or (
                 model.table is None
                 and model.sql is None
-                and (
-                    _extends_chain_has(model_name, unsupported_dt_views)
-                    or (model.meta or {}).get("unsupported_derived_table")
-                )
+                and _extends_chain_has(model_name, unsupported_dt_views)
             ):
+                # A view that declares its OWN unsupported derived_table is non-representable even
+                # when it INHERITED a sql_table_name from a table-backed extends parent -- Looker
+                # would use the derived_table source, not the inherited table -- so stamp the marker
+                # BEFORE the source check, like the extension_required case above. (Without this,
+                # resolve_model_inheritance copies the parent's table onto the child and the guard
+                # below leaves the unsupported view registerable against that physical table.) A view
+                # that merely INHERITS an unsupported derived table through the extends CHAIN is a
+                # template only when it has no source of its own; if it overrode with its own
+                # table/sql it is a concrete, queryable view and must not be skipped.
                 model.meta = {**(model.meta or {}), "unsupported_derived_table": True, "lookml_template": True}
                 is_template = True
             if is_template:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -483,8 +483,15 @@ class LookMLAdapter(BaseAdapter):
                     # seed from parents IN the base's include scope, mirroring the extends resolution
                     # below -- otherwise a table-backed view would expose an archived parent's field
                     # Looker (and the resolved extends) would not include.
+                    # Include refinement-added unsupported parents, not just the pre-refinement
+                    # snapshot: an earlier `view: +pdt_base` refinement can turn a parent into an
+                    # unsupported derived table, and seeding a later `view: +child` from it would
+                    # resurrect a parent-only field on the child's real table.
                     inherited_fields = self._inherited_raw_fields(
-                        base_name, raw_view_defs, _parent_in_scope, unsupported_parents=unsupported_pre
+                        base_name,
+                        raw_view_defs,
+                        _parent_in_scope,
+                        unsupported_parents=unsupported_pre | refinement_unsupported_dt,
                     )
                     # A refinement can touch a field that exists ONLY on an unsupported derived-table
                     # parent (dropped by the loader). Seeding skips it above, but the refinement's

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -219,12 +219,29 @@ class LookMLAdapter(BaseAdapter):
         for model_name, model in graph.models.items():
             if model.table is not None or model.sql is not None:
                 continue
+            is_template = False
             if model_name in abstract_views:
                 model.meta = {**(model.meta or {}), "extension_required": True, "lookml_template": True}
+                is_template = True
             elif _extends_chain_has(model_name, unsupported_dt_views) or (model.meta or {}).get(
                 "unsupported_derived_table"
             ):
                 model.meta = {**(model.meta or {}), "unsupported_derived_table": True, "lookml_template": True}
+                is_template = True
+            if is_template:
+                # Stamp this template's GRAPH-LEVEL measures (time_comparison/conversion, which
+                # add_model auto-registers into graph.metrics) with a parser-owned provenance
+                # marker. The loader drops orphaned graph metrics by this marker -- proving they
+                # came from a dropped template -- instead of guessing from the base ref, so a
+                # same-named standalone metric from another file (no marker) is never dropped.
+                # Mark BOTH the model's (possibly refinement-reconstructed) metric AND the graph-
+                # registered object (auto-registered pre-refinement, so a different instance).
+                for mt in model.metrics or []:
+                    if mt.type in ("time_comparison", "conversion"):
+                        mt.meta = {**(mt.meta or {}), "_lookml_template_metric": True}
+                        gm = graph.metrics.get(mt.name)
+                        if gm is not None:
+                            gm.meta = {**(gm.meta or {}), "_lookml_template_metric": True}
 
         # Rebuild adjacency graph now that relationships have been added
         graph.build_adjacency()
@@ -2089,10 +2106,13 @@ class LookMLAdapter(BaseAdapter):
         # A LookML view with no sql_table_name/derived_table implicitly uses a table
         # named after the view (Looker's default). A view with a derived_table the
         # adapter cannot turn into SQL must NOT get such a default; mark it so the
-        # post-merge pass skips it (the raw derived_table dict is not retained).
+        # post-merge pass skips it, and RETAIN the raw derived_table dict so export can
+        # re-emit it -- a derived_table with no `sql` keeps the view unsupported on
+        # re-import instead of being defaulted to a physical table named after the view.
         unsupported_derived_table = bool(view_def.get("derived_table")) and sql is None
         if unsupported_derived_table:
             model_meta["unsupported_derived_table"] = True
+            model_meta["_unsupported_derived_table_raw"] = view_def["derived_table"]
 
         # Build kwargs conditionally so that unset scalars don't appear in
         # model_fields_set. This matters for refinements: merge_model treats
@@ -4097,10 +4117,25 @@ class LookMLAdapter(BaseAdapter):
         """
         view = {"name": model.name}
 
+        # Re-emit `extension: required` for an abstract (tableless) base so a round-trip keeps
+        # it non-queryable; otherwise it re-imports as an ordinary tableless view and the
+        # implicit-table default assigns it a physical table named after the view. Only for a
+        # genuinely TABLELESS view: a concrete child INHERITS `extension_required` in meta via
+        # inheritance but has its own table, so emitting the marker would wrongly make the
+        # usable child abstract on round-trip.
+        if (model.meta or {}).get("extension_required") and not model.table and not model.sql:
+            view["extension"] = "required"
+
         if model.sql:
             view["derived_table"] = {"sql": model.sql}
         elif model.table:
             view["sql_table_name"] = model.table
+        elif (model.meta or {}).get("unsupported_derived_table"):
+            # Re-emit the unsupported derived_table (no `sql`) so re-import keeps it marked
+            # unsupported instead of defaulting it to a physical table. Prefer the retained
+            # raw dict; fall back to a minimal non-sql marker.
+            raw = (model.meta or {}).get("_unsupported_derived_table_raw")
+            view["derived_table"] = raw if isinstance(raw, dict) and raw else {"sql_trigger_value": "select 1"}
 
         if model.description:
             view["description"] = model.description

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -678,14 +678,18 @@ class LookMLAdapter(BaseAdapter):
         # `unsupported_derived_table` keys -- a native/other-format model that happens to
         # carry those user-facing keys must still surface its missing-source error.
         for model_name, model in graph.models.items():
-            if model.table is not None or model.sql is not None:
-                continue
             is_template = False
             if model_name in abstract_views:
+                # An `extension: required` view is hidden by Looker even when it declares or inherits
+                # a sql_table_name (valid for a reusable base), so stamp the template marker BEFORE
+                # the source check -- otherwise the loader registers the table-backed base as a
+                # queryable model.
                 model.meta = {**(model.meta or {}), "extension_required": True, "lookml_template": True}
                 is_template = True
-            elif _extends_chain_has(model_name, unsupported_dt_views) or (model.meta or {}).get(
-                "unsupported_derived_table"
+            elif (
+                model.table is None
+                and model.sql is None
+                and (_extends_chain_has(model_name, unsupported_dt_views) or (model.meta or {}).get("unsupported_derived_table"))
             ):
                 model.meta = {**(model.meta or {}), "unsupported_derived_table": True, "lookml_template": True}
                 is_template = True

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -153,12 +153,12 @@ class LookMLAdapter(BaseAdapter):
                         # onto this result rather than the original base.
                         raw_view_defs[base_name] = merged_raw
                 if remerged is not None:
-                    graph.models[base_name] = remerged
+                    self._replace_model_refreshing_graph_metrics(graph, base_name, remerged)
                 else:
                     # Create a copy with the base name for merging
                     refinement_for_merge = refinement.model_copy(update={"name": base_name})
                     merged = merge_model(refinement_for_merge, graph.models[base_name])
-                    graph.models[base_name] = merged
+                    self._replace_model_refreshing_graph_metrics(graph, base_name, merged)
 
         # Union the pre-merge snapshot, every refinement's own flags, and the post-merge
         # state (so a flag added by ANY refinement is caught even if a later refinement
@@ -677,6 +677,31 @@ class LookMLAdapter(BaseAdapter):
     # LookML view keys holding a named-field LIST. A refinement's entry for an EXISTING field
     # updates that field's properties; it does not replace the field.
     _VIEW_FIELD_LIST_KEYS = ("dimensions", "dimension_groups", "measures", "filters", "parameters", "sets")
+
+    # Metric types SemanticGraph.add_model auto-registers at graph level (accessible unprefixed).
+    _GRAPH_LEVEL_METRIC_TYPES = ("time_comparison", "conversion")
+
+    @classmethod
+    def _replace_model_refreshing_graph_metrics(cls, graph: SemanticGraph, name: str, model: Model) -> None:
+        """Install ``model`` over ``graph.models[name]``, refreshing its graph-level metrics.
+
+        ``add_model`` auto-registered the ORIGINAL view's graph-level measures (time_comparison /
+        conversion) into ``graph.metrics``. A refinement can change one into a normal measure or
+        drop it, so replacing the model alone would leave a STALE graph metric that no loaded model
+        defines -- and the CLI registers graph metrics separately, exposing it. Drop the ones this
+        model registered (identity-checked, so a same-named STANDALONE metric is untouched), then
+        register the merged view's set.
+        """
+        old = graph.models.get(name)
+        if old is not None:
+            for metric in old.metrics or []:
+                if metric.type in cls._GRAPH_LEVEL_METRIC_TYPES and graph.metrics.get(metric.name) is metric:
+                    graph.metrics.pop(metric.name, None)
+        graph.models[name] = model
+        for metric in model.metrics or []:
+            if metric.type in cls._GRAPH_LEVEL_METRIC_TYPES and metric.name not in graph.metrics:
+                graph.metrics[metric.name] = metric
+        graph._mark_dirty()
 
     @classmethod
     def _merge_view_defs(cls, base: dict, refinement: dict) -> dict:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -4522,8 +4522,12 @@ class LookMLAdapter(BaseAdapter):
                 # for native dims fall back to the common suffix list.
                 base_name = dim.name
                 stored_tf = (dim.meta or {}).get("lookml_timeframe")
+                implicit_group = False
                 if stored_tf and dim.name.endswith("_" + stored_tf):
                     base_name = dim.name[: -(len(stored_tf) + 1)]
+                    # An imported `dimension_group` that omits `sql` reads ONE implicit column
+                    # named after the GROUP (`created`), shared by every timeframe it generates.
+                    implicit_group = dim.sql is None
                 else:
                     # Native dims (no stored timeframe): strip any known LookML truncation
                     # timeframe suffix, LONGEST first so e.g. `_minute15`/`_time_of_day`/
@@ -4537,8 +4541,12 @@ class LookMLAdapter(BaseAdapter):
                 # both rely on their default column (sql is None for both) still read DIFFERENT
                 # columns -- `started` and `started_hour` -- and keying on None would collapse
                 # them into one dimension_group, emitting a single field backed by the wrong
-                # column and losing the other dim entirely.
-                base_name_groups.setdefault((base_name, dim.sql_expr), []).append(dim)
+                # column and losing the other dim entirely. An imported no-sql group is the
+                # opposite case: its timeframes SHARE the implicit `<base>` column, so key them
+                # on the group (None) -- keying on the generated field name would read each
+                # timeframe as its own source and split the group into standalone dims backed by
+                # columns that do not exist (`DATE_TRUNC('week', created_week)`).
+                base_name_groups.setdefault((base_name, None if implicit_group else dim.sql_expr), []).append(dim)
 
             # When one base name spans multiple source SQLs, only ONE can be the
             # dimension_group (a second `dimension_group: <base>` is illegal LookML);
@@ -4646,7 +4654,12 @@ class LookMLAdapter(BaseAdapter):
             for (base_name, group_sql), dims in ordered_groups:
                 if base_name_counts[base_name] > 1 and base_name in assigned_names:
                     for dim in dims:
-                        cdim = self._export_collision_time_dim(dim, group_sql, used_names)
+                        # An implicit group (group_sql None) is backed by the `<base>` column;
+                        # without it the standalone would fall back to its own generated field
+                        # name and reference a column that does not exist.
+                        cdim = self._export_collision_time_dim(
+                            dim, base_name if group_sql is None else group_sql, used_names
+                        )
                         used_names.add(cdim["name"])
                         collision_dims.append(cdim)
                     continue

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -511,6 +511,25 @@ class LookMLAdapter(BaseAdapter):
             resolved.update(unresolvable)
             graph.models = resolved
 
+        # Looker allows a view to extend SEVERAL parents (`extends: [a, b]`, and additive
+        # refinement extends). Model.extends is single, so core resolution above followed only the
+        # FIRST parent; merge the fields of any EXTRA in-scope parents so none are silently lost.
+        # Fields already present (the child's own and its first-parent chain) win; extra parents
+        # only fill gaps -- exact left-to-right override precedence on CONFLICTING field names is
+        # not modeled, but the common case of parents contributing disjoint fields is correct.
+        for name, model in graph.models.items():
+            raw = raw_view_defs.get(name)
+            if raw is None:
+                continue
+            for parent_name in self._all_extends_parents(raw)[1:]:
+                parent = graph.models.get(parent_name)
+                if parent is None or not _parent_in_scope(name, parent_name):
+                    continue
+                have_dims = {d.name for d in model.dimensions}
+                model.dimensions.extend(d.model_copy(deep=True) for d in parent.dimensions if d.name not in have_dims)
+                have_metrics = {mm.name for mm in model.metrics}
+                model.metrics.extend(mm.model_copy(deep=True) for mm in parent.metrics if mm.name not in have_metrics)
+
         def _extends_chain_has(name: str, flagset: set[str]) -> bool:
             """True if name or any of its extends-ancestors is in flagset."""
             seen: set[str] = set()
@@ -1117,15 +1136,35 @@ class LookMLAdapter(BaseAdapter):
         graph._mark_dirty()
 
     @staticmethod
+    def _all_extends_parents(raw: dict) -> list[str]:
+        """All ``extends`` parent names of a raw view dict, in order and de-duplicated.
+
+        lkml stores extends as ``extends__all`` -- a list of per-statement lists
+        (``[["base_a"], ["base_b"]]`` for additive statements, ``[["base_a", "base_b"]]`` for a
+        single multi-parent statement); both flatten to ``["base_a", "base_b"]``.
+        """
+        parents: list[str] = []
+        raw_all = raw.get("extends__all")
+        if isinstance(raw_all, list):
+            for stmt in raw_all:
+                if isinstance(stmt, list):
+                    parents.extend(p for p in stmt if isinstance(p, str))
+                elif isinstance(stmt, str):
+                    parents.append(stmt)
+        else:
+            ev = raw.get("extends")
+            if isinstance(ev, str):
+                parents.append(ev)
+            elif isinstance(ev, list):
+                parents.extend(p for p in ev if isinstance(p, str))
+        seen: set = set()
+        return [p for p in parents if not (p in seen or seen.add(p))]
+
+    @staticmethod
     def _raw_extends_parent(raw: dict) -> str | None:
-        """The immediate ``extends`` parent name of a raw view dict, or None (first parent only)."""
-        extends_list = raw.get("extends") or raw.get("extends__all")
-        if isinstance(extends_list, list):
-            flat = extends_list
-            while flat and isinstance(flat[0], list):
-                flat = flat[0]
-            return flat[0] if flat else None
-        return extends_list if isinstance(extends_list, str) else None
+        """The FIRST ``extends`` parent name of a raw view dict, or None."""
+        parents = LookMLAdapter._all_extends_parents(raw)
+        return parents[0] if parents else None
 
     @classmethod
     def _inherited_raw_fields(cls, base_name: str, raw_view_defs: dict, parent_in_scope=None) -> dict:
@@ -1204,6 +1243,14 @@ class LookMLAdapter(BaseAdapter):
                         else:
                             by_name[fname] = copy.deepcopy(item)
                 merged[key] = list(by_name.values()) + extras
+            elif key in ("extends", "extends__all") and isinstance(value, list):
+                # Looker refinements are ADDITIVE for `extends`: a refinement's parents are appended
+                # to the view's existing extends chain, not replaced
+                # (https://cloud.google.com/looker/docs/lookml-refinements#refinement_extends_are_additive).
+                # Wholesale replacement dropped fields inherited only from the base's original
+                # parents. lkml stores this as `extends__all`, a list of per-statement lists
+                # ([["base_a"]]); concatenate the base's statements first, then the refinement's.
+                merged[key] = list(merged.get(key) or []) + list(value)
             else:
                 merged[key] = copy.deepcopy(value)
         merged["name"] = base.get("name")
@@ -2694,18 +2741,11 @@ class LookMLAdapter(BaseAdapter):
         if view_def.get("tags"):
             model_meta["tags"] = view_def["tags"]
 
-        # Extract extends (lkml parses as list, e.g. ["base_view"])
-        extends_list = view_def.get("extends") or view_def.get("extends__all")
-        extends = None
-        if extends_list:
-            if isinstance(extends_list, list):
-                # Flatten nested lists from extends__all format
-                flat = extends_list
-                while flat and isinstance(flat[0], list):
-                    flat = flat[0]
-                extends = flat[0] if flat else None
-            elif isinstance(extends_list, str):
-                extends = extends_list
+        # Extract extends. Model.extends is a single parent, so keep the FIRST here for the
+        # single-parent chain resolution; any ADDITIONAL parents (extends: [a, b] or additive
+        # refinement extends) are merged into the child after resolution (see the project parse).
+        _all_parents = self._all_extends_parents(view_def)
+        extends = _all_parents[0] if _all_parents else None
 
         # A LookML view with no sql_table_name/derived_table implicitly uses a table
         # named after the view (Looker's default). A view with a derived_table the

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -112,8 +112,8 @@ class LookMLAdapter(BaseAdapter):
         include_specs: list[tuple[Path, str]] = []
         raw_view_defs: dict[str, dict] = {}
         view_source_files: dict[str, str] = {}
+        view_candidates: list[tuple[Path, dict, Model]] = []
         for lkml_file in lkml_files:
-            _before = set(graph.models)
             self._parse_views_from_file(
                 lkml_file,
                 graph,
@@ -122,9 +122,8 @@ class LookMLAdapter(BaseAdapter):
                 refinement_raw_defs,
                 refinement_source_files,
                 include_specs,
+                view_candidates,
             )
-            for _new in set(graph.models) - _before:
-                view_source_files[_new] = str(lkml_file)
 
         # When the project DECLARES includes (a model file listing the view files it uses), a
         # refinement in an un-included file must not silently override a loaded view -- e.g. a
@@ -140,6 +139,31 @@ class LookMLAdapter(BaseAdapter):
         if included_paths:
             # A file declaring includes is part of the project itself.
             included_paths |= {f.resolve() for f, _ in include_specs}
+
+        # Install base views, resolving a SAME-NAME collision between files by include: an
+        # archived copy of a view alongside the live one would otherwise make add_model raise
+        # "Model X already exists" and fail the whole project load. Only a collision consults the
+        # includes -- a view with no rival is kept regardless, so an imperfectly-resolved include
+        # can never silently drop a view.
+        chosen: dict[str, tuple[Path, dict, Model]] = {}
+        for _file, _view_def, _model in view_candidates:
+            previous = chosen.get(_model.name)
+            if previous is None:
+                chosen[_model.name] = (_file, _view_def, _model)
+                continue
+            if included_paths and _file.resolve() in included_paths and previous[0].resolve() not in included_paths:
+                chosen[_model.name] = (_file, _view_def, _model)  # the included copy wins
+            else:
+                logger.debug(
+                    "Ignoring duplicate LookML view %r from %s (already defined by %s).",
+                    _model.name,
+                    _file,
+                    previous[0],
+                )
+        for _name, (_file, _view_def, _model) in chosen.items():
+            raw_view_defs[_name] = _view_def
+            view_source_files[_name] = str(_file)
+            graph.add_model(_model)
 
         # Snapshot abstract / unsupported-derived_table flags BEFORE refinement merge:
         # merge_model REPLACES a base view's meta when the refinement carries metadata,
@@ -336,6 +360,7 @@ class LookMLAdapter(BaseAdapter):
         refinement_raw_defs: list[dict] | None = None,
         refinement_source_files: list[Path] | None = None,
         include_specs: list[tuple[Path, str]] | None = None,
+        view_candidates: list[tuple[Path, dict, Model]] | None = None,
     ) -> None:
         """Parse views from a single LookML file.
 
@@ -377,6 +402,11 @@ class LookMLAdapter(BaseAdapter):
                             refinement_raw_defs.append(view_def)
                         if refinement_source_files is not None:
                             refinement_source_files.append(file_path)
+                elif view_candidates is not None:
+                    # Defer installation: two files under the tree can define the SAME view (an
+                    # archived copy alongside the live one), and which wins depends on the
+                    # `include:` declarations, which are only known once every file is parsed.
+                    view_candidates.append((file_path, view_def, model))
                 else:
                     if raw_view_defs is not None:
                         raw_view_defs[model.name] = view_def
@@ -736,10 +766,18 @@ class LookMLAdapter(BaseAdapter):
         if pattern.startswith("//"):
             return set()
         base, pat = (root, pattern[1:]) if pattern.startswith("/") else (including_file.parent, pattern)
-        try:
-            return {p.resolve() for p in base.glob(pat) if p.is_file()}
-        except (OSError, ValueError):
-            return set()
+        # LookML allows the .lkml suffix to be omitted -- `include: "/views/*.view"` and
+        # `include: "/views/orders.view"` match the on-disk *.view.lkml files -- so try the
+        # suffixed form too. Without it such an include resolves to nothing, which silently
+        # skews the included set (an included refinement looks un-included, or nothing is scoped).
+        patterns = [pat] if pat.endswith(".lkml") else [pat, pat + ".lkml"]
+        out: set[Path] = set()
+        for candidate in patterns:
+            try:
+                out |= {p.resolve() for p in base.glob(candidate) if p.is_file()}
+            except (OSError, ValueError):
+                continue
+        return out
 
     @classmethod
     def _replace_model_refreshing_graph_metrics(cls, graph: SemanticGraph, name: str, model: Model) -> None:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -542,6 +542,11 @@ class LookMLAdapter(BaseAdapter):
                 return True
             if not _parent_in_scope(name, model.extends):
                 return False
+            if model.extends in unsupported_dt_views:
+                # The parent is an unsupported derived table (dropped by the loader). Treating the
+                # chain as resolvable would inherit the PDT's fields onto the child's own real table
+                # (secret AS pdt_only FROM child_t), so leave the chain unresolved instead.
+                return False
             visited.add(name)
             return _chain_resolvable(model.extends, visited)
 

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -402,7 +402,10 @@ class LookMLAdapter(BaseAdapter):
                 ref_raw = refinement_raw_defs[_ridx] if _ridx < len(refinement_raw_defs) else None
                 remerged = None
                 if base_raw is not None and ref_raw is not None:
-                    merged_raw = self._merge_view_defs(base_raw, ref_raw)
+                    # A refinement can touch a field the base only has via `extends`; seed those from
+                    # the inherited definition so the partial refinement does not clobber it.
+                    inherited_fields = self._inherited_raw_fields(base_name, raw_view_defs)
+                    merged_raw = self._merge_view_defs(base_raw, ref_raw, inherited_fields)
                     remerged = self._parse_view(merged_raw)
                     if remerged is not None:
                         # Keep the merged raw so a SECOND refinement of the same view stacks
@@ -1068,8 +1071,40 @@ class LookMLAdapter(BaseAdapter):
                 graph.metrics[metric.name] = metric
         graph._mark_dirty()
 
+    @staticmethod
+    def _raw_extends_parent(raw: dict) -> str | None:
+        """The immediate ``extends`` parent name of a raw view dict, or None (first parent only)."""
+        extends_list = raw.get("extends") or raw.get("extends__all")
+        if isinstance(extends_list, list):
+            flat = extends_list
+            while flat and isinstance(flat[0], list):
+                flat = flat[0]
+            return flat[0] if flat else None
+        return extends_list if isinstance(extends_list, str) else None
+
     @classmethod
-    def _merge_view_defs(cls, base: dict, refinement: dict) -> dict:
+    def _inherited_raw_fields(cls, base_name: str, raw_view_defs: dict) -> dict:
+        """Fields a view inherits via ``extends``, as ``{(list_key, field_name): field_def}``.
+
+        Walks the extends chain through the raw view dicts (nearest parent wins). Lets a refinement
+        of an INHERITED field seed from the real definition instead of adding a bare partial field
+        that re-parses to a categorical default and then overrides the inherited one.
+        """
+        fields: dict[tuple[str, str], dict] = {}
+        seen: set[str] = {base_name}
+        parent = cls._raw_extends_parent(raw_view_defs.get(base_name) or {})
+        while parent is not None and parent not in seen:
+            seen.add(parent)
+            parent_raw = raw_view_defs.get(parent) or {}
+            for key in cls._VIEW_FIELD_LIST_KEYS:
+                for item in parent_raw.get(key) or []:
+                    if isinstance(item, dict) and item.get("name"):
+                        fields.setdefault((key, item["name"]), copy.deepcopy(item))  # nearest wins
+            parent = cls._raw_extends_parent(parent_raw)
+        return fields
+
+    @classmethod
+    def _merge_view_defs(cls, base: dict, refinement: dict, inherited_fields: dict | None = None) -> dict:
         """Merge a `view: +name` refinement's RAW LookML dict onto the base view's RAW dict.
 
         Merging at the RAW level (then re-parsing) is what makes a PARTIAL field refinement work:
@@ -1102,7 +1137,18 @@ class LookMLAdapter(BaseAdapter):
                         # Field-level refinement: override ONLY the properties it specifies.
                         by_name[fname].update({k: copy.deepcopy(v) for k, v in item.items() if k != "name"})
                     else:
-                        by_name[fname] = copy.deepcopy(item)
+                        # The base view does not define this field itself. If it INHERITS the field
+                        # via `extends`, seed from the inherited definition so a partial refinement
+                        # (`dimension: amount { label: "Amount" }`) keeps the inherited sql/type
+                        # instead of re-parsing to a bare categorical field that then overrides the
+                        # inherited one. Otherwise it is a genuinely new field.
+                        inherited = (inherited_fields or {}).get((key, fname))
+                        if inherited is not None:
+                            seed = copy.deepcopy(inherited)
+                            seed.update({k: copy.deepcopy(v) for k, v in item.items() if k != "name"})
+                            by_name[fname] = seed
+                        else:
+                            by_name[fname] = copy.deepcopy(item)
                 merged[key] = list(by_name.values()) + extras
             else:
                 merged[key] = copy.deepcopy(value)

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -253,6 +253,10 @@ class LookMLAdapter(BaseAdapter):
         # Which model files reach each file. Used to tell a refinement that every model sharing a
         # view agrees on from one only SOME of them select.
         _models_by_file: dict[Path, set[Path]] = {}
+        # How many models have each view in scope. An explore's mandatory filters (sql_always_where
+        # / always_filter) attach to the single shared base model, so if fewer models reach the
+        # explore than use the base view, the rest get a filter Looker would not give them.
+        _view_model_count: dict[str, int] = {}
         if _scoping_active:
             for _model_file in _model_files:
                 _closure = _include_closure(_model_file)
@@ -261,6 +265,8 @@ class LookMLAdapter(BaseAdapter):
                     _scopes_by_file.setdefault(_reached, []).append(_allowed)
                     _scope_by_file.setdefault(_reached, set()).update(_allowed)
                     _models_by_file.setdefault(_reached, set()).add(_model_file)
+                for _v in _allowed:
+                    _view_model_count[_v] = _view_model_count.get(_v, 0) + 1
 
         # Snapshot abstract / unsupported-derived_table flags BEFORE refinement merge:
         # merge_model REPLACES a base view's meta when the refinement carries metadata,
@@ -514,7 +520,9 @@ class LookMLAdapter(BaseAdapter):
             if _resolved not in _scopes_by_file:
                 logger.debug("Ignoring LookML explores in %s: not reached by any include.", lkml_file)
                 continue
-            self._parse_explores_from_file(lkml_file, graph, model_scopes=_scopes_by_file[_resolved])
+            self._parse_explores_from_file(
+                lkml_file, graph, model_scopes=_scopes_by_file[_resolved], view_model_count=_view_model_count
+            )
 
         # Re-apply the default: explores can add segments (sql_always_where /
         # always_filter) to an otherwise-fieldless view, which only now makes it
@@ -635,7 +643,11 @@ class LookMLAdapter(BaseAdapter):
                     graph.add_model(model)
 
     def _parse_explores_from_file(
-        self, file_path: Path, graph: SemanticGraph, model_scopes: list[set[str]] | None = None
+        self,
+        file_path: Path,
+        graph: SemanticGraph,
+        model_scopes: list[set[str]] | None = None,
+        view_model_count: dict[str, int] | None = None,
     ) -> None:
         """Parse explores from a single LookML file and add relationships.
 
@@ -644,6 +656,9 @@ class LookMLAdapter(BaseAdapter):
             graph: Semantic graph to add relationships to
             model_scopes: One view set per model that includes this file, or None to allow any.
                 Scopes each explore to the views a SINGLE model can see, as Looker resolves them.
+            view_model_count: How many models have each view in scope project-wide. Lets an explore
+                tell that some models use its base view WITHOUT this explore, so its mandatory
+                filters would leak onto the shared base model.
         """
         lkml = _import_lkml()
 
@@ -658,7 +673,7 @@ class LookMLAdapter(BaseAdapter):
         # Parse explores. The scope check lives in _parse_explore, which owns the from:/fallback
         # resolution of the base view -- duplicating that resolution here would drift from it.
         for explore_def in parsed.get("explores") or []:
-            self._parse_explore(explore_def, graph, model_scopes=model_scopes)
+            self._parse_explore(explore_def, graph, model_scopes=model_scopes, view_model_count=view_model_count)
 
     # Matches ${field} and ${view.field}. ${TABLE} is handled specially.
     _REF_RE = re.compile(r"\$\{(?:([a-zA-Z_]\w*)\.)?([a-zA-Z_]\w*)\}")
@@ -3941,7 +3956,11 @@ class LookMLAdapter(BaseAdapter):
         )
 
     def _parse_explore(
-        self, explore_def: dict, graph: SemanticGraph, model_scopes: list[set[str]] | None = None
+        self,
+        explore_def: dict,
+        graph: SemanticGraph,
+        model_scopes: list[set[str]] | None = None,
+        view_model_count: dict[str, int] | None = None,
     ) -> None:
         """Parse LookML explore and add relationships to models.
 
@@ -3951,6 +3970,8 @@ class LookMLAdapter(BaseAdapter):
             model_scopes: One view set per model including this explore's file, or None to allow
                 any. An explore resolves within a SINGLE model, so its base view and joins are
                 checked against the same model's scope rather than the models' combined views.
+            view_model_count: How many models have each view in scope project-wide, used to detect
+                that some models use the base view without this explore's mandatory filters.
         """
         explore_name = explore_def.get("name")
         if not explore_name:
@@ -3997,6 +4018,26 @@ class LookMLAdapter(BaseAdapter):
                 base_model.meta.update(explore_meta)
             else:
                 base_model.meta = explore_meta
+
+        # An explore's mandatory filters (sql_always_where / always_filter) become segments on the
+        # single shared base model. If some models use that base view WITHOUT reaching this explore
+        # (base_scopes counts only the models that DO), those models expose a filter Looker would
+        # not give them. One model per view name cannot hold both the filtered and unfiltered
+        # explore, so the segment is kept -- dropping it would un-filter the model that wanted it,
+        # and the segment is opt-in, not auto-applied -- and the divergence is reported.
+        _has_explore_filters = bool(explore_def.get("sql_always_where") or explore_def.get("always_filter"))
+        if _has_explore_filters and view_model_count is not None and base_scopes is not None:
+            if view_model_count.get(base_model_name, len(base_scopes)) > len(base_scopes):
+                logger.warning(
+                    "LookML explore %r sets a mandatory filter (sql_always_where/always_filter), but only "
+                    "some of the models using view %r include this explore. The filter becomes a segment on "
+                    "the single %r model, so the models without this explore expose a filter Looker would not "
+                    "give them. Include this explore from every model that uses %r, or give them separate views.",
+                    explore_name,
+                    base_model_name,
+                    base_model_name,
+                    base_model_name,
+                )
 
         # Convert sql_always_where to a segment (use explore name for uniqueness)
         from sidemantic.core.segment import Segment

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -4484,7 +4484,12 @@ class LookMLAdapter(BaseAdapter):
                         if dim.name.endswith("_" + tf):
                             base_name = dim.name[: -(len(tf) + 1)]
                             break
-                base_name_groups.setdefault((base_name, dim.sql), []).append(dim)
+                # Key on the EFFECTIVE expression, not the explicit `sql`: two native dims that
+                # both rely on their default column (sql is None for both) still read DIFFERENT
+                # columns -- `started` and `started_hour` -- and keying on None would collapse
+                # them into one dimension_group, emitting a single field backed by the wrong
+                # column and losing the other dim entirely.
+                base_name_groups.setdefault((base_name, dim.sql_expr), []).append(dim)
 
             # When one base name spans multiple source SQLs, only ONE can be the
             # dimension_group (a second `dimension_group: <base>` is illegal LookML);

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -164,6 +164,45 @@ def load_from_directory(
             _handle_parse_error(tmdl_root, e, strict=strict)
             logging.warning("Could not parse TMDL models in %s: %s", tmdl_root, e)
 
+    # LookML projects are folder-based: a view and its `+view` refinement (or an `extends` base)
+    # routinely live in DIFFERENT .lkml files. Parsing each file independently never merges those
+    # refinements, so an `extension: required` abstract base would miss its marker, get defaulted
+    # to a physical table, and be registered as queryable -- CLI validate/queries would silently
+    # target a fabricated table. Parse the whole tree once instead (mirrors the TMDL handling).
+    lookml_root = None
+    if only_file is None and any(directory.rglob("*.lkml")):
+        lookml_root = directory
+
+    if lookml_root:
+        try:
+            graph = _run_without_auto_registration(LookMLAdapter().parse, str(lookml_root))
+            _merge_graph_passthrough_metadata(layer.graph, graph)
+            _extend_import_warnings(import_warnings, graph)
+            for model in graph.models.values():
+                if not hasattr(model, "_source_format"):
+                    model._source_format = "LookML"
+                # The adapter stamps the defining .lkml file; make it relative to the load root.
+                src = getattr(model, "_source_file", None)
+                if src:
+                    try:
+                        model._source_file = str(Path(src).relative_to(directory))
+                    except ValueError:
+                        pass
+                else:
+                    model._source_file = str(lookml_root.relative_to(directory))
+            all_models.update(graph.models)
+            all_metrics.update(graph.metrics)
+            all_parameters.update(graph.parameters)
+        except Exception as e:
+            _append_import_warning(
+                import_warnings,
+                code="adapter_parse_error",
+                message=str(e),
+                source_format="LookML",
+                source_file=str(lookml_root.relative_to(directory)),
+            )
+            _handle_parse_error(lookml_root, e, strict=strict)
+
     if only_file is None:
         _load_graphene_project(directory, all_models, all_metrics, all_parameters, strict=strict)
 
@@ -185,6 +224,8 @@ def load_from_directory(
                 continue
             adapter = TMDLAdapter()
         elif suffix == ".lkml":
+            if lookml_root:
+                continue  # already parsed as one project above (cross-file refinements)
             adapter = LookMLAdapter()
         elif suffix == ".malloy":
             from sidemantic.adapters.malloy import MalloyAdapter

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -26,9 +26,14 @@ def _is_registerable_model(model) -> bool:
     missing-source validation error. Any OTHER tableless model (e.g. an erroneous Hex view
     missing its base) is likewise left in.
     """
+    # A parser-owned LookML template (extension: required base / unsupported derived table) is never
+    # a queryable model even when it declares or inherits a sql_table_name -- Looker hides it and
+    # only uses it through extends -- so this marker is checked BEFORE the source check below.
+    if (model.meta or {}).get("lookml_template"):
+        return False
     if model.table or model.sql or getattr(model, "dax", None) or getattr(model, "source_uri", None):
         return True
-    return not (model.meta or {}).get("lookml_template")
+    return True
 
 
 def _drop_non_registerable_models(

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -56,13 +56,19 @@ def _drop_non_registerable_models(
     """
     kept = {name: model for name, model in all_models.items() if _is_registerable_model(model)}
     dropped = set(all_models) - set(kept)
-    # Also strip joins to a name that WAS a template but got overwritten by a real model (so it is
-    # in `kept`, not `dropped`): the join was defined against the template, not the replacement.
-    strip_targets = dropped | (set(template_target_names or set()) & set(kept))
+    # A join to a name that WAS a template but got overwritten by a real model (so it is in `kept`,
+    # not `dropped`) is stripped ONLY from LookML-sourced models: the explore join that created it
+    # targeted the template. A native/other-format model's relationship to the same name was
+    # authored for the REPLACEMENT model, so it must be preserved.
+    overwritten_templates = set(template_target_names or set()) & set(kept)
     for model in kept.values():
         rels = getattr(model, "relationships", None)
-        if rels:
-            model.relationships = [r for r in rels if r.name not in strip_targets]
+        if not rels:
+            continue
+        from_lookml = getattr(model, "_source_format", None) == "LookML"
+        model.relationships = [
+            r for r in rels if r.name not in dropped and not (from_lookml and r.name in overwritten_templates)
+        ]
     if all_metrics is not None:
         # add_model auto-registers a model's GRAPH-LEVEL measures (time_comparison/conversion)
         # into the graph; a dropped template's such measure would linger in all_metrics with

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -53,7 +53,7 @@ def _drop_non_registerable_models(all_models: dict, all_metrics: dict | None = N
         rels = getattr(model, "relationships", None)
         if rels:
             model.relationships = [r for r in rels if r.name not in dropped]
-    if all_metrics is not None and dropped:
+    if all_metrics is not None:
         # add_model auto-registers a model's GRAPH-LEVEL measures (time_comparison/conversion)
         # into the graph; a dropped template's such measure would linger in all_metrics with
         # its base model gone. Drop by PROVENANCE: the LookML parser stamps a template's graph
@@ -61,6 +61,13 @@ def _drop_non_registerable_models(all_models: dict, all_metrics: dict | None = N
         # the Metric object). That proves the metric came from a dropped template -- unlike a
         # base-ref heuristic, it never drops a same-named STANDALONE metric from another file
         # (no marker) nor mistakes an unqualified base that merely exists on a surviving model.
+        #
+        # The marker alone is the proof, so this does NOT key off `dropped`: the parser only
+        # stamps templates, which are never registerable. Requiring a drop this pass missed the
+        # case where a LATER file OVERWRITES the template name with a real model -- nothing is
+        # dropped, yet the template's orphaned graph metric survives and breaks compile/info.
+        # A same-named metric redefined by that later file overwrites this one and carries no
+        # marker, so it is kept.
         for mn in list(all_metrics):
             if (all_metrics[mn].meta or {}).get("_lookml_template_metric"):
                 all_metrics.pop(mn, None)

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -201,7 +201,12 @@ def load_from_directory(
                 source_format="LookML",
                 source_file=str(lookml_root.relative_to(directory)),
             )
-            _handle_parse_error(lookml_root, e, strict=strict)
+            _handle_parse_error(lookml_root, e, strict=strict)  # raises when strict
+            # Non-strict: ONE malformed .lkml must not drop every valid sibling view. Fall back
+            # to the per-file scan below, which loads what it can and warns per bad file (the
+            # non-strict contract used throughout this loader). Cross-file refinements are lost
+            # in that degraded mode, but partial loading beats loading nothing.
+            lookml_root = None
 
     if only_file is None:
         _load_graphene_project(directory, all_models, all_metrics, all_parameters, strict=strict)

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -31,7 +31,9 @@ def _is_registerable_model(model) -> bool:
     return not (model.meta or {}).get("lookml_template")
 
 
-def _drop_non_registerable_models(all_models: dict, all_metrics: dict | None = None) -> dict:
+def _drop_non_registerable_models(
+    all_models: dict, all_metrics: dict | None = None, template_target_names: set | None = None
+) -> dict:
     """Filter to registerable models AND strip any relationship targeting a dropped one.
 
     An explore may have already added a relationship pointing at a now-skipped template
@@ -39,6 +41,11 @@ def _drop_non_registerable_models(all_models: dict, all_metrics: dict | None = N
     ``sidemantic validate``. Only relationships to models THIS function drops are removed
     -- a relationship to a never-defined model is a real error that validation must still
     surface, so it is left intact. Returns the filtered dict (mutating survivors' rels).
+
+    ``template_target_names`` names models that were parsed as non-registerable templates at some
+    point. A relationship to such a name is stripped even when a later same-name real model
+    OVERWROTE the template (so the name is now registerable): the join was defined against the
+    template, so it would otherwise silently point at the replacement model.
 
     When ``all_metrics`` is given, also drop graph-level metrics contributed by a dropped
     model -- ``SemanticGraph.add_model()`` auto-registers a model's ``time_comparison`` /
@@ -49,10 +56,13 @@ def _drop_non_registerable_models(all_models: dict, all_metrics: dict | None = N
     """
     kept = {name: model for name, model in all_models.items() if _is_registerable_model(model)}
     dropped = set(all_models) - set(kept)
+    # Also strip joins to a name that WAS a template but got overwritten by a real model (so it is
+    # in `kept`, not `dropped`): the join was defined against the template, not the replacement.
+    strip_targets = dropped | (set(template_target_names or set()) & set(kept))
     for model in kept.values():
         rels = getattr(model, "relationships", None)
         if rels:
-            model.relationships = [r for r in rels if r.name not in dropped]
+            model.relationships = [r for r in rels if r.name not in strip_targets]
     if all_metrics is not None:
         # add_model auto-registers a model's GRAPH-LEVEL measures (time_comparison/conversion)
         # into the graph; a dropped template's such measure would linger in all_metrics with
@@ -152,6 +162,9 @@ def load_from_directory(
     # Snowflake relationship definitions whose tables live in other files.
     all_pending_relationships: list = []
     import_warnings: list[dict[str, object]] = []
+    # Model names that were parsed as non-registerable templates at some point, tracked so a join
+    # relationship targeting a template survives being OVERWRITTEN by a later same-name real model.
+    template_target_names: set[str] = set()
 
     # Project-level formats (SML/TMDL/Graphene) are directory-based; in single-file
     # mode (only_file set) skip their whole-directory scans and parse just that file.
@@ -218,6 +231,10 @@ def load_from_directory(
                         pass
                 else:
                     model._source_file = str(lookml_root.relative_to(directory))
+            # Record template / unsupported-derived-table names before a later same-name file can
+            # overwrite them, so their dangling join relationships are still stripped (see
+            # _drop_non_registerable_models).
+            template_target_names |= {n for n, m in graph.models.items() if not _is_registerable_model(m)}
             all_models.update(graph.models)
             all_metrics.update(graph.metrics)
             all_parameters.update(graph.parameters)
@@ -426,6 +443,10 @@ def load_from_directory(
                         metric._source_format = adapter_name
                     if not hasattr(metric, "_source_file"):
                         metric._source_file = str(file_path.relative_to(directory))
+                # Record non-registerable (template / unsupported-derived-table) model names BEFORE
+                # a later same-name file overwrites them, so their dangling join relationships can
+                # still be stripped even when the name is reused by a registerable model.
+                template_target_names |= {n for n, m in graph.models.items() if not _is_registerable_model(m)}
                 all_models.update(graph.models)
                 all_metrics.update(graph.metrics)
                 all_parameters.update(graph.parameters)
@@ -463,7 +484,7 @@ def load_from_directory(
     # unsupported derived tables) BEFORE inference + registration, so FK inference never
     # targets a model that won't be registered (which would leave a dangling relationship)
     # and add_model never rejects a template that was never meant to be queried.
-    all_models = _drop_non_registerable_models(all_models, all_metrics)
+    all_models = _drop_non_registerable_models(all_models, all_metrics, template_target_names)
 
     # Infer cross-model relationships based on naming conventions
     _infer_relationships(all_models)

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -1370,7 +1370,14 @@ def _infer_relationships(models: dict) -> None:
     """
     from sidemantic.core.relationship import Relationship
 
+    def _unincluded(m) -> bool:
+        # A LookML view outside every model's include closure: Looker cannot see it, so it must
+        # neither originate nor receive an inferred join (see LookMLAdapter's `_lookml_unincluded`).
+        return bool((getattr(m, "meta", None) or {}).get("_lookml_unincluded"))
+
     for model_name, model in models.items():
+        if _unincluded(model):
+            continue
         # Look at all dimensions to find potential foreign keys
         for dimension in model.dimensions:
             dim_name = dimension.name.lower()
@@ -1391,7 +1398,7 @@ def _infer_relationships(models: dict) -> None:
 
             # Find if any of these tables exist
             for target in potential_targets:
-                if target in models and target != model_name:
+                if target in models and target != model_name and not _unincluded(models[target]):
                     # Check if this relationship already exists
                     existing = [r for r in model.relationships if r.name == target]
                     if not existing:

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -74,9 +74,13 @@ def _drop_non_registerable_models(all_models: dict, all_metrics: dict | None = N
         # whose measure/time dimension the metric needs. The parser stamps every LookML graph
         # metric with its owning model, so drop it when the SURVIVING model of that name no longer
         # defines it -- gone entirely, or replaced by a model without this measure. A later file
-        # that redefines the metric overwrites this object (no owner stamp), so it is kept.
+        # that redefines the metric AT GRAPH LEVEL overwrites this object (no owner stamp), so it is
+        # kept. The surviving model must still define it as the SAME graph-level kind: a same-named
+        # MODEL-SCOPED metric (a normal measure named revenue_yoy) does not replace the orphaned
+        # graph-level metric in all_metrics, so a name-only match would keep a broken one.
         for mn in list(all_metrics):
-            meta = all_metrics[mn].meta or {}
+            stale = all_metrics[mn]
+            meta = stale.meta or {}
             if meta.get("_lookml_template_metric"):
                 all_metrics.pop(mn, None)
                 continue
@@ -84,7 +88,8 @@ def _drop_non_registerable_models(all_models: dict, all_metrics: dict | None = N
             if owner is not None:
                 owner_model = kept.get(owner)
                 if owner_model is None or not any(
-                    getattr(x, "name", None) == mn for x in (getattr(owner_model, "metrics", None) or [])
+                    getattr(x, "name", None) == mn and getattr(x, "type", None) == stale.type
+                    for x in (getattr(owner_model, "metrics", None) or [])
                 ):
                     all_metrics.pop(mn, None)
     return kept

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -68,9 +68,25 @@ def _drop_non_registerable_models(all_models: dict, all_metrics: dict | None = N
         # dropped, yet the template's orphaned graph metric survives and breaks compile/info.
         # A same-named metric redefined by that later file overwrites this one and carries no
         # marker, so it is kept.
+        #
+        # A NORMAL (non-template) LookML view's graph metric carries no template marker, but the
+        # same overwrite orphans it: a later Python/YAML model of the same name replaces the model
+        # whose measure/time dimension the metric needs. The parser stamps every LookML graph
+        # metric with its owning model, so drop it when the SURVIVING model of that name no longer
+        # defines it -- gone entirely, or replaced by a model without this measure. A later file
+        # that redefines the metric overwrites this object (no owner stamp), so it is kept.
         for mn in list(all_metrics):
-            if (all_metrics[mn].meta or {}).get("_lookml_template_metric"):
+            meta = all_metrics[mn].meta or {}
+            if meta.get("_lookml_template_metric"):
                 all_metrics.pop(mn, None)
+                continue
+            owner = meta.get("_lookml_graph_metric_owner")
+            if owner is not None:
+                owner_model = kept.get(owner)
+                if owner_model is None or not any(
+                    getattr(x, "name", None) == mn for x in (getattr(owner_model, "metrics", None) or [])
+                ):
+                    all_metrics.pop(mn, None)
     return kept
 
 

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -56,36 +56,13 @@ def _drop_non_registerable_models(all_models: dict, all_metrics: dict | None = N
     if all_metrics is not None and dropped:
         # add_model auto-registers a model's GRAPH-LEVEL measures (time_comparison/conversion)
         # into the graph; a dropped template's such measure would linger in all_metrics with
-        # its base model gone. Decide orphan-ness by whether the metric's BASE reference proves
-        # it belongs to a surviving source -- NOT object identity (a refinement reconstructs the
-        # Metric object) and NOT a bare base NAME merely existing somewhere. Only a QUALIFIED
-        # ref to a surviving model (e.g. a standalone `${orders.total}`) proves the metric is
-        # legitimate; a template's measure references its base UNqualified (`total`, a measure
-        # on the template itself), so an unqualified base -- even if a surviving model happens
-        # to also have a `total` -- does not save it. Such candidates are dropped as orphans.
-        _ref_fields = ("base_metric", "numerator", "denominator", "base_event", "conversion_event")
-
-        def _resolves_to_surviving(metric) -> bool:
-            for f in _ref_fields:
-                ref = getattr(metric, f, None)
-                if isinstance(ref, str) and "." in ref and ref.split(".", 1)[0] in kept:
-                    return True  # qualified ref to a surviving model
-            return False
-
-        # Names of graph-level measures contributed by dropped templates (orphan candidates).
-        candidates = {
-            mm.name
-            for name in dropped
-            for mm in (getattr(all_models[name], "metrics", None) or [])
-            if mm.type in ("time_comparison", "conversion")
-        }
-        for mn in candidates:
-            m = all_metrics.get(mn)
-            if (
-                m is not None
-                and getattr(m, "type", None) in ("time_comparison", "conversion")
-                and not _resolves_to_surviving(m)
-            ):
+        # its base model gone. Drop by PROVENANCE: the LookML parser stamps a template's graph
+        # measures with `_lookml_template_metric` (surviving even when a refinement reconstructs
+        # the Metric object). That proves the metric came from a dropped template -- unlike a
+        # base-ref heuristic, it never drops a same-named STANDALONE metric from another file
+        # (no marker) nor mistakes an unqualified base that merely exists on a surviving model.
+        for mn in list(all_metrics):
+            if (all_metrics[mn].meta or {}).get("_lookml_template_metric"):
                 all_metrics.pop(mn, None)
     return kept
 

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -13,6 +13,83 @@ if TYPE_CHECKING:
     from sidemantic.core.semantic_layer import SemanticLayer
 
 
+def _is_registerable_model(model) -> bool:
+    """True unless ``model`` is an INTENTIONAL non-queryable template that should be
+    skipped rather than registered/validated.
+
+    Only LookML's ``extension: required`` abstract bases and unsupported derived tables
+    (kept in the parsed graph as tableless templates) are skipped -- ``add_model`` would
+    reject them and abort loading an otherwise-valid project. The skip keys off the
+    PARSER-OWNED ``lookml_template`` marker (set by the LookML adapter), NOT the public
+    ``extension_required``/``unsupported_derived_table`` keys, so a native or other-format
+    tableless model that merely carries those user-facing keys still surfaces its real
+    missing-source validation error. Any OTHER tableless model (e.g. an erroneous Hex view
+    missing its base) is likewise left in.
+    """
+    if model.table or model.sql or getattr(model, "dax", None) or getattr(model, "source_uri", None):
+        return True
+    return not (model.meta or {}).get("lookml_template")
+
+
+def _drop_non_registerable_models(all_models: dict, all_metrics: dict | None = None) -> dict:
+    """Filter to registerable models AND strip any relationship targeting a dropped one.
+
+    An explore may have already added a relationship pointing at a now-skipped template
+    (e.g. an `extension: required` join target); leaving it would dangle and fail
+    ``sidemantic validate``. Only relationships to models THIS function drops are removed
+    -- a relationship to a never-defined model is a real error that validation must still
+    surface, so it is left intact. Returns the filtered dict (mutating survivors' rels).
+
+    When ``all_metrics`` is given, also drop graph-level metrics contributed by a dropped
+    model -- ``SemanticGraph.add_model()`` auto-registers a model's ``time_comparison`` /
+    ``conversion`` measures into the graph, so a ``period_over_period`` measure on an
+    ``extension: required`` template would otherwise linger as a graph metric whose base
+    model is gone, breaking ``compile``/``info``. A metric still defined on a SURVIVING
+    model is kept.
+    """
+    kept = {name: model for name, model in all_models.items() if _is_registerable_model(model)}
+    dropped = set(all_models) - set(kept)
+    for model in kept.values():
+        rels = getattr(model, "relationships", None)
+        if rels:
+            model.relationships = [r for r in rels if r.name not in dropped]
+    if all_metrics is not None and dropped:
+        # add_model auto-registers a model's GRAPH-LEVEL measures (time_comparison/conversion)
+        # into the graph; a dropped template's such measure would linger in all_metrics with
+        # its base model gone. Decide orphan-ness by whether the metric's BASE reference proves
+        # it belongs to a surviving source -- NOT object identity (a refinement reconstructs the
+        # Metric object) and NOT a bare base NAME merely existing somewhere. Only a QUALIFIED
+        # ref to a surviving model (e.g. a standalone `${orders.total}`) proves the metric is
+        # legitimate; a template's measure references its base UNqualified (`total`, a measure
+        # on the template itself), so an unqualified base -- even if a surviving model happens
+        # to also have a `total` -- does not save it. Such candidates are dropped as orphans.
+        _ref_fields = ("base_metric", "numerator", "denominator", "base_event", "conversion_event")
+
+        def _resolves_to_surviving(metric) -> bool:
+            for f in _ref_fields:
+                ref = getattr(metric, f, None)
+                if isinstance(ref, str) and "." in ref and ref.split(".", 1)[0] in kept:
+                    return True  # qualified ref to a surviving model
+            return False
+
+        # Names of graph-level measures contributed by dropped templates (orphan candidates).
+        candidates = {
+            mm.name
+            for name in dropped
+            for mm in (getattr(all_models[name], "metrics", None) or [])
+            if mm.type in ("time_comparison", "conversion")
+        }
+        for mn in candidates:
+            m = all_metrics.get(mn)
+            if (
+                m is not None
+                and getattr(m, "type", None) in ("time_comparison", "conversion")
+                and not _resolves_to_surviving(m)
+            ):
+                all_metrics.pop(mn, None)
+    return kept
+
+
 def load_from_directory(
     layer: "SemanticLayer",
     directory: str | Path,
@@ -331,10 +408,16 @@ def load_from_directory(
     # table pair.
     _apply_snowflake_pending_relationships(all_models, all_pending_relationships)
 
+    # Drop non-queryable template models (LookML `extension: required` abstract bases /
+    # unsupported derived tables) BEFORE inference + registration, so FK inference never
+    # targets a model that won't be registered (which would leave a dangling relationship)
+    # and add_model never rejects a template that was never meant to be queried.
+    all_models = _drop_non_registerable_models(all_models, all_metrics)
+
     # Infer cross-model relationships based on naming conventions
     _infer_relationships(all_models)
 
-    # Add all models to the layer (now with relationships)
+    # Add all models to the layer (now with relationships).
     for model in all_models.values():
         if model.name not in layer.graph.models:
             layer.add_model(model)
@@ -420,6 +503,8 @@ def _load_sml_directory(layer: "SemanticLayer", directory: Path, all_models: dic
         if not hasattr(model, "_source_file"):
             model._source_file = str(directory)
     all_models.update(graph.models)
+    # Drop non-queryable templates (+ their dangling rels) before inference + registration.
+    all_models = _drop_non_registerable_models(all_models)
     _infer_relationships(all_models)
     for model in all_models.values():
         if model.name not in layer.graph.models:

--- a/tests/adapters/lookml/test_advanced_measure_types.py
+++ b/tests/adapters/lookml/test_advanced_measure_types.py
@@ -129,7 +129,7 @@ class TestDimensionGroupTimeframes:
     def test_time_truncation_timeframes_are_time(self, graph):
         model = graph.get_model("events_calendar")
         for tf, gran in [
-            ("occurred_time", "hour"),
+            ("occurred_time", "second"),
             ("occurred_date", "day"),
             ("occurred_week", "week"),
             ("occurred_month", "month"),

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -4530,6 +4530,44 @@ def test_lookml_suffixless_collision_no_dimension_group_field_duplicate():
     assert not dups, f"duplicate generated field names: {dups}"
 
 
+def test_lookml_suffixless_collision_group_field_maps_to_owning_source():
+    """The generated group field must map to the source that ORIGINALLY owned that field name.
+
+    `started` (hour, source A) + `started_hour` (hour, source B): the `dimension_group` slot must
+    go to the suffixed `started_hour` so the group's generated `started_hour` field comes from
+    source B (its own source). If the suffixless `started` won the slot, the group would generate
+    `started_hour` from source A while the real `started_hour` got renamed to `started_2_hour` --
+    so a round-tripped query for `started_hour` would silently read the WRONG column.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started", type="time", granularity="hour", sql="src_suffixless"),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="src_started_hour"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    reloaded = LookMLAdapter().parse(out).get_model("ev")
+    by_name = {d.name: d.sql for d in reloaded.dimensions}
+    # started_hour must still resolve to its own source, not the suffixless dim's source.
+    assert "src_started_hour" in (by_name.get("started_hour") or ""), by_name
+    assert "src_suffixless" not in (by_name.get("started_hour") or ""), by_name
+    # The suffixless dim's source survives under a distinct, time-recoverable name.
+    assert any("src_suffixless" in (s or "") for n, s in by_name.items() if n != "started_hour"), by_name
+
+
 def test_lookml_suffixless_collision_synth_name_avoids_duplicate():
     """Synthesizing a recoverable suffix must not duplicate an existing field name.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -4286,6 +4286,41 @@ view: v {
     assert {"created_second", "created_date"} <= names  # supported grains still import
 
 
+def test_lookml_dimension_group_leading_unsupported_timeframe_resolves_ref_base_sql():
+    """A group whose FIRST timeframe is unsupported must still resolve a ${ref} in its base sql.
+
+    The base sql was keyed off timeframes[0]; when that leading timeframe is unsupported (minute15)
+    it is never seeded in the resolved lookup, so the lookup missed and fell back to the RAW group
+    sql -- leaving `sql: ${ts_src}` literally unresolved so the surviving `date` field compiled to
+    DATE_TRUNC('day', ${ts_src}). Key off the first SUPPORTED timeframe so the ref resolves.
+    """
+    from sidemantic.core.semantic_layer import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: events {
+  sql_table_name: events ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: ts_src { type: time  sql: ${TABLE}.created_at ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [minute15, date]
+    sql: ${ts_src} ;;
+  }
+}
+"""
+    )
+    created = next(d for d in graph.get_model("events").dimensions if d.name == "created_date")
+    assert "${ts_src}" not in created.sql  # ref resolved, not leaked literally
+    assert "created_at" in created.sql
+
+    layer = SemanticLayer()
+    layer.graph = graph
+    sql = layer.compile(dimensions=["events.created_date"])
+    assert "${ts_src}" not in sql  # compiles against the real column
+    assert "created_at" in sql
+
+
 def test_lookml_time_grain_roundtrip():
     """time/hour/minute/date grains round-trip through export without grain or suffix corruption."""
     import tempfile

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -4116,6 +4116,51 @@ def test_lookml_native_suffix_contradicting_grain_uses_grain():
     assert grains == {"created_hour": "hour"}  # grain preserved (not silently downgraded to second)
 
 
+def test_lookml_minute_bucket_timeframes_query_at_bucket_grain():
+    """Importing minute15/minute30 must bucket at 15/30 minutes, not truncate to the minute.
+
+    These are N-minute BUCKETS, but map to the coarse `minute` granularity, so importing them with
+    the raw base timestamp made the generator emit DATE_TRUNC('minute', ts) -- collapsing the
+    bucket the field name promises. The bucket expression is baked into the SQL, so a query lands
+    on 15/30-minute boundaries; the timeframe still round-trips through export.
+    """
+    import tempfile
+
+    import duckdb
+
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension_group: created { type: time  timeframes: [minute15, minute30] sql: ${TABLE}.ts ;; }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(model)
+    sql = layer.compile(dimensions=["orders.created_minute15"])
+    con = duckdb.connect()
+    con.execute(
+        "create table orders as select 1 id, TIMESTAMP '2024-01-01 12:07:33' ts "
+        "union all select 2, TIMESTAMP '2024-01-01 12:22:48' ts"
+    )
+    # 12:07 -> 12:00 and 12:22 -> 12:15 (15-minute buckets), NOT 12:07 / 12:22 (minute truncation).
+    assert sorted(str(r[0]) for r in con.execute(sql).fetchall()) == [
+        "2024-01-01 12:00:00",
+        "2024-01-01 12:15:00",
+    ]
+
+    # The timeframe still round-trips through export.
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    exported = Path(out).read_text()
+    assert "minute15" in exported and "minute30" in exported
+
+
 def test_lookml_native_minute15_name_does_not_widen_grain():
     """A native created_minute15 at MINUTE grain must not export [minute15] (15-min buckets).
 
@@ -4207,10 +4252,14 @@ def test_lookml_native_inexact_timeframe_suffix_preserves_grain_not_name():
         assert grains == [grain], f"{name}: grain not preserved -> {grains}"
 
 
-def test_lookml_uncommon_timeframe_suffix_roundtrips():
-    """Imported timeframes like millisecond/microsecond round-trip (base derived from stored timeframe)."""
-    import tempfile
+def test_lookml_subsecond_timeframes_are_unsupported():
+    """millisecond/microsecond are FINER than the finest granularity (second), so they are dropped.
 
+    A time dimension can only carry a granularity from the enum whose finest member is `second`, so
+    importing these as time dimensions truncated to the second and silently dropped the sub-second
+    precision the field name promises. Rather than expose a wrong-grain field, leave them
+    unsupported; other timeframes in the same group still import normally.
+    """
     graph = _parse_lkml(
         """
 view: v {
@@ -4218,17 +4267,15 @@ view: v {
   dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
   dimension_group: created {
     type: time
-    timeframes: [millisecond, microsecond, date]
+    timeframes: [millisecond, microsecond, second, date]
     sql: ${TABLE}.created_at ;;
   }
 }
 """
     )
-    out = tempfile.mktemp(suffix=".lkml")
-    LookMLAdapter().export(graph, out)
-    names = {d.name for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"}
-    assert {"created_millisecond", "created_microsecond"} <= names
-    assert not any(n.endswith("_millisecond_millisecond") or n.endswith("_microsecond_microsecond") for n in names)
+    names = {d.name for d in graph.get_model("v").dimensions if d.type == "time"}
+    assert "created_millisecond" not in names and "created_microsecond" not in names  # unsupported
+    assert {"created_second", "created_date"} <= names  # supported grains still import
 
 
 def test_lookml_time_grain_roundtrip():

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5405,6 +5405,37 @@ def test_lookml_parse_raises_on_duplicate_model_in_active_layer():
             LookMLAdapter().parse(path)
 
 
+def test_lookml_refinement_refreshes_graph_level_metrics():
+    """Replacing a refined model must refresh its graph-level metrics, not leave a stale one.
+
+    add_model auto-registers a view's graph-level measures (period_over_period ->
+    time_comparison) into graph.metrics. A refinement turning that measure into a normal one left
+    the ORIGINAL time_comparison registered, so a CLI load exposed a metric no model still defines.
+    A refinement that does NOT touch it must leave the graph metric registered.
+    """
+    import tempfile
+
+    base_view = (
+        "view: base {\n  sql_table_name: t ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n"
+        "  dimension: created { type: time  timeframes: [date]  sql: ${TABLE}.created ;; }\n"
+        "  measure: cnt { type: count }\n"
+        "  measure: pop { type: period_over_period  based_on: cnt  period: date  kind: relative_change }\n}\n"
+    )
+
+    # Refined into a normal measure -> the stale graph-level metric must be gone.
+    refined = Path(tempfile.mkdtemp())
+    (refined / "a.lkml").write_text(base_view)
+    (refined / "b.lkml").write_text("view: +base {\n  measure: pop { type: count }\n}\n")
+    assert "pop" not in LookMLAdapter().parse(str(refined)).metrics
+
+    # An unrelated refinement leaves the graph-level metric registered.
+    untouched = Path(tempfile.mkdtemp())
+    (untouched / "a.lkml").write_text(base_view)
+    (untouched / "b.lkml").write_text("view: +base {\n  label: Refined\n}\n")
+    graph = LookMLAdapter().parse(str(untouched))
+    assert graph.metrics["pop"].type == "time_comparison"
+
+
 def test_lookml_refinement_deep_merges_partial_field_properties():
     """A refinement that sets ONE property of a field must not clobber the field's other props.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6269,6 +6269,28 @@ view: +child {
     assert a_field is not None and a_field.label == "Renamed A"  # supported-parent refinement seeds
 
 
+def test_lookml_refinement_to_unsupported_derived_table_clears_stale_table():
+    """A refinement adding an unsupported derived_table to a table-backed view drops the stale table.
+
+    Otherwise both keys remain, the template stamping (tableless-only) leaves it registerable, and
+    the loader queries the stale physical table instead of hiding the unsupported PDT."""
+    graph = _parse_lkml(
+        """
+view: pdt_base {
+  sql_table_name: real_table ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+}
+view: +pdt_base {
+  derived_table: { persist_for: "24 hours" }
+}
+"""
+    )
+    model = graph.get_model("pdt_base")
+    assert model.table is None  # stale sql_table_name dropped
+    assert (model.meta or {}).get("unsupported_derived_table")
+    assert (model.meta or {}).get("lookml_template")  # now stamped as a template -> loader hides it
+
+
 def test_lookml_refinement_made_unsupported_parent_not_seeded():
     """A parent turned unsupported by an EARLIER refinement is skipped when seeding a later one.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5572,6 +5572,39 @@ def test_lookml_only_model_file_includes_activate_scoping():
     assert LookMLAdapter().parse(str(scoped)).get_model("orders").table == "real_orders"
 
 
+def test_lookml_every_model_file_seeds_include_scoping():
+    """A self-contained model file must not be scoped out by an include-based sibling.
+
+    Seeding the include closure only from models that DECLARE `include:` left a model carrying
+    its own views and explores unseeded, so once a sibling model switched scoping on, the
+    self-contained file looked un-included and its explore segment was silently dropped.
+    """
+    import tempfile
+
+    view = "view: %s {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+
+    directory = Path(tempfile.mkdtemp())
+    (directory / "views").mkdir()
+    (directory / "one.model.lkml").write_text('include: "/views/*.view.lkml"\n')
+    (directory / "views" / "orders.view.lkml").write_text(view % ("orders", "real_orders"))
+    # Declares no includes: its view and explore live in the file itself.
+    (directory / "two.model.lkml").write_text(
+        (view % ("local", "local_tbl")) + "explore: local {\n  sql_always_where: ${local.id} > 0 ;;\n}\n"
+    )
+
+    graph = LookMLAdapter().parse(str(directory))
+    assert [s.name for s in graph.get_model("local").segments] == ["_sql_always_where_local"]
+    # The include-based sibling still loads normally.
+    assert graph.get_model("orders").table == "real_orders"
+
+    # Model files present but NONE declaring an include leaves scoping off entirely.
+    unscoped = Path(tempfile.mkdtemp())
+    (unscoped / "m.model.lkml").write_text("explore: orders {}\n")
+    (unscoped / "orders.view.lkml").write_text(view % ("orders", "real_orders"))
+    (unscoped / "ref.view.lkml").write_text("view: +orders {\n  sql_table_name: REFINED ;;\n}\n")
+    assert LookMLAdapter().parse(str(unscoped)).get_model("orders").table == "REFINED"
+
+
 def test_lookml_project_parse_ignores_explores_from_unincluded_files():
     """An explore in a model file no include reaches must not mutate the live model.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6082,6 +6082,32 @@ view: +child {
     assert amount.type == "numeric"
 
 
+def test_lookml_multi_parent_extends_skips_unsupported_derived_table_parent():
+    """An extra extends parent that is an unsupported derived table has its fields skipped.
+
+    Its table is never registered (the loader drops it), so copying its fields would leave the
+    child querying a nonexistent column. The supported parent's fields still come through.
+    """
+    graph = _parse_lkml(
+        """
+view: base_a { sql_table_name: base_a ;; dimension: a_field { type: string  sql: ${TABLE}.a_field ;; } }
+view: pdt_base {
+  derived_table: { persist_for: "24 hours" }
+  dimension: pdt_only { type: string  sql: ${TABLE}.pdt_only ;; }
+}
+view: child {
+  sql_table_name: child ;;
+  extends: [base_a, pdt_base]
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+}
+"""
+    )
+    model = graph.get_model("child")
+    dims = {d.name for d in model.dimensions}
+    assert "pdt_only" not in dims  # not copied from the unsupported derived-table parent
+    assert "a_field" in dims  # the supported parent still contributes
+
+
 def test_lookml_extends_parent_required_in_all_model_scopes(caplog):
     """A parent only SOME models reaching the child include must not be inherited, and it warns.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5737,6 +5737,58 @@ def test_lookml_every_model_file_seeds_include_scoping():
     assert LookMLAdapter().parse(str(unscoped)).get_model("orders").table == "REFINED"
 
 
+def test_lookml_included_explore_sidecar_inherits_model_scope():
+    """An explore sidecar included by a model must be scoped like the model file itself.
+
+    Scope was keyed on the file NAME (`.model.lkml`), but explores routinely live in an included
+    `orders.explore.lkml` sidecar. That file fell through to the unscoped branch, so its joins
+    could wire to any loaded unique view -- including an archived one -- and send queries to a
+    stale table. Scope is keyed on reachability instead: a sidecar inherits its includer's scope.
+    """
+    import tempfile
+
+    view = "view: %s {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    join = (
+        "explore: orders {\n  join: customers { sql_on: ${orders.id} = ${customers.id} ;; "
+        "relationship: many_to_one }\n}\n"
+    )
+
+    # Sidecar included by the model; customers.view.lkml is NOT included.
+    archived = Path(tempfile.mkdtemp())
+    (archived / "archive").mkdir()
+    (archived / "orders.model.lkml").write_text('include: "orders.view.lkml"\ninclude: "orders.explore.lkml"\n')
+    (archived / "orders.view.lkml").write_text(view % ("orders", "real_orders"))
+    (archived / "orders.explore.lkml").write_text(join)
+    (archived / "archive" / "customers.view.lkml").write_text(view % ("customers", "archived_cust"))
+
+    graph = LookMLAdapter().parse(str(archived))
+    assert [r.name for r in (graph.get_model("orders").relationships or [])] == []
+    assert graph.models["customers"].table == "archived_cust"  # loaded, but never joined
+
+    # The same sidecar wires normally when the model includes the join target.
+    included = Path(tempfile.mkdtemp())
+    (included / "orders.model.lkml").write_text(
+        'include: "orders.view.lkml"\ninclude: "customers.view.lkml"\ninclude: "orders.explore.lkml"\n'
+    )
+    (included / "orders.view.lkml").write_text(view % ("orders", "real_orders"))
+    (included / "customers.view.lkml").write_text(view % ("customers", "real_customers"))
+    (included / "orders.explore.lkml").write_text(join)
+    assert [r.name for r in (LookMLAdapter().parse(str(included)).get_model("orders").relationships or [])] == [
+        "customers"
+    ]
+
+    # A sidecar reached by two models sees the union of their scopes.
+    shared = Path(tempfile.mkdtemp())
+    (shared / "a.model.lkml").write_text('include: "orders.view.lkml"\ninclude: "shared.explore.lkml"\n')
+    (shared / "b.model.lkml").write_text('include: "customers.view.lkml"\ninclude: "shared.explore.lkml"\n')
+    (shared / "orders.view.lkml").write_text(view % ("orders", "real_orders"))
+    (shared / "customers.view.lkml").write_text(view % ("customers", "real_customers"))
+    (shared / "shared.explore.lkml").write_text(join)
+    assert [r.name for r in (LookMLAdapter().parse(str(shared)).get_model("orders").relationships or [])] == [
+        "customers"
+    ]
+
+
 def test_lookml_explore_joins_scoped_to_included_views():
     """A join must not wire to a view the explore's own model file cannot see.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6115,6 +6115,60 @@ view: child {
     assert "child_amount" in graph2.get_model("child").get_dimension("amount").sql  # child's own wins
 
 
+def test_lookml_multi_parent_extra_fields_propagate_to_descendant():
+    """A non-first extends parent's fields reach not just the direct child but its DESCENDANTS.
+
+    Model.extends is single, so resolve_model_inheritance follows only the first parent; the extra
+    parent's fields are merged in a later pass. That pass ran per-view and only merged each view's
+    own extra parents, so `parent extends: [base, audit]` got `audit_flag`, but `child extends:
+    [parent]` was flattened from `parent` BEFORE it received `audit_flag` and never revisited it.
+    Merging bottom-up and re-pulling the first parent propagates it down the chain.
+    """
+    graph = _parse_lkml(
+        """
+view: base { sql_table_name: base_t ;; dimension: base_field { type: string  sql: ${TABLE}.bf ;; } }
+view: audit { dimension: audit_flag { type: string  sql: ${TABLE}.af ;; } }
+view: parent { extends: [base, audit]  dimension: parent_field { type: string  sql: ${TABLE}.pf ;; } }
+view: child { extends: [parent]  dimension: child_field { type: string  sql: ${TABLE}.cf ;; } }
+"""
+    )
+    parent_dims = {d.name for d in graph.get_model("parent").dimensions}
+    child_dims = {d.name for d in graph.get_model("child").dimensions}
+    assert "audit_flag" in parent_dims  # the intermediate got its extra parent's field
+    assert "audit_flag" in child_dims  # ...and it propagated to the descendant
+    assert {"base_field", "parent_field", "child_field"} <= child_dims  # nothing else lost
+
+
+def test_lookml_multi_parent_extends_inherits_source_from_later_parent():
+    """The source (sql_table_name) follows the same later-parent precedence as fields.
+
+    For `extends: [base_a, base_b]` with a table on each, resolve_model_inheritance took base_a's
+    table, but the extra-parent pass copied base_b's FIELDS -- so those fields queried real_a. The
+    later-listed parent must win for the source too, and a source the child declares itself still
+    wins over any parent.
+    """
+    graph = _parse_lkml(
+        """
+view: base_a { sql_table_name: real_a ;; dimension: a_field { type: string  sql: ${TABLE}.a ;; } }
+view: base_b { sql_table_name: real_b ;; dimension: b_field { type: string  sql: ${TABLE}.b ;; } }
+view: child { extends: [base_a, base_b]  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } }
+"""
+    )
+    model = graph.get_model("child")
+    assert model.table == "real_b"  # later parent's table wins
+    assert {"a_field", "b_field"} <= {d.name for d in model.dimensions}  # both parents' fields present
+
+    # A source declared on the child itself still wins over the parents.
+    graph2 = _parse_lkml(
+        """
+view: base_a { sql_table_name: real_a ;; dimension: a_field { type: string  sql: ${TABLE}.a ;; } }
+view: base_b { sql_table_name: real_b ;; dimension: b_field { type: string  sql: ${TABLE}.b ;; } }
+view: child { extends: [base_a, base_b]  sql_table_name: own_t ;;  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } }
+"""
+    )
+    assert graph2.get_model("child").table == "own_t"
+
+
 def test_lookml_export_table_backed_extension_required_reemits_marker():
     """A table-backed `extension: required` base re-emits BOTH extension: required and its table.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5449,6 +5449,55 @@ def test_lookml_project_parse_handles_duplicate_views_and_extensionless_includes
         build(None, duplicate_dir="archive")
 
 
+def test_lookml_project_parse_resolves_view_with_several_archived_copies():
+    """SEVERAL archived copies plus one included copy must still resolve to the included one.
+
+    The decision is made over ALL candidates for a name at once: judging them pairwise as files
+    stream in mis-handles two archived copies sorting before the live one, because the first pair
+    looks unresolvable before the winner has even been seen.
+    """
+    import tempfile
+
+    view = "view: orders {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    directory = Path(tempfile.mkdtemp())
+    for name in ("aa_old", "ab_old", "views"):
+        (directory / name).mkdir()
+    (directory / "m.model.lkml").write_text('include: "/views/*.view.lkml"\n')
+    (directory / "aa_old" / "o.view.lkml").write_text(view % "arch1")  # both sort BEFORE views/
+    (directory / "ab_old" / "o.view.lkml").write_text(view % "arch2")
+    (directory / "views" / "o.view.lkml").write_text(view % "real_orders")
+
+    assert LookMLAdapter().parse(str(directory)).get_model("orders").table == "real_orders"
+
+
+def test_lookml_only_model_file_includes_activate_scoping():
+    """A VIEW file's helper include must not activate project-wide include scoping.
+
+    `include:` in a view file pulls in a helper; it says nothing about which files the project
+    selects. Letting it populate the included set made unrelated sibling refinements (and
+    explores) look un-included and silently dropped them from a plain single-directory load.
+    """
+    import tempfile
+
+    view = "view: %s {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+
+    directory = Path(tempfile.mkdtemp())
+    (directory / "helper.view.lkml").write_text(view % ("helper", "h"))
+    (directory / "orders.view.lkml").write_text('include: "helper.view.lkml"\n' + (view % ("orders", "real_orders")))
+    (directory / "ref.view.lkml").write_text("view: +orders {\n  sql_table_name: REFINED ;;\n}\n")
+    # The sibling refinement is valid and must still apply.
+    assert LookMLAdapter().parse(str(directory)).get_model("orders").table == "REFINED"
+
+    # A MODEL file's include still scopes: the stale refinement stays out.
+    scoped = Path(tempfile.mkdtemp())
+    (scoped / "views").mkdir()
+    (scoped / "archive").mkdir()
+    (scoped / "m.model.lkml").write_text('include: "/views/*.view.lkml"\n')
+    (scoped / "views" / "o.view.lkml").write_text(view % ("orders", "real_orders"))
+    (scoped / "archive" / "stale.view.lkml").write_text("view: +orders {\n  sql_table_name: STALE ;;\n}\n")
+    assert LookMLAdapter().parse(str(scoped)).get_model("orders").table == "real_orders"
+
+
 def test_lookml_project_parse_ignores_explores_from_unincluded_files():
     """An explore in a model file no include reaches must not mutate the live model.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6072,6 +6072,37 @@ def test_lookml_project_parse_skips_duplicate_views_no_model_includes():
     assert LookMLAdapter().parse(str(scoped)).get_model("legacy").table == "live_legacy"
 
 
+def test_lookml_bracketed_include_activates_scoping():
+    """A bracketed `include: [...]` must scope like a scalar include, not be silently dropped.
+
+    lkml parses bracketed includes as a NESTED list, so the string-only guard dropped them --
+    scoping never activated and a stale un-included refinement leaked back in. Flattening the list
+    makes the bracketed form behave like the scalar one; both single and multi-element forms work.
+    """
+    import tempfile
+
+    view = "view: %s {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+
+    # Bracketed include selecting only the live view: an archived refinement stays excluded.
+    scoped = Path(tempfile.mkdtemp())
+    (scoped / "views").mkdir()
+    (scoped / "archive").mkdir()
+    (scoped / "orders.model.lkml").write_text('include: ["/views/orders.view.lkml"]\n')
+    (scoped / "views" / "orders.view.lkml").write_text(view % ("orders", "real_orders"))
+    (scoped / "archive" / "stale.view.lkml").write_text("view: +orders {\n  sql_table_name: STALE ;;\n}\n")
+    assert LookMLAdapter().parse(str(scoped)).get_model("orders").table == "real_orders"
+
+    # A multi-element bracketed include pulls in every listed view.
+    multi = Path(tempfile.mkdtemp())
+    (multi / "views").mkdir()
+    (multi / "orders.model.lkml").write_text('include: ["/views/orders.view.lkml", "/views/customers.view.lkml"]\n')
+    (multi / "views" / "orders.view.lkml").write_text(view % ("orders", "real_orders"))
+    (multi / "views" / "customers.view.lkml").write_text(view % ("customers", "real_customers"))
+    graph = LookMLAdapter().parse(str(multi))
+    assert graph.get_model("orders").table == "real_orders"
+    assert graph.get_model("customers").table == "real_customers"
+
+
 def test_lookml_include_scoping_follows_closure_from_model_files():
     """Includes are a closure SEEDED from model files, not a flat set of every declaration.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5379,6 +5379,37 @@ def test_lookml_abstract_base_not_registered_inside_layer_context():
     assert layer.graph.get_model("orders").table == "orders"  # concrete child registered
 
 
+def test_lookml_table_backed_abstract_base_not_registered_inside_layer_context():
+    """A TABLE-BACKED abstract base must be skipped by deferred registration too.
+
+    The deferred auto-registration skip set keyed off tablelessness, so an `extension: required`
+    base that declares its own `sql_table_name` (a valid LookML abstract base) slipped through and
+    was registered as a queryable model in the active layer -- diverging from the CLI loader path,
+    which drops every `lookml_template` model regardless of source. The parser-owned marker, not
+    tablelessness, must decide.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".lkml", delete=False) as f:
+        f.write(
+            "view: base { extension: required  sql_table_name: real_base ;; "
+            "dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } } "
+            "view: orders { extends: [base]  dimension: y { type: number  sql: ${TABLE}.y ;; } }"
+        )
+        f.flush()
+        path = Path(f.name)
+
+    with SemanticLayer() as layer:
+        LookMLAdapter().parse(path)  # must not raise
+    # The table-backed abstract base is hidden (Looker only uses it through extends), so it must not
+    # be registered even though it has a source.
+    assert "base" not in layer.graph.models
+    # The concrete child still registers, inheriting the base's table through extends.
+    assert layer.graph.get_model("orders").table == "real_base"
+
+
 def test_lookml_directory_load_merges_cross_file_refinement_before_defaulting_table():
     """A CLI directory load must merge `+view` refinements from OTHER files before defaulting.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5737,6 +5737,62 @@ def test_lookml_every_model_file_seeds_include_scoping():
     assert LookMLAdapter().parse(str(unscoped)).get_model("orders").table == "REFINED"
 
 
+def test_lookml_explore_joins_scoped_to_included_views():
+    """A join must not wire to a view the explore's own model file cannot see.
+
+    Scoping only the explore's BASE view left its joins unrestricted: unique un-included views
+    are still installed, so a model including just orders.view.lkml could silently wire
+    `join: customers` to an archived customers.view.lkml and query the wrong table. A join to a
+    NEVER-DEFINED view is still kept -- that dangling relationship is a real error `validate`
+    must surface, and dropping it would hide the typo.
+    """
+    import tempfile
+
+    view = "view: %s {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+
+    def relationships(explore, include, *, archived=(), views=("orders",)):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "views").mkdir()
+        (directory / "archive").mkdir()
+        (directory / "orders.model.lkml").write_text(f'include: "{include}"\n' + explore)
+        for name in views:
+            (directory / "views" / f"{name}.view.lkml").write_text(view % (name, f"real_{name}"))
+        for name in archived:
+            (directory / "archive" / f"{name}.view.lkml").write_text(view % (name, f"archived_{name}"))
+        graph = LookMLAdapter().parse(str(directory))
+        return graph, [r.name for r in (graph.get_model("orders").relationships or [])]
+
+    join = (
+        "explore: orders {\n  join: customers { sql_on: ${orders.id} = ${customers.id} ;; "
+        "relationship: many_to_one }\n}\n"
+    )
+
+    # Archived join target: not reached by the model's include -> not wired.
+    graph, archived_join = relationships(join, "/views/orders.view.lkml", archived=("customers",))
+    assert archived_join == [], archived_join
+    assert "customers" in graph.models  # still loaded; just not joinable from this model
+
+    # Included join target still wires.
+    _, included_join = relationships(join, "/views/*.view.lkml", views=("orders", "customers"))
+    assert included_join == ["customers"]
+
+    # A join's from: target is the view it actually reads, so it is scoped too.
+    aliased = (
+        "explore: orders {\n  join: c_alias { from: customers  sql_on: ${orders.id} = ${c_alias.id} ;; "
+        "relationship: many_to_one }\n}\n"
+    )
+    _, aliased_join = relationships(aliased, "/views/orders.view.lkml", archived=("customers",))
+    assert aliased_join == [], aliased_join
+
+    # A never-defined target is NOT scoped away: validate must still surface it.
+    typo = (
+        "explore: orders {\n  join: typo_view { sql_on: ${orders.id} = ${typo_view.id} ;; "
+        "relationship: many_to_one }\n}\n"
+    )
+    _, dangling = relationships(typo, "/views/orders.view.lkml")
+    assert dangling == ["typo_view"], dangling
+
+
 def test_lookml_project_parse_ignores_explores_from_unincluded_files():
     """An explore in a model file no include reaches must not mutate the live model.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -4050,6 +4050,469 @@ def test_lookml_self_referential_dimension_terminates():
     assert selfd.sql.count("+ 1") <= 2
 
 
+def test_lookml_view_with_unsupported_derived_table_not_defaulted():
+    """A view with a derived_table the adapter can't read must NOT get a default physical table."""
+    adapter = LookMLAdapter()
+    model = adapter._parse_view(
+        {
+            "name": "ndt_unknown",
+            # derived_table with no sql / explore_source the adapter understands
+            "derived_table": {"persist_for": "1 hour"},
+            "dimensions": [{"name": "id", "type": "number", "sql": "${TABLE}.id"}],
+        }
+    )
+    assert model.table is None  # not fabricated as a physical table named after the view
+
+
+def test_lookml_view_without_table_defaults_to_view_name():
+    """A view with no sql_table_name/derived_table should default its table to the view name."""
+    from sidemantic import SemanticLayer
+
+    graph = _parse_lkml(
+        "view: just_fields { "
+        "dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+        "measure: c { type: count } }"
+    )
+    model = graph.get_model("just_fields")
+    assert model.table == "just_fields"
+    # And it must be a valid, queryable model (previously raised ModelValidationError).
+    layer = SemanticLayer()
+    layer.add_model(model)
+    assert "just_fields" in layer.compile(metrics=["just_fields.c"])
+
+
+def test_lookml_parse_tableless_view_inside_layer_context():
+    """Parsing a tableless view inside a `with SemanticLayer()` block must not crash.
+
+    Auto-registration fires during Model construction; the default table is applied
+    after parse, so parsing must suppress registration until models are complete.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".lkml", delete=False) as f:
+        f.write(
+            "view: just_fields { dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } measure: c { type: count } }"
+        )
+        f.flush()
+        path = Path(f.name)
+
+    with SemanticLayer() as layer:
+        LookMLAdapter().parse(path)
+    # The model is registered to the context layer with its defaulted table.
+    assert layer.graph.get_model("just_fields").table == "just_fields"
+
+
+def test_lookml_fieldless_ordinary_view_gets_default_table():
+    """An ordinary fieldless view (or one with only adapter-ignored fields) still defaults.
+
+    Looker defaults the table name to the view name regardless of parsed fields, so a
+    `view: orders {}` must not be left tableless (which would fail CLI load/registration).
+    Abstract/unsupported templates are still skipped; this only covers ordinary views.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    d = tempfile.mkdtemp()
+    with open(Path(d) / "v.lkml", "w") as f:
+        f.write("view: orders {}\nview: just_set { set: foo { fields: [a, b] } }\n")
+
+    layer = SemanticLayer()
+    load_from_directory(layer, d)  # must not raise the no-table ModelValidationError
+    assert layer.graph.get_model("orders").table == "orders"
+    assert layer.graph.get_model("just_set").table == "just_set"
+
+
+def test_lookml_abstract_base_not_registered_inside_layer_context():
+    """An abstract (extension: required) base must NOT be registered inside a `with` layer.
+
+    It's intentionally tableless; deferred registration must skip it (not raise) while the
+    concrete child still registers with its defaulted table.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".lkml", delete=False) as f:
+        f.write(
+            "view: base { extension: required  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+            "dimension: x { type: number  sql: ${TABLE}.x ;; } } "
+            "view: orders { extends: [base]  dimension: y { type: number  sql: ${TABLE}.y ;; } }"
+        )
+        f.flush()
+        path = Path(f.name)
+
+    with SemanticLayer() as layer:
+        LookMLAdapter().parse(path)  # must not raise ModelValidationError
+    assert "base" not in layer.graph.models  # abstract base skipped
+    assert layer.graph.get_model("orders").table == "orders"  # concrete child registered
+
+
+def test_lookml_broken_tableless_view_surfaces_error_inside_layer_context():
+    """A genuinely-broken tableless view (unresolved extends) must NOT be silently skipped.
+
+    Deferred registration skips only INTENTIONAL templates (extension:required / unsupported
+    derived tables). A `view: child { extends: [missing] }` stays tableless because its parent
+    can't resolve -- that's a real error, so add_model must still raise rather than drop it.
+    """
+    import tempfile
+
+    import pytest
+
+    from sidemantic import SemanticLayer
+    from sidemantic.validation import ModelValidationError
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".lkml", delete=False) as f:
+        f.write(
+            "view: child { extends: [missing]  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } }"
+        )
+        f.flush()
+        path = Path(f.name)
+
+    with pytest.raises(ModelValidationError):
+        with SemanticLayer():
+            LookMLAdapter().parse(path)
+
+
+def test_lookml_abstract_base_does_not_break_directory_load():
+    """The CLI path (load_from_directory) must skip the abstract base, not abort the project."""
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    d = tempfile.mkdtemp()
+    with open(Path(d) / "v.lkml", "w") as f:
+        f.write(
+            "view: base { extension: required  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+            "dimension: x { type: number  sql: ${TABLE}.x ;; } } "
+            "view: orders { extends: [base]  dimension: y { type: number  sql: ${TABLE}.y ;; } }"
+        )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, d)  # must not raise ModelValidationError on `base`
+    assert "base" not in layer.graph.models  # non-queryable abstract base skipped
+    assert layer.graph.get_model("orders").table == "orders"
+
+
+def test_lookml_drop_metrics_uses_base_resolution_not_identity_or_name():
+    """Orphan-metric drop keys off whether the BASE resolves to a surviving model.
+
+    NOT object identity (a refinement reconstructs the Metric object) and NOT bare name (a
+    same-named standalone from another file must survive). The orphan is the one whose base
+    measure lives only on dropped models.
+    """
+    from sidemantic import Metric, Model
+    from sidemantic.loaders import _drop_non_registerable_models
+
+    def pop(bm):
+        return Metric(
+            name="pop", type="time_comparison", base_metric=bm, comparison_type="yoy", calculation="difference"
+        )
+
+    template = Model(name="base", meta={"lookml_template": True}, metrics=[pop("total")])
+    orders = Model(name="orders", table="orders")
+
+    # A standalone `pop` over a SURVIVING model's measure (qualified ref) must be preserved.
+    standalone = pop("orders.total")
+    metrics = {"pop": standalone}
+    _drop_non_registerable_models({"base": template, "orders": orders}, metrics)
+    assert metrics.get("pop") is standalone
+
+    # A refinement reconstructs the template's `pop` (DIFFERENT object than template.metrics[0]),
+    # base `total` resolves to no surviving model -> orphan, must be dropped (identity would miss it).
+    metrics2 = {"pop": pop("total")}
+    _drop_non_registerable_models({"base": template, "orders": orders}, metrics2)
+    assert "pop" not in metrics2
+
+    # Even when a SURVIVING model has a same-named `total` measure, the template's `pop` (whose
+    # base `total` is UNQUALIFIED -- pointing at the template's own measure) is still an orphan;
+    # a bare base name existing somewhere must not save it.
+    orders_with_total = Model(name="orders", table="orders", metrics=[Metric(name="total", agg="sum", sql="amt")])
+    metrics3 = {"pop": pop("total")}
+    _drop_non_registerable_models({"base": template, "orders": orders_with_total}, metrics3)
+    assert "pop" not in metrics3
+
+
+def test_lookml_dropped_template_metric_dropped_despite_samename_local_measure():
+    """A dropped template's graph metric is removed even if a surviving model has a same-named measure.
+
+    The orphan check matches graph-level metric types (time_comparison/conversion), not bare
+    names: a surviving `orders.pop` SIMPLE measure must not keep the template's `pop`
+    period_over_period alive (which would expose a metric whose base model is gone).
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    d = tempfile.mkdtemp()
+    with open(Path(d) / "v.lkml", "w") as f:
+        f.write(
+            "view: base { extension: required "
+            "  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+            "  dimension: amt { type: number  sql: ${TABLE}.amt ;; } "
+            "  measure: total { type: sum  sql: ${amt} ;; } "
+            "  measure: pop { type: period_over_period  based_on: total  period: year  kind: difference } } "
+            "view: orders { sql_table_name: orders ;; "
+            "  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+            "  measure: pop { type: count } }"
+        )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, d)
+    assert "base" not in layer.graph.models
+    assert "pop" not in layer.graph.metrics  # template graph metric dropped despite orders.pop
+    assert layer.graph.get_model("orders").get_metric("pop") is not None  # local measure survives
+
+
+def test_lookml_dropped_template_graph_metric_not_orphaned():
+    """A graph metric (period_over_period) on a dropped template must not linger after CLI load.
+
+    add_model auto-registers time_comparison/conversion measures as graph metrics; when the
+    only model carrying it is a skipped extension:required template, the metric must be
+    dropped too, else compile/info expose a metric whose base model is missing.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    d = tempfile.mkdtemp()
+    with open(Path(d) / "v.lkml", "w") as f:
+        f.write(
+            "view: base { extension: required "
+            "  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+            "  dimension: amt { type: number  sql: ${TABLE}.amt ;; } "
+            "  measure: total { type: sum  sql: ${amt} ;; } "
+            "  measure: pop { type: period_over_period  based_on: total  period: year  kind: difference } }"
+        )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, d)  # must not raise
+    assert "base" not in layer.graph.models  # template skipped
+    assert "pop" not in layer.graph.metrics  # orphaned graph metric dropped too
+
+
+def test_lookml_registerability_keys_off_parser_marker_not_user_meta():
+    """A tableless model with user `extension_required` meta but no parser marker must surface error.
+
+    The skip keys off the parser-owned `lookml_template` marker so a native/other-format
+    model that merely carries the public `extension_required` key is still registered (and
+    its missing-source error surfaced), not silently dropped.
+    """
+    from types import SimpleNamespace
+
+    from sidemantic.loaders import _is_registerable_model
+
+    user_meta = SimpleNamespace(table=None, sql=None, dax=None, source_uri=None, meta={"extension_required": True})
+    assert _is_registerable_model(user_meta) is True  # surfaces error, not dropped
+    template = SimpleNamespace(
+        table=None, sql=None, dax=None, source_uri=None, meta={"extension_required": True, "lookml_template": True}
+    )
+    assert _is_registerable_model(template) is False  # genuine LookML template skipped
+
+
+def test_lookml_abstract_marker_survives_later_refinement_meta_overwrite():
+    """A refinement overwriting meta must not strip the abstract marker the loader keys off.
+
+    `+base { extension: required }` then `+base { label: ... }` leaves base tableless but
+    its final meta only has the label; the marker is re-asserted so the CLI loader still
+    skips it instead of raising the no-table validation error.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    d = tempfile.mkdtemp()
+    with open(Path(d) / "v.lkml", "w") as f:
+        f.write(
+            "view: base { dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+            "dimension: x { type: number  sql: ${TABLE}.x ;; } } "
+            "view: +base { extension: required } "
+            'view: +base { label: "Base" } '
+            "view: orders { extends: [base]  dimension: y { type: number  sql: ${TABLE}.y ;; } }"
+        )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, d)  # must not raise even though `extension_required` was overwritten
+    assert "base" not in layer.graph.models
+    assert layer.graph.get_model("orders").table == "orders"
+
+
+def test_lookml_fk_inference_skips_abstract_template_no_dangling_rel():
+    """FK inference must not target a skipped abstract template, leaving a dangling relationship."""
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    d = tempfile.mkdtemp()
+    with open(Path(d) / "v.lkml", "w") as f:
+        f.write(
+            "view: customer { extension: required  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } } "
+            "view: customers { extends: [customer]  sql_table_name: customers ;; "
+            "dimension: name { type: string  sql: ${TABLE}.name ;; } } "
+            "view: orders { sql_table_name: orders ;; dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+            "dimension: customer_id { type: number  sql: ${TABLE}.customer_id ;; } }"
+        )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, d)
+    assert "customer" not in layer.graph.models  # abstract template not registered
+    # No model carries a relationship pointing at the skipped template.
+    for model in layer.graph.models.values():
+        for rel in getattr(model, "relationships", []) or []:
+            assert rel.name in layer.graph.models, f"dangling relationship to {rel.name}"
+
+
+def test_lookml_explore_join_to_template_no_dangling_rel():
+    """An explore join to a skipped template must not leave a dangling relationship."""
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    d = tempfile.mkdtemp()
+    with open(Path(d) / "v.lkml", "w") as f:
+        f.write(
+            "view: customer { extension: required  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } } "
+            "view: orders { sql_table_name: orders ;; dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+            "dimension: customer_id { type: number  sql: ${TABLE}.customer_id ;; } } "
+            "explore: orders { join: customer { sql_on: ${orders.customer_id} = ${customer.id} ;; relationship: many_to_one } }"
+        )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, d)
+    assert "customer" not in layer.graph.models
+    for model in layer.graph.models.values():
+        for rel in getattr(model, "relationships", []) or []:
+            assert rel.name in layer.graph.models, f"dangling relationship to {rel.name}"
+
+
+def test_lookml_active_layer_explore_join_to_template_no_dangling_rel():
+    """Same as above but via the ACTIVE-layer parse() path (with SemanticLayer())."""
+    import tempfile
+
+    from sidemantic import SemanticLayer
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".lkml", delete=False) as f:
+        f.write(
+            "view: customer { extension: required  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } } "
+            "view: orders { sql_table_name: orders ;; dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+            "dimension: customer_id { type: number  sql: ${TABLE}.customer_id ;; } } "
+            "explore: orders { join: customer { sql_on: ${orders.customer_id} = ${customer.id} ;; relationship: many_to_one } }"
+        )
+        f.flush()
+        path = Path(f.name)
+
+    with SemanticLayer() as layer:
+        LookMLAdapter().parse(path)
+    assert "customer" not in layer.graph.models
+    for model in layer.graph.models.values():
+        for rel in getattr(model, "relationships", []) or []:
+            assert rel.name in layer.graph.models, f"dangling relationship to {rel.name}"
+
+
+def test_lookml_extends_tableless_view_keeps_own_table():
+    """A child extending a tableless base must default to its OWN name, not inherit the base's default."""
+    graph = _parse_lkml(
+        "view: base { dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+        "dimension: x { type: number  sql: ${TABLE}.x ;; } } "
+        "view: child { extends: [base]  dimension: y { type: number  sql: ${TABLE}.y ;; } }"
+    )
+    assert graph.get_model("base").table == "base"
+    assert graph.get_model("child").table == "child"
+
+
+def test_lookml_refinement_adds_fields_then_defaults_table():
+    """A fieldless base whose fields come from a +refinement still defaults its table after merge."""
+    graph = _parse_lkml(
+        "view: orders {} view: +orders { dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } }"
+    )
+    assert graph.get_model("orders").table == "orders"
+
+
+def test_lookml_filter_only_view_gets_default_table():
+    """A view that declares only LookML `filter` fields (-> segments) still defaults its table.
+
+    Such a view is not 'fieldless' -- without the default it fails validation (no table/sql).
+    """
+    graph = _parse_lkml("view: ff { filter: recent { type: yesno  sql: ${TABLE}.x ;; } }")
+    model = graph.get_model("ff")
+    assert model.table == "ff"
+    assert [s.name for s in model.segments] == ["recent"]
+
+
+def test_lookml_concrete_child_of_abstract_view_gets_table():
+    """A concrete view extending an extension:required base must default to its OWN name, not be treated as abstract."""
+    graph = _parse_lkml(
+        "view: base { extension: required  "
+        "dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+        "dimension: x { type: number  sql: ${TABLE}.x ;; } } "
+        "view: orders { extends: [base]  dimension: y { type: number  sql: ${TABLE}.y ;; } }"
+    )
+    assert graph.get_model("base").table is None  # abstract base stays table-less
+    assert graph.get_model("orders").table == "orders"  # concrete child defaults to its name
+
+
+def test_lookml_unsupported_derived_table_marker_survives_refinement():
+    """The unsupported-derived_table marker must survive a refinement that carries meta (e.g. label)."""
+    graph = _parse_lkml(
+        "view: ndt { derived_table: { sql_trigger_value: SELECT CURRENT_DATE() ;; } "
+        "dimension: id { type: number  sql: ${TABLE}.id ;; } } "
+        'view: +ndt { label: "NDT View" }'
+    )
+    ndt = graph.get_model("ndt")
+    # Not defaulted to a physical table even though the refinement replaced its meta.
+    assert ndt.table is None
+    assert ndt.sql is None
+
+
+def test_lookml_child_inheriting_unsupported_derived_table_not_defaulted():
+    """A child extending a parent with an unsupported derived_table must stay table-less too."""
+    graph = _parse_lkml(
+        "view: base_ndt { derived_table: { sql_trigger_value: SELECT 1 ;; } "
+        "dimension: id { type: number  sql: ${TABLE}.id ;; } } "
+        "view: child_ndt { extends: [base_ndt] }"
+    )
+    # Inherited the unsupported-derived_table marker via extends -> not defaulted.
+    assert graph.get_model("child_ndt").table is None
+
+
+def test_lookml_refinement_added_extension_required_stays_abstract():
+    """A +refinement that adds extension: required must keep the refined view tableless."""
+    graph = _parse_lkml(
+        "view: base { dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } } "
+        "view: +base { extension: required }"
+    )
+    assert graph.get_model("base").table is None
+
+
+def test_lookml_abstract_flag_survives_later_refinement():
+    """extension: required added by one refinement survives a later refinement that replaces meta."""
+    graph = _parse_lkml(
+        "view: base { dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } } "
+        "view: +base { extension: required } "
+        'view: +base { label: "Base" }'
+    )
+    assert graph.get_model("base").table is None
+
+
+def test_lookml_child_of_unsupported_dt_with_own_meta_not_defaulted():
+    """A child extending an unsupported derived_table base must stay tableless even with its own meta."""
+    graph = _parse_lkml(
+        "view: base { derived_table: { sql_trigger_value: SELECT 1 ;; } "
+        "dimension: id { type: number  sql: ${TABLE}.id ;; } } "
+        'view: child { extends: [base]  label: "Child" }'
+    )
+    assert graph.get_model("child").table is None
+
+
 def test_lookml_export_unmapped_aggregations_not_count():
     """Unmapped aggregations / complex types must not be silently exported as COUNT."""
     import tempfile

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5405,6 +5405,36 @@ def test_lookml_parse_raises_on_duplicate_model_in_active_layer():
             LookMLAdapter().parse(path)
 
 
+def test_lookml_project_parse_ignores_refinements_from_unincluded_files():
+    """A refinement in a file no `include:` reaches must not override a loaded view.
+
+    Parsing the whole tree merges every `view: +...` it finds, so a stale refinement left in e.g.
+    archive/ could silently change a model's sql_table_name even though the LookML model only
+    includes views/. Only the REFINEMENT merge is scoped -- views still all parse -- and a project
+    that declares no includes is unaffected.
+    """
+    import tempfile
+
+    def build(*, declares_includes, refinement_dir):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "views").mkdir()
+        (directory / "archive").mkdir()
+        if declares_includes:
+            (directory / "orders.model.lkml").write_text('include: "/views/*.view.lkml"\nexplore: orders {}\n')
+        (directory / "views" / "orders.view.lkml").write_text(
+            "view: orders {\n  sql_table_name: real_orders ;;\n"
+            "  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+        )
+        (directory / refinement_dir / "ref.view.lkml").write_text("view: +orders {\n  sql_table_name: REFINED ;;\n}\n")
+        return LookMLAdapter().parse(str(directory)).get_model("orders").table
+
+    # Declared includes: an un-included refinement is ignored, an included one still applies.
+    assert build(declares_includes=True, refinement_dir="archive") == "real_orders"
+    assert build(declares_includes=True, refinement_dir="views") == "REFINED"
+    # No includes declared (the common single-directory project): nothing is filtered.
+    assert build(declares_includes=False, refinement_dir="archive") == "REFINED"
+
+
 def test_lookml_refinement_refreshes_graph_level_metrics():
     """Replacing a refined model must refresh its graph-level metrics, not leave a stale one.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6108,6 +6108,31 @@ view: child {
     assert "a_field" in dims  # the supported parent still contributes
 
 
+def test_lookml_extends_unsupported_derived_table_first_parent_not_inherited():
+    """A concrete view extending an unsupported derived table as its FIRST parent must not inherit it.
+
+    The PDT is dropped by the loader, so inheriting its fields onto the child's real table would
+    compile `secret AS pdt_only FROM child_t`. The chain is treated as unresolvable so the fields
+    are left off; the child keeps its own. A supported first parent still inherits normally.
+    """
+    graph = _parse_lkml(
+        """
+view: pdt_base {
+  derived_table: { persist_for: "24 hours" }
+  dimension: pdt_only { type: string  sql: ${TABLE}.secret ;; }
+}
+view: child {
+  extends: [pdt_base]
+  sql_table_name: child_t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+}
+"""
+    )
+    dims = {d.name for d in graph.get_model("child").dimensions}
+    assert "pdt_only" not in dims  # unsupported PDT parent not inherited onto the child's table
+    assert "id" in dims  # the child keeps its own field
+
+
 def test_lookml_refinement_of_unsupported_parent_field_is_dropped():
     """Refining a field that exists only on an unsupported derived-table parent must not add it.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6539,6 +6539,48 @@ def test_lookml_refinement_deep_merges_partial_field_properties():
     check(LookMLAdapter().parse(str(directory)).get_model("base"))
 
 
+def test_lookml_refinement_of_inherited_field_keeps_inherited_definition():
+    """A partial refinement of a field a view only has via `extends` must keep the inherited props.
+
+    The target's own raw view does not contain the field, so the refinement was added as a bare new
+    field that re-parsed to a categorical with no sql and then OVERRODE the inherited definition --
+    turning an inherited numeric `amount` into a categorical dimension with no SQL. The refinement
+    now seeds from the inherited definition, so the partial props merge onto the real field.
+    """
+    import tempfile
+
+    base = (
+        "view: base {\n  sql_table_name: base_t ;;\n"
+        "  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n"
+        "  dimension: amount { type: number  sql: ${TABLE}.amount ;; }\n}\n"
+    )
+    child = "view: orders {\n  extends: [base]\n  sql_table_name: orders ;;\n}\n"
+
+    def amount(model):
+        return next(d for d in model.dimensions if d.name == "amount")
+
+    # A partial refinement (label only) keeps the inherited numeric type and sql.
+    partial = _parse_lkml(base + child + 'view: +orders {\n  dimension: amount { label: "Amount" }\n}\n').get_model(
+        "orders"
+    )
+    assert amount(partial).type == "numeric"
+    assert amount(partial).sql == "{model}.amount"
+    assert amount(partial).label == "Amount"
+
+    # An explicit override still applies (type -> string/categorical) while keeping inherited sql.
+    override = _parse_lkml(base + child + "view: +orders {\n  dimension: amount { type: string }\n}\n").get_model(
+        "orders"
+    )
+    assert amount(override).type == "categorical"
+    assert amount(override).sql == "{model}.amount"
+
+    # A genuinely new field (not inherited) is still added as a normal field.
+    directory = Path(tempfile.mkdtemp())
+    (directory / "v.lkml").write_text(base + child + 'view: +orders {\n  dimension: brand_new { label: "New" }\n}\n')
+    new_model = LookMLAdapter().parse(str(directory)).get_model("orders")
+    assert any(d.name == "brand_new" for d in new_model.dimensions)
+
+
 def test_lookml_project_parse_merges_refinements_deterministically():
     """Refinements merge in sorted file order, not filesystem traversal order.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5889,8 +5889,51 @@ def test_lookml_extends_parent_scoped_per_model_not_project_wide():
     # One model selecting both still inherits.
     assert {"secret", "leaked"} <= fields(("a", "/views/*.view.lkml"))
 
-    # The child's file reached by a model that also selects the parent: union -> inherited.
-    assert {"secret", "leaked"} <= fields(("a", "/views/orders.view.lkml"), ("b", "/views/*.view.lkml"))
+    # The child is reached by BOTH models but only b includes the parent: EVERY model reaching the
+    # child must include the parent, else its fields would leak to a. Not inherited (see
+    # test_lookml_extends_parent_required_in_all_model_scopes for the full contract).
+    assert fields(("a", "/views/orders.view.lkml"), ("b", "/views/*.view.lkml")) == {"id"}
+
+
+def test_lookml_extends_parent_required_in_all_model_scopes(caplog):
+    """A parent only SOME models reaching the child include must not be inherited, and it warns.
+
+    `_scope_by_file` unioned the visible views of every model reaching a shared child, so a parent
+    that only one model included read as in-scope -- and the single graph `child` model inherited
+    it, exposing its fields to the models that could not see it. Require the parent in EVERY such
+    model's scope; when they disagree, do not inherit and report the ambiguity.
+    """
+    import logging
+    import tempfile
+
+    child = "view: child {\n  extends: [base]\n  sql_table_name: child_t ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    base = "view: base {\n  sql_table_name: base_t ;;\n  dimension: secret { sql: ${TABLE}.secret ;; }\n}\n"
+
+    def parse(*models):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "views").mkdir()
+        for name, include in models:
+            (directory / f"{name}.model.lkml").write_text(include)
+        (directory / "views" / "child.view.lkml").write_text(child)
+        (directory / "views" / "base.view.lkml").write_text(base)
+        return LookMLAdapter().parse(str(directory)).get_model("child")
+
+    # a includes child + base, b includes only child: not inherited, and the ambiguity is warned.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="sidemantic.adapters.lookml"):
+        model = parse(
+            ("a", 'include: "/views/child.view.lkml"\ninclude: "/views/base.view.lkml"\n'),
+            ("b", 'include: "/views/child.view.lkml"\n'),
+        )
+    assert "secret" not in {d.name for d in model.dimensions}
+    assert "only some of the models" in caplog.text
+
+    # Every model reaching the child includes the parent: inherited, no warning.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="sidemantic.adapters.lookml"):
+        model = parse(("a", 'include: "/views/*.view.lkml"\n'), ("b", 'include: "/views/*.view.lkml"\n'))
+    assert "secret" in {d.name for d in model.dimensions}
+    assert "only some of the models" not in caplog.text
 
 
 def test_lookml_abstract_template_conflicting_with_active_model_is_not_skipped():

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5406,40 +5406,79 @@ def test_lookml_parse_raises_on_duplicate_model_in_active_layer():
 
 
 def test_lookml_project_parse_handles_duplicate_views_and_extensionless_includes():
-    """Two files defining the SAME view must not fail the load, and includes may omit .lkml.
+    """An ARCHIVED copy of a view must not fail the load; a real duplicate must still surface.
 
     Parsing the tree as one project means an archived copy of a view alongside the live one hits
-    add_model's "Model X already exists" and fails everything. Includes decide the winner; with no
-    includes it is a deterministic first-wins rather than a crash. LookML also allows the .lkml
-    suffix to be omitted (`include: "/views/*.view"`), which must still resolve on disk -- else the
-    included set is skewed and stale refinements leak back in.
+    add_model's duplicate error and fails everything. Includes decide the winner -- but ONLY when
+    exactly one copy is included: if both are included (or there are no includes), nothing
+    distinguishes them, so the conflict is a real project error and must be raised rather than
+    silently loading one at random. LookML also allows the .lkml suffix to be omitted
+    (`include: "/views/*.view"`), which must still resolve on disk -- else the included set is
+    skewed and stale refinements leak back in.
     """
     import tempfile
 
     view = "view: orders {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
 
-    def build(include_pattern, *, duplicate=False, stale_refinement=False):
+    def build(include_pattern, *, duplicate_dir=None, stale_refinement=False):
         directory = Path(tempfile.mkdtemp())
         (directory / "views").mkdir()
         (directory / "archive").mkdir()
         if include_pattern:
             (directory / "m.model.lkml").write_text(f'include: "{include_pattern}"\nexplore: orders {{}}\n')
         (directory / "views" / "orders.view.lkml").write_text(view % "real_orders")
-        if duplicate:
-            (directory / "archive" / "orders.view.lkml").write_text(view % "archived_orders")
+        if duplicate_dir:
+            (directory / duplicate_dir / "dup.view.lkml").write_text(view % "other_orders")
         if stale_refinement:
             (directory / "archive" / "stale.view.lkml").write_text("view: +orders {\n  sql_table_name: STALE ;;\n}\n")
         return LookMLAdapter().parse(str(directory)).get_model("orders")
 
-    # A duplicate view no longer fails the load; the INCLUDED copy wins.
-    assert build("/views/*.view.lkml", duplicate=True).table == "real_orders"
+    # Exactly one copy included: the archived one is ignored instead of failing the load.
+    assert build("/views/*.view.lkml", duplicate_dir="archive").table == "real_orders"
     # Extensionless include patterns still resolve, so the stale refinement stays out.
     assert build("/views/*.view", stale_refinement=True).table == "real_orders"
     assert build("/views/orders.view", stale_refinement=True).table == "real_orders"
-    # With NO includes a duplicate is deterministic rather than a crash (no ValueError).
-    assert build(None, duplicate=True).table in {"real_orders", "archived_orders"}
     # A view no include matches is NEVER dropped -- include scoping only breaks ties.
     assert build("/nonexistent/*.view.lkml").table == "real_orders"
+
+    # BOTH copies included, or no includes at all: nothing distinguishes them, so the duplicate is
+    # a real conflict and must surface rather than silently loading one.
+    with pytest.raises(ValueError, match="already exists"):
+        build("/views/*.view.lkml", duplicate_dir="views")
+    with pytest.raises(ValueError, match="already exists"):
+        build(None, duplicate_dir="archive")
+
+
+def test_lookml_project_parse_ignores_explores_from_unincluded_files():
+    """An explore in a model file no include reaches must not mutate the live model.
+
+    Loading the tree as one project runs every file's explores against the loaded views, so an
+    archived or alternate model file's joins would silently attach to the live model. A file
+    DECLARING includes is part of the project, so the active model file's explores still apply.
+    """
+    import tempfile
+
+    view = "view: %s {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    join = (
+        "explore: orders {\n  join: customers { sql_on: ${orders.id} = ${customers.id} ;; "
+        "relationship: many_to_one }\n}\n"
+    )
+
+    def relationships(*, live_explore, archived_explore):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "views").mkdir()
+        (directory / "archive").mkdir()
+        (directory / "orders.model.lkml").write_text('include: "/views/*.view.lkml"\n' + (join if live_explore else ""))
+        (directory / "views" / "orders.view.lkml").write_text(view % ("orders", "real_orders"))
+        (directory / "views" / "customers.view.lkml").write_text(view % ("customers", "cust"))
+        if archived_explore:
+            (directory / "archive" / "old.model.lkml").write_text(join)
+        model = LookMLAdapter().parse(str(directory)).get_model("orders")
+        return [r.name for r in (model.relationships or [])]
+
+    assert relationships(live_explore=False, archived_explore=True) == []  # archived join must not leak
+    assert relationships(live_explore=True, archived_explore=False) == ["customers"]  # live one applies
+    assert relationships(live_explore=True, archived_explore=True) == ["customers"]  # and only once
 
 
 def test_lookml_project_parse_ignores_refinements_from_unincluded_files():

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5327,6 +5327,58 @@ def test_lookml_drop_metrics_uses_provenance_marker_not_base_ref():
     assert "pop" not in metrics2
 
 
+def test_lookml_parse_raises_on_duplicate_model_in_active_layer():
+    """A model the active layer already defines is a conflict -- deferral must not hide it.
+
+    Deferring registration must not silently skip a name that already exists: parsing a view
+    `orders` into a layer that already has a different `orders` model previously raised via
+    auto-registration, and must still raise rather than leave the old definition in place.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model, SemanticLayer
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".lkml", delete=False) as f:
+        f.write(
+            "view: orders {\n  sql_table_name: lookml_orders ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+        )
+        f.flush()
+        path = Path(f.name)
+
+    layer = SemanticLayer()
+    layer.add_model(
+        Model(
+            name="orders",
+            table="manual_orders",
+            primary_key="id",
+            dimensions=[Dimension(name="id", type="numeric", sql="id")],
+        )
+    )
+    with pytest.raises(ValueError, match="already exists"):
+        with layer:
+            LookMLAdapter().parse(path)
+
+
+def test_lookml_project_parse_merges_refinements_deterministically():
+    """Refinements merge in sorted file order, not filesystem traversal order.
+
+    Two refinement files setting the same property must resolve the same way on every load;
+    an unsorted rglob would make the winner depend on directory traversal.
+    """
+    import tempfile
+
+    directory = Path(tempfile.mkdtemp())
+    (directory / "a.lkml").write_text(
+        "view: base {\n  sql_table_name: t ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    )
+    (directory / "m_second.lkml").write_text("view: +base {\n  label: SECOND\n}\n")
+    (directory / "b_first.lkml").write_text("view: +base {\n  label: FIRST\n}\n")
+
+    labels = {LookMLAdapter().parse(str(directory)).get_model("base").meta.get("label") for _ in range(5)}
+    assert len(labels) == 1, f"nondeterministic refinement merge: {labels}"
+    assert labels == {"SECOND"}  # last file in SORTED order wins
+
+
 def test_lookml_directory_load_non_strict_falls_back_after_project_parse_error():
     """A single malformed .lkml must not drop every valid sibling in a non-strict load.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6050,6 +6050,38 @@ view: orders {
     assert "b_total" in {m.name for m in model.metrics}
 
 
+def test_lookml_multi_parent_extends_copies_segments_and_seeds_refinements():
+    """Extra extends parents contribute segments too, and a refinement of a non-first-parent field
+    seeds from the real inherited definition (not a bare categorical re-parse)."""
+    graph = _parse_lkml(
+        """
+view: base_a { sql_table_name: base_a ;; dimension: a_field { type: string  sql: ${TABLE}.a_field ;; } }
+view: base_b {
+  sql_table_name: base_b ;;
+  dimension: amount { type: number  sql: ${TABLE}.amount ;; }
+  filter: big_orders { type: number  sql: ${TABLE}.amount > 100 ;; }
+}
+view: child {
+  sql_table_name: child ;;
+  extends: [base_a, base_b]
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+}
+view: +child {
+  dimension: amount { label: "The Amount" }
+}
+"""
+    )
+    model = graph.get_model("child")
+    # A segment defined only by the non-first parent is inherited.
+    assert model.get_segment("big_orders") is not None
+    amount = model.get_dimension("amount")
+    # The partial refinement seeded from base_b's real definition: SQL preserved, label applied --
+    # not re-parsed to a bare categorical field with no sql.
+    assert amount is not None and amount.sql and "amount" in amount.sql
+    assert amount.label == "The Amount"
+    assert amount.type == "numeric"
+
+
 def test_lookml_extends_parent_required_in_all_model_scopes(caplog):
     """A parent only SOME models reaching the child include must not be inherited, and it warns.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6271,6 +6271,33 @@ def test_lookml_project_parse_handles_duplicate_views_and_extensionless_includes
         build(None, duplicate_dir="archive")
 
 
+def test_lookml_project_parse_allows_per_model_duplicate_views(caplog):
+    """Two models each including their OWN `orders` view is valid and must not abort the load.
+
+    A single graph can hold only one `orders`, but the duplication is ACROSS models (prod model ->
+    prod/orders, stage model -> stage/orders), a layout LookML considers valid, so keep the first
+    and warn rather than raising `Model orders already exists` over the whole directory.
+    """
+    import logging
+    import tempfile
+
+    directory = Path(tempfile.mkdtemp())
+    (directory / "prod").mkdir()
+    (directory / "stage").mkdir()
+    (directory / "prod.model.lkml").write_text('include: "/prod/orders.view.lkml"\n')
+    (directory / "stage.model.lkml").write_text('include: "/stage/orders.view.lkml"\n')
+    view = "view: orders {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    (directory / "prod" / "orders.view.lkml").write_text(view % "prod.orders")
+    (directory / "stage" / "orders.view.lkml").write_text(view % "stage.orders")
+
+    with caplog.at_level(logging.WARNING):
+        graph = LookMLAdapter().parse(str(directory))
+    orders = graph.get_model("orders")
+    assert orders is not None  # loaded, not aborted
+    assert orders.table in ("prod.orders", "stage.orders")  # one winner kept
+    assert any("multiple models" in rec.getMessage() for rec in caplog.records)
+
+
 def test_lookml_project_parse_resolves_view_with_several_archived_copies():
     """SEVERAL archived copies plus one included copy must still resolve to the included one.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5504,6 +5504,58 @@ def test_lookml_included_view_does_not_extend_unincluded_parent():
     assert {"secret", "leaked"} <= ({d.name for d in model.dimensions} | {m.name for m in model.metrics})
 
 
+def test_lookml_refinement_selected_by_only_some_models_warns(caplog):
+    """A refinement only SOME models include is ambiguous and must be surfaced, not silent.
+
+    Looker resolves each model separately: prod sees the plain view, staging the refined one. A
+    graph holds ONE model per view name and cannot hold both, so a staging-only
+    `+orders { sql_table_name: staging_orders }` silently repoints the view prod also uses. The
+    refinement is still applied -- refusing a valid project, or dropping it and mis-serving the
+    model that DID select it, are both worse -- but the load no longer resolves it silently.
+    """
+    import logging
+    import tempfile
+
+    base = "view: orders {\n  sql_table_name: real_orders ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    refinement = "view: +orders {\n  sql_table_name: staging_orders ;;\n}\n"
+
+    def parse(models, refinement_dir="views"):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "views").mkdir()
+        (directory / refinement_dir).mkdir(exist_ok=True)
+        for name, include in models:
+            (directory / f"{name}.model.lkml").write_text(include)
+        (directory / "views" / "orders.view.lkml").write_text(base)
+        (directory / refinement_dir / "staging_refine.view.lkml").write_text(refinement)
+        return LookMLAdapter().parse(str(directory))
+
+    # Only staging includes the refinement, but prod uses the same view -> warn, still apply.
+    with caplog.at_level(logging.WARNING, logger="sidemantic.adapters.lookml"):
+        graph = parse(
+            [
+                ("prod", 'include: "/views/orders.view.lkml"\n'),
+                ("staging", 'include: "/views/orders.view.lkml"\ninclude: "/views/staging_refine.view.lkml"\n'),
+            ]
+        )
+    assert graph.get_model("orders").table == "staging_orders"  # applied: the project still loads
+    assert "prod.model.lkml" in caplog.text
+    assert "not included by these models" in caplog.text
+
+    # Every model that uses the view includes the refinement: unambiguous, no warning.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="sidemantic.adapters.lookml"):
+        graph = parse([("prod", 'include: "/views/*.view.lkml"\n'), ("staging", 'include: "/views/*.view.lkml"\n')])
+    assert graph.get_model("orders").table == "staging_orders"
+    assert caplog.text == ""
+
+    # An un-included refinement is skipped as before -- not applied, and not an ambiguity.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="sidemantic.adapters.lookml"):
+        graph = parse([("prod", 'include: "/views/*.view.lkml"\n')], refinement_dir="archive")
+    assert graph.get_model("orders").table == "real_orders"
+    assert caplog.text == ""
+
+
 def test_lookml_extends_parent_scoped_per_model_not_project_wide():
     """A parent selected by ANOTHER model is not in scope for this model's child.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5414,6 +5414,95 @@ def test_lookml_drop_metrics_uses_provenance_marker_not_base_ref():
     _drop_non_registerable_models({"base": template, "orders": orders}, metrics2)
     assert "pop" not in metrics2
 
+    # A LATER file can OVERWRITE the template's name with a real model, so NOTHING is dropped
+    # this pass -- the marked metric is still orphaned and must go. Keying the cleanup off
+    # "something was dropped" left it registered and broke compile with "No models found".
+    real_base = Model(name="base", table="real_base", metrics=[Metric(name="cnt", agg="count", sql="id")])
+    metrics3 = {"pop": pop("revenue", template_metric=True)}
+    kept = _drop_non_registerable_models({"base": real_base, "orders": orders}, metrics3)
+    assert "pop" not in metrics3
+    assert set(kept) == {"base", "orders"}  # nothing dropped: only the orphaned metric goes
+
+
+def test_lookml_template_metric_dropped_when_later_file_overwrites_template():
+    """A template's orphaned metric must go even when a later file reuses the template's name.
+
+    The template is skipped, but a native file defining a real `base` overwrites it in the model
+    dict, so the load drops NOTHING -- and the cleanup, gated on a drop having happened, left the
+    template's auto-registered `pop` behind. `compile(metrics=["pop"])` then failed with
+    "No models found for query".
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    directory = Path(tempfile.mkdtemp())
+    (directory / "base.view.lkml").write_text(
+        """view: base {
+  extension: required
+  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }
+  dimension_group: created { type: time  timeframes: [date]  sql: ${TABLE}.created ;; }
+  measure: revenue { type: sum  sql: ${TABLE}.amount ;; }
+  measure: pop { type: period_over_period  based_on: revenue  based_on_time: created_date  period: year }
+}
+"""
+    )
+    # Sorts after the .lkml file, so it overwrites `base` with a real model.
+    (directory / "zz_native.py").write_text(
+        "from sidemantic import Dimension, Metric, Model\n"
+        'model = Model(name="base", table="real_base", primary_key="id",\n'
+        '              dimensions=[Dimension(name="id", type="numeric", sql="id")],\n'
+        '              metrics=[Metric(name="cnt", agg="count", sql="id")])\n'
+    )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, directory, strict=False)
+
+    assert layer.graph.models["base"].table == "real_base"  # the real model won
+    assert "pop" not in layer.graph.metrics  # the template's orphan did not survive it
+
+
+def test_lookml_included_view_does_not_extend_unincluded_parent():
+    """An included view must not inherit fields from a parent no model include reaches.
+
+    A unique view is installed even when un-included (an imperfectly-resolved include must never
+    silently drop a view), but loaded is not in-scope: `extends: [base]` resolving against an
+    archived `base` merged fields Looker would never expose in that model. The parent is treated
+    as absent instead, leaving the child's extends unresolved -- the child still loads.
+    """
+    import tempfile
+
+    child = "view: orders {\n  extends: [base]\n  sql_table_name: orders ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    parent = "view: base {\n  sql_table_name: base_t ;;\n  dimension: secret { sql: ${TABLE}.secret ;; }\n  measure: leaked { type: sum  sql: ${TABLE}.amount ;; }\n}\n"
+
+    def fields(parent_dir, include):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "views").mkdir()
+        (directory / parent_dir).mkdir(exist_ok=True)
+        (directory / "orders.model.lkml").write_text(f'include: "{include}"\n')
+        (directory / "views" / "orders.view.lkml").write_text(child)
+        (directory / parent_dir / "base.view.lkml").write_text(parent)
+        graph = LookMLAdapter().parse(str(directory))
+        model = graph.get_model("orders")
+        return graph, {d.name for d in model.dimensions} | {m.name for m in model.metrics}
+
+    # Parent in archive/: NOT reached by the model's include -> not inherited.
+    graph, archived = fields("archive", "/views/orders.view.lkml")
+    assert archived == {"id"}, archived
+    assert "base" in graph.models  # the un-included view still LOADS; it is just not a parent
+
+    # Parent reached by the include -> inherited as before.
+    _, included = fields("views", "/views/*.view.lkml")
+    assert {"secret", "leaked"} <= included, included
+
+    # With no include declared anywhere, scoping is off and inheritance is unaffected.
+    plain = Path(tempfile.mkdtemp())
+    (plain / "orders.view.lkml").write_text(child)
+    (plain / "base.view.lkml").write_text(parent)
+    model = LookMLAdapter().parse(str(plain)).get_model("orders")
+    assert {"secret", "leaked"} <= ({d.name for d in model.dimensions} | {m.name for m in model.metrics})
+
 
 def test_lookml_abstract_template_conflicting_with_active_model_is_not_skipped():
     """A template whose name collides with an existing model must not silently take the skip path.

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -4064,6 +4064,917 @@ def test_lookml_view_with_unsupported_derived_table_not_defaulted():
     assert model.table is None  # not fabricated as a physical table named after the view
 
 
+def test_lookml_time_timeframe_keeps_second_precision():
+    """Looker's "time" timeframe keeps to-the-second precision, not hour."""
+    graph = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [time, date, minute]
+    sql: ${TABLE}.created_at ;;
+  }
+}
+"""
+    )
+    model = graph.get_model("v")
+    assert model.get_dimension("created_time").granularity == "second"
+    assert model.get_dimension("created_minute").granularity == "minute"
+    assert model.get_dimension("created_date").granularity == "day"
+
+
+def test_lookml_native_suffix_contradicting_grain_uses_grain():
+    """A native dim whose name suffix CONTRADICTS its granularity preserves the GRAIN, not the name.
+
+    created_time at hour granularity must export as [hour] (-> created_hour), not [time]
+    (which imports as second), so queries keep grouping by hour.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="created_time", type="time", granularity="hour", sql="ts"),  # suffix `time` != hour
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    grains = {
+        d.name: d.granularity for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"
+    }
+    assert grains == {"created_hour": "hour"}  # grain preserved (not silently downgraded to second)
+
+
+def test_lookml_native_minute15_name_does_not_widen_grain():
+    """A native created_minute15 at MINUTE grain must not export [minute15] (15-min buckets).
+
+    The coarse mapping of minute15 equals `minute`, so the old name-suffix inference emitted
+    [minute15] -- silently re-bucketing 1-minute data into 15-minute intervals. Inexact
+    suffixes are now excluded from name inference, so it exports [minute] (true grain).
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="created_minute15", type="time", granularity="minute", sql="ts"),  # no meta
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    txt = open(out).read()
+    assert "minute15" not in txt  # no silent grain widening
+    assert "minute" in txt
+    # meta-preserved minute15 still round-trips as a 15-min bucket (import path unaffected)
+    graph2 = SemanticGraph()
+    graph2.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="created_minute15",
+                    type="time",
+                    granularity="minute",
+                    sql="ts",
+                    meta={"lookml_timeframe": "minute15"},
+                ),
+            ],
+        )
+    )
+    out2 = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph2, out2)
+    assert "minute15" in open(out2).read()
+
+
+def test_lookml_native_inexact_timeframe_suffix_preserves_grain_not_name():
+    """NATIVE inexact-suffix time dims (no meta) preserve the GRAIN, even if the name changes.
+
+    minute15 / minute30 / millisecond / microsecond / time_of_day map MANY-to-one onto a
+    coarser-or-finer sidemantic grain, so a native created_minute15 at MINUTE grain must NOT
+    export [minute15] (which buckets into 15-min intervals -- a silent grain change). It
+    exports at the true grain instead, so the field re-imports renamed (created_minute) but
+    with the CORRECT queryable grain. Exact name round-trip for these needs preserved
+    meta['lookml_timeframe'] (the import path), covered separately.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    for name, grain in [
+        ("created_minute15", "minute"),
+        ("created_millisecond", "second"),
+        ("created_time_of_day", "hour"),
+    ]:
+        graph = SemanticGraph()
+        graph.add_model(
+            Model(
+                name="v",
+                table="t",
+                primary_key="id",
+                dimensions=[
+                    Dimension(name="id", type="numeric", sql="id"),
+                    Dimension(name=name, type="time", granularity=grain, sql="ts"),  # no meta
+                ],
+            )
+        )
+        out = tempfile.mktemp(suffix=".lkml")
+        LookMLAdapter().export(graph, out)
+        grains = [d.granularity for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"]
+        assert grains == [grain], f"{name}: grain not preserved -> {grains}"
+
+
+def test_lookml_uncommon_timeframe_suffix_roundtrips():
+    """Imported timeframes like millisecond/microsecond round-trip (base derived from stored timeframe)."""
+    import tempfile
+
+    graph = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [millisecond, microsecond, date]
+    sql: ${TABLE}.created_at ;;
+  }
+}
+"""
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    names = {d.name for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"}
+    assert {"created_millisecond", "created_microsecond"} <= names
+    assert not any(n.endswith("_millisecond_millisecond") or n.endswith("_microsecond_microsecond") for n in names)
+
+
+def test_lookml_time_grain_roundtrip():
+    """time/hour/minute/date grains round-trip through export without grain or suffix corruption."""
+    import tempfile
+
+    graph = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [time, hour, minute, date]
+    sql: ${TABLE}.created_at ;;
+  }
+}
+"""
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    grains = {
+        d.name: d.granularity for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"
+    }
+    assert grains == {
+        "created_time": "second",
+        "created_hour": "hour",
+        "created_minute": "minute",
+        "created_date": "day",
+    }
+
+
+def test_lookml_native_second_grain_roundtrips():
+    """A second-grain dimension not imported from LookML (no meta) exports as `second`, not `time`."""
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="created_second", type="time", granularity="second", sql="{model}.created_at"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    names = {d.name for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"}
+    assert "created_second" in names
+
+
+def test_lookml_same_prefix_time_dims_different_sources_not_merged():
+    """Same-prefix time dims backed by different columns must not merge to one group (wrong source)."""
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started_date", type="time", granularity="day", sql="{model}.started_at"),
+                Dimension(name="started_second", type="time", granularity="second", sql="{model}.other_at"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    time_dims = [d for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"]
+    sources = {d.sql for d in time_dims}
+    # Each field keeps its own source column (no rewiring to the other group's SQL).
+    assert any("started_at" in (s or "") for s in sources)
+    assert any("other_at" in (s or "") for s in sources)
+    # Split groups get suffix-free, collision-free names (no started_date_date etc.).
+    assert not any(d.name.endswith("_date_date") or d.name.endswith("_hour_hour") for d in time_dims)
+
+
+def test_lookml_collision_subsecond_timeframe_preserves_precision():
+    """A millisecond/microsecond collision dim exports DATE_TRUNC at that grain (not second).
+
+    sidemantic stores them as `second`, so the exported SQL must use the LookML timeframe
+    grain to keep sub-second precision, and re-import recovers second grain + the timeframe.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="started_date", type="time", granularity="day", sql="a", meta={"lookml_timeframe": "date"}
+                ),
+                Dimension(
+                    name="started_millisecond",
+                    type="time",
+                    granularity="second",
+                    sql="b",
+                    meta={"lookml_timeframe": "millisecond"},
+                ),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    out = tempfile.mktemp(suffix=".lkml")
+    adapter.export(graph, out)
+    assert "DATE_TRUNC('millisecond'" in open(out).read()  # sub-second precision kept, not 'second'
+    g = adapter.parse(Path(out))
+    ms = g.get_model("v").get_dimension("started_millisecond")
+    assert ms.granularity == "second" and (ms.meta or {}).get("lookml_timeframe") == "millisecond"
+    # second round-trip stable (no nested DATE_TRUNC)
+    out2 = tempfile.mktemp(suffix=".lkml")
+    adapter.export(g, out2)
+    assert "DATE_TRUNC('millisecond', DATE_TRUNC" not in open(out2).read()
+
+
+def test_lookml_collision_disambiguation_reserves_future_group_fields():
+    """Disambiguating a standalone must avoid names a LATER dimension_group will generate.
+
+    `started` + `started_hour` (base `started`) plus `started_2_hour` (base `started_2`): the
+    standalone must not disambiguate to `started_2_hour` because the `started_2` group also
+    generates it. used_names is pre-seeded with every group's generated fields, so it skips to
+    `started_3_hour` -- no duplicate LookML field across the whole view.
+    """
+    import re
+    import tempfile
+    from collections import Counter
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started", type="time", granularity="hour", sql="a"),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="b"),
+                Dimension(name="started_2_hour", type="time", granularity="hour", sql="c"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    text = open(out).read()
+    names = re.findall(r"\n  dimension: (\w+) \{", text)
+    for base, tfs in re.findall(r"dimension_group: (\w+) \{[^}]*?timeframes:\s*\[([^\]]*)\]", text, re.S):
+        names += [f"{base}_{tf.strip()}" for tf in tfs.split(",")]
+    dups = {n: c for n, c in Counter(names).items() if c > 1}
+    assert not dups, f"duplicate field names: {dups}"
+
+
+def test_lookml_minute_bucket_collision_field_deduplicated():
+    """A minute15/30 collision dim must go through the same uniqueness logic (no duplicate names).
+
+    The minute-bucket path previously returned early, bypassing used_names dedup, so a
+    suffixless `started` (minute15) colliding with an existing `started_minute15` could emit
+    two `started_minute15` fields. It now disambiguates (`started_2_minute15`), still recoverable.
+    """
+    import re
+    import tempfile
+    from collections import Counter
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="started", type="time", granularity="minute", sql="a", meta={"lookml_timeframe": "minute15"}
+                ),
+                Dimension(
+                    name="started_minute15",
+                    type="time",
+                    granularity="minute",
+                    sql="b",
+                    meta={"lookml_timeframe": "minute15"},
+                ),
+                Dimension(
+                    name="started_date", type="time", granularity="day", sql="c", meta={"lookml_timeframe": "date"}
+                ),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    text = open(out).read()
+    names = re.findall(r"\n  dimension: (\w+) \{", text)
+    for base, tfs in re.findall(r"dimension_group: (\w+) \{[^}]*?timeframes:\s*\[([^\]]*)\]", text, re.S):
+        names += [f"{base}_{tf.strip()}" for tf in tfs.split(",")]
+    dups = {n: c for n, c in Counter(names).items() if c > 1}
+    assert not dups, f"duplicate field names: {dups}"
+    # the disambiguated field is still time-recoverable (ends in a real timeframe suffix)
+    g2 = LookMLAdapter().parse(Path(out))
+    assert all(d.type == "time" for d in g2.get_model("ev").dimensions if d.name.startswith("started"))
+
+
+def test_lookml_collision_disambiguated_field_stays_time_recoverable():
+    """A disambiguated collision field must stay TIME-recoverable, not become categorical.
+
+    The unrepresentable trio (`started` + `started_hour` + `started_date`, all different SQL)
+    forces one field to be renamed for uniqueness. The disambiguator goes into the STEM
+    (`started_2_hour`, not `started_hour_2`) so the trailing timeframe is preserved and the
+    field re-imports as time@hour, not a categorical dim. Stable across round-trips.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started", type="time", granularity="hour", sql="a"),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="b"),
+                Dimension(name="started_date", type="time", granularity="day", sql="c"),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    g = graph
+    for _ in range(2):
+        out = tempfile.mktemp(suffix=".lkml")
+        adapter.export(g, out)
+        g = adapter.parse(Path(out))
+        kinds = {d.name: d.type for d in g.get_model("ev").dimensions if d.name != "id"}
+        # all three time sources stay TIME (none degraded to categorical), 3 distinct names
+        assert all(t == "time" for t in kinds.values()), kinds
+        assert len(kinds) == 3, kinds
+
+
+def test_lookml_suffixless_collision_no_dimension_group_field_duplicate():
+    """A suffixless dim must not win the group slot and GENERATE a name a sibling standalone owns.
+
+    `started` (hour) + `started_hour` (hour, diff SQL) + `started_date`: if suffixless `started`
+    won the dimension_group, the group would generate `started_hour` AND a standalone
+    `started_hour` would exist -> a runtime field collision. A suffixed sibling wins the group
+    slot instead, so every generated field name (group fields + standalones) is unique.
+    """
+    import re
+    import tempfile
+    from collections import Counter
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started", type="time", granularity="hour", sql="a"),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="b"),
+                Dimension(name="started_date", type="time", granularity="day", sql="c"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    text = open(out).read()
+    generated = re.findall(r"\n  dimension: (\w+) \{", text)  # standalones
+    for base, tfs in re.findall(r"dimension_group: (\w+) \{[^}]*?timeframes:\s*\[([^\]]*)\]", text, re.S):
+        generated += [f"{base}_{tf.strip()}" for tf in tfs.split(",")]  # group-generated fields
+    dups = {n: c for n, c in Counter(generated).items() if c > 1}
+    assert not dups, f"duplicate generated field names: {dups}"
+
+
+def test_lookml_suffixless_collision_synth_name_avoids_duplicate():
+    """Synthesizing a recoverable suffix must not duplicate an existing field name.
+
+    `started` (hour) alongside an EXISTING `started_hour` and a `started_date` source must not
+    emit two `started_hour` blocks; the suffixless one keeps its name (no data-losing dup).
+    """
+    import re
+    import tempfile
+    from collections import Counter
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started", type="time", granularity="hour", sql="a"),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="b"),  # already exists
+                Dimension(name="started_date", type="time", granularity="day", sql="c"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    names = re.findall(r"dimension(?:_group)?: (\w+)", open(out).read())
+    dups = {n: c for n, c in Counter(names).items() if c > 1}
+    assert not dups, f"duplicate field names emitted: {dups}"
+
+
+def test_lookml_suffixless_collision_time_dim_stays_time():
+    """A suffixless collision time dim must remain a TIME dim across round-trips, not categorical.
+
+    `started` (hour grain) colliding with `started_date` (day, different SQL) can't keep its
+    bare name as a recoverable standalone, so the collision export appends the grain timeframe
+    (-> `started_hour`) so re-import restores time granularity instead of dropping to a
+    categorical dim (which would break time queries/filters on the field).
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started", type="time", granularity="hour", sql="created_at"),  # suffixless
+                Dimension(name="started_date", type="time", granularity="day", sql="updated_at"),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    g = graph
+    for _ in range(2):
+        out = tempfile.mktemp(suffix=".lkml")
+        adapter.export(g, out)
+        g = adapter.parse(Path(out))
+        times = {d.name: d.granularity for d in g.get_model("ev").dimensions if d.type == "time"}
+        # the suffixless dim is recoverable as time@hour (renamed started -> started_hour)
+        assert times.get("started_hour") == "hour", times
+        assert times.get("started_date") == "day", times
+
+
+def test_lookml_native_collision_inexact_name_not_widened_on_import():
+    """A NATIVE collision dim named *_minute15 (no meta) must not gain false minute15 meta.
+
+    Without meta the collision exporter writes a plain DATE_TRUNC('minute', ...), so import
+    must recover grain=minute with NO lookml_timeframe (recording 'minute15' would make the
+    next export widen the 1-minute dim into a 15-minute bucket). Stable across round-trips.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started_date", type="time", granularity="day", sql="created_at"),
+                # same prefix, DIFFERENT sql -> collision; NO meta
+                Dimension(name="started_minute15", type="time", granularity="minute", sql="updated_at"),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    out = tempfile.mktemp(suffix=".lkml")
+    adapter.export(graph, out)
+    assert "DATE_TRUNC('minute'" in open(out).read()  # plain minute trunc, not a 15-min bucket
+    g = adapter.parse(Path(out))
+    m15 = g.get_model("ev").get_dimension("started_minute15")
+    assert m15.granularity == "minute"
+    assert not (m15.meta or {}).get("lookml_timeframe")  # NO false minute15 meta
+    # stable: second round-trip still minute, still no bucket
+    out2 = tempfile.mktemp(suffix=".lkml")
+    adapter.export(g, out2)
+    assert "FLOOR(" not in open(out2).read()  # never widened into a bucket
+    m15b = adapter.parse(Path(out2)).get_model("ev").get_dimension("started_minute15")
+    assert m15b.granularity == "minute" and not (m15b.meta or {}).get("lookml_timeframe")
+
+
+def test_lookml_collision_minute15_bucket_roundtrips():
+    """A minute15 collision dim exports a faithful 15-min bucket (not minute) and round-trips.
+
+    sidemantic has no 15-min grain (stores minute15 as `minute` + meta), so the standalone
+    collision form must emit an explicit N-minute bucket that the importer recovers back to
+    grain=minute + meta['lookml_timeframe']='minute15', stable across repeated round-trips.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="started_date", type="time", granularity="day", sql="a", meta={"lookml_timeframe": "date"}
+                ),
+                Dimension(
+                    name="started_minute15",
+                    type="time",
+                    granularity="minute",
+                    sql="b",
+                    meta={"lookml_timeframe": "minute15"},
+                ),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    out = tempfile.mktemp(suffix=".lkml")
+    adapter.export(graph, out)
+    text = open(out).read()
+    # Faithful 15-minute bucket via PORTABLE FLOOR (not DuckDB-only //), not DATE_TRUNC('minute').
+    assert "FLOOR(" in text and " / 15) * 15" in text and "//" not in text
+    g = adapter.parse(Path(out))
+    m15 = g.get_model("v").get_dimension("started_minute15")
+    assert m15.granularity == "minute" and (m15.meta or {}).get("lookml_timeframe") == "minute15"
+    # The recovered dim KEEPS the bucket expression (so QUERIES bucket 15-min, not minute).
+    assert "FLOOR(" in (m15.sql or "")
+    # second round-trip stays stable (no nested bucket)
+    out2 = tempfile.mktemp(suffix=".lkml")
+    adapter.export(g, out2)
+    assert "FLOOR(EXTRACT(MINUTE FROM DATE_TRUNC('hour'" not in open(out2).read()  # no FLOOR(...bucket...)
+    m15b = adapter.parse(Path(out2)).get_model("v").get_dimension("started_minute15")
+    assert m15b.granularity == "minute" and (m15b.meta or {}).get("lookml_timeframe") == "minute15"
+
+
+def test_lookml_collision_minute15_query_buckets_by_15_minutes():
+    """A round-tripped minute15 collision dim must GROUP queries by 15-minute buckets, not minute."""
+    import tempfile
+
+    import duckdb
+
+    from sidemantic import Dimension, Metric, Model, SemanticLayer
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="v",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="started_date", type="time", granularity="day", sql="a", meta={"lookml_timeframe": "date"}
+                ),
+                Dimension(
+                    name="started_minute15",
+                    type="time",
+                    granularity="minute",
+                    sql="ts",
+                    meta={"lookml_timeframe": "minute15"},
+                ),
+            ],
+            metrics=[Metric(name="cnt", agg="count")],
+        )
+    )
+    adapter = LookMLAdapter()
+    out = tempfile.mktemp(suffix=".lkml")
+    adapter.export(graph, out)
+    g = adapter.parse(Path(out))
+    layer = SemanticLayer(auto_register=False)
+    for m in g.models.values():
+        layer.add_model(m)
+    sql = layer.compile(dimensions=["v.started_minute15"], metrics=["v.cnt"])
+    con = duckdb.connect()
+    con.execute(
+        "create table v as select 1 id, TIMESTAMP '2024-01-01 10:07' a, TIMESTAMP '2024-01-01 10:07' ts "
+        "union all select 2, TIMESTAMP '2024-01-01 10:11', TIMESTAMP '2024-01-01 10:11' "
+        "union all select 3, TIMESTAMP '2024-01-01 10:22', TIMESTAMP '2024-01-01 10:22'"
+    )
+    import datetime
+
+    rows = sorted(con.execute(sql).fetchall())
+    assert rows == [(datetime.datetime(2024, 1, 1, 10, 0), 2), (datetime.datetime(2024, 1, 1, 10, 15), 1)]
+
+
+def test_lookml_collision_time_dim_multiword_timeframe_suffix_recovered():
+    """A collision standalone dim with a MULTI-WORD timeframe suffix (time_of_day) recovers.
+
+    The grain suffix is matched against the longest known LookML timeframe, not just the
+    text after the last underscore, so started_time_of_day round-trips as a time dimension
+    (gran=hour), not a renamed categorical.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="started_date", type="time", granularity="day", sql="a", meta={"lookml_timeframe": "date"}
+                ),
+                Dimension(
+                    name="started_time_of_day",
+                    type="time",
+                    granularity="hour",
+                    sql="b",
+                    meta={"lookml_timeframe": "time_of_day"},
+                ),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    # Repeated round-trips must be STABLE: the recovered timeframe is stored in meta so
+    # the next export strips the _time_of_day suffix instead of renaming the field.
+    g = graph
+    for _ in range(3):
+        out = tempfile.mktemp(suffix=".lkml")
+        adapter.export(g, out)
+        g = adapter.parse(Path(out))
+        grains = {d.name: d.granularity for d in g.get_model("v").dimensions if d.type == "time"}
+        assert grains == {"started_date": "day", "started_time_of_day": "hour"}
+
+
+def test_lookml_same_prefix_time_dims_roundtrip_names_and_grains_losslessly():
+    """Collision time dims must round-trip with EXACT names AND granularities.
+
+    Two same-prefix time dims on different sources can't both be dimension_groups, so
+    the extra one is exported as a standalone DATE_TRUNC dimension. Both the field name
+    and the granularity must survive re-import (no started_2_minute rename, no grain
+    loss), and a second round-trip must be stable (no nested DATE_TRUNC).
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id", primary_key=True),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="started_at"),
+                Dimension(name="started_minute", type="time", granularity="minute", sql="completed_at"),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    out1 = tempfile.mktemp(suffix=".lkml")
+    adapter.export(graph, out1)
+    g2 = adapter.parse(Path(out1))
+    grains = {d.name: d.granularity for d in g2.get_model("v").dimensions if d.type == "time"}
+    assert grains == {"started_hour": "hour", "started_minute": "minute"}
+
+    # Second round-trip is stable and never nests DATE_TRUNC.
+    out2 = tempfile.mktemp(suffix=".lkml")
+    adapter.export(g2, out2)
+    assert "DATE_TRUNC('minute', DATE_TRUNC" not in open(out2).read()
+    assert "DATE_TRUNC('hour', DATE_TRUNC" not in open(out2).read()
+    grains2 = {d.name: d.granularity for d in adapter.parse(Path(out2)).get_model("v").dimensions if d.type == "time"}
+    assert grains2 == {"started_hour": "hour", "started_minute": "minute"}
+
+
+def test_lookml_handwritten_date_trunc_dimension_not_hijacked():
+    """A hand-written DATE_TRUNC dimension must keep its name/type, not be turned into a time group.
+
+    The DATE_TRUNC granularity recovery is only for the collision-export form (name ends
+    in _<grain>); an arbitrary-named dim like `created` stays categorical (no rename to
+    created_date), and an unsupported dialect grain like 'isoweek' must not crash parsing.
+    """
+    import tempfile
+
+    # Unsupported grain must not raise a granularity validation error.
+    graph = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: w { type: date_time  sql: DATE_TRUNC('isoweek', ${TABLE}.created_at) ;; }
+}
+"""
+    )
+    w = graph.get_model("v").get_dimension("w")
+    assert w.type == "categorical" and w.granularity is None
+
+    # Arbitrary-named DATE_TRUNC dim keeps its exact name across a round-trip.
+    graph2 = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: created { type: date_time  sql: DATE_TRUNC('day', ${TABLE}.created_at) ;; }
+}
+"""
+    )
+    assert graph2.get_model("v").get_dimension("created").type == "categorical"
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph2, out)
+    names = {d.name for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions}
+    assert "created" in names and "created_date" not in names
+
+    # A hand-written dim whose NAME does carry a timeframe suffix (created_date) but also
+    # has dimension-level properties (hidden/label) is NOT the collision-export form, so
+    # it stays a plain dimension and those properties survive the round-trip.
+    graph3 = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: created_date { type: date_time  hidden: yes  label: "Created"  sql: DATE_TRUNC('day', ${TABLE}.created_at) ;; }
+}
+"""
+    )
+    assert graph3.get_model("v").get_dimension("created_date").type == "categorical"
+    out3 = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph3, out3)
+    text3 = open(out3).read()
+    assert "created_date" in {d.name for d in LookMLAdapter().parse(Path(out3)).get_model("v").dimensions}
+    assert "hidden: yes" in text3 and "Created" in text3  # properties preserved
+
+
+def test_lookml_split_time_group_names_avoid_existing_bases():
+    """A synthetic split-group name must not collide with an existing time-group base."""
+    import re
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started_date", type="time", granularity="day", sql="{model}.a"),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="{model}.b"),
+                Dimension(name="started_2_hour", type="time", granularity="hour", sql="{model}.c"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    names = re.findall(r"dimension_group: (\w+)", open(out).read())
+    assert len(names) == len(set(names)), f"colliding dimension_group names: {names}"
+
+
+def test_lookml_native_time_named_second_grain_roundtrips():
+    """A native second-grain dim named *_time must export as `time` so the name round-trips."""
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="created_time", type="time", granularity="second", sql="{model}.created_at"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    names = {d.name for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"}
+    assert "created_time" in names  # not renamed to created_second
+
+
+def test_lookml_time_and_second_timeframes_no_duplicate_export():
+    """A group with both `time` and `second` (both -> second grain) must not emit duplicate timeframes."""
+    import re
+    import tempfile
+
+    graph = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [time, second, hour]
+    sql: ${TABLE}.created_at ;;
+  }
+}
+"""
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    text = open(out).read()
+    timeframes = re.search(r"timeframes:\s*\[([^\]]*)\]", text).group(1)
+    parts = [p.strip() for p in timeframes.split(",")]
+    assert len(parts) == len(set(parts)), f"duplicate timeframes exported: {parts}"
+    # Both `time` and `second` are preserved (no collapse/drop) via the stored
+    # original timeframe, so re-import keeps every member.
+    names = {d.name for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"}
+    assert {"created_time", "created_second", "created_hour"} <= names
+
+
 def test_lookml_view_without_table_defaults_to_view_name():
     """A view with no sql_table_name/derived_table should default its table to the view name."""
     from sidemantic import SemanticLayer

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5153,6 +5153,37 @@ def test_lookml_abstract_base_not_registered_inside_layer_context():
     assert layer.graph.get_model("orders").table == "orders"  # concrete child registered
 
 
+def test_lookml_directory_load_merges_cross_file_refinement_before_defaulting_table():
+    """A CLI directory load must merge `+view` refinements from OTHER files before defaulting.
+
+    `view: base` in one file and `view: +base { extension: required }` in another is a normal
+    LookML layout. Parsing each .lkml independently never merged that refinement, so `base` missed
+    its abstract marker, got defaulted to a physical table named `base`, and was registered as
+    queryable -- validate/queries would silently target a fabricated table.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    directory = Path(tempfile.mkdtemp())
+    (directory / "a.lkml").write_text("view: base {\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n")
+    (directory / "b.lkml").write_text("view: +base {\n  extension: required\n}\n")
+    (directory / "c.lkml").write_text(
+        "view: orders {\n  extends: [base]\n  sql_table_name: raw_orders ;;\n  measure: cnt { type: count }\n}\n"
+    )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, directory)
+
+    # The refined abstract base stays non-queryable instead of getting a fabricated table.
+    assert "base" not in layer.graph.models
+    orders = layer.graph.get_model("orders")
+    assert orders.table == "raw_orders"
+    # Per-file provenance still points at the DEFINING file, not the project root.
+    assert getattr(orders, "_source_file", None) == "c.lkml"
+
+
 def test_lookml_broken_tableless_view_surfaces_error_inside_layer_context():
     """A genuinely-broken tableless view (unresolved extends) must NOT be silently skipped.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -4875,6 +4875,49 @@ def test_lookml_time_dims_grouped_by_effective_sql_not_explicit_sql():
     assert same_source == {"started_hour": "a"}, same_source
 
 
+def test_lookml_imported_dimension_group_without_sql_stays_one_group():
+    """An imported `dimension_group` that omits `sql` must round-trip as ONE group.
+
+    Its timeframes all read the same implicit `<base>` column, but each generated Dimension has
+    sql=None, so keying them on the effective expression (which falls back to the generated field
+    name) read every timeframe as its own source. The group was split into standalone dims backed
+    by columns that never existed -- `sql: DATE_TRUNC('week', created_week)`.
+    """
+    import tempfile
+
+    source = """view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [date, week, month]
+  }
+}
+"""
+    directory = Path(tempfile.mkdtemp())
+    (directory / "orders.view.lkml").write_text(source)
+    graph = LookMLAdapter().parse(str(directory / "orders.view.lkml"))
+
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    exported = Path(out).read_text()
+
+    # One dimension_group carrying every timeframe, and no phantom-column standalones.
+    assert exported.count("dimension_group:") == 1, exported
+    assert "timeframes: [date, week, month]" in exported, exported
+    assert "created_week" not in exported, exported
+    assert "created_month" not in exported, exported
+    # The implicit column stays implicit: no invented `sql:` on the group.
+    assert "sql: created" not in exported, exported
+
+    reimported = LookMLAdapter().parse(Path(out)).get_model("orders")
+    assert sorted((d.name, d.granularity) for d in reimported.dimensions if d.type == "time") == [
+        ("created_date", "day"),
+        ("created_month", "month"),
+        ("created_week", "week"),
+    ]
+
+
 def test_lookml_collision_time_of_day_recovers_timeframe_meta_and_survives_sibling_drop():
     """A collision-exported `time_of_day` standalone must recover its timeframe into meta.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6040,6 +6040,83 @@ def test_lookml_every_model_file_seeds_include_scoping():
     assert LookMLAdapter().parse(str(unscoped)).get_model("orders").table == "REFINED"
 
 
+def test_lookml_partial_explore_filter_kept_and_reported(caplog):
+    """An explore's mandatory filter must not silently leak onto models without that explore.
+
+    sql_always_where / always_filter become segments on the single shared base model. When one
+    model includes the base view plus a filtered explore sidecar and another includes only the
+    base view, the filter attached to the shared model -- exposing a segment Looker would not give
+    the second model. One model per view name cannot hold both shapes, so the segment is kept (it
+    is opt-in, and dropping it would un-filter the model that wanted it) and the divergence warned.
+    """
+    import logging
+    import tempfile
+
+    view = "view: %s {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    sidecar = 'include: "/views/filtered.explore.lkml"\n'
+
+    def parse(models, explore_body):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "views").mkdir()
+        for name, include in models:
+            (directory / f"{name}.model.lkml").write_text(include)
+        (directory / "views" / "orders.view.lkml").write_text(view % ("orders", "real_orders"))
+        (directory / "views" / "filtered.explore.lkml").write_text(explore_body)
+        return LookMLAdapter().parse(str(directory)).get_model("orders")
+
+    where = "explore: orders {\n  sql_always_where: ${orders.id} > 100 ;;\n}\n"
+
+    # One model includes the filtered explore, another uses the base view without it -> warn, keep.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="sidemantic.adapters.lookml"):
+        model = parse(
+            [
+                ("orders", 'include: "/views/orders.view.lkml"\n'),
+                ("filtered", 'include: "/views/orders.view.lkml"\n' + sidecar),
+            ],
+            where,
+        )
+    assert [s.name for s in model.segments] == ["_sql_always_where_orders"]  # kept
+    assert "mandatory filter" in caplog.text
+
+    # Every model using the base view includes the explore: no divergence.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="sidemantic.adapters.lookml"):
+        model = parse(
+            [
+                ("a", 'include: "/views/orders.view.lkml"\n' + sidecar),
+                ("b", 'include: "/views/orders.view.lkml"\n' + sidecar),
+            ],
+            where,
+        )
+    assert [s.name for s in model.segments] == ["_sql_always_where_orders"]
+    assert "mandatory filter" not in caplog.text
+
+    # always_filter diverges the same way.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="sidemantic.adapters.lookml"):
+        parse(
+            [
+                ("orders", 'include: "/views/orders.view.lkml"\n'),
+                ("filtered", 'include: "/views/orders.view.lkml"\n' + sidecar),
+            ],
+            'explore: orders {\n  always_filter: {\n    filters: [orders.id: "100"]\n  }\n}\n',
+        )
+    assert "mandatory filter" in caplog.text
+
+    # A partial explore with NO mandatory filter has nothing to leak -> no warning.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="sidemantic.adapters.lookml"):
+        parse(
+            [
+                ("orders", 'include: "/views/orders.view.lkml"\n'),
+                ("filtered", 'include: "/views/orders.view.lkml"\n' + sidecar),
+            ],
+            'explore: orders {\n  label: "Orders"\n}\n',
+        )
+    assert "mandatory filter" not in caplog.text
+
+
 def test_lookml_shared_explore_sidecar_checked_against_one_model_scope(caplog):
     """An explore in a sidecar two models share resolves within ONE model, not their union.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -4139,6 +4139,36 @@ view: orders {
     assert {"created_minute", "created_hour"} <= names  # supported grains still import
 
 
+def test_lookml_reference_to_unsupported_timeframe_does_not_resolve_to_raw():
+    """A ${...} reference to a DROPPED timeframe must not expand to the raw base column.
+
+    _build_timeframe_dimension drops minute15/minute30/millisecond/microsecond, but the reference
+    lookup was seeded for every timeframe, so ${created_minute15} in a measure expanded to the raw
+    group column and the measure ran on UNBUCKETED timestamps. The unsupported timeframes are now
+    kept out of the lookup, so the reference is left unresolved (like any unknown ref) rather than
+    silently mis-resolved; a SUPPORTED timeframe still resolves.
+    """
+    model = _parse_lkml(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension_group: created { type: time  timeframes: [minute15, date]  sql: ${TABLE}.ts ;; }
+  measure: bad { type: count_distinct  sql: ${created_minute15} ;; }
+  dimension: is_new { type: yesno  sql: ${created_minute15} > '2020-01-01' ;; }
+  measure: good { type: count_distinct  sql: ${created_date} ;; }
+}
+"""
+    ).get_model("orders")
+
+    fields = {f.name: f.sql for f in [*model.dimensions, *model.metrics]}
+    # The unsupported-timeframe refs are NOT expanded to the raw base column.
+    assert "{model}.ts" not in (fields["bad"] or "")
+    assert "{model}.ts" not in (fields["is_new"] or "")
+    # The supported `created_date` reference still resolves to the group column.
+    assert fields["good"] == "({model}.ts)"
+
+
 def test_lookml_native_minute15_name_does_not_widen_grain():
     """A native created_minute15 at MINUTE grain must not export [minute15] (15-min buckets).
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5504,6 +5504,95 @@ def test_lookml_included_view_does_not_extend_unincluded_parent():
     assert {"secret", "leaked"} <= ({d.name for d in model.dimensions} | {m.name for m in model.metrics})
 
 
+def test_lookml_implicit_dimension_group_compiles_against_group_column():
+    """A dimension_group without `sql` reads Looker's implicit `<group>` column.
+
+    Its generated dimensions carried sql=None, so each fell back to its OWN field name and
+    compiled DATE_TRUNC('day', created_date) -- a column that does not exist -- against an
+    otherwise valid view. The dims resolve to `created`, and export still re-emits the group
+    without inventing a `sql`, since an implicit group is marked rather than inferred from sql.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+
+    directory = Path(tempfile.mkdtemp())
+    (directory / "orders.view.lkml").write_text(
+        """view: orders {
+  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [date, week]
+  }
+  measure: cnt { type: count }
+}
+"""
+    )
+    graph = LookMLAdapter().parse(str(directory / "orders.view.lkml"))
+    assert [d.sql for d in graph.get_model("orders").dimensions if d.name == "created_date"] == ["{model}.created"]
+
+    layer = SemanticLayer()
+    layer.graph = graph
+    sql = layer.compile(dimensions=["orders.created_date"], metrics=["orders.cnt"])
+    assert "DATE_TRUNC('day', created)" in sql, sql
+    assert "'day', created_date)" not in sql, sql  # never the generated field name
+
+    # Export still round-trips the group with no invented sql.
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    exported = Path(out).read_text()
+    assert exported.count("dimension_group:") == 1, exported
+    assert "sql:" not in exported[exported.index("dimension_group:") :], exported
+
+
+def test_lookml_conflicting_per_model_refinement_order_warns(caplog):
+    """Models disagreeing on refinement include order must be surfaced, not silently resolved.
+
+    Looker applies refinements in each model's own include order. One model per view name can
+    hold only one result, so a model including z_ref then a_ref and another doing the reverse
+    cannot both be served -- the first model file's order silently won.
+    """
+    import logging
+    import tempfile
+
+    base = "view: orders {\n  sql_table_name: real_orders ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    orders_include = 'include: "/views/orders.view.lkml"\n'
+    z_then_a = orders_include + 'include: "/views/z_ref.view.lkml"\ninclude: "/views/a_ref.view.lkml"\n'
+    a_then_z = orders_include + 'include: "/views/a_ref.view.lkml"\ninclude: "/views/z_ref.view.lkml"\n'
+
+    def parse(*models):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "views").mkdir()
+        for name, include in models:
+            (directory / f"{name}.model.lkml").write_text(include)
+        (directory / "views" / "orders.view.lkml").write_text(base)
+        (directory / "views" / "z_ref.view.lkml").write_text("view: +orders {\n  sql_table_name: from_z ;;\n}\n")
+        (directory / "views" / "a_ref.view.lkml").write_text("view: +orders {\n  sql_table_name: from_a ;;\n}\n")
+        return LookMLAdapter().parse(str(directory))
+
+    def order_conflict(*models):
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="sidemantic.adapters.lookml"):
+            graph = parse(*models)
+        return graph, any("disagree on the include order" in r.getMessage() for r in caplog.records)
+
+    graph, conflicted = order_conflict(("a_first", z_then_a), ("b_second", a_then_z))
+    assert conflicted
+    assert graph.get_model("orders").table == "from_a"  # first model file's order; still loads
+
+    # Agreeing models are not a conflict.
+    _, conflicted = order_conflict(("a", z_then_a), ("b", z_then_a))
+    assert not conflicted
+
+    # A model including only SOME of the refinements orders nothing differently.
+    _, conflicted = order_conflict(("a", z_then_a), ("b", orders_include + 'include: "/views/a_ref.view.lkml"\n'))
+    assert not conflicted
+
+    # A single model has nothing to disagree with.
+    _, conflicted = order_conflict(("a", z_then_a))
+    assert not conflicted
+
+
 def test_lookml_refinements_merge_in_include_order_not_pathname_order():
     """Refinements follow the model's include order; the last-included one wins.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -4116,49 +4116,27 @@ def test_lookml_native_suffix_contradicting_grain_uses_grain():
     assert grains == {"created_hour": "hour"}  # grain preserved (not silently downgraded to second)
 
 
-def test_lookml_minute_bucket_timeframes_query_at_bucket_grain():
-    """Importing minute15/minute30 must bucket at 15/30 minutes, not truncate to the minute.
+def test_lookml_minute_bucket_timeframes_are_unsupported():
+    """minute15/minute30 are N-minute buckets sidemantic cannot represent portably, so drop them.
 
-    These are N-minute BUCKETS, but map to the coarse `minute` granularity, so importing them with
-    the raw base timestamp made the generator emit DATE_TRUNC('minute', ts) -- collapsing the
-    bucket the field name promises. The bucket expression is baked into the SQL, so a query lands
-    on 15/30-minute boundaries; the timeframe still round-trips through export.
+    The coarse `minute` granularity would truncate to the minute and drop the bucket, and baking
+    the bucket expression stores dialect-specific SQL (DuckDB/Postgres DATE_TRUNC + INTERVAL) into
+    Dimension.sql, which the generator does not transpile -- so it fails on BigQuery/Snowflake. The
+    import adapter has no query dialect to generate it correctly, so leave them unsupported; the
+    supported grains in the same group still import.
     """
-    import tempfile
-
-    import duckdb
-
-    from sidemantic import SemanticLayer
-
     graph = _parse_lkml(
         """
 view: orders {
   sql_table_name: orders ;;
   dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
-  dimension_group: created { type: time  timeframes: [minute15, minute30] sql: ${TABLE}.ts ;; }
+  dimension_group: created { type: time  timeframes: [minute15, minute30, minute, hour] sql: ${TABLE}.ts ;; }
 }
 """
     )
-    model = graph.get_model("orders")
-    layer = SemanticLayer(auto_register=False)
-    layer.add_model(model)
-    sql = layer.compile(dimensions=["orders.created_minute15"])
-    con = duckdb.connect()
-    con.execute(
-        "create table orders as select 1 id, TIMESTAMP '2024-01-01 12:07:33' ts "
-        "union all select 2, TIMESTAMP '2024-01-01 12:22:48' ts"
-    )
-    # 12:07 -> 12:00 and 12:22 -> 12:15 (15-minute buckets), NOT 12:07 / 12:22 (minute truncation).
-    assert sorted(str(r[0]) for r in con.execute(sql).fetchall()) == [
-        "2024-01-01 12:00:00",
-        "2024-01-01 12:15:00",
-    ]
-
-    # The timeframe still round-trips through export.
-    out = tempfile.mktemp(suffix=".lkml")
-    LookMLAdapter().export(graph, out)
-    exported = Path(out).read_text()
-    assert "minute15" in exported and "minute30" in exported
+    names = {d.name for d in graph.get_model("orders").dimensions if d.type == "time"}
+    assert "created_minute15" not in names and "created_minute30" not in names  # unsupported
+    assert {"created_minute", "created_hour"} <= names  # supported grains still import
 
 
 def test_lookml_native_minute15_name_does_not_widen_grain():

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5463,6 +5463,52 @@ def test_lookml_template_metric_dropped_when_later_file_overwrites_template():
     assert "pop" not in layer.graph.metrics  # the template's orphan did not survive it
 
 
+def test_lookml_normal_view_graph_metric_dropped_when_model_overwritten():
+    """A NORMAL view's graph metric must go when a later file overwrites its model without it.
+
+    A period_over_period on a plain (non-template) view auto-registers graph metric `pop`. The
+    project-level LookML load runs before the per-file scan, so a later Python model of the same
+    name replaces the model whose measure/time dimension `pop` needs -- but `pop` carries no
+    template marker, so it lingered and `compile(["pop"])` failed with "No models found". The
+    parser stamps every LookML graph metric with its owner, so the load drops it here; when the
+    model is NOT overwritten the metric survives.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    view = """view: orders {
+  sql_table_name: real_orders ;;
+  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }
+  dimension_group: created { type: time  timeframes: [date]  sql: ${TABLE}.created ;; }
+  measure: revenue { type: sum  sql: ${TABLE}.amount ;; }
+  measure: pop { type: period_over_period  based_on: revenue  based_on_time: created_date  period: year }
+}
+"""
+
+    # Overwritten by a later Python model that does not define `pop` -> the orphan is dropped.
+    overwritten = Path(tempfile.mkdtemp())
+    (overwritten / "orders.view.lkml").write_text(view)
+    (overwritten / "zz_native.py").write_text(
+        "from sidemantic import Dimension, Metric, Model\n"
+        'model = Model(name="orders", table="py_orders", primary_key="id",\n'
+        '              dimensions=[Dimension(name="id", type="numeric", sql="id")],\n'
+        '              metrics=[Metric(name="cnt", agg="count", sql="id")])\n'
+    )
+    layer = SemanticLayer()
+    load_from_directory(layer, overwritten, strict=False)
+    assert layer.graph.models["orders"].table == "py_orders"  # the Python model won
+    assert "pop" not in layer.graph.metrics  # its orphan did not survive
+
+    # Not overwritten: the metric is a normal, working graph metric and must be kept.
+    intact = Path(tempfile.mkdtemp())
+    (intact / "orders.view.lkml").write_text(view)
+    layer = SemanticLayer()
+    load_from_directory(layer, intact, strict=False)
+    assert "pop" in layer.graph.metrics
+
+
 def test_lookml_included_view_does_not_extend_unincluded_parent():
     """An included view must not inherit fields from a parent no model include reaches.
 
@@ -5948,6 +5994,42 @@ def test_lookml_project_parse_resolves_view_with_several_archived_copies():
     (directory / "views" / "o.view.lkml").write_text(view % "real_orders")
 
     assert LookMLAdapter().parse(str(directory)).get_model("orders").table == "real_orders"
+
+
+def test_lookml_project_parse_skips_duplicate_views_no_model_includes():
+    """Several archived copies of a view that NO model include reaches must not fail the load.
+
+    When scoping is active, a duplicate the includes can distinguish resolves to the included copy.
+    But two archived copies with no included rival used to install both and raise
+    "Model X already exists" -- failing a valid project over views it never selects. Skip them
+    instead; a lone unincluded view (no rival) still loads, so only genuinely-ambiguous dead
+    copies are dropped. A real duplicate (both included, or scoping off) still surfaces.
+    """
+    import tempfile
+
+    view = "view: %s {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+
+    directory = Path(tempfile.mkdtemp())
+    for name in ("views", "archive1", "archive2"):
+        (directory / name).mkdir()
+    (directory / "m.model.lkml").write_text('include: "/views/orders.view.lkml"\n')
+    (directory / "views" / "orders.view.lkml").write_text(view % ("orders", "real_orders"))
+    # Two archived copies of `legacy`; no model include reaches either.
+    (directory / "archive1" / "legacy.view.lkml").write_text(view % ("legacy", "legacy_v1"))
+    (directory / "archive2" / "legacy.view.lkml").write_text(view % ("legacy", "legacy_v2"))
+
+    graph = LookMLAdapter().parse(str(directory))  # must not raise
+    assert graph.get_model("orders").table == "real_orders"
+    assert "legacy" not in graph.models  # unreachable dead copies dropped, not installed
+
+    # One of the copies IS included: it wins, the other is ignored (unchanged behavior).
+    scoped = Path(tempfile.mkdtemp())
+    (scoped / "views").mkdir()
+    (scoped / "archive").mkdir()
+    (scoped / "m.model.lkml").write_text('include: "/views/*.view.lkml"\n')
+    (scoped / "views" / "legacy.view.lkml").write_text(view % ("legacy", "live_legacy"))
+    (scoped / "archive" / "legacy.view.lkml").write_text(view % ("legacy", "dead_legacy"))
+    assert LookMLAdapter().parse(str(scoped)).get_model("legacy").table == "live_legacy"
 
 
 def test_lookml_include_scoping_follows_closure_from_model_files():

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -4286,6 +4286,54 @@ view: v {
     assert {"created_second", "created_date"} <= names  # supported grains still import
 
 
+def test_lookml_preserved_unsupported_timeframe_round_trips_as_standalone():
+    """A dim preserving an unsupported timeframe exports as a standalone dim, not a lost group tf.
+
+    A dimension_group `timeframes: [minute15]` is dropped on re-import (unsupported), so a dimension
+    carrying meta['lookml_timeframe']='minute15' must export through the standalone collision form
+    (a plain N-minute bucket) so it survives the round-trip. Supported timeframes sharing the base
+    still form the group.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="events",
+            table="events",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="created_date",
+                    type="time",
+                    granularity="day",
+                    sql="{model}.created_at",
+                    meta={"lookml_timeframe": "date"},
+                ),
+                Dimension(
+                    name="created_minute15",
+                    type="time",
+                    granularity="minute",
+                    sql="{model}.created_at",
+                    meta={"lookml_timeframe": "minute15"},
+                ),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    text = open(out).read()
+    assert "[minute15]" not in text  # never emitted as an unimportable group timeframe list
+    assert "dimension: created_minute15" in text  # emitted as a standalone dimension instead
+    names = {d.name for d in LookMLAdapter().parse(Path(out)).get_model("events").dimensions}
+    # Both survive the round-trip: the supported grain via the group, the bucket via a standalone.
+    assert {"created_date", "created_minute15"} <= names
+
+
 def test_lookml_dimension_group_leading_unsupported_timeframe_resolves_ref_base_sql():
     """A group whose FIRST timeframe is unsupported must still resolve a ${ref} in its base sql.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -4830,6 +4830,59 @@ def test_lookml_collision_time_dim_multiword_timeframe_suffix_recovered():
         assert grains == {"started_date": "day", "started_time_of_day": "hour"}
 
 
+def test_lookml_collision_time_of_day_recovers_timeframe_meta_and_survives_sibling_drop():
+    """A collision-exported `time_of_day` standalone must recover its timeframe into meta.
+
+    time_of_day has no finer SQL form -- its collision export is a PLAIN hour DATE_TRUNC named
+    `*_time_of_day`. On import the recovery guard must still store `lookml_timeframe=time_of_day`
+    (it was wrongly grouped with the exact-form minute-bucket / sub-second timeframes and dropped).
+    Without the meta, a later export WITHOUT a colliding sibling loses the timeframe and renames the
+    field to `*_hour`. This differs from the multiword test above, where the collision itself masks
+    the loss via name preservation.
+    """
+    import re
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    adapter = LookMLAdapter()
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="started", type="time", granularity="hour", sql="a", meta={"lookml_timeframe": "time_of_day"}
+                ),
+                Dimension(name="started_time_of_day", type="time", granularity="hour", sql="b"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    adapter.export(graph, out)
+    reimported = adapter.parse(Path(out)).get_model("ev")
+    tf = {d.name: (d.meta or {}).get("lookml_timeframe") for d in reimported.dimensions}
+    assert tf.get("started_time_of_day") == "time_of_day", tf  # recovered, not dropped
+
+    # Drop the colliding sibling so the time_of_day field exports ALONE: it must keep its name,
+    # NOT fall back to the hour timeframe and rename to started_hour.
+    reimported.dimensions = [d for d in reimported.dimensions if d.name != "started_hour"]
+    solo = SemanticGraph()
+    solo.add_model(reimported)
+    out2 = tempfile.mktemp(suffix=".lkml")
+    adapter.export(solo, out2)
+    text2 = open(out2).read()
+    names = re.findall(r"\n  dimension: (\w+) \{", text2)
+    for base, tfs in re.findall(r"dimension_group: (\w+) \{[^}]*?timeframes:\s*\[([^\]]*)\]", text2, re.S):
+        names += [f"{base}_{x.strip()}" for x in tfs.split(",")]
+    assert "started_time_of_day" in names, names
+    assert "started_hour" not in names, names  # no bogus rename
+
+
 def test_lookml_same_prefix_time_dims_roundtrip_names_and_grains_losslessly():
     """Collision time dims must round-trip with EXACT names AND granularities.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5991,6 +5991,67 @@ def test_lookml_every_model_file_seeds_include_scoping():
     assert LookMLAdapter().parse(str(unscoped)).get_model("orders").table == "REFINED"
 
 
+def test_lookml_shared_explore_sidecar_checked_against_one_model_scope(caplog):
+    """An explore in a sidecar two models share resolves within ONE model, not their union.
+
+    Giving a shared sidecar the combined view set let `explore: orders { join: customers }` attach
+    when an orders model included only `orders` and a customers model only `customers` -- a pair no
+    single LookML model can see -- wiring queries to an out-of-scope table. Base view and joins are
+    now checked against the same model's scope.
+    """
+    import logging
+    import tempfile
+
+    view = "view: %s {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    sidecar = 'include: "/views/shared.explore.lkml"\n'
+    join = (
+        "explore: orders {\n  join: customers { sql_on: ${orders.id} = ${customers.id} ;; "
+        "relationship: many_to_one }\n}\n"
+    )
+
+    def relationships(*models):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "views").mkdir()
+        for name, include in models:
+            (directory / f"{name}.model.lkml").write_text(include)
+        for name in ("orders", "customers"):
+            (directory / "views" / f"{name}.view.lkml").write_text(view % (name, f"real_{name}"))
+        (directory / "views" / "shared.explore.lkml").write_text(join)
+        graph = LookMLAdapter().parse(str(directory))
+        return [r.name for r in (graph.get_model("orders").relationships or [])]
+
+    # Neither model sees both views: the join belongs to no model.
+    assert (
+        relationships(
+            ("orders", 'include: "/views/orders.view.lkml"\n' + sidecar),
+            ("customers", 'include: "/views/customers.view.lkml"\n' + sidecar),
+        )
+        == []
+    )
+
+    # One model seeing both still wires it.
+    assert relationships(("both", 'include: "/views/*.view.lkml"\n' + sidecar)) == ["customers"]
+
+    # Two models that both see everything agree: no divergence to report.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="sidemantic.adapters.lookml"):
+        wired = relationships(
+            ("a", 'include: "/views/*.view.lkml"\n' + sidecar), ("b", 'include: "/views/*.view.lkml"\n' + sidecar)
+        )
+    assert wired == ["customers"]
+    assert "only some of the models" not in caplog.text
+
+    # One model has the target and another does not: kept for the model that does, and reported.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="sidemantic.adapters.lookml"):
+        wired = relationships(
+            ("a", 'include: "/views/*.view.lkml"\n' + sidecar),
+            ("b", 'include: "/views/orders.view.lkml"\n' + sidecar),
+        )
+    assert wired == ["customers"]
+    assert "only some of the models" in caplog.text
+
+
 def test_lookml_included_explore_sidecar_inherits_model_scope():
     """An explore sidecar included by a model must be scoped like the model file itself.
 
@@ -6031,16 +6092,16 @@ def test_lookml_included_explore_sidecar_inherits_model_scope():
         "customers"
     ]
 
-    # A sidecar reached by two models sees the union of their scopes.
+    # A sidecar two models share is checked against ONE model's scope, never their combined views:
+    # neither model below sees both `orders` and `customers`, so the join belongs to no model. See
+    # test_lookml_shared_explore_sidecar_checked_against_one_model_scope for the full contract.
     shared = Path(tempfile.mkdtemp())
     (shared / "a.model.lkml").write_text('include: "orders.view.lkml"\ninclude: "shared.explore.lkml"\n')
     (shared / "b.model.lkml").write_text('include: "customers.view.lkml"\ninclude: "shared.explore.lkml"\n')
     (shared / "orders.view.lkml").write_text(view % ("orders", "real_orders"))
     (shared / "customers.view.lkml").write_text(view % ("customers", "real_customers"))
     (shared / "shared.explore.lkml").write_text(join)
-    assert [r.name for r in (LookMLAdapter().parse(str(shared)).get_model("orders").relationships or [])] == [
-        "customers"
-    ]
+    assert [r.name for r in (LookMLAdapter().parse(str(shared)).get_model("orders").relationships or [])] == []
 
 
 def test_lookml_explore_joins_scoped_to_included_views():

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5327,6 +5327,54 @@ def test_lookml_drop_metrics_uses_provenance_marker_not_base_ref():
     assert "pop" not in metrics2
 
 
+def test_lookml_directory_load_keeps_standalone_metric_overwritten_by_template():
+    """A directory load must not lose a standalone metric that shares a template metric's name.
+
+    `all_metrics.update(graph.metrics)` overwrites by name, so if a .lkml template's graph metric
+    landed AFTER a same-named standalone metric, the marked template metric won and the orphan
+    drop popped the name entirely -- silently losing the valid standalone. LookML is now parsed as
+    one project BEFORE the per-file scan, so a standalone always wins; an orphan template metric
+    with no standalone is still dropped.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    template = (
+        "view: tmpl {\n  extension: required\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n"
+        "  dimension: created { type: time  timeframes: [date]  sql: ${TABLE}.created ;; }\n"
+        "  measure: cnt { type: count }\n"
+        "  measure: pop { type: period_over_period  based_on: cnt  period: date  kind: relative_change }\n}\n"
+    )
+    base_model = (
+        "models:\n  - name: orders\n    table: raw_orders\n    primary_key: id\n"
+        "    dimensions:\n      - name: id\n        type: numeric\n        sql: id\n"
+        "    metrics:\n      - name: total\n        agg: sum\n        sql: amount\n"
+    )
+
+    # 'z.lkml' sorts AFTER the metric file -- the overwrite-then-drop ordering.
+    with_standalone = Path(tempfile.mkdtemp())
+    (with_standalone / "z.lkml").write_text(template)
+    (with_standalone / "metrics.yml").write_text(
+        base_model + "metrics:\n  - name: pop\n    type: ratio\n    numerator: orders.total\n"
+        "    denominator: orders.total\n"
+    )
+    layer = SemanticLayer()
+    load_from_directory(layer, with_standalone)
+    assert "tmpl" not in layer.graph.models  # abstract template still dropped
+    assert "pop" in layer.graph.metrics  # standalone survives the template's same-named metric
+    assert layer.graph.metrics["pop"].type == "ratio"  # ...and it IS the standalone
+
+    # With NO standalone, the orphan template metric is still dropped.
+    template_only = Path(tempfile.mkdtemp())
+    (template_only / "z.lkml").write_text(template)
+    (template_only / "m.yml").write_text(base_model)
+    layer2 = SemanticLayer()
+    load_from_directory(layer2, template_only)
+    assert "pop" not in layer2.graph.metrics
+
+
 def test_lookml_dropped_template_metric_dropped_despite_samename_local_measure():
     """A dropped template's graph metric is removed even if a surviving model has a same-named measure.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5515,6 +5515,35 @@ def test_lookml_project_parse_resolves_view_with_several_archived_copies():
     assert LookMLAdapter().parse(str(directory)).get_model("orders").table == "real_orders"
 
 
+def test_lookml_include_scoping_follows_closure_from_model_files():
+    """Includes are a closure SEEDED from model files, not a flat set of every declaration.
+
+    Reachability from a model file is the rule. A refinement reached THROUGH a model-selected view
+    (model -> orders.view -> refine.view) is part of the project and must apply; a stray view
+    file's helper include in a directory no model selects must not switch scoping on at all.
+    """
+    import tempfile
+
+    view = "view: %s {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+
+    # Reachable through the selected view: the nested refinement applies.
+    nested = Path(tempfile.mkdtemp())
+    (nested / "views").mkdir()
+    (nested / "m.model.lkml").write_text('include: "/views/orders.view.lkml"\n')
+    (nested / "views" / "orders.view.lkml").write_text(
+        'include: "refine.view.lkml"\n' + (view % ("orders", "real_orders"))
+    )
+    (nested / "views" / "refine.view.lkml").write_text("view: +orders {\n  sql_table_name: REFINED ;;\n}\n")
+    assert LookMLAdapter().parse(str(nested)).get_model("orders").table == "REFINED"
+
+    # NOT reachable from any model (there is none): scoping stays off entirely.
+    stray = Path(tempfile.mkdtemp())
+    (stray / "helper.view.lkml").write_text(view % ("helper", "h"))
+    (stray / "orders.view.lkml").write_text('include: "helper.view.lkml"\n' + (view % ("orders", "real_orders")))
+    (stray / "ref.view.lkml").write_text("view: +orders {\n  sql_table_name: REFINED ;;\n}\n")
+    assert LookMLAdapter().parse(str(stray)).get_model("orders").table == "REFINED"
+
+
 def test_lookml_only_model_file_includes_activate_scoping():
     """A VIEW file's helper include must not activate project-wide include scoping.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6200,6 +6200,36 @@ view: +child {
     assert a_field is not None and a_field.label == "Renamed A"  # supported-parent refinement seeds
 
 
+def test_lookml_refinement_made_unsupported_parent_not_seeded():
+    """A parent turned unsupported by an EARLIER refinement is skipped when seeding a later one.
+
+    `view: +pdt_base` turns pdt_base into an unsupported derived table; a later `view: +child`
+    refinement of a pdt_base-only field must not seed it (the loader drops pdt_base, so the field
+    would query the child's real table). Only the pre-refinement snapshot was consulted before."""
+    graph = _parse_lkml(
+        """
+view: pdt_base {
+  sql_table_name: pdt_t ;;
+  dimension: pdt_only { type: string  sql: ${TABLE}.pdt_only ;; }
+}
+view: +pdt_base {
+  derived_table: { persist_for: "24 hours" }
+}
+view: child {
+  extends: [pdt_base]
+  sql_table_name: child_t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+}
+view: +child {
+  dimension: pdt_only { label: "The PDT field" }
+}
+"""
+    )
+    dims = {d.name for d in graph.get_model("child").dimensions}
+    assert "pdt_only" not in dims  # not seeded from the refinement-made-unsupported parent
+    assert "id" in dims
+
+
 def test_lookml_extends_parent_required_in_all_model_scopes(caplog):
     """A parent only SOME models reaching the child include must not be inherited, and it warns.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5504,6 +5504,86 @@ def test_lookml_included_view_does_not_extend_unincluded_parent():
     assert {"secret", "leaked"} <= ({d.name for d in model.dimensions} | {m.name for m in model.metrics})
 
 
+def test_lookml_refinements_merge_in_include_order_not_pathname_order():
+    """Refinements follow the model's include order; the last-included one wins.
+
+    Looker documents that refinements leverage include order, but the tree walk is sorted by
+    pathname (for determinism), so a model including z_ref then a_ref applied a_ref FIRST and let
+    z_ref win -- leaving the view pointed at the wrong table. Include order now drives the merge,
+    and the sorted walk still decides anything the includes do not order.
+    """
+    import tempfile
+
+    base = "view: orders {\n  sql_table_name: real_orders ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+
+    def refinement(table):
+        return f"view: +orders {{\n  sql_table_name: {table} ;;\n}}\n"
+
+    def table(model_text, files):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "views").mkdir()
+        (directory / "m.model.lkml").write_text(model_text)
+        (directory / "views" / "orders.view.lkml").write_text(base)
+        for name, content in files.items():
+            (directory / "views" / f"{name}.view.lkml").write_text(content)
+        return LookMLAdapter().parse(str(directory)).get_model("orders").table
+
+    refs = {"z_ref": refinement("from_z"), "a_ref": refinement("from_a")}
+
+    # Include order wins over pathname order, in both directions.
+    assert (
+        table(
+            'include: "/views/orders.view.lkml"\ninclude: "/views/z_ref.view.lkml"\ninclude: "/views/a_ref.view.lkml"\n',
+            refs,
+        )
+        == "from_a"
+    )
+    assert (
+        table(
+            'include: "/views/orders.view.lkml"\ninclude: "/views/a_ref.view.lkml"\ninclude: "/views/z_ref.view.lkml"\n',
+            refs,
+        )
+        == "from_z"
+    )
+
+    # A glob cannot express an order, so its matches stay sorted -- the load is deterministic.
+    assert table('include: "/views/*.view.lkml"\n', refs) == "from_z"
+
+    # Two refinements in ONE file keep their in-file order.
+    assert (
+        table(
+            'include: "/views/orders.view.lkml"\ninclude: "/views/multi.view.lkml"\n',
+            {"multi": refinement("from_first") + refinement("from_second")},
+        )
+        == "from_second"
+    )
+
+    # An included file's refinement lands BEFORE the includer's own: include: brings that content
+    # in where it is written, above the includer's definitions.
+    nested = Path(tempfile.mkdtemp())
+    (nested / "views").mkdir()
+    (nested / "m.model.lkml").write_text('include: "/views/orders.view.lkml"\ninclude: "/views/z_ref.view.lkml"\n')
+    (nested / "views" / "orders.view.lkml").write_text(base)
+    (nested / "views" / "z_ref.view.lkml").write_text('include: "/views/a_ref.view.lkml"\n' + refinement("from_z"))
+    (nested / "views" / "a_ref.view.lkml").write_text(refinement("from_a"))
+    assert LookMLAdapter().parse(str(nested)).get_model("orders").table == "from_z"
+
+    # A circular include must not hang the ordered walk.
+    circular = Path(tempfile.mkdtemp())
+    (circular / "views").mkdir()
+    (circular / "m.model.lkml").write_text('include: "/views/x.view.lkml"\n')
+    (circular / "views" / "x.view.lkml").write_text('include: "/views/y.view.lkml"\n' + base)
+    (circular / "views" / "y.view.lkml").write_text('include: "/views/x.view.lkml"\n' + refinement("from_y"))
+    assert LookMLAdapter().parse(str(circular)).get_model("orders").table == "from_y"
+
+    # With no include scope at all, the deterministic sorted order still applies.
+    plain = Path(tempfile.mkdtemp())
+    (plain / "orders.view.lkml").write_text(base)
+    (plain / "a_ref.view.lkml").write_text(refinement("from_a"))
+    (plain / "z_ref.view.lkml").write_text(refinement("from_z"))
+    assert LookMLAdapter().parse(str(plain)).get_model("orders").table == "from_z"
+
+
 def test_lookml_refinement_selected_by_only_some_models_warns(caplog):
     """A refinement only SOME models include is ambiguous and must be surfaced, not silent.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5960,6 +5960,48 @@ def test_lookml_extends_parent_scoped_per_model_not_project_wide():
     assert fields(("a", "/views/orders.view.lkml"), ("b", "/views/*.view.lkml")) == {"id"}
 
 
+def test_lookml_refinement_extends_is_additive():
+    """A refinement's `extends` is APPENDED to the base's chain, not replaced (Looker semantics).
+
+    `view: orders { extends: [base_a] }` then `view: +orders { extends: [base_b] }` must inherit
+    from BOTH bases; wholesale replacement dropped every field defined only in base_a.
+    """
+    graph = _parse_lkml(
+        """
+view: base_a { sql_table_name: base_a ;; dimension: a_field { type: string  sql: ${TABLE}.a_field ;; } }
+view: base_b { sql_table_name: base_b ;; dimension: b_field { type: string  sql: ${TABLE}.b_field ;; } }
+view: orders {
+  sql_table_name: orders ;;
+  extends: [base_a]
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+}
+view: +orders {
+  extends: [base_b]
+}
+"""
+    )
+    dims = {d.name for d in graph.get_model("orders").dimensions}
+    assert {"a_field", "b_field", "id"} <= dims  # both bases inherited, base_a not dropped
+
+
+def test_lookml_multi_parent_extends_inherits_all_bases():
+    """A single `extends: [base_a, base_b]` statement inherits from every listed parent."""
+    graph = _parse_lkml(
+        """
+view: base_a { sql_table_name: base_a ;; dimension: a_field { type: string  sql: ${TABLE}.a_field ;; } }
+view: base_b { sql_table_name: base_b ;; measure: b_total { type: sum  sql: ${TABLE}.amount ;; } }
+view: orders {
+  sql_table_name: orders ;;
+  extends: [base_a, base_b]
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+}
+"""
+    )
+    model = graph.get_model("orders")
+    assert {"a_field", "id"} <= {d.name for d in model.dimensions}
+    assert "b_total" in {m.name for m in model.metrics}
+
+
 def test_lookml_extends_parent_required_in_all_model_scopes(caplog):
     """A parent only SOME models reaching the child include must not be inherited, and it warns.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5327,6 +5327,32 @@ def test_lookml_drop_metrics_uses_provenance_marker_not_base_ref():
     assert "pop" not in metrics2
 
 
+def test_lookml_directory_load_non_strict_falls_back_after_project_parse_error():
+    """A single malformed .lkml must not drop every valid sibling in a non-strict load.
+
+    LookML is parsed as one project, so a parse error there covers the whole tree. Non-strict
+    loading must fall back to the per-file scan (loading what it can, warning about the bad file)
+    rather than skipping every .lkml. Strict mode must still raise.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    directory = Path(tempfile.mkdtemp())
+    (directory / "good.lkml").write_text(
+        "view: good {\n  sql_table_name: raw_good ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    )
+    (directory / "bad.lkml").write_text("view: bad { dimension: x { sql: ${TABLE}.x ;; }\n")  # unclosed brace
+
+    layer = SemanticLayer()
+    load_from_directory(layer, directory, strict=False)
+    assert "good" in layer.graph.models  # valid sibling survives the bad file
+
+    with pytest.raises(ValueError):
+        load_from_directory(SemanticLayer(), directory, strict=True)
+
+
 def test_lookml_directory_load_keeps_standalone_metric_overwritten_by_template():
     """A directory load must not lose a standalone metric that shares a template metric's name.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6133,6 +6133,39 @@ view: child {
     assert "id" in dims  # the child keeps its own field
 
 
+def test_lookml_rejected_extends_link_cleared_so_reresolution_does_not_remerge():
+    """A rejected extends link (out-of-scope / unsupported parent) is cleared so a downstream
+    unscoped re-resolution cannot merge the parent's fields back in. A MISSING parent is kept."""
+    from sidemantic.core.inheritance import resolve_model_inheritance
+
+    # Unsupported derived-table parent: extends cleared, so an unscoped re-resolve does not
+    # reintroduce the PDT's fields.
+    graph = _parse_lkml(
+        """
+view: pdt_base {
+  derived_table: { persist_for: "24 hours" }
+  dimension: pdt_only { type: string  sql: ${TABLE}.secret ;; }
+}
+view: child {
+  extends: [pdt_base]
+  sql_table_name: child_t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+}
+"""
+    )
+    child = graph.get_model("child")
+    assert child.extends is None  # rejected link cleared
+    reresolved = resolve_model_inheritance(dict(graph.models))
+    assert "pdt_only" not in {d.name for d in reresolved["child"].dimensions}  # no re-merge
+
+    # A genuinely MISSING parent is a real error, so its extends is preserved for validation.
+    graph2 = _parse_lkml(
+        "view: orphan { sql_table_name: t ;; extends: [nonexistent]  "
+        "dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } }"
+    )
+    assert graph2.get_model("orphan").extends == "nonexistent"
+
+
 def test_lookml_refinement_of_unsupported_parent_field_is_dropped():
     """Refining a field that exists only on an unsupported derived-table parent must not add it.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5504,6 +5504,39 @@ def test_lookml_included_view_does_not_extend_unincluded_parent():
     assert {"secret", "leaked"} <= ({d.name for d in model.dimensions} | {m.name for m in model.metrics})
 
 
+def test_lookml_extends_parent_scoped_per_model_not_project_wide():
+    """A parent selected by ANOTHER model is not in scope for this model's child.
+
+    Checking the parent against the project-wide union of included paths meant that with two
+    models -- A including only orders.view.lkml, B including only base.view.lkml -- `orders`
+    inherited from `base` anyway, exposing fields from another model's include scope. The parent
+    must be visible from the CHILD's own file.
+    """
+    import tempfile
+
+    child = "view: orders {\n  extends: [base]\n  sql_table_name: orders ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+    parent = "view: base {\n  sql_table_name: base_t ;;\n  dimension: secret { sql: ${TABLE}.secret ;; }\n  measure: leaked { type: sum  sql: ${TABLE}.amount ;; }\n}\n"
+
+    def fields(*models):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "views").mkdir()
+        for name, include in models:
+            (directory / f"{name}.model.lkml").write_text(f'include: "{include}"\n')
+        (directory / "views" / "orders.view.lkml").write_text(child)
+        (directory / "views" / "base.view.lkml").write_text(parent)
+        model = LookMLAdapter().parse(str(directory)).get_model("orders")
+        return {d.name for d in model.dimensions} | {m.name for m in model.metrics}
+
+    # Separate scopes: the child's model cannot see the parent -> not inherited.
+    assert fields(("a", "/views/orders.view.lkml"), ("b", "/views/base.view.lkml")) == {"id"}
+
+    # One model selecting both still inherits.
+    assert {"secret", "leaked"} <= fields(("a", "/views/*.view.lkml"))
+
+    # The child's file reached by a model that also selects the parent: union -> inherited.
+    assert {"secret", "leaked"} <= fields(("a", "/views/orders.view.lkml"), ("b", "/views/*.view.lkml"))
+
+
 def test_lookml_abstract_template_conflicting_with_active_model_is_not_skipped():
     """A template whose name collides with an existing model must not silently take the skip path.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5555,6 +5555,21 @@ def test_lookml_normal_view_graph_metric_dropped_when_model_overwritten():
     load_from_directory(layer, intact, strict=False)
     assert "pop" in layer.graph.metrics
 
+    # Overwritten by a model whose same-named metric is MODEL-SCOPED (a normal measure), not a
+    # graph-level metric: it does not replace the orphaned graph metric, so a name-only match would
+    # wrongly keep the broken one. It must still be dropped.
+    same_name = Path(tempfile.mkdtemp())
+    (same_name / "orders.view.lkml").write_text(view)
+    (same_name / "zz_native.py").write_text(
+        "from sidemantic import Dimension, Metric, Model\n"
+        'model = Model(name="orders", table="py_orders", primary_key="id",\n'
+        '              dimensions=[Dimension(name="id", type="numeric", sql="id")],\n'
+        '              metrics=[Metric(name="pop", agg="sum", sql="id")])\n'
+    )
+    layer = SemanticLayer()
+    load_from_directory(layer, same_name, strict=False)
+    assert "pop" not in layer.graph.metrics  # the stale graph-level metric is not rescued by name
+
 
 def test_lookml_included_view_does_not_extend_unincluded_parent():
     """An included view must not inherit fields from a parent no model include reaches.

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5405,6 +5405,43 @@ def test_lookml_parse_raises_on_duplicate_model_in_active_layer():
             LookMLAdapter().parse(path)
 
 
+def test_lookml_project_parse_handles_duplicate_views_and_extensionless_includes():
+    """Two files defining the SAME view must not fail the load, and includes may omit .lkml.
+
+    Parsing the tree as one project means an archived copy of a view alongside the live one hits
+    add_model's "Model X already exists" and fails everything. Includes decide the winner; with no
+    includes it is a deterministic first-wins rather than a crash. LookML also allows the .lkml
+    suffix to be omitted (`include: "/views/*.view"`), which must still resolve on disk -- else the
+    included set is skewed and stale refinements leak back in.
+    """
+    import tempfile
+
+    view = "view: orders {\n  sql_table_name: %s ;;\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+
+    def build(include_pattern, *, duplicate=False, stale_refinement=False):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "views").mkdir()
+        (directory / "archive").mkdir()
+        if include_pattern:
+            (directory / "m.model.lkml").write_text(f'include: "{include_pattern}"\nexplore: orders {{}}\n')
+        (directory / "views" / "orders.view.lkml").write_text(view % "real_orders")
+        if duplicate:
+            (directory / "archive" / "orders.view.lkml").write_text(view % "archived_orders")
+        if stale_refinement:
+            (directory / "archive" / "stale.view.lkml").write_text("view: +orders {\n  sql_table_name: STALE ;;\n}\n")
+        return LookMLAdapter().parse(str(directory)).get_model("orders")
+
+    # A duplicate view no longer fails the load; the INCLUDED copy wins.
+    assert build("/views/*.view.lkml", duplicate=True).table == "real_orders"
+    # Extensionless include patterns still resolve, so the stale refinement stays out.
+    assert build("/views/*.view", stale_refinement=True).table == "real_orders"
+    assert build("/views/orders.view", stale_refinement=True).table == "real_orders"
+    # With NO includes a duplicate is deterministic rather than a crash (no ValueError).
+    assert build(None, duplicate=True).table in {"real_orders", "archived_orders"}
+    # A view no include matches is NEVER dropped -- include scoping only breaks ties.
+    assert build("/nonexistent/*.view.lkml").table == "real_orders"
+
+
 def test_lookml_project_parse_ignores_refinements_from_unincluded_files():
     """A refinement in a file no `include:` reaches must not override a loaded view.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6050,6 +6050,75 @@ view: orders {
     assert "b_total" in {m.name for m in model.metrics}
 
 
+def test_lookml_multi_parent_extends_later_parent_overrides_earlier():
+    """For a conflicting field, a LATER-listed extends parent wins (Looker precedence).
+
+    child extends: [base_a, base_b] with `amount` in both -> base_b's amount. The child's OWN
+    definition still wins over any parent.
+    """
+    graph = _parse_lkml(
+        """
+view: base_a { sql_table_name: base_a ;; dimension: amount { type: number  sql: ${TABLE}.a_amount ;; } }
+view: base_b { sql_table_name: base_b ;; dimension: amount { type: number  sql: ${TABLE}.b_amount ;; } }
+view: child {
+  sql_table_name: child ;;
+  extends: [base_a, base_b]
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+}
+"""
+    )
+    assert "b_amount" in graph.get_model("child").get_dimension("amount").sql  # later parent wins
+
+    graph2 = _parse_lkml(
+        """
+view: base_a { sql_table_name: base_a ;; dimension: amount { type: number  sql: ${TABLE}.a_amount ;; } }
+view: base_b { sql_table_name: base_b ;; dimension: amount { type: number  sql: ${TABLE}.b_amount ;; } }
+view: child {
+  sql_table_name: child ;;
+  extends: [base_a, base_b]
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: amount { type: number  sql: ${TABLE}.child_amount ;; }
+}
+"""
+    )
+    assert "child_amount" in graph2.get_model("child").get_dimension("amount").sql  # child's own wins
+
+
+def test_lookml_export_table_backed_extension_required_reemits_marker():
+    """A table-backed `extension: required` base re-emits BOTH extension: required and its table.
+
+    Keying the export off `not model.table` dropped the abstract marker for a base with a
+    sql_table_name, so a round-trip registered it as a queryable view. Key off the parser-owned
+    lookml_template marker instead; re-import marks it a template again.
+    """
+    import tempfile
+
+    graph = _parse_lkml(
+        """
+view: base {
+  extension: required
+  sql_table_name: real_base ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+}
+view: child {
+  extends: [base]
+  sql_table_name: child_t ;;
+  dimension: cid { primary_key: yes  type: number  sql: ${TABLE}.cid ;; }
+}
+"""
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    text = open(out).read()
+    base_block = text[text.index("view: base") :]
+    base_block = base_block[: base_block.index("view: child")] if "view: child" in base_block else base_block
+    assert "extension: required" in base_block  # abstract marker re-emitted
+    assert "sql_table_name: real_base" in base_block  # its table re-emitted too
+    # Re-import marks the base a template again.
+    reimported = LookMLAdapter().parse(Path(out)).get_model("base")
+    assert (reimported.meta or {}).get("lookml_template")
+
+
 def test_lookml_multi_parent_extends_copies_segments_and_seeds_refinements():
     """Extra extends parents contribute segments too, and a refinement of a non-first-parent field
     seeds from the real inherited definition (not a bare categorical re-parse)."""

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5359,6 +5359,44 @@ def test_lookml_parse_raises_on_duplicate_model_in_active_layer():
             LookMLAdapter().parse(path)
 
 
+def test_lookml_refinement_deep_merges_partial_field_properties():
+    """A refinement that sets ONE property of a field must not clobber the field's other props.
+
+    `view: +base { dimension: id { label: "ID" } }` only sets a label, so the base field's sql /
+    type / primary_key must survive. Merging the PARSED models replaced the field wholesale (the
+    parser defaults a bare `dimension:` to a categorical with no sql), so the model silently fell
+    back to a default column. Applies to a refinement in the SAME file or another one.
+    """
+    import tempfile
+
+    base_view = (
+        "view: base {\n  sql_table_name: t ;;\n"
+        "  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }\n"
+        "  dimension: amount { type: number  sql: ${TABLE}.amount ;; }\n}\n"
+    )
+    refinement = 'view: +base {\n  dimension: id { label: "The ID" }\n}\n'
+
+    def check(model):
+        by_name = {d.name: d for d in model.dimensions}
+        assert by_name["id"].sql == "{model}.id"  # base sql survived
+        assert by_name["id"].type == "numeric"  # base type survived
+        assert by_name["id"].label == "The ID"  # refinement applied
+        assert model.primary_key == "id"  # base primary_key survived
+        assert by_name["amount"].sql == "{model}.amount"  # untouched field intact
+
+    # Same file.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".lkml", delete=False) as f:
+        f.write(base_view + refinement)
+        f.flush()
+        check(LookMLAdapter().parse(Path(f.name)).get_model("base"))
+
+    # Across files (the CLI project-load path).
+    directory = Path(tempfile.mkdtemp())
+    (directory / "a.lkml").write_text(base_view)
+    (directory / "b.lkml").write_text(refinement)
+    check(LookMLAdapter().parse(str(directory)).get_model("base"))
+
+
 def test_lookml_project_parse_merges_refinements_deterministically():
     """Refinements merge in sorted file order, not filesystem traversal order.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5504,6 +5504,55 @@ def test_lookml_included_view_does_not_extend_unincluded_parent():
     assert {"secret", "leaked"} <= ({d.name for d in model.dimensions} | {m.name for m in model.metrics})
 
 
+def test_lookml_implicit_dimension_group_resolves_in_field_references():
+    """A ${created_date} reference to a no-sql dimension_group reads the implicit `<group>` column.
+
+    Resolving the group's implicit column on the generated Dimension objects alone was too late:
+    the lookup that expands ${ref}s in other fields is built first, so a measure or dimension over
+    the timeframe still queried the generated field name -- a column that does not exist -- even
+    though a direct query of the timeframe was correct.
+    """
+    import tempfile
+
+    directory = Path(tempfile.mkdtemp())
+    (directory / "orders.view.lkml").write_text(
+        """view: orders {
+  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [date, week]
+  }
+  measure: cd { type: count_distinct  sql: ${created_date} ;; }
+  dimension: is_new { type: yesno  sql: ${created_date} > '2020-01-01' ;; }
+}
+"""
+    )
+    model = LookMLAdapter().parse(str(directory / "orders.view.lkml")).get_model("orders")
+    fields = {f.name: f.sql for f in [*model.dimensions, *model.metrics]}
+
+    assert fields["cd"] == "({model}.created)"
+    assert fields["is_new"] == "({model}.created) > '2020-01-01'"
+    # Nothing references the generated field name, which is not a real column.
+    assert not [name for name, sql in fields.items() if sql and "created_date" in sql], fields
+
+    # An explicit sql: on the group still wins for references.
+    explicit = Path(tempfile.mkdtemp())
+    (explicit / "orders.view.lkml").write_text(
+        """view: orders {
+  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [date]
+    sql: ${TABLE}.ts ;;
+  }
+  measure: cd { type: count_distinct  sql: ${created_date} ;; }
+}
+"""
+    )
+    referring = LookMLAdapter().parse(str(explicit / "orders.view.lkml")).get_model("orders")
+    assert [m.sql for m in referring.metrics if m.name == "cd"] == ["({model}.ts)"]
+
+
 def test_lookml_implicit_dimension_group_compiles_against_group_column():
     """A dimension_group without `sql` reads Looker's implicit `<group>` column.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6233,6 +6233,50 @@ view: child {
     assert "id" in dims  # the child keeps its own field
 
 
+def test_lookml_own_unsupported_derived_table_not_registered_despite_inherited_table():
+    """A view that declares its OWN unsupported derived_table must be skipped even if it inherits a
+    table from a table-backed extends parent.
+
+    resolve_model_inheritance() copies the parent's sql_table_name onto the child before the marker
+    pass runs. The unsupported-derived-table marker was gated on `table`/`sql` both being None, so
+    the child kept the inherited table, missed the `lookml_template` marker, and load_from_directory
+    exposed it as a query against the parent's PHYSICAL table -- even though Looker would use the
+    derived-table source, which this adapter cannot represent. A view whose OWN source is an
+    unsupported derived table must be marked regardless of the inherited table.
+    """
+    import tempfile
+
+    from sidemantic import SemanticLayer
+    from sidemantic.loaders import load_from_directory
+
+    directory = Path(tempfile.mkdtemp())
+    (directory / "views.view.lkml").write_text(
+        "view: base_tbl { sql_table_name: real_base ;; "
+        "dimension: id { primary_key: yes  sql: ${TABLE}.id ;; } } "
+        'view: ndt { extends: [base_tbl]  derived_table: { persist_for: "1 hour" } '
+        "dimension: name { type: string  sql: ${TABLE}.name ;; } }"
+    )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, directory)
+    # The unsupported derived-table view is skipped, not registered against the inherited real_base.
+    assert "ndt" not in layer.graph.models
+    assert "base_tbl" in layer.graph.models  # the ordinary table-backed base still registers
+
+    # A view that INHERITS an unsupported derived table but OVERRIDES it with its own table stays
+    # queryable -- the marker must not over-reach to concrete children.
+    directory2 = Path(tempfile.mkdtemp())
+    (directory2 / "views.view.lkml").write_text(
+        'view: pdt_base { derived_table: { persist_for: "24 hours" } '
+        "dimension: pdt_only { type: string  sql: ${TABLE}.secret ;; } } "
+        "view: child { extends: [pdt_base]  sql_table_name: child_t ;; "
+        "dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } }"
+    )
+    layer2 = SemanticLayer()
+    load_from_directory(layer2, directory2)
+    assert layer2.graph.get_model("child").table == "child_t"
+
+
 def test_lookml_rejected_extends_link_cleared_so_reresolution_does_not_remerge():
     """A rejected extends link (out-of-scope / unsupported parent) is cleared so a downstream
     unscoped re-resolution cannot merge the parent's fields back in. A MISSING parent is kept."""

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5327,6 +5327,52 @@ def test_lookml_drop_metrics_uses_provenance_marker_not_base_ref():
     assert "pop" not in metrics2
 
 
+def test_lookml_abstract_template_conflicting_with_active_model_is_not_skipped():
+    """A template whose name collides with an existing model must not silently take the skip path.
+
+    Skipping tableless templates is right in general, but when the active layer ALREADY defines
+    that name the parsed definition was dropped and the pre-existing model silently left in place.
+    Such a name must reach add_model so the conflict surfaces. With no collision the template is
+    still skipped and the concrete child registers.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model, SemanticLayer
+
+    template = "view: base {\n  extension: required\n  dimension: id { primary_key: yes  sql: ${TABLE}.id ;; }\n}\n"
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".lkml", delete=False) as f:
+        f.write(template)
+        f.flush()
+        collide_path = Path(f.name)
+
+    layer = SemanticLayer()
+    layer.add_model(
+        Model(
+            name="base",
+            table="manual_base",
+            primary_key="id",
+            dimensions=[Dimension(name="id", type="numeric", sql="id")],
+        )
+    )
+    # Raises rather than silently keeping manual_base (the exact error depends on which
+    # validation fires first; the point is it is surfaced, not swallowed).
+    with pytest.raises(Exception):
+        with layer:
+            LookMLAdapter().parse(collide_path)
+
+    # No collision: the template is still skipped and the concrete child registers.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".lkml", delete=False) as f:
+        f.write(template + "view: orders {\n  extends: [base]\n  sql_table_name: raw_orders ;;\n}\n")
+        f.flush()
+        ok_path = Path(f.name)
+    clean = SemanticLayer()
+    with clean:
+        LookMLAdapter().parse(ok_path)
+    assert "base" not in clean.graph.models
+    assert clean.graph.get_model("orders").table == "raw_orders"
+
+
 def test_lookml_parse_raises_on_duplicate_model_in_active_layer():
     """A model the active layer already defines is a conflict -- deferral must not hide it.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6108,6 +6108,40 @@ view: child {
     assert "a_field" in dims  # the supported parent still contributes
 
 
+def test_lookml_refinement_of_unsupported_parent_field_is_dropped():
+    """Refining a field that exists only on an unsupported derived-table parent must not add it.
+
+    Seeding skips the unsupported parent, but the refinement's bare field would still be added as an
+    own field querying a table that never gets registered, so it is dropped entirely. A refinement
+    of a SUPPORTED-parent field, and a genuinely new field, are unaffected.
+    """
+    graph = _parse_lkml(
+        """
+view: base_a { sql_table_name: base_a ;; dimension: a_field { type: string  sql: ${TABLE}.a_field ;; } }
+view: pdt_base {
+  derived_table: { persist_for: "24 hours" }
+  dimension: pdt_only { type: string  sql: ${TABLE}.pdt_only ;; }
+}
+view: child {
+  sql_table_name: child ;;
+  extends: [base_a, pdt_base]
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+}
+view: +child {
+  dimension: pdt_only { label: "The PDT field" }
+  dimension: a_field { label: "Renamed A" }
+  dimension: brand_new { type: string  sql: ${TABLE}.brand_new ;; }
+}
+"""
+    )
+    model = graph.get_model("child")
+    dims = {d.name for d in model.dimensions}
+    assert "pdt_only" not in dims  # refinement of an unsupported-parent-only field is dropped
+    assert "brand_new" in dims  # a genuinely new refinement field is still added
+    a_field = model.get_dimension("a_field")
+    assert a_field is not None and a_field.label == "Renamed A"  # supported-parent refinement seeds
+
+
 def test_lookml_extends_parent_required_in_all_model_scopes(caplog):
     """A parent only SOME models reaching the child include must not be inherited, and it warns.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -4830,6 +4830,51 @@ def test_lookml_collision_time_dim_multiword_timeframe_suffix_recovered():
         assert grains == {"started_date": "day", "started_time_of_day": "hour"}
 
 
+def test_lookml_time_dims_grouped_by_effective_sql_not_explicit_sql():
+    """Two default-column time dims must not collapse just because both have sql=None.
+
+    `started` and `started_hour` at hour grain with no explicit sql read DIFFERENT columns, but
+    grouping on the raw `sql` field saw None for both and merged them into one dimension_group --
+    emitting a single field bound to the WRONG column and losing the other dim entirely. Group on
+    the EFFECTIVE expression (sql or name). Dims that genuinely share a source still group.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    def roundtrip(*dims):
+        graph = SemanticGraph()
+        graph.add_model(
+            Model(
+                name="ev",
+                table="t",
+                primary_key="id",
+                dimensions=[Dimension(name="id", type="numeric", sql="id"), *dims],
+            )
+        )
+        out = tempfile.mktemp(suffix=".lkml")
+        LookMLAdapter().export(graph, out)
+        reimported = LookMLAdapter().parse(Path(out)).get_model("ev")
+        return {d.name: d.sql for d in reimported.dimensions if d.name != "id"}
+
+    # Both default-column: BOTH must survive, and started_hour must read started_hour.
+    both_default = roundtrip(
+        Dimension(name="started", type="time", granularity="hour"),
+        Dimension(name="started_hour", type="time", granularity="hour"),
+    )
+    assert len(both_default) == 2, both_default
+    assert both_default["started_hour"] == "started_hour", both_default  # not the `started` column
+    assert any("started" in (sql or "") for name, sql in both_default.items() if name != "started_hour")
+
+    # A genuinely shared source still collapses into one dimension_group (unchanged).
+    same_source = roundtrip(
+        Dimension(name="started", type="time", granularity="hour", sql="a"),
+        Dimension(name="started_hour", type="time", granularity="hour", sql="a"),
+    )
+    assert same_source == {"started_hour": "a"}, same_source
+
+
 def test_lookml_collision_time_of_day_recovers_timeframe_meta_and_survives_sibling_drop():
     """A collision-exported `time_of_day` standalone must recover its timeframe into meta.
 

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -5088,6 +5088,63 @@ def test_lookml_broken_tableless_view_surfaces_error_inside_layer_context():
             LookMLAdapter().parse(path)
 
 
+def test_lookml_export_unsupported_derived_table_stays_tableless_on_reimport():
+    """An unsupported derived_table must round-trip as tableless, not gain a physical table.
+
+    _export_view re-emits the (retained) derived_table with no `sql`, so re-import keeps it
+    marked unsupported instead of the implicit-table default assigning `table = <view name>`.
+    """
+    import tempfile
+
+    d = tempfile.mkdtemp()
+    with open(Path(d) / "v.lkml", "w") as f:
+        f.write(
+            'view: pdt { derived_table: { sql_trigger_value: "SELECT max(id) FROM orders" ;;  persist_for: "24 hours" } '
+            "  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } }"
+        )
+    graph = LookMLAdapter().parse(Path(d))
+    assert graph.get_model("pdt").table is None
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    text = open(out).read()
+    assert "derived_table" in text and "sql_trigger_value" in text
+    reimported = LookMLAdapter().parse(Path(out))
+    m = reimported.get_model("pdt")
+    assert m.table is None  # stays tableless, not defaulted to 'pdt'
+    assert (m.meta or {}).get("unsupported_derived_table")
+
+
+def test_lookml_export_abstract_view_stays_tableless_on_reimport():
+    """An abstract (extension: required) base must round-trip as tableless, not gain a table.
+
+    _export_view must re-emit `extension: required` so the re-imported base stays non-queryable
+    instead of the implicit-table default assigning it a physical table named after the view.
+    """
+    import tempfile
+
+    d = tempfile.mkdtemp()
+    with open(Path(d) / "v.lkml", "w") as f:
+        f.write(
+            "view: base { extension: required "
+            "  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } "
+            "  dimension: x { type: number  sql: ${TABLE}.x ;; } } "
+            "view: orders { extends: [base]  dimension: y { type: number  sql: ${TABLE}.y ;; } }"
+        )
+    graph = LookMLAdapter().parse(Path(d))
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    text = open(out).read()
+    import re
+
+    assert "extension: required" in re.search(r"view: base \{.*?\n\}", text, re.S).group(0)  # base abstract
+    # The concrete child INHERITS extension_required in meta but has its own table; it must NOT
+    # re-emit the marker (that would make the usable child abstract on round-trip).
+    assert "extension: required" not in re.search(r"view: orders \{.*?\n\}", text, re.S).group(0)
+    reimported = LookMLAdapter().parse(Path(out))
+    assert reimported.get_model("base").table is None  # base stays tableless, not defaulted
+    assert reimported.get_model("orders").table == "orders"  # child stays usable
+
+
 def test_lookml_abstract_base_does_not_break_directory_load():
     """The CLI path (load_from_directory) must skip the abstract base, not abort the project."""
     import tempfile
@@ -5109,43 +5166,43 @@ def test_lookml_abstract_base_does_not_break_directory_load():
     assert layer.graph.get_model("orders").table == "orders"
 
 
-def test_lookml_drop_metrics_uses_base_resolution_not_identity_or_name():
-    """Orphan-metric drop keys off whether the BASE resolves to a surviving model.
+def test_lookml_drop_metrics_uses_provenance_marker_not_base_ref():
+    """Orphan-metric drop keys off the parser-owned `_lookml_template_metric` PROVENANCE marker.
 
-    NOT object identity (a refinement reconstructs the Metric object) and NOT bare name (a
-    same-named standalone from another file must survive). The orphan is the one whose base
-    measure lives only on dropped models.
+    A metric the LookML parser stamped as coming from a template is dropped; a same-named
+    STANDALONE metric from another file (no marker) is preserved -- regardless of whether the
+    base ref is qualified or unqualified, and regardless of object identity (refinements
+    reconstruct the object but the marker is re-stamped on the graph-registered instance).
     """
     from sidemantic import Metric, Model
     from sidemantic.loaders import _drop_non_registerable_models
 
-    def pop(bm):
+    def pop(bm, template_metric=False):
+        meta = {"_lookml_template_metric": True} if template_metric else None
         return Metric(
-            name="pop", type="time_comparison", base_metric=bm, comparison_type="yoy", calculation="difference"
+            name="pop",
+            type="time_comparison",
+            base_metric=bm,
+            comparison_type="yoy",
+            calculation="difference",
+            meta=meta,
         )
 
-    template = Model(name="base", meta={"lookml_template": True}, metrics=[pop("total")])
-    orders = Model(name="orders", table="orders")
+    template = Model(name="base", meta={"lookml_template": True})
+    orders = Model(name="orders", table="orders", metrics=[Metric(name="total", agg="sum", sql="amt")])
 
-    # A standalone `pop` over a SURVIVING model's measure (qualified ref) must be preserved.
-    standalone = pop("orders.total")
+    # A standalone `pop` (NO provenance marker) is preserved, even with an UNqualified base that
+    # matches a surviving model's `total` -- and even qualified.
+    standalone = pop("total")
     metrics = {"pop": standalone}
     _drop_non_registerable_models({"base": template, "orders": orders}, metrics)
     assert metrics.get("pop") is standalone
 
-    # A refinement reconstructs the template's `pop` (DIFFERENT object than template.metrics[0]),
-    # base `total` resolves to no surviving model -> orphan, must be dropped (identity would miss it).
-    metrics2 = {"pop": pop("total")}
+    # A template's `pop` (marked) is dropped -- unqualified base, same-named surviving `total`
+    # present: the marker (not the base ref) decides.
+    metrics2 = {"pop": pop("total", template_metric=True)}
     _drop_non_registerable_models({"base": template, "orders": orders}, metrics2)
     assert "pop" not in metrics2
-
-    # Even when a SURVIVING model has a same-named `total` measure, the template's `pop` (whose
-    # base `total` is UNQUALIFIED -- pointing at the template's own measure) is still an orphan;
-    # a bare base name existing somewhere must not save it.
-    orders_with_total = Model(name="orders", table="orders", metrics=[Metric(name="total", agg="sum", sql="amt")])
-    metrics3 = {"pop": pop("total")}
-    _drop_non_registerable_models({"base": template, "orders": orders_with_total}, metrics3)
-    assert "pop" not in metrics3
 
 
 def test_lookml_dropped_template_metric_dropped_despite_samename_local_measure():

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -6612,6 +6612,51 @@ def test_lookml_refinement_of_inherited_field_keeps_inherited_definition():
     assert any(d.name == "brand_new" for d in new_model.dimensions)
 
 
+def test_lookml_refinement_seeding_respects_include_scope():
+    """Seeding an inherited field must only pull from parents IN the model's include scope.
+
+    When include scoping is active and an included `orders` extends `base` but the model does NOT
+    include `base.view.lkml`, the extends resolution leaves it unresolved -- but the refinement
+    seeding walked the unscoped raw dicts and copied the archived `base.amount` into `orders`,
+    exposing a parent field Looker would not include. Seeding now gates each extends link the same
+    way; when the parent IS included it still seeds.
+    """
+    import tempfile
+
+    child = "view: orders {\n  extends: [base]\n  sql_table_name: orders ;;\n}\n"
+    base = (
+        "view: base {\n  sql_table_name: base_t ;;\n  dimension: amount { type: number  sql: ${TABLE}.amount ;; }\n}\n"
+    )
+    refine = 'view: +orders {\n  dimension: amount { label: "Amount" }\n}\n'
+
+    def amount(directory):
+        model = LookMLAdapter().parse(str(directory)).get_model("orders")
+        return next((d for d in model.dimensions if d.name == "amount"), None)
+
+    # base is archived (NOT included): the refinement must not seed base's numeric amount.
+    unscoped_parent = Path(tempfile.mkdtemp())
+    (unscoped_parent / "views").mkdir()
+    (unscoped_parent / "archive").mkdir()
+    (unscoped_parent / "orders.model.lkml").write_text(
+        'include: "/views/orders.view.lkml"\ninclude: "/views/refine.view.lkml"\n'
+    )
+    (unscoped_parent / "views" / "orders.view.lkml").write_text(child)
+    (unscoped_parent / "archive" / "base.view.lkml").write_text(base)
+    (unscoped_parent / "views" / "refine.view.lkml").write_text(refine)
+    leaked = amount(unscoped_parent)
+    assert leaked is None or leaked.sql != "{model}.amount"  # base's field is NOT exposed
+
+    # base IS included: the inherited field is seeded (numeric sql kept, label applied).
+    scoped_parent = Path(tempfile.mkdtemp())
+    (scoped_parent / "views").mkdir()
+    (scoped_parent / "orders.model.lkml").write_text('include: "/views/*.view.lkml"\n')
+    (scoped_parent / "views" / "orders.view.lkml").write_text(child)
+    (scoped_parent / "views" / "base.view.lkml").write_text(base)
+    (scoped_parent / "views" / "refine.view.lkml").write_text(refine)
+    kept = amount(scoped_parent)
+    assert kept is not None and kept.type == "numeric" and kept.sql == "{model}.amount" and kept.label == "Amount"
+
+
 def test_lookml_project_parse_merges_refinements_deterministically():
     """Refinements merge in sorted file order, not filesystem traversal order.
 

--- a/tests/adapters/lookml/test_fixtures.py
+++ b/tests/adapters/lookml/test_fixtures.py
@@ -69,7 +69,7 @@ class TestRedshiftAdmin:
         model = self.graph.get_model("redshift_etl_errors")
         assert model.get_dimension("error_time") is not None
         assert model.get_dimension("error_time").type == "time"
-        assert model.get_dimension("error_time").granularity == "hour"
+        assert model.get_dimension("error_time").granularity == "second"
         assert model.get_dimension("error_date") is not None
         assert model.get_dimension("error_date").type == "time"
         assert model.get_dimension("error_date").granularity == "day"
@@ -332,7 +332,7 @@ class TestPyLookMLKitchenSink:
         assert model.get_dimension("created_month") is not None
         assert model.get_dimension("created_year") is not None
         assert model.get_dimension("created_time") is not None
-        assert model.get_dimension("created_time").granularity == "hour"
+        assert model.get_dimension("created_time").granularity == "second"
 
     def test_shipped_time_group(self):
         model = self.graph.get_model("order_items")

--- a/tests/adapters/lookml/test_parsing.py
+++ b/tests/adapters/lookml/test_parsing.py
@@ -119,7 +119,8 @@ def test_lookml_adapter_ecommerce():
     # Test dimension group with multiple timeframes
     created_time = orders.get_dimension("created_time")
     assert created_time is not None
-    assert created_time.granularity == "hour"
+    # Looker's "time" timeframe keeps to-the-second precision.
+    assert created_time.granularity == "second"
 
     created_date = orders.get_dimension("created_date")
     assert created_date is not None

--- a/tests/adapters/test_added_fixture_coverage.py
+++ b/tests/adapters/test_added_fixture_coverage.py
@@ -227,7 +227,8 @@ ADDED_EXPECTED_NO_COMPILE_QUERY_FIXTURES = {
     "tests/fixtures/lookml/ga360_ga_block.view.lkml",
     "tests/fixtures/lookml/lkml_model_all_fields.model.lkml",
     "tests/fixtures/lookml/lkml_parameter_join.model.lkml",
-    "tests/fixtures/lookml/node_lookml_refinement_merging.model.lkml",
+    # node_lookml_refinement_merging now compiles: its `deep_merging` view has a
+    # dimension and (per Looker semantics) defaults its table to the view name.
     "tests/fixtures/lookml/node_lookml_refinement_sequencing.model.lkml",
     "tests/fixtures/lookml/pylookml_aggregate_tables.model.lkml",
     "tests/fixtures/lookml/pylookml_manifest.lkml",

--- a/tests/adapters/test_fixture_functionality_contracts.py
+++ b/tests/adapters/test_fixture_functionality_contracts.py
@@ -147,7 +147,10 @@ NON_EXECUTION_REASON_ALLOWED_ADAPTERS = {
         "RillAdapter",
         "ThoughtSpotAdapter",
     },
-    "source_fragments_without_fields": {"AtScaleSMLAdapter", "MalloyAdapter", "RillAdapter"},
+    # LookML: a fieldless view now gets its implicit "table = view name" default (Looker
+    # behavior), so a refinement-fragment fixture with field-less views is a source fragment
+    # without fields rather than a tableless semantic-only model.
+    "source_fragments_without_fields": {"AtScaleSMLAdapter", "LookMLAdapter", "MalloyAdapter", "RillAdapter"},
     "semantic_only_no_sources": {
         "AtScaleSMLAdapter",
         "HolisticsAdapter",

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -454,3 +454,37 @@ def test_load_from_directory_lenient_does_not_partially_parse_tmdl_project_after
             "message": "simulated project-level failure",
         }
     ]
+
+
+def test_load_from_directory_strips_template_join_after_native_overwrite(tmp_path):
+    """A LookML explore join to an `extension: required` template must be stripped even when a later
+    native model of the same name overwrites the template (so the join does not silently retarget it)."""
+    (tmp_path / "a.model.lkml").write_text(
+        "view: base {\n"
+        "  extension: required\n"
+        "  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }\n"
+        "}\n"
+        "view: orders {\n"
+        "  sql_table_name: orders ;;\n"
+        "  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }\n"
+        "  dimension: ref_col { type: number  sql: ${TABLE}.ref_col ;; }\n"
+        "}\n"
+        "explore: orders {\n"
+        "  join: base { sql_on: ${orders.ref_col} = ${base.id} ;; relationship: many_to_one }\n"
+        "}\n"
+    )
+    (tmp_path / "native.py").write_text(
+        "from sidemantic import Model, Dimension\n"
+        "base = Model(name='base', table='real_base', primary_key='id',\n"
+        "             dimensions=[Dimension(name='id', type='numeric', sql='id')])\n"
+    )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, tmp_path, strict=False)
+
+    orders = layer.graph.models.get("orders")
+    assert orders is not None
+    # The template-defined explore join is stripped; it must not point at the overwriting real model.
+    assert "base" not in {r.name for r in (orders.relationships or [])}
+    # The real model still loads.
+    assert layer.graph.models["base"].table == "real_base"

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -516,3 +516,30 @@ def test_load_from_directory_preserves_native_join_to_overwritten_template_name(
     # The native-authored relationship to the real customer is preserved, not stripped as a template join.
     assert "customer" in {r.name for r in (orders.relationships or [])}
     assert layer.graph.models["customer"].table == "real_customer"
+
+
+def test_load_from_directory_no_fk_inference_to_unincluded_lookml_view(tmp_path):
+    """FK inference must not join to a LookML view outside every model's include closure.
+
+    An archived `customers` view no model includes is kept (so an imperfect include never silently
+    drops a view), but Looker cannot see it, so `orders.customer_id -> customers` must NOT be
+    inferred against it. An INCLUDED customers view is still inferred normally."""
+    (tmp_path / "views").mkdir()
+    (tmp_path / "archive").mkdir()
+    (tmp_path / "orders.model.lkml").write_text('include: "/views/orders.view.lkml"\n')
+    (tmp_path / "views" / "orders.view.lkml").write_text(
+        "view: orders {\n  sql_table_name: orders ;;\n"
+        "  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }\n"
+        "  dimension: customer_id { type: number  sql: ${TABLE}.customer_id ;; }\n}\n"
+    )
+    (tmp_path / "archive" / "customers.view.lkml").write_text(
+        "view: customers { dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; } }\n"
+    )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, tmp_path, strict=False)
+
+    orders = layer.graph.models.get("orders")
+    assert orders is not None
+    # No inferred join to the unincluded archived customers view.
+    assert "customers" not in {r.name for r in (orders.relationships or [])}

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -488,3 +488,31 @@ def test_load_from_directory_strips_template_join_after_native_overwrite(tmp_pat
     assert "base" not in {r.name for r in (orders.relationships or [])}
     # The real model still loads.
     assert layer.graph.models["base"].table == "real_base"
+
+
+def test_load_from_directory_preserves_native_join_to_overwritten_template_name(tmp_path):
+    """A NATIVE relationship authored for the replacement model must survive, only LookML template
+    joins to the overwritten name are stripped."""
+    (tmp_path / "a.model.lkml").write_text(
+        "view: customer {\n"
+        "  extension: required\n"
+        "  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }\n"
+        "}\n"
+    )
+    (tmp_path / "native.py").write_text(
+        "from sidemantic import Model, Dimension, Relationship\n"
+        "customer = Model(name='customer', table='real_customer', primary_key='id',\n"
+        "                 dimensions=[Dimension(name='id', type='numeric', sql='id')])\n"
+        "orders = Model(name='orders', table='orders', primary_key='id',\n"
+        "  dimensions=[Dimension(name='id', type='numeric', sql='id'), Dimension(name='cust_ref', type='numeric', sql='cust_ref')],\n"
+        "  relationships=[Relationship(name='customer', type='many_to_one', foreign_key='cust_ref')])\n"
+    )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, tmp_path, strict=False)
+
+    orders = layer.graph.models.get("orders")
+    assert orders is not None
+    # The native-authored relationship to the real customer is preserved, not stripped as a template join.
+    assert "customer" in {r.name for r in (orders.relationships or [])}
+    assert layer.graph.models["customer"].table == "real_customer"

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -543,3 +543,26 @@ def test_load_from_directory_no_fk_inference_to_unincluded_lookml_view(tmp_path)
     assert orders is not None
     # No inferred join to the unincluded archived customers view.
     assert "customers" not in {r.name for r in (orders.relationships or [])}
+
+
+def test_load_from_directory_hides_extension_required_view_with_table(tmp_path):
+    """An `extension: required` base that declares a sql_table_name is still hidden (not queryable).
+
+    Looker uses such a reusable base only through `extends`, so the loader must not register it as
+    a CLI model even though it has a table. Its child still inherits its fields."""
+    (tmp_path / "m.model.lkml").write_text(
+        'include: "*.view.lkml"\n'
+        "view: base {\n  extension: required\n  sql_table_name: real_base ;;\n"
+        "  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }\n"
+        "  dimension: shared { type: string  sql: ${TABLE}.shared ;; }\n}\n"
+        "view: child {\n  extends: [base]\n  sql_table_name: child_t ;;\n"
+        "  dimension: cid { primary_key: yes  type: number  sql: ${TABLE}.cid ;; }\n}\n"
+    )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, tmp_path, strict=False)
+
+    assert "base" not in layer.graph.models  # abstract base hidden despite its table
+    child = layer.graph.models.get("child")
+    assert child is not None
+    assert child.get_dimension("shared") is not None  # child still inherited the base's fields


### PR DESCRIPTION
## Summary
Part of the LookML adapter correctness series. **Stacked on #243** (base = `fix/lookml-export-aggregations`).

In Looker, a view with no `sql_table_name` and no `derived_table` implicitly queries a table named after the view. The adapter left `table` unset, so importing such a (perfectly valid) view crashed with `ModelValidationError: Model must have a table`.

## Changes
- Default `table` to the view name when there is no `sql_table_name`, no `derived_table`, no `extends`, it is not a refinement (`+view`), and not `extension: required`.
- Regression test (parse + compile).

These exclusions preserve correct behavior for abstract/extended/refinement views, which legitimately have no table of their own.