### PR TITLE
Preserve sub-hour precision for LookML 'time' timeframe

### DIFF
--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -1302,8 +1302,75 @@ class LookMLAdapter(BaseAdapter):
             if sql:
                 sql = sql.replace("${TABLE}", "{model}")
 
+        # Recover the granularity of the collision-export form: a standalone time
+        # dimension we emit as `type: date_time sql: DATE_TRUNC('<grain>', ...)` whose
+        # name carries a LookML timeframe suffix for that grain (e.g. started_date with
+        # DATE_TRUNC('day', ...), started_minute with DATE_TRUNC('minute', ...) -- see
+        # _export_collision_time_dim). Guard tightly so a hand-written DATE_TRUNC dim is
+        # NOT hijacked: the grain must be one sidemantic supports, the name's trailing
+        # `_<suffix>` must be a LookML timeframe mapping to that exact grain, AND the dim
+        # must carry no other properties (the collision form emits only name/type/sql).
+        # This keeps a hand-written `created` (DATE_TRUNC('day', ...)) on the categorical
+        # path (no rename to created_date), preserves a hand-written `created_date` with
+        # `hidden`/`label`/etc. as a plain dimension (props not dropped), and never copies
+        # a dialect grain like 'isoweek' into Dimension.granularity (a validation error).
+        granularity = None
+        recovered_timeframe = None
+        if (
+            dim_type in ("date", "date_time", "datetime", "time")
+            and sql
+            and not (set(dim_def) & self._PRESERVED_DIM_PROPS)
+        ):
+            bucket = self._MINUTE_BUCKET_RE.match(sql)
+            tm = self._DATE_TRUNC_RE.match(sql)
+            if bucket:
+                # A collision-export minute15/minute30 bucket: recover minute grain + the
+                # exact timeframe. KEEP the full bucket expression as the dim's sql (do NOT
+                # reduce to the raw column) so QUERIES bucket every 15/30 minutes; the
+                # generator's DATE_TRUNC('minute', ...) wrap is idempotent on an already
+                # minute-aligned bucket. Re-export detects this bucket to avoid re-wrapping.
+                tf = f"minute{bucket.group(2)}"
+                if name.endswith("_" + tf):
+                    sidemantic_type = "time"
+                    granularity = "minute"
+                    recovered_timeframe = tf
+            elif tm:
+                grain = tm.group(1).lower()
+                if grain in self._SUBSECOND_TF and name.endswith("_" + grain):
+                    # A collision-export sub-second DATE_TRUNC (millisecond/microsecond):
+                    # sidemantic has no such grain, so store the nearest (second) + the
+                    # exact timeframe in meta, KEEPING the sub-second DATE_TRUNC sql so the
+                    # exported precision round-trips (queries run at second, sidemantic's max).
+                    sidemantic_type = "time"
+                    granularity = "second"
+                    recovered_timeframe = grain
+                # Match the LONGEST known timeframe suffix, not just text after the last
+                # underscore -- multi-word timeframes like "time_of_day" must round-trip
+                # (started_time_of_day, not a bogus "day" suffix lookup).
+                elif grain in self._SUPPORTED_GRAINS:
+                    matched_tf = None
+                    for tf, g in self._TIME_GRANULARITY_TIMEFRAMES.items():
+                        if name.endswith("_" + tf) and g == grain and (not matched_tf or len(tf) > len(matched_tf)):
+                            matched_tf = tf
+                    if matched_tf:
+                        sidemantic_type = "time"
+                        granularity = grain
+                        # Only STORE the timeframe when it's an EXACT one-to-one match for the
+                        # grain. An INEXACT suffix (minute15/30, sub-second, time_of_day) on a
+                        # PLAIN DATE_TRUNC does NOT preserve that timeframe's semantics (the
+                        # explicit bucket/subsecond forms, handled above, do) -- recording it
+                        # would make the next export WIDEN a 1-minute dim into a 15-min bucket.
+                        # Recover as a plain grain time dim (no inexact meta) instead.
+                        if matched_tf not in self._INEXACT_NAME_TF:
+                            recovered_timeframe = matched_tf
+
         # Build meta dict from LookML-specific display properties
         meta = {}
+        if recovered_timeframe:
+            # Remember the exact LookML timeframe so the NEXT export strips this suffix
+            # (e.g. _time_of_day) instead of re-deriving a wrong one and renaming the
+            # field -- keeps repeated collision round-trips stable.
+            meta["lookml_timeframe"] = recovered_timeframe
         if dim_def.get("hidden") in ("yes", True):
             meta["hidden"] = True
         if dim_def.get("group_label"):
@@ -1319,6 +1386,7 @@ class LookMLAdapter(BaseAdapter):
             name=name,
             type=sidemantic_type,
             sql=sql,
+            granularity=granularity,
             description=dim_def.get("description"),
             label=dim_def.get("label"),
             value_format_name=dim_def.get("value_format_name"),
@@ -1377,7 +1445,9 @@ class LookMLAdapter(BaseAdapter):
     # Timeframes that truncate a timestamp to a coarser time grain. These keep
     # type="time" with a Sidemantic granularity so they behave as time dimensions.
     _TIME_GRANULARITY_TIMEFRAMES = {
-        "time": "hour",
+        # Looker's "time" timeframe keeps full timestamp precision (to the second);
+        # truncating to the hour silently collapses sub-hour rows.
+        "time": "second",
         "time_of_day": "hour",
         "hour": "hour",
         "minute": "minute",
@@ -1437,7 +1507,10 @@ class LookMLAdapter(BaseAdapter):
         label = dim_group_def.get("label")
         description = dim_group_def.get("description")
 
-        # Time-truncation timeframes -> time dimension with granularity.
+        # Time-truncation timeframes -> time dimension with granularity. Remember the
+        # original LookML timeframe so export can round-trip it exactly: several
+        # timeframes (e.g. "time" and "second") map to the same sidemantic granularity
+        # and would otherwise collapse to one on export.
         granularity = self._TIME_GRANULARITY_TIMEFRAMES.get(timeframe)
         if granularity is not None:
             return Dimension(
@@ -1447,6 +1520,7 @@ class LookMLAdapter(BaseAdapter):
                 granularity=granularity,
                 label=label,
                 description=description,
+                meta={"lookml_timeframe": timeframe},
             )
 
         # Fiscal quarter/year truncations honoring fiscal_month_offset. The base
@@ -2661,6 +2735,138 @@ class LookMLAdapter(BaseAdapter):
             return None
         return f"{func}(CASE WHEN {conds} THEN {arg} END)"
 
+    # DATE_TRUNC('<grain>', <expr>) emitted for collision time dimensions, and matched
+    # on import to recover the grain. The grain is the first capture; expr is the rest.
+    _DATE_TRUNC_RE = re.compile(r"(?is)^\s*DATE_TRUNC\(\s*'(\w+)'\s*,\s*(.+)\)\s*$")
+    # minute15 / minute30 bucket every N minutes -- sidemantic has no such grain (it
+    # stores them as `minute` + meta), and DATE_TRUNC('minute', ...) loses the bucket.
+    # The collision export emits the expression below; this regex recovers (src, N).
+    _MINUTE_BUCKET_TF = {"minute15": 15, "minute30": 30}
+    # Sub-second LookML timeframes finer than sidemantic's `second` grain but valid as
+    # DATE_TRUNC units; the collision export truncates at these and import recovers them.
+    _SUBSECOND_TF = frozenset({"millisecond", "microsecond"})
+    # LookML timeframes that map MANY-to-one onto a coarser/finer sidemantic grain (15/30-min
+    # buckets -> minute, sub-second -> second, time-of-day extraction -> hour). A native dim's
+    # NAME suffix must NOT infer these on export: `created_minute15` at MINUTE grain is 1-minute
+    # data, not 15-minute buckets, so emitting `[minute15]` would silently re-bucket. They only
+    # round-trip when preserved in meta['lookml_timeframe'] (the import path).
+    _INEXACT_NAME_TF = frozenset(_MINUTE_BUCKET_TF) | _SUBSECOND_TF | {"time_of_day"}
+    # Canonical EXACT LookML timeframe for each sidemantic grain (inverse of the common
+    # cases in _TIME_GRANULARITY_TIMEFRAMES). Used to give a suffixless collision time dim
+    # a recoverable name on export (e.g. `started` at hour grain -> `started_hour`).
+    _GRAIN_TO_TIMEFRAME = {
+        "second": "second",
+        "minute": "minute",
+        "hour": "hour",
+        "day": "date",
+        "week": "week",
+        "month": "month",
+        "quarter": "quarter",
+        "year": "year",
+    }
+    _MINUTE_BUCKET_RE = re.compile(
+        r"(?is)^\s*DATE_TRUNC\('hour',\s*(.+?)\)\s*\+\s*INTERVAL '1 minute'\s*\*\s*"
+        r"CAST\(FLOOR\(EXTRACT\(MINUTE FROM .+?\)\s*/\s*(15|30)\)\s*\*\s*(?:15|30)\s*AS INTEGER\)\s*$"
+    )
+
+    @staticmethod
+    def _minute_bucket_sql(src: str, n: int) -> str:
+        """An N-minute bucket truncation of ``src`` (N = 15 or 30).
+
+        Uses portable ``FLOOR(x / n) * n`` (not DuckDB-only ``//``) so the exported SQL
+        runs on Postgres/BigQuery/Snowflake too.
+        """
+        return (
+            f"DATE_TRUNC('hour', {src}) + INTERVAL '1 minute' * "
+            f"CAST(FLOOR(EXTRACT(MINUTE FROM {src}) / {n}) * {n} AS INTEGER)"
+        )
+
+    # Grains sidemantic's Dimension.granularity accepts; used to guard DATE_TRUNC recovery.
+    _SUPPORTED_GRAINS = frozenset({"second", "minute", "hour", "day", "week", "month", "quarter", "year"})
+    # Dimension-level properties the collision-export form never emits (it writes only
+    # name/type/sql). Their presence marks a HAND-WRITTEN DATE_TRUNC dimension that must
+    # not be reclassified into a time dimension (which would drop these on round-trip).
+    _PRESERVED_DIM_PROPS = frozenset(
+        {
+            "hidden",
+            "label",
+            "group_label",
+            "description",
+            "order_by_field",
+            "value_format",
+            "value_format_name",
+            "tags",
+            "can_filter",
+            "primary_key",
+            "drill_fields",
+        }
+    )
+
+    @classmethod
+    def _export_collision_time_dim(cls, dim, group_sql: str | None, used_names: set | None = None) -> dict:
+        """Export a same-prefix time dimension (different source) as a standalone dim.
+
+        Such a dimension cannot share its base name's dimension_group, so it is written
+        as a plain ``type: date_time`` dimension preserving its exact field name, with
+        the granularity baked into ``DATE_TRUNC`` so re-import recovers it (see
+        ``_parse_dimension``). If the source SQL is already a DATE_TRUNC at this grain it
+        is reused verbatim, keeping repeated round-trips stable (no nested truncation).
+        """
+        src = (group_sql if group_sql is not None else dim.sql) or ""
+        src = src.replace("{model}", "${TABLE}")
+        grain = (dim.granularity or "").lower()
+        tf = (dim.meta or {}).get("lookml_timeframe")
+        # Compute the exported SQL for each class of timeframe:
+        n = cls._MINUTE_BUCKET_TF.get(tf)
+        if n is not None:
+            # minute15/minute30 (stored as `minute` grain + meta): emit an explicit N-minute
+            # bucket so Looker buckets correctly, not every minute. Reuse the dim's sql if it
+            # is ALREADY that bucket (recovered on a prior import) to avoid nesting.
+            bm = cls._MINUTE_BUCKET_RE.match(src)
+            sql = src if (bm and int(bm.group(2)) == n) else cls._minute_bucket_sql(src, n)
+        else:
+            # millisecond/microsecond are finer than the stored `second` grain but ARE valid
+            # DATE_TRUNC units, so truncate at the LookML timeframe to keep sub-second precision.
+            if tf in cls._SUBSECOND_TF:
+                grain = tf
+            m = cls._DATE_TRUNC_RE.match(src)
+            sql = src if (m and m.group(1).lower() == grain) else f"DATE_TRUNC('{grain}', {src})"
+
+        # A standalone dim is only recoverable as a TIME dim if its name ends in a LookML
+        # timeframe suffix that re-import maps to this grain (see _parse_dimension). Determine
+        # that trailing `_<tf>` (prefer the STORED lookml_timeframe -- e.g. minute15/millisecond
+        # -- so bucket/sub-second forms round-trip; else a name suffix matching the grain; else
+        # synthesize the grain's canonical timeframe for a suffixless name like `started`, which
+        # would otherwise re-import categorical). `stem` is the name without that suffix.
+        name = dim.name
+        tf_suffix = None
+        if tf and name.endswith("_" + tf):
+            tf_suffix = tf
+        elif grain in cls._SUBSECOND_TF and name.endswith("_" + grain):
+            tf_suffix = grain
+        else:
+            for t, g in cls._TIME_GRANULARITY_TIMEFRAMES.items():
+                if name.endswith("_" + t) and g == grain and (tf_suffix is None or len(t) > len(tf_suffix)):
+                    tf_suffix = t
+        if tf_suffix is not None:
+            stem = name[: -(len(tf_suffix) + 1)]
+        else:
+            tf_suffix = tf or (grain if grain in cls._SUBSECOND_TF else cls._GRAIN_TO_TIMEFRAME.get(grain, "date"))
+            stem = name
+            name = f"{stem}_{tf_suffix}"
+        # Guarantee uniqueness against every other emitted field (a sibling standalone, a
+        # dimension_group's generated `<base>_<tf>` field, a regular dimension/measure). This
+        # trio (`started` + `started_hour` + `started_date`, all different SQL) is otherwise
+        # unrepresentable; insert the disambiguator into the STEM (`started_2_hour`, NOT
+        # `started_hour_2`) so the trailing timeframe -- and thus time-recoverability on
+        # re-import -- is preserved. Valid + lossless.
+        if used_names is not None and name in used_names:
+            i = 2
+            while f"{stem}_{i}_{tf_suffix}" in used_names:
+                i += 1
+            name = f"{stem}_{i}_{tf_suffix}"
+        return {"name": name, "type": "date_time", "sql": sql}
+
     def _export_view(self, model: Model, graph: SemanticGraph) -> dict:
         """Export model to LookML view definition.
 
@@ -2739,55 +2945,151 @@ class LookMLAdapter(BaseAdapter):
         # Group time dimensions by base name
         time_dims = [d for d in model.dimensions if d.type == "time" and d.granularity]
         if time_dims:
-            # Group by base name and collect all timeframes
-            from collections import defaultdict
+            # Group by (base name, source SQL): same-prefix time dimensions backed by
+            # DIFFERENT columns are not one dimension_group, and merging them would
+            # rewire a field to the wrong source on round-trip.
+            from collections import Counter
 
-            base_name_groups = defaultdict(list)
+            base_name_groups: dict[tuple[str, str | None], list] = {}
 
             for dim in time_dims:
-                # Extract base name (remove _date, _week, etc suffix)
+                # Extract the base name by stripping the timeframe suffix. For imported
+                # dims, use the EXACT stored LookML timeframe (covers every mapped
+                # timeframe, e.g. millisecond/microsecond, not just the common few);
+                # for native dims fall back to the common suffix list.
                 base_name = dim.name
-                for suffix in ["_date", "_week", "_month", "_quarter", "_year", "_time", "_hour"]:
-                    if dim.name.endswith(suffix):
-                        base_name = dim.name[: -len(suffix)]
-                        break
-                base_name_groups[base_name].append(dim)
+                stored_tf = (dim.meta or {}).get("lookml_timeframe")
+                if stored_tf and dim.name.endswith("_" + stored_tf):
+                    base_name = dim.name[: -(len(stored_tf) + 1)]
+                else:
+                    # Native dims (no stored timeframe): strip any known LookML truncation
+                    # timeframe suffix, LONGEST first so e.g. `_minute15`/`_time_of_day`/
+                    # `_millisecond` win over `_minute`/`_time`/`_second` (else the field
+                    # re-imports renamed, e.g. created_minute15 -> created_minute15_minute).
+                    for tf in sorted(self._TIME_GRANULARITY_TIMEFRAMES, key=len, reverse=True):
+                        if dim.name.endswith("_" + tf):
+                            base_name = dim.name[: -(len(tf) + 1)]
+                            break
+                base_name_groups.setdefault((base_name, dim.sql), []).append(dim)
+
+            # When one base name spans multiple source SQLs, only ONE can be the
+            # dimension_group (a second `dimension_group: <base>` is illegal LookML);
+            # the rest are emitted as standalone DATE_TRUNC dimensions below so their
+            # field names round-trip exactly instead of being renamed.
+            base_name_counts = Counter(bn for (bn, _) in base_name_groups)
+            assigned_names: set[str] = set()
+
+            # Map granularity to timeframe. Used as a fallback for dimensions not
+            # imported from LookML (which carry no meta['lookml_timeframe']); a
+            # second-grain dimension maps to the LookML `second` timeframe so native
+            # `*_second` fields round-trip instead of collapsing to `time`.
+            granularity_mapping = {
+                "second": "second",
+                "minute": "minute",
+                "hour": "hour",
+                "day": "date",
+                "week": "week",
+                "month": "month",
+                "quarter": "quarter",
+                "year": "year",
+            }
 
             dimension_groups = []
-            for base_name, dims in base_name_groups.items():
-                # Map granularity to timeframe
-                granularity_mapping = {
-                    "hour": "time",
-                    "day": "date",
-                    "week": "week",
-                    "month": "month",
-                    "quarter": "quarter",
-                    "year": "year",
-                }
+            # Same-prefix time dimensions backed by a DIFFERENT source column can't all
+            # be dimension_groups: a second `dimension_group: <base>` is illegal LookML,
+            # and renaming it (started_2) would rename its fields (started_minute ->
+            # started_2_minute) and break every reference. The first source keeps the
+            # dimension_group; the rest are emitted as standalone dimensions that
+            # preserve the exact field name (granularity baked into DATE_TRUNC so the
+            # importer recovers it losslessly).
+            collision_dims = []
+            # Field names already taken by fields NOT produced by this time-dim pass (regular
+            # dimensions + measures). Time dims get their emitted names added below as each
+            # dimension_group (base + generated `<base>_<tf>` fields) and collision standalone
+            # is built, so a collision standalone never duplicates a group-generated field,
+            # another standalone, or a regular field (see _export_collision_time_dim).
+            _time_names = {d.name for d in time_dims}
+            used_names: set[str] = {d.name for d in model.dimensions if d.name not in _time_names}
+            used_names |= {m.name for m in model.metrics}
+            # Within a colliding base, let a clean (non-DATE_TRUNC) source win the
+            # dimension_group slot so the choice is stable across repeated round-trips
+            # (a DATE_TRUNC-sourced winner would otherwise nest truncations).
+            ordered_groups = sorted(
+                base_name_groups.items(),
+                key=lambda kv: (kv[0][0], 1 if self._DATE_TRUNC_RE.match(kv[0][1] or "") else 0, kv[0][1] or ""),
+            )
 
-                # Collect all timeframes for this base name
+            def _group_timeframes(dims):
+                # De-duplicated LookML timeframes for a dimension_group's dims. LookML's
+                # "time" and "second" both import to second granularity, so dedup avoids
+                # emitting [time, time] and dropping a field on re-import.
                 timeframes = []
-                sql = None
+                seen_timeframes = set()
                 for dim in dims:
-                    timeframe = granularity_mapping.get(dim.granularity, "date")
-                    timeframes.append(timeframe)
-                    if dim.sql and not sql:
-                        sql = dim.sql
+                    # Prefer the original LookML timeframe captured at import (so
+                    # "time"/"second"/etc. round-trip distinctly).
+                    timeframe = (dim.meta or {}).get("lookml_timeframe")
+                    if timeframe is None:
+                        # Native (non-import) dim: derive from the field-name suffix (longest
+                        # known timeframe) so the EXACT name round-trips (created_hour -> [hour])
+                        # -- but ONLY when that suffix is an EXACT one-to-one match for the grain.
+                        # Skip the inexact/bucketing timeframes (minute15/30, milli/microsecond,
+                        # time_of_day): their coarse mapping equals the grain, so a native
+                        # created_minute15 at MINUTE grain would wrongly export [minute15]. Also
+                        # skip a suffix that CONTRADICTS the grain. Otherwise fall back to grain.
+                        for tf in sorted(self._TIME_GRANULARITY_TIMEFRAMES, key=len, reverse=True):
+                            if (
+                                tf not in self._INEXACT_NAME_TF
+                                and dim.name.endswith("_" + tf)
+                                and self._TIME_GRANULARITY_TIMEFRAMES[tf] == dim.granularity
+                            ):
+                                timeframe = tf
+                                break
+                        if timeframe is None:
+                            timeframe = granularity_mapping.get(dim.granularity, "date")
+                    if timeframe not in seen_timeframes:
+                        seen_timeframes.add(timeframe)
+                        timeframes.append(timeframe)
+                return timeframes
+
+            # PRE-SEED used_names with every field ANY dimension_group will generate BEFORE
+            # emitting collision standalones. The group winner is the FIRST entry per base; a
+            # standalone processed earlier must not pick a disambiguated name (`started_2_hour`)
+            # that a LATER group (`started_2`) also generates. Without this pre-pass the
+            # incremental seeding misses future groups' outputs.
+            _seeded_bases: set[str] = set()
+            for (base_name, _group_sql), dims in ordered_groups:
+                if base_name in _seeded_bases:
+                    continue
+                _seeded_bases.add(base_name)
+                used_names.add(base_name)
+                used_names.update(f"{base_name}_{tf}" for tf in _group_timeframes(dims))
+
+            for (base_name, group_sql), dims in ordered_groups:
+                if base_name_counts[base_name] > 1 and base_name in assigned_names:
+                    for dim in dims:
+                        cdim = self._export_collision_time_dim(dim, group_sql, used_names)
+                        used_names.add(cdim["name"])
+                        collision_dims.append(cdim)
+                    continue
+                group_name = base_name
+                assigned_names.add(group_name)
 
                 dim_group_def = {
-                    "name": base_name,
+                    "name": group_name,
                     "type": "time",
-                    "timeframes": timeframes,
+                    "timeframes": _group_timeframes(dims),
                 }
 
-                if sql:
-                    sql = sql.replace("{model}", "${TABLE}")
-                    dim_group_def["sql"] = sql
+                if group_sql:
+                    dim_group_def["sql"] = group_sql.replace("{model}", "${TABLE}")
 
                 dimension_groups.append(dim_group_def)
 
             if dimension_groups:
                 view["dimension_groups"] = dimension_groups
+            if collision_dims:
+                view.setdefault("dimensions", []).extend(collision_dims)
 
         # Export measures
         from sidemantic.sql.aggregation_detection import sql_has_aggregate as _sql_has_aggregate

--- a/tests/adapters/lookml/test_advanced_measure_types.py
+++ b/tests/adapters/lookml/test_advanced_measure_types.py
@@ -129,7 +129,7 @@ class TestDimensionGroupTimeframes:
     def test_time_truncation_timeframes_are_time(self, graph):
         model = graph.get_model("events_calendar")
         for tf, gran in [
-            ("occurred_time", "hour"),
+            ("occurred_time", "second"),
             ("occurred_date", "day"),
             ("occurred_week", "week"),
             ("occurred_month", "month"),

--- a/tests/adapters/lookml/test_edge_cases.py
+++ b/tests/adapters/lookml/test_edge_cases.py
@@ -2983,6 +2983,917 @@ def test_lookml_view_with_unsupported_derived_table_not_defaulted():
     assert model.table is None  # not fabricated as a physical table named after the view
 
 
+def test_lookml_time_timeframe_keeps_second_precision():
+    """Looker's "time" timeframe keeps to-the-second precision, not hour."""
+    graph = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [time, date, minute]
+    sql: ${TABLE}.created_at ;;
+  }
+}
+"""
+    )
+    model = graph.get_model("v")
+    assert model.get_dimension("created_time").granularity == "second"
+    assert model.get_dimension("created_minute").granularity == "minute"
+    assert model.get_dimension("created_date").granularity == "day"
+
+
+def test_lookml_native_suffix_contradicting_grain_uses_grain():
+    """A native dim whose name suffix CONTRADICTS its granularity preserves the GRAIN, not the name.
+
+    created_time at hour granularity must export as [hour] (-> created_hour), not [time]
+    (which imports as second), so queries keep grouping by hour.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="created_time", type="time", granularity="hour", sql="ts"),  # suffix `time` != hour
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    grains = {
+        d.name: d.granularity for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"
+    }
+    assert grains == {"created_hour": "hour"}  # grain preserved (not silently downgraded to second)
+
+
+def test_lookml_native_minute15_name_does_not_widen_grain():
+    """A native created_minute15 at MINUTE grain must not export [minute15] (15-min buckets).
+
+    The coarse mapping of minute15 equals `minute`, so the old name-suffix inference emitted
+    [minute15] -- silently re-bucketing 1-minute data into 15-minute intervals. Inexact
+    suffixes are now excluded from name inference, so it exports [minute] (true grain).
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="created_minute15", type="time", granularity="minute", sql="ts"),  # no meta
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    txt = open(out).read()
+    assert "minute15" not in txt  # no silent grain widening
+    assert "minute" in txt
+    # meta-preserved minute15 still round-trips as a 15-min bucket (import path unaffected)
+    graph2 = SemanticGraph()
+    graph2.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="created_minute15",
+                    type="time",
+                    granularity="minute",
+                    sql="ts",
+                    meta={"lookml_timeframe": "minute15"},
+                ),
+            ],
+        )
+    )
+    out2 = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph2, out2)
+    assert "minute15" in open(out2).read()
+
+
+def test_lookml_native_inexact_timeframe_suffix_preserves_grain_not_name():
+    """NATIVE inexact-suffix time dims (no meta) preserve the GRAIN, even if the name changes.
+
+    minute15 / minute30 / millisecond / microsecond / time_of_day map MANY-to-one onto a
+    coarser-or-finer sidemantic grain, so a native created_minute15 at MINUTE grain must NOT
+    export [minute15] (which buckets into 15-min intervals -- a silent grain change). It
+    exports at the true grain instead, so the field re-imports renamed (created_minute) but
+    with the CORRECT queryable grain. Exact name round-trip for these needs preserved
+    meta['lookml_timeframe'] (the import path), covered separately.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    for name, grain in [
+        ("created_minute15", "minute"),
+        ("created_millisecond", "second"),
+        ("created_time_of_day", "hour"),
+    ]:
+        graph = SemanticGraph()
+        graph.add_model(
+            Model(
+                name="v",
+                table="t",
+                primary_key="id",
+                dimensions=[
+                    Dimension(name="id", type="numeric", sql="id"),
+                    Dimension(name=name, type="time", granularity=grain, sql="ts"),  # no meta
+                ],
+            )
+        )
+        out = tempfile.mktemp(suffix=".lkml")
+        LookMLAdapter().export(graph, out)
+        grains = [d.granularity for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"]
+        assert grains == [grain], f"{name}: grain not preserved -> {grains}"
+
+
+def test_lookml_uncommon_timeframe_suffix_roundtrips():
+    """Imported timeframes like millisecond/microsecond round-trip (base derived from stored timeframe)."""
+    import tempfile
+
+    graph = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [millisecond, microsecond, date]
+    sql: ${TABLE}.created_at ;;
+  }
+}
+"""
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    names = {d.name for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"}
+    assert {"created_millisecond", "created_microsecond"} <= names
+    assert not any(n.endswith("_millisecond_millisecond") or n.endswith("_microsecond_microsecond") for n in names)
+
+
+def test_lookml_time_grain_roundtrip():
+    """time/hour/minute/date grains round-trip through export without grain or suffix corruption."""
+    import tempfile
+
+    graph = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [time, hour, minute, date]
+    sql: ${TABLE}.created_at ;;
+  }
+}
+"""
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    grains = {
+        d.name: d.granularity for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"
+    }
+    assert grains == {
+        "created_time": "second",
+        "created_hour": "hour",
+        "created_minute": "minute",
+        "created_date": "day",
+    }
+
+
+def test_lookml_native_second_grain_roundtrips():
+    """A second-grain dimension not imported from LookML (no meta) exports as `second`, not `time`."""
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="created_second", type="time", granularity="second", sql="{model}.created_at"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    names = {d.name for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"}
+    assert "created_second" in names
+
+
+def test_lookml_same_prefix_time_dims_different_sources_not_merged():
+    """Same-prefix time dims backed by different columns must not merge to one group (wrong source)."""
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started_date", type="time", granularity="day", sql="{model}.started_at"),
+                Dimension(name="started_second", type="time", granularity="second", sql="{model}.other_at"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    time_dims = [d for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"]
+    sources = {d.sql for d in time_dims}
+    # Each field keeps its own source column (no rewiring to the other group's SQL).
+    assert any("started_at" in (s or "") for s in sources)
+    assert any("other_at" in (s or "") for s in sources)
+    # Split groups get suffix-free, collision-free names (no started_date_date etc.).
+    assert not any(d.name.endswith("_date_date") or d.name.endswith("_hour_hour") for d in time_dims)
+
+
+def test_lookml_collision_subsecond_timeframe_preserves_precision():
+    """A millisecond/microsecond collision dim exports DATE_TRUNC at that grain (not second).
+
+    sidemantic stores them as `second`, so the exported SQL must use the LookML timeframe
+    grain to keep sub-second precision, and re-import recovers second grain + the timeframe.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="started_date", type="time", granularity="day", sql="a", meta={"lookml_timeframe": "date"}
+                ),
+                Dimension(
+                    name="started_millisecond",
+                    type="time",
+                    granularity="second",
+                    sql="b",
+                    meta={"lookml_timeframe": "millisecond"},
+                ),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    out = tempfile.mktemp(suffix=".lkml")
+    adapter.export(graph, out)
+    assert "DATE_TRUNC('millisecond'" in open(out).read()  # sub-second precision kept, not 'second'
+    g = adapter.parse(Path(out))
+    ms = g.get_model("v").get_dimension("started_millisecond")
+    assert ms.granularity == "second" and (ms.meta or {}).get("lookml_timeframe") == "millisecond"
+    # second round-trip stable (no nested DATE_TRUNC)
+    out2 = tempfile.mktemp(suffix=".lkml")
+    adapter.export(g, out2)
+    assert "DATE_TRUNC('millisecond', DATE_TRUNC" not in open(out2).read()
+
+
+def test_lookml_collision_disambiguation_reserves_future_group_fields():
+    """Disambiguating a standalone must avoid names a LATER dimension_group will generate.
+
+    `started` + `started_hour` (base `started`) plus `started_2_hour` (base `started_2`): the
+    standalone must not disambiguate to `started_2_hour` because the `started_2` group also
+    generates it. used_names is pre-seeded with every group's generated fields, so it skips to
+    `started_3_hour` -- no duplicate LookML field across the whole view.
+    """
+    import re
+    import tempfile
+    from collections import Counter
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started", type="time", granularity="hour", sql="a"),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="b"),
+                Dimension(name="started_2_hour", type="time", granularity="hour", sql="c"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    text = open(out).read()
+    names = re.findall(r"\n  dimension: (\w+) \{", text)
+    for base, tfs in re.findall(r"dimension_group: (\w+) \{[^}]*?timeframes:\s*\[([^\]]*)\]", text, re.S):
+        names += [f"{base}_{tf.strip()}" for tf in tfs.split(",")]
+    dups = {n: c for n, c in Counter(names).items() if c > 1}
+    assert not dups, f"duplicate field names: {dups}"
+
+
+def test_lookml_minute_bucket_collision_field_deduplicated():
+    """A minute15/30 collision dim must go through the same uniqueness logic (no duplicate names).
+
+    The minute-bucket path previously returned early, bypassing used_names dedup, so a
+    suffixless `started` (minute15) colliding with an existing `started_minute15` could emit
+    two `started_minute15` fields. It now disambiguates (`started_2_minute15`), still recoverable.
+    """
+    import re
+    import tempfile
+    from collections import Counter
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="started", type="time", granularity="minute", sql="a", meta={"lookml_timeframe": "minute15"}
+                ),
+                Dimension(
+                    name="started_minute15",
+                    type="time",
+                    granularity="minute",
+                    sql="b",
+                    meta={"lookml_timeframe": "minute15"},
+                ),
+                Dimension(
+                    name="started_date", type="time", granularity="day", sql="c", meta={"lookml_timeframe": "date"}
+                ),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    text = open(out).read()
+    names = re.findall(r"\n  dimension: (\w+) \{", text)
+    for base, tfs in re.findall(r"dimension_group: (\w+) \{[^}]*?timeframes:\s*\[([^\]]*)\]", text, re.S):
+        names += [f"{base}_{tf.strip()}" for tf in tfs.split(",")]
+    dups = {n: c for n, c in Counter(names).items() if c > 1}
+    assert not dups, f"duplicate field names: {dups}"
+    # the disambiguated field is still time-recoverable (ends in a real timeframe suffix)
+    g2 = LookMLAdapter().parse(Path(out))
+    assert all(d.type == "time" for d in g2.get_model("ev").dimensions if d.name.startswith("started"))
+
+
+def test_lookml_collision_disambiguated_field_stays_time_recoverable():
+    """A disambiguated collision field must stay TIME-recoverable, not become categorical.
+
+    The unrepresentable trio (`started` + `started_hour` + `started_date`, all different SQL)
+    forces one field to be renamed for uniqueness. The disambiguator goes into the STEM
+    (`started_2_hour`, not `started_hour_2`) so the trailing timeframe is preserved and the
+    field re-imports as time@hour, not a categorical dim. Stable across round-trips.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started", type="time", granularity="hour", sql="a"),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="b"),
+                Dimension(name="started_date", type="time", granularity="day", sql="c"),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    g = graph
+    for _ in range(2):
+        out = tempfile.mktemp(suffix=".lkml")
+        adapter.export(g, out)
+        g = adapter.parse(Path(out))
+        kinds = {d.name: d.type for d in g.get_model("ev").dimensions if d.name != "id"}
+        # all three time sources stay TIME (none degraded to categorical), 3 distinct names
+        assert all(t == "time" for t in kinds.values()), kinds
+        assert len(kinds) == 3, kinds
+
+
+def test_lookml_suffixless_collision_no_dimension_group_field_duplicate():
+    """A suffixless dim must not win the group slot and GENERATE a name a sibling standalone owns.
+
+    `started` (hour) + `started_hour` (hour, diff SQL) + `started_date`: if suffixless `started`
+    won the dimension_group, the group would generate `started_hour` AND a standalone
+    `started_hour` would exist -> a runtime field collision. A suffixed sibling wins the group
+    slot instead, so every generated field name (group fields + standalones) is unique.
+    """
+    import re
+    import tempfile
+    from collections import Counter
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started", type="time", granularity="hour", sql="a"),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="b"),
+                Dimension(name="started_date", type="time", granularity="day", sql="c"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    text = open(out).read()
+    generated = re.findall(r"\n  dimension: (\w+) \{", text)  # standalones
+    for base, tfs in re.findall(r"dimension_group: (\w+) \{[^}]*?timeframes:\s*\[([^\]]*)\]", text, re.S):
+        generated += [f"{base}_{tf.strip()}" for tf in tfs.split(",")]  # group-generated fields
+    dups = {n: c for n, c in Counter(generated).items() if c > 1}
+    assert not dups, f"duplicate generated field names: {dups}"
+
+
+def test_lookml_suffixless_collision_synth_name_avoids_duplicate():
+    """Synthesizing a recoverable suffix must not duplicate an existing field name.
+
+    `started` (hour) alongside an EXISTING `started_hour` and a `started_date` source must not
+    emit two `started_hour` blocks; the suffixless one keeps its name (no data-losing dup).
+    """
+    import re
+    import tempfile
+    from collections import Counter
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started", type="time", granularity="hour", sql="a"),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="b"),  # already exists
+                Dimension(name="started_date", type="time", granularity="day", sql="c"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    names = re.findall(r"dimension(?:_group)?: (\w+)", open(out).read())
+    dups = {n: c for n, c in Counter(names).items() if c > 1}
+    assert not dups, f"duplicate field names emitted: {dups}"
+
+
+def test_lookml_suffixless_collision_time_dim_stays_time():
+    """A suffixless collision time dim must remain a TIME dim across round-trips, not categorical.
+
+    `started` (hour grain) colliding with `started_date` (day, different SQL) can't keep its
+    bare name as a recoverable standalone, so the collision export appends the grain timeframe
+    (-> `started_hour`) so re-import restores time granularity instead of dropping to a
+    categorical dim (which would break time queries/filters on the field).
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started", type="time", granularity="hour", sql="created_at"),  # suffixless
+                Dimension(name="started_date", type="time", granularity="day", sql="updated_at"),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    g = graph
+    for _ in range(2):
+        out = tempfile.mktemp(suffix=".lkml")
+        adapter.export(g, out)
+        g = adapter.parse(Path(out))
+        times = {d.name: d.granularity for d in g.get_model("ev").dimensions if d.type == "time"}
+        # the suffixless dim is recoverable as time@hour (renamed started -> started_hour)
+        assert times.get("started_hour") == "hour", times
+        assert times.get("started_date") == "day", times
+
+
+def test_lookml_native_collision_inexact_name_not_widened_on_import():
+    """A NATIVE collision dim named *_minute15 (no meta) must not gain false minute15 meta.
+
+    Without meta the collision exporter writes a plain DATE_TRUNC('minute', ...), so import
+    must recover grain=minute with NO lookml_timeframe (recording 'minute15' would make the
+    next export widen the 1-minute dim into a 15-minute bucket). Stable across round-trips.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="ev",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started_date", type="time", granularity="day", sql="created_at"),
+                # same prefix, DIFFERENT sql -> collision; NO meta
+                Dimension(name="started_minute15", type="time", granularity="minute", sql="updated_at"),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    out = tempfile.mktemp(suffix=".lkml")
+    adapter.export(graph, out)
+    assert "DATE_TRUNC('minute'" in open(out).read()  # plain minute trunc, not a 15-min bucket
+    g = adapter.parse(Path(out))
+    m15 = g.get_model("ev").get_dimension("started_minute15")
+    assert m15.granularity == "minute"
+    assert not (m15.meta or {}).get("lookml_timeframe")  # NO false minute15 meta
+    # stable: second round-trip still minute, still no bucket
+    out2 = tempfile.mktemp(suffix=".lkml")
+    adapter.export(g, out2)
+    assert "FLOOR(" not in open(out2).read()  # never widened into a bucket
+    m15b = adapter.parse(Path(out2)).get_model("ev").get_dimension("started_minute15")
+    assert m15b.granularity == "minute" and not (m15b.meta or {}).get("lookml_timeframe")
+
+
+def test_lookml_collision_minute15_bucket_roundtrips():
+    """A minute15 collision dim exports a faithful 15-min bucket (not minute) and round-trips.
+
+    sidemantic has no 15-min grain (stores minute15 as `minute` + meta), so the standalone
+    collision form must emit an explicit N-minute bucket that the importer recovers back to
+    grain=minute + meta['lookml_timeframe']='minute15', stable across repeated round-trips.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="started_date", type="time", granularity="day", sql="a", meta={"lookml_timeframe": "date"}
+                ),
+                Dimension(
+                    name="started_minute15",
+                    type="time",
+                    granularity="minute",
+                    sql="b",
+                    meta={"lookml_timeframe": "minute15"},
+                ),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    out = tempfile.mktemp(suffix=".lkml")
+    adapter.export(graph, out)
+    text = open(out).read()
+    # Faithful 15-minute bucket via PORTABLE FLOOR (not DuckDB-only //), not DATE_TRUNC('minute').
+    assert "FLOOR(" in text and " / 15) * 15" in text and "//" not in text
+    g = adapter.parse(Path(out))
+    m15 = g.get_model("v").get_dimension("started_minute15")
+    assert m15.granularity == "minute" and (m15.meta or {}).get("lookml_timeframe") == "minute15"
+    # The recovered dim KEEPS the bucket expression (so QUERIES bucket 15-min, not minute).
+    assert "FLOOR(" in (m15.sql or "")
+    # second round-trip stays stable (no nested bucket)
+    out2 = tempfile.mktemp(suffix=".lkml")
+    adapter.export(g, out2)
+    assert "FLOOR(EXTRACT(MINUTE FROM DATE_TRUNC('hour'" not in open(out2).read()  # no FLOOR(...bucket...)
+    m15b = adapter.parse(Path(out2)).get_model("v").get_dimension("started_minute15")
+    assert m15b.granularity == "minute" and (m15b.meta or {}).get("lookml_timeframe") == "minute15"
+
+
+def test_lookml_collision_minute15_query_buckets_by_15_minutes():
+    """A round-tripped minute15 collision dim must GROUP queries by 15-minute buckets, not minute."""
+    import tempfile
+
+    import duckdb
+
+    from sidemantic import Dimension, Metric, Model, SemanticLayer
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="v",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="started_date", type="time", granularity="day", sql="a", meta={"lookml_timeframe": "date"}
+                ),
+                Dimension(
+                    name="started_minute15",
+                    type="time",
+                    granularity="minute",
+                    sql="ts",
+                    meta={"lookml_timeframe": "minute15"},
+                ),
+            ],
+            metrics=[Metric(name="cnt", agg="count")],
+        )
+    )
+    adapter = LookMLAdapter()
+    out = tempfile.mktemp(suffix=".lkml")
+    adapter.export(graph, out)
+    g = adapter.parse(Path(out))
+    layer = SemanticLayer(auto_register=False)
+    for m in g.models.values():
+        layer.add_model(m)
+    sql = layer.compile(dimensions=["v.started_minute15"], metrics=["v.cnt"])
+    con = duckdb.connect()
+    con.execute(
+        "create table v as select 1 id, TIMESTAMP '2024-01-01 10:07' a, TIMESTAMP '2024-01-01 10:07' ts "
+        "union all select 2, TIMESTAMP '2024-01-01 10:11', TIMESTAMP '2024-01-01 10:11' "
+        "union all select 3, TIMESTAMP '2024-01-01 10:22', TIMESTAMP '2024-01-01 10:22'"
+    )
+    import datetime
+
+    rows = sorted(con.execute(sql).fetchall())
+    assert rows == [(datetime.datetime(2024, 1, 1, 10, 0), 2), (datetime.datetime(2024, 1, 1, 10, 15), 1)]
+
+
+def test_lookml_collision_time_dim_multiword_timeframe_suffix_recovered():
+    """A collision standalone dim with a MULTI-WORD timeframe suffix (time_of_day) recovers.
+
+    The grain suffix is matched against the longest known LookML timeframe, not just the
+    text after the last underscore, so started_time_of_day round-trips as a time dimension
+    (gran=hour), not a renamed categorical.
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(
+                    name="started_date", type="time", granularity="day", sql="a", meta={"lookml_timeframe": "date"}
+                ),
+                Dimension(
+                    name="started_time_of_day",
+                    type="time",
+                    granularity="hour",
+                    sql="b",
+                    meta={"lookml_timeframe": "time_of_day"},
+                ),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    # Repeated round-trips must be STABLE: the recovered timeframe is stored in meta so
+    # the next export strips the _time_of_day suffix instead of renaming the field.
+    g = graph
+    for _ in range(3):
+        out = tempfile.mktemp(suffix=".lkml")
+        adapter.export(g, out)
+        g = adapter.parse(Path(out))
+        grains = {d.name: d.granularity for d in g.get_model("v").dimensions if d.type == "time"}
+        assert grains == {"started_date": "day", "started_time_of_day": "hour"}
+
+
+def test_lookml_same_prefix_time_dims_roundtrip_names_and_grains_losslessly():
+    """Collision time dims must round-trip with EXACT names AND granularities.
+
+    Two same-prefix time dims on different sources can't both be dimension_groups, so
+    the extra one is exported as a standalone DATE_TRUNC dimension. Both the field name
+    and the granularity must survive re-import (no started_2_minute rename, no grain
+    loss), and a second round-trip must be stable (no nested DATE_TRUNC).
+    """
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id", primary_key=True),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="started_at"),
+                Dimension(name="started_minute", type="time", granularity="minute", sql="completed_at"),
+            ],
+        )
+    )
+    adapter = LookMLAdapter()
+    out1 = tempfile.mktemp(suffix=".lkml")
+    adapter.export(graph, out1)
+    g2 = adapter.parse(Path(out1))
+    grains = {d.name: d.granularity for d in g2.get_model("v").dimensions if d.type == "time"}
+    assert grains == {"started_hour": "hour", "started_minute": "minute"}
+
+    # Second round-trip is stable and never nests DATE_TRUNC.
+    out2 = tempfile.mktemp(suffix=".lkml")
+    adapter.export(g2, out2)
+    assert "DATE_TRUNC('minute', DATE_TRUNC" not in open(out2).read()
+    assert "DATE_TRUNC('hour', DATE_TRUNC" not in open(out2).read()
+    grains2 = {d.name: d.granularity for d in adapter.parse(Path(out2)).get_model("v").dimensions if d.type == "time"}
+    assert grains2 == {"started_hour": "hour", "started_minute": "minute"}
+
+
+def test_lookml_handwritten_date_trunc_dimension_not_hijacked():
+    """A hand-written DATE_TRUNC dimension must keep its name/type, not be turned into a time group.
+
+    The DATE_TRUNC granularity recovery is only for the collision-export form (name ends
+    in _<grain>); an arbitrary-named dim like `created` stays categorical (no rename to
+    created_date), and an unsupported dialect grain like 'isoweek' must not crash parsing.
+    """
+    import tempfile
+
+    # Unsupported grain must not raise a granularity validation error.
+    graph = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: w { type: date_time  sql: DATE_TRUNC('isoweek', ${TABLE}.created_at) ;; }
+}
+"""
+    )
+    w = graph.get_model("v").get_dimension("w")
+    assert w.type == "categorical" and w.granularity is None
+
+    # Arbitrary-named DATE_TRUNC dim keeps its exact name across a round-trip.
+    graph2 = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: created { type: date_time  sql: DATE_TRUNC('day', ${TABLE}.created_at) ;; }
+}
+"""
+    )
+    assert graph2.get_model("v").get_dimension("created").type == "categorical"
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph2, out)
+    names = {d.name for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions}
+    assert "created" in names and "created_date" not in names
+
+    # A hand-written dim whose NAME does carry a timeframe suffix (created_date) but also
+    # has dimension-level properties (hidden/label) is NOT the collision-export form, so
+    # it stays a plain dimension and those properties survive the round-trip.
+    graph3 = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension: created_date { type: date_time  hidden: yes  label: "Created"  sql: DATE_TRUNC('day', ${TABLE}.created_at) ;; }
+}
+"""
+    )
+    assert graph3.get_model("v").get_dimension("created_date").type == "categorical"
+    out3 = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph3, out3)
+    text3 = open(out3).read()
+    assert "created_date" in {d.name for d in LookMLAdapter().parse(Path(out3)).get_model("v").dimensions}
+    assert "hidden: yes" in text3 and "Created" in text3  # properties preserved
+
+
+def test_lookml_split_time_group_names_avoid_existing_bases():
+    """A synthetic split-group name must not collide with an existing time-group base."""
+    import re
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="started_date", type="time", granularity="day", sql="{model}.a"),
+                Dimension(name="started_hour", type="time", granularity="hour", sql="{model}.b"),
+                Dimension(name="started_2_hour", type="time", granularity="hour", sql="{model}.c"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    names = re.findall(r"dimension_group: (\w+)", open(out).read())
+    assert len(names) == len(set(names)), f"colliding dimension_group names: {names}"
+
+
+def test_lookml_native_time_named_second_grain_roundtrips():
+    """A native second-grain dim named *_time must export as `time` so the name round-trips."""
+    import tempfile
+
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="v",
+            table="t",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", type="numeric", sql="id"),
+                Dimension(name="created_time", type="time", granularity="second", sql="{model}.created_at"),
+            ],
+        )
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    names = {d.name for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"}
+    assert "created_time" in names  # not renamed to created_second
+
+
+def test_lookml_time_and_second_timeframes_no_duplicate_export():
+    """A group with both `time` and `second` (both -> second grain) must not emit duplicate timeframes."""
+    import re
+    import tempfile
+
+    graph = _parse_lkml(
+        """
+view: v {
+  sql_table_name: t ;;
+  dimension: id { primary_key: yes  type: number  sql: ${TABLE}.id ;; }
+  dimension_group: created {
+    type: time
+    timeframes: [time, second, hour]
+    sql: ${TABLE}.created_at ;;
+  }
+}
+"""
+    )
+    out = tempfile.mktemp(suffix=".lkml")
+    LookMLAdapter().export(graph, out)
+    text = open(out).read()
+    timeframes = re.search(r"timeframes:\s*\[([^\]]*)\]", text).group(1)
+    parts = [p.strip() for p in timeframes.split(",")]
+    assert len(parts) == len(set(parts)), f"duplicate timeframes exported: {parts}"
+    # Both `time` and `second` are preserved (no collapse/drop) via the stored
+    # original timeframe, so re-import keeps every member.
+    names = {d.name for d in LookMLAdapter().parse(Path(out)).get_model("v").dimensions if d.type == "time"}
+    assert {"created_time", "created_second", "created_hour"} <= names
+
+
 def test_lookml_view_without_table_defaults_to_view_name():
     """A view with no sql_table_name/derived_table should default its table to the view name."""
     from sidemantic import SemanticLayer

--- a/tests/adapters/lookml/test_fixtures.py
+++ b/tests/adapters/lookml/test_fixtures.py
@@ -69,7 +69,7 @@ class TestRedshiftAdmin:
         model = self.graph.get_model("redshift_etl_errors")
         assert model.get_dimension("error_time") is not None
         assert model.get_dimension("error_time").type == "time"
-        assert model.get_dimension("error_time").granularity == "hour"
+        assert model.get_dimension("error_time").granularity == "second"
         assert model.get_dimension("error_date") is not None
         assert model.get_dimension("error_date").type == "time"
         assert model.get_dimension("error_date").granularity == "day"
@@ -332,7 +332,7 @@ class TestPyLookMLKitchenSink:
         assert model.get_dimension("created_month") is not None
         assert model.get_dimension("created_year") is not None
         assert model.get_dimension("created_time") is not None
-        assert model.get_dimension("created_time").granularity == "hour"
+        assert model.get_dimension("created_time").granularity == "second"
 
     def test_shipped_time_group(self):
         model = self.graph.get_model("order_items")

--- a/tests/adapters/lookml/test_parsing.py
+++ b/tests/adapters/lookml/test_parsing.py
@@ -119,7 +119,8 @@ def test_lookml_adapter_ecommerce():
     # Test dimension group with multiple timeframes
     created_time = orders.get_dimension("created_time")
     assert created_time is not None
-    assert created_time.granularity == "hour"
+    # Looker's "time" timeframe keeps to-the-second precision.
+    assert created_time.granularity == "second"
 
     created_date = orders.get_dimension("created_date")
     assert created_date is not None


### PR DESCRIPTION
## Summary
Part of the LookML adapter correctness series. **Stacked on #244** (base = `fix/lookml-default-view-table`).

Looker's `time` timeframe returns the timestamp to the second, but the adapter mapped it to **hour** granularity (`DATE_TRUNC('hour', ...)`), silently collapsing every sub-hour row into one.

## Changes
- Map the `time` timeframe to `second` granularity (sidemantic supports it).
- Add `second`/`minute` to the export granularity->timeframe map so they round-trip instead of degrading to `date`.
- Update the four existing tests that asserted the old (buggy) `hour` grain, and add a dedicated test.

## Not included (deferred)
`minute15`/`minute30` (no native 15/30-min granularity in sidemantic) and `time_of_day` (clock-time extraction) remain approximations — documented in the audit.