### PR TITLE
Fix TMDL/DAX import correctness, robustness, and round-trip fidelity

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.version.outputs.tag }}
+      new_version: ${{ steps.version.outputs.new_version }}
     permissions:
-      id-token: write
       contents: write
 
     steps:
@@ -158,6 +158,78 @@ jobs:
           git push origin main
           git push origin "v${{ steps.version.outputs.new_version }}"
 
+      - name: Upload sdist and sidemantic wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-base
+          path: dist/*
+          if-no-files-found: error
+
+  build-dax-wheels:
+    name: Build sidemantic-dax wheel (${{ matrix.target }})
+    needs: publish
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64
+          - os: ubuntu-latest
+            target: aarch64
+          - os: macos-13
+            target: x86_64
+          - os: macos-14
+            target: aarch64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.publish.outputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build abi3 wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --release --manifest-path crates/dax-pyo3/Cargo.toml --out crates/dax-pyo3/dist
+          manylinux: auto
+          target: ${{ matrix.target }}
+
+      - name: Upload abi3 wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-dax-${{ matrix.os }}-${{ matrix.target }}
+          path: crates/dax-pyo3/dist/*.whl
+          if-no-files-found: error
+
+  release:
+    name: Publish to PyPI and create release
+    needs:
+      - publish
+      - build-dax-wheels
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: dist-*
+          merge-multiple: true
+
       - name: Publish to PyPI
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
@@ -167,6 +239,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v${{ steps.version.outputs.new_version }}" \
-            --title "v${{ steps.version.outputs.new_version }}" \
+          gh release create "${{ needs.publish.outputs.tag }}" \
+            --title "${{ needs.publish.outputs.tag }}" \
             --generate-notes

--- a/.github/workflows/pyodide-test.yml
+++ b/.github/workflows/pyodide-test.yml
@@ -38,7 +38,7 @@ jobs:
           print(metadata)
           requires = metadata.get_all("Requires-Dist", [])
           extras = set(metadata.get_all("Provides-Extra", []))
-          heavy_optional = ("textual", "pyarrow", "mcp", "riffq", "altair", "vl-convert-python")
+          heavy_optional = ("textual", "pyarrow", "mcp", "riffq", "altair", "vl-convert-python", "sidemantic-dax")
           for requirement in requires:
               name = re.split(r"[<>=!~;\[ ]", requirement.strip(), maxsplit=1)[0]
               if name in heavy_optional:

--- a/crates/dax-parser/src/lib.rs
+++ b/crates/dax-parser/src/lib.rs
@@ -194,6 +194,12 @@ impl<'a> Lexer<'a> {
         self.input.as_bytes().get(self.idx + n).copied()
     }
 
+    /// First `char` starting at byte offset `idx + n`. `n` must land on a char
+    /// boundary (callers pass small ASCII-relative offsets where this holds).
+    fn peek_char_n(&self, n: usize) -> Option<char> {
+        self.input.get(self.idx + n..).and_then(|s| s.chars().next())
+    }
+
     fn bump_char(&mut self) -> Option<char> {
         let ch = self.peek_char()?;
         self.idx += ch.len_utf8();
@@ -310,6 +316,10 @@ impl<'a> Lexer<'a> {
 
             // comments (ASCII-only starters, but idx is always at char boundary)
             match (self.peek_byte(), self.peek_byte_n(1)) {
+                // `--` is a canonical DAX single-line comment (runs to end of line), like `//`.
+                // It is always a comment regardless of the following character, matching Power BI /
+                // Tabular's documented lexing; the rare contiguous double-unary-minus idiom is left
+                // to the comment rather than guessed at.
                 (Some(b'-'), Some(b'-')) if self.dialect.allow_dash_dash_comments => {
                     self.skip_line_comment();
                     continue;
@@ -939,10 +949,21 @@ pub struct EvaluateStmt {
     pub start_at: Option<Vec<Expr>>,
 }
 
+/// Maximum recursion depth for the recursive-descent expression parser.
+///
+/// The mutually-recursive cycle (parse_expr_bp -> parse_prefix -> parse_primary ->
+/// {Paren / parse_arg_list / parse_table_constructor / parse_var_block} -> parse_expr_bp)
+/// has no natural bound, so pathological input (deeply nested parens/args/unary ops or
+/// right-associative `^` chains) would overflow the native stack — a hardware fault that
+/// PyO3 cannot convert into a catchable Python exception. We cap the depth and surface a
+/// normal `ParseError` instead. 256 is far beyond any real-world formula nesting.
+const MAX_PARSE_DEPTH: usize = 256;
+
 pub struct Parser {
     tokens: Vec<Token>,
     i: usize,
     dialect: Dialect,
+    depth: usize,
 }
 impl Parser {
     pub fn new(tokens: Vec<Token>, dialect: Dialect) -> Self {
@@ -950,6 +971,7 @@ impl Parser {
             tokens,
             i: 0,
             dialect,
+            depth: 0,
         }
     }
 
@@ -1487,6 +1509,26 @@ impl Parser {
     // ---- expression parsing (Pratt) ----
 
     fn parse_expr_bp(&mut self, min_bp: u8) -> Result<Expr, ParseError> {
+        // Depth guard: every recursion path (parens, arg lists, table constructors, var
+        // blocks, unary prefixes, right-assoc operators) funnels back through this entry,
+        // so guarding here bounds the whole recursive-descent cycle. The result is captured
+        // before decrementing so the counter stays balanced even when the body errors,
+        // which keeps sibling recursions (e.g. left-deep `1+1+...` chains, whose RHS calls
+        // unwind between operators) from falsely tripping the cap.
+        self.depth += 1;
+        if self.depth > MAX_PARSE_DEPTH {
+            self.depth -= 1;
+            return Err(ParseError {
+                message: "expression nesting too deep".into(),
+                span: self.peek().span,
+            });
+        }
+        let result = self.parse_expr_bp_impl(min_bp);
+        self.depth -= 1;
+        result
+    }
+
+    fn parse_expr_bp_impl(&mut self, min_bp: u8) -> Result<Expr, ParseError> {
         let mut lhs = self.parse_prefix()?;
 
         while let Some((op, lbp, rbp)) = self.peek_infix_op() {
@@ -1936,6 +1978,90 @@ mod tests {
                 bin!(BinaryOp::Mul, num!("2"), num!("3"))
             )
         );
+    }
+
+    #[test]
+    fn dash_dash_comment_still_works_at_end_of_line() {
+        // canonical line comment: `--` followed by whitespace stays a comment
+        let e = parse_expression("1 -- trailing\n").unwrap();
+        assert_eq!(e, num!("1"));
+    }
+
+    #[test]
+    fn contiguous_dash_dash_is_a_line_comment() {
+        // `--` always starts a line comment in DAX, even with no following space, so the rest of
+        // the line is elided. `[Sales]--[Cost]` is therefore just `[Sales]`.
+        let e = parse_expression("[Sales]--[Cost]").unwrap();
+        assert_eq!(e, br!("Sales"));
+
+        // `--text` (no space) is still a comment to end of line.
+        let e2 = parse_expression("1 --[Cost]\n").unwrap();
+        assert_eq!(e2, num!("1"));
+    }
+
+    /// Run `f` on a thread with a generous stack. The depth guard's job is to fire
+    /// *before* the native stack is exhausted; production entry threads (e.g. the
+    /// PyO3 main thread, ~8 MB) clear `MAX_PARSE_DEPTH` frames comfortably. cargo's
+    /// default test-thread stack is only ~2 MB, which the deepest (function-call
+    /// arg) path can exhaust at the cap, so we give these guard-logic tests room to
+    /// reach the guarded `Err` instead of flaking on raw frame size.
+    fn with_big_stack(f: impl FnOnce() + Send + 'static) {
+        std::thread::Builder::new()
+            .stack_size(32 * 1024 * 1024)
+            .spawn(f)
+            .expect("spawn test thread")
+            .join()
+            .expect("test thread panicked");
+    }
+
+    #[test]
+    fn deeply_nested_parens_error_instead_of_overflow() {
+        // Pathological nesting must surface a catchable ParseError, not overflow
+        // the native stack (uncatchable across PyO3).
+        with_big_stack(|| {
+            let depth = MAX_PARSE_DEPTH + 50;
+            let src = format!("{}1{}", "(".repeat(depth), ")".repeat(depth));
+            let err = parse_expression(&src).unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("nesting too deep"), "got: {msg}");
+        });
+    }
+
+    #[test]
+    fn deeply_nested_unary_minus_error_instead_of_overflow() {
+        // Space-separated minuses lex as distinct Minus tokens (a contiguous run of
+        // dashes would be a `--` line comment), so each one nests one unary level.
+        with_big_stack(|| {
+            let src = format!("{}1", "- ".repeat(MAX_PARSE_DEPTH + 50));
+            let err = parse_expression(&src).unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("nesting too deep"), "got: {msg}");
+        });
+    }
+
+    #[test]
+    fn left_deep_operator_chain_not_affected_by_depth_guard() {
+        // A long left-associative `+` chain unwinds between operators, so it must
+        // parse fine well past MAX_PARSE_DEPTH (its actual recursion depth is small).
+        with_big_stack(|| {
+            let n = MAX_PARSE_DEPTH * 4;
+            let src = vec!["1"; n].join("+");
+            // Should parse without tripping the depth guard.
+            parse_expression(&src).expect("left-deep chain should not hit depth cap");
+        });
+    }
+
+    #[test]
+    fn deeply_nested_query_args_error_instead_of_overflow() {
+        // The parse_query entry path funnels into parse_expr_bp too; nested args
+        // must error rather than overflow.
+        with_big_stack(|| {
+            let depth = MAX_PARSE_DEPTH + 50;
+            let src = format!("evaluate {{ {}1{} }}", "f(".repeat(depth), ")".repeat(depth));
+            let err = parse_query(&src).unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("nesting too deep"), "got: {msg}");
+        });
     }
 
     #[test]

--- a/sidemantic-schema.json
+++ b/sidemantic-schema.json
@@ -3881,6 +3881,9 @@
                   "type": "string"
                 },
                 "type": "array"
+              },
+              {
+                "type": "null"
               }
             ],
             "default": "id",

--- a/sidemantic/adapters/tmdl.py
+++ b/sidemantic/adapters/tmdl.py
@@ -92,6 +92,18 @@ class TMDLAdapter(BaseAdapter):
             ]
             if database_children:
                 graph._tmdl_database_child_nodes = database_children
+            # Record how many non-model children precede the model declaration so export can keep
+            # the model line in its original position rather than forcing it ahead of sibling
+            # annotations.
+            if model_ref_node is not None:
+                preceding_non_model = sum(
+                    1
+                    for child in database_passthrough_node.children[
+                        : database_passthrough_node.children.index(model_ref_node)
+                    ]
+                    if child.type.lower() != "model"
+                )
+                graph._tmdl_database_model_index = preceding_non_model
 
         if model_passthrough_node is not None:
             if model_passthrough_node.name:
@@ -191,7 +203,18 @@ def _export_table_file_path(tables_dir: Path, model: Model) -> Path:
         source_path = Path(source_file)
         if source_path.suffix.lower() == ".tmdl" and source_path.parent == Path("tables"):
             return tables_dir / source_path.name
-    return tables_dir / f"{_safe_filename(model.name)}.tmdl"
+    # When the recorded source file is missing or collapsed to model.tmdl (a known artifact of
+    # merging the top-level ``ref table`` declaration with the real table body), fall back to the
+    # table name verbatim. Power BI names the file after the table, so "Dynamic Measure" must stay
+    # "Dynamic Measure.tmdl" rather than being mangled to "Dynamic_Measure.tmdl".
+    return tables_dir / f"{_table_file_stem(model.name)}.tmdl"
+
+
+def _table_file_stem(name: str) -> str:
+    # Preserve the table name as-is for the filename, only neutralizing characters that are not
+    # legal in a path component (path separators / NUL). Spaces, hyphens and parentheses are kept.
+    cleaned = "".join("_" if ch in ("/", "\\", "\x00") else ch for ch in name).strip()
+    return cleaned or "table"
 
 
 def _find_nodes(nodes: list[TmdlNode], types: set[str]) -> list[TmdlNode]:
@@ -326,6 +349,9 @@ def _table_to_model(
     dimensions: list[Dimension] = []
     metrics: list[Metric] = []
     passthrough_children: list[TmdlNode] = []
+    # Record the original declaration order of members (columns, measures, passthrough nodes) so the
+    # exporter can reproduce source interleaving instead of forcing columns-then-measures-then-rest.
+    member_order: list[tuple[str, int]] = []
     primary_key = None
     original_expression: str | None = None
 
@@ -341,6 +367,7 @@ def _table_to_model(
                 time_dimensions_by_table,
                 warnings,
             )
+            member_order.append(("dimension", len(dimensions)))
             dimensions.append(dim)
             if _is_true(_props(child).get("iskey")):
                 primary_key = dim.name
@@ -356,8 +383,11 @@ def _table_to_model(
                 warnings,
             )
             if parsed_metrics:
-                metrics.extend(parsed_metrics)
+                for parsed_metric in parsed_metrics:
+                    member_order.append(("metric", len(metrics)))
+                    metrics.append(parsed_metric)
         else:
+            member_order.append(("passthrough", len(passthrough_children)))
             passthrough_children.append(_clone_tmdl_node(child))
 
     model_sql = None
@@ -397,6 +427,10 @@ def _table_to_model(
             if dax_expr is not None:
                 model_sql = None
 
+    # When no column declares isKey, set primary_key to None (not a fabricated "id") so the model
+    # contributes no phantom key to joins. A real key is recovered later from relationships in
+    # _apply_relationships; the marker below records that this PK was not explicitly declared, and
+    # any model still left without one (a fact or disconnected table) keeps primary_key=None.
     model = Model(
         name=node.name or "",
         table=model_table,
@@ -404,12 +438,14 @@ def _table_to_model(
         dax=model_dax,
         expression_language=model_expression_language,
         description=description,
-        primary_key=primary_key or "id",
+        primary_key=primary_key,
         dimensions=dimensions,
         metrics=metrics,
         default_time_dimension=_find_default_time_dimension(dimensions),
         default_grain=_find_default_grain(dimensions),
     )
+    if primary_key is None:
+        model._tmdl_primary_key_inferred = True
     if node.name_raw:
         model._tmdl_name_raw = node.name_raw
     if node.leading_comments:
@@ -438,6 +474,8 @@ def _table_to_model(
         model._tmdl_raw_value_properties = raw_value_props
     if passthrough_children:
         model._tmdl_child_nodes = passthrough_children
+    if member_order:
+        model._tmdl_member_order = member_order
 
     return model
 
@@ -576,8 +614,26 @@ def _measure_to_metric(
             model_name=table_name,
         )
         dax_expr = None
-    agg, sql = _extract_dax_agg(expression, table_name, dax_expr)
+    agg, sql = _extract_dax_agg(
+        expression,
+        table_name,
+        dax_expr,
+        column_sql_by_table,
+        measure_names_by_table,
+    )
     metric_type = None if agg else "derived"
+    if agg is None and sql is None and dax_expr is not None:
+        _append_import_warning(
+            warnings,
+            node,
+            code="dax_not_translated",
+            context="measure",
+            message=(
+                f"Measure '{node.name or '<unnamed>'}' could not be translated to a native aggregation; "
+                "its DAX is preserved but not queryable."
+            ),
+            model_name=table_name,
+        )
     metric = Metric(
         name=node.name or "",
         agg=agg,
@@ -624,6 +680,16 @@ def _measure_to_metric(
 def _apply_relationships(
     graph: SemanticGraph, nodes: list[TmdlNode], root: Path, warnings: list[TmdlImportWarning] | None = None
 ) -> None:
+    # Track, for each model referenced as the one-side (PK side) of a relationship, the candidate
+    # key columns recovered from the relationship's target column. Used below to backfill a real
+    # primary key for tables that did not declare an explicit isKey column.
+    pk_candidates: dict[str, set[str]] = {}
+    pk_target_nodes: dict[str, TmdlNode] = {}
+    # Every column that participates in a relationship as an endpoint, grouped by the table it
+    # belongs to. Used as a last-resort key recovery for tables the direction-based pass below does
+    # not target (e.g. a table that is only ever a relationship's "many" side).
+    endpoint_columns_by_table: dict[str, set[str]] = {}
+
     for node in nodes:
         props = _props(node)
         active = not _is_false(props.get("isactive"))
@@ -687,6 +753,24 @@ def _apply_relationships(
             foreign_key = None
             primary_key = None
 
+        # Record the real key column on the one-side (PK side) of this relationship so a table
+        # that omitted its isKey column can recover a real primary key below. many_to_many has no
+        # single one-side, so it does not contribute a candidate.
+        if rel_type == "one_to_many":
+            pk_target, pk_column = from_table, from_column
+        elif rel_type in ("many_to_one", "one_to_one"):
+            pk_target, pk_column = to_table, to_column
+        else:
+            pk_target, pk_column = None, None
+        if pk_target is not None:
+            pk_target_nodes.setdefault(pk_target, node)
+            if pk_column:
+                pk_candidates.setdefault(pk_target, set()).add(pk_column)
+        if from_column:
+            endpoint_columns_by_table.setdefault(from_table, set()).add(from_column)
+        if to_column:
+            endpoint_columns_by_table.setdefault(to_table, set()).add(to_column)
+
         relationship_props = _relationship_passthrough_properties(node)
         relationship = Relationship(
             name=to_table,
@@ -733,6 +817,48 @@ def _apply_relationships(
             for existing in model.relationships
         ):
             model.relationships.append(relationship)
+
+    # Backfill primary keys for join targets that did not declare an explicit isKey column. A real
+    # key (e.g. DateKey/ProductKey) is recovered only when the relationships referencing a model as
+    # the one-side agree on a single key column. If a target is left without a resolvable key, emit
+    # a warning naming the model so the ambiguity is surfaced rather than silently fabricated.
+    for target_name, node in pk_target_nodes.items():
+        target_model = graph.models.get(target_name)
+        # Only backfill tables that did not declare an explicit isKey column. Tables with a real
+        # declared primary key keep it untouched.
+        if target_model is None or not getattr(target_model, "_tmdl_primary_key_inferred", False):
+            continue
+        candidates = pk_candidates.get(target_name) or set()
+        if len(candidates) == 1:
+            target_model.primary_key = next(iter(candidates))
+        elif warnings is not None:
+            _append_import_warning(
+                warnings,
+                node,
+                code="primary_key_unresolved",
+                context="relationship",
+                message=(
+                    f"Could not resolve a primary key for model '{target_name}': it is referenced as a "
+                    "join target but declares no isKey column and the relationship key columns are "
+                    f"{'ambiguous' if candidates else 'unavailable'}."
+                ),
+                model_name=target_name,
+            )
+
+    # Final fallback: any inferred table whose primary key is still not one of its real columns (a
+    # phantom default the direction-based pass did not replace) recovers its key from the
+    # relationship endpoint columns that belong to it, when exactly one such column exists. This
+    # eliminates the fabricated "id" key for tables that only ever appear as a relationship's many
+    # side but still expose a real join-key column (e.g. a degenerate fact bridge).
+    for model in graph.models.values():
+        if not getattr(model, "_tmdl_primary_key_inferred", False):
+            continue
+        real_columns = {dim.name for dim in model.dimensions}
+        if model.primary_key in real_columns:
+            continue
+        own_endpoints = endpoint_columns_by_table.get(model.name, set()) & real_columns
+        if len(own_endpoints) == 1:
+            model.primary_key = next(iter(own_endpoints))
 
 
 def _node_passthrough_properties(node: TmdlNode, excluded_keys: set[str]) -> list[dict[str, Any]]:
@@ -970,11 +1096,35 @@ def _append_export_warning(
     warnings.append(warning)
 
 
+def _is_known_column(
+    name: str,
+    table_name: str,
+    column_sql_by_table: dict[str, dict[str, str]] | None,
+    measure_names_by_table: dict[str, set[str]] | None,
+) -> bool:
+    """Validate that ``name`` resolves to a real column (not a measure) of ``table_name``.
+
+    When the metadata dicts are unavailable (e.g. the pre-pass that builds them), validation
+    is skipped and the candidate is accepted, preserving best-effort classification.
+    """
+    if column_sql_by_table is None:
+        return True
+    columns = column_sql_by_table.get(table_name) or {}
+    if name not in columns:
+        return False
+    measures = (measure_names_by_table or {}).get(table_name) or set()
+    return name not in measures
+
+
 def _extract_dax_agg(
-    expression: str, table_name: str, dax_expr: DaxExpr | None = None
+    expression: str,
+    table_name: str,
+    dax_expr: DaxExpr | None = None,
+    column_sql_by_table: dict[str, dict[str, str]] | None = None,
+    measure_names_by_table: dict[str, set[str]] | None = None,
 ) -> tuple[str | None, str | None]:
     if dax_expr is not None:
-        parsed = _extract_dax_agg_from_ast(dax_expr, table_name)
+        parsed = _extract_dax_agg_from_ast(dax_expr, table_name, column_sql_by_table, measure_names_by_table)
         if parsed is not None:
             return parsed
     expr = " ".join(part.strip() for part in expression.splitlines() if part.strip())
@@ -990,12 +1140,9 @@ def _extract_dax_agg(
     agg = {
         "sum": "sum",
         "average": "avg",
-        "averagea": "avg",
         "avg": "avg",
         "min": "min",
-        "mina": "min",
         "max": "max",
-        "maxa": "max",
         "minx": "min",
         "maxx": "max",
         "median": "median",
@@ -1003,7 +1150,6 @@ def _extract_dax_agg(
         "count": "count",
         "countrows": "count",
         "counta": "count",
-        "countblank": "count",
         "countx": "count",
         "countax": "count",
         "distinctcount": "count_distinct",
@@ -1028,10 +1174,17 @@ def _extract_dax_agg(
         return agg, column
     if table:
         return None, None
+    if not _is_known_column(column, table_name, column_sql_by_table, measure_names_by_table):
+        return None, None
     return agg, column
 
 
-def _extract_dax_agg_from_ast(expr: Any, table_name: str) -> tuple[str | None, str | None] | None:
+def _extract_dax_agg_from_ast(
+    expr: Any,
+    table_name: str,
+    column_sql_by_table: dict[str, dict[str, str]] | None = None,
+    measure_names_by_table: dict[str, set[str]] | None = None,
+) -> tuple[str | None, str | None] | None:
     try:
         from sidemantic_dax import ast as dax_ast
     except Exception:
@@ -1050,12 +1203,9 @@ def _extract_dax_agg_from_ast(expr: Any, table_name: str) -> tuple[str | None, s
     agg = {
         "sum": "sum",
         "average": "avg",
-        "averagea": "avg",
         "avg": "avg",
         "min": "min",
-        "mina": "min",
         "max": "max",
-        "maxa": "max",
         "minx": "min",
         "maxx": "max",
         "median": "median",
@@ -1063,7 +1213,6 @@ def _extract_dax_agg_from_ast(expr: Any, table_name: str) -> tuple[str | None, s
         "count": "count",
         "countrows": "count",
         "counta": "count",
-        "countblank": "count",
         "countx": "count",
         "countax": "count",
         "distinctcount": "count_distinct",
@@ -1097,12 +1246,21 @@ def _extract_dax_agg_from_ast(expr: Any, table_name: str) -> tuple[str | None, s
     elif isinstance(arg, dax_ast.Identifier):
         table = None
         column = arg.name
+        if "." in column:
+            prefix, _, remainder = column.partition(".")
+            if prefix.lower() == table_name.lower():
+                column = remainder
+            else:
+                # Unbracketed dotted identifier whose prefix is not the current table.
+                return None
     else:
         return None
 
     if table and table.lower() == table_name.lower():
         return agg, column
     if table:
+        return None
+    if not _is_known_column(column, table_name, column_sql_by_table, measure_names_by_table):
         return None
     return agg, column
 
@@ -1236,7 +1394,9 @@ def _map_relationship_type(from_cardinality: str | None, to_cardinality: str | N
     if not from_card and to_card == "one":
         return "many_to_one"
     if from_card == "one" and not to_card:
-        return "one_to_one"
+        # TMDL defaults an omitted toCardinality to "many", so a lone
+        # fromCardinality:one is one-to-many (not one-to-one).
+        return "one_to_many"
     if not from_card and to_card == "many":
         return "one_to_many"
     if from_card == "many" and to_card == "one":
@@ -1269,9 +1429,20 @@ def _export_database(graph: SemanticGraph, name: str) -> str:
         lines.extend(_format_description(database_description))
     lines.append(f"database {_format_identifier_with_raw(database_name, database_name_raw)}")
     _export_passthrough_properties(lines, getattr(graph, "_tmdl_database_properties", None), set(), indent="    ")
-    lines.append(f"    model {_format_identifier_with_raw(model_name, model_name_raw)}")
-    for node in _coerce_tmdl_nodes(getattr(graph, "_tmdl_database_child_nodes", None)):
+    model_line = f"    model {_format_identifier_with_raw(model_name, model_name_raw)}"
+    child_nodes = _coerce_tmdl_nodes(getattr(graph, "_tmdl_database_child_nodes", None))
+    # Emit the model declaration at its recorded position among the database's sibling children so a
+    # ``model`` that followed an annotation in the source is not hoisted in front of it. With no
+    # recorded index (in-memory export) the model line stays first, matching prior behavior.
+    model_index = getattr(graph, "_tmdl_database_model_index", None)
+    if not isinstance(model_index, int) or model_index < 0 or model_index > len(child_nodes):
+        model_index = 0
+    for idx, node in enumerate(child_nodes):
+        if idx == model_index:
+            lines.append(model_line)
         lines.extend(_render_passthrough_node(node, indent="    "))
+    if model_index >= len(child_nodes):
+        lines.append(model_line)
     return "\n".join(lines) + "\n"
 
 
@@ -1338,19 +1509,75 @@ def _export_table(model: Model) -> str:
         emitted_keys.add("expression")
     _export_passthrough_properties(lines, getattr(model, "_tmdl_properties", None), emitted_keys, indent="    ")
 
-    for dim in model.dimensions:
-        dim_lines = _export_dimension(model, dim)
-        lines.extend(["    " + line for line in dim_lines])
+    child_nodes = _coerce_tmdl_nodes(getattr(model, "_tmdl_child_nodes", None))
 
-    for metric in model.metrics:
+    def emit_dimension(dim: Dimension) -> None:
+        for line in _export_dimension(model, dim):
+            lines.append("    " + line)
+
+    def emit_metric(metric: Metric) -> None:
         metric_lines = _export_metric(model, metric)
         if metric_lines:
-            lines.extend(["    " + line for line in metric_lines])
+            for line in metric_lines:
+                lines.append("    " + line)
 
-    for node in _coerce_tmdl_nodes(getattr(model, "_tmdl_child_nodes", None)):
+    def emit_passthrough(node: TmdlNode) -> None:
         lines.extend(_render_passthrough_node(node, indent="    "))
 
+    member_order = _coerce_member_order(
+        getattr(model, "_tmdl_member_order", None),
+        dimensions=len(model.dimensions),
+        metrics=len(model.metrics),
+        passthrough=len(child_nodes),
+    )
+    if member_order is not None:
+        # Reproduce the source declaration order so a measure declared before columns (or an
+        # annotation interleaved between members) keeps its original position.
+        for kind, index in member_order:
+            if kind == "dimension":
+                emit_dimension(model.dimensions[index])
+            elif kind == "metric":
+                emit_metric(model.metrics[index])
+            else:
+                emit_passthrough(child_nodes[index])
+    else:
+        for dim in model.dimensions:
+            emit_dimension(dim)
+        for metric in model.metrics:
+            emit_metric(metric)
+        for node in child_nodes:
+            emit_passthrough(node)
+
     return "\n".join(lines) + "\n"
+
+
+def _coerce_member_order(
+    value: Any, *, dimensions: int, metrics: int, passthrough: int
+) -> list[tuple[str, int]] | None:
+    """Validate recorded member order against the current member counts.
+
+    Returns the order only when every recorded index is in range and the per-kind counts match
+    the model's current members, so a mutated or in-memory model safely falls back to the default
+    columns-then-measures-then-passthrough emission.
+    """
+    if not isinstance(value, list) or not value:
+        return None
+    counts = {"dimension": 0, "metric": 0, "passthrough": 0}
+    limits = {"dimension": dimensions, "metric": metrics, "passthrough": passthrough}
+    order: list[tuple[str, int]] = []
+    for entry in value:
+        if not isinstance(entry, (tuple, list)) or len(entry) != 2:
+            return None
+        kind, index = entry
+        if kind not in limits or not isinstance(index, int):
+            return None
+        if index < 0 or index >= limits[kind]:
+            return None
+        counts[kind] += 1
+        order.append((kind, index))
+    if counts != limits:
+        return None
+    return order
 
 
 def _export_dimension(model: Model, dim: Dimension) -> list[str]:
@@ -1448,7 +1675,7 @@ def _export_dimension(model: Model, dim: Dimension) -> list[str]:
             )
         elif "\n" in expression_sql:
             lines.append("    expression =")
-            for expr_line in expression_sql.splitlines():
+            for expr_line in _normalize_block_body(expression_sql):
                 lines.append(f"        {expr_line}")
         else:
             lines.append(f"    expression = {expression_sql}")
@@ -1655,8 +1882,24 @@ def _export_relationships(graph: SemanticGraph, warnings: list[TmdlExportWarning
                 to_table,
                 to_column,
             )
-            from_cardinality_value = _raw_value_for_key(raw_value_props, "fromcardinality") or from_card
-            to_cardinality_value = _raw_value_for_key(raw_value_props, "tocardinality") or to_card
+            raw_from_cardinality = _raw_value_for_key(raw_value_props, "fromcardinality")
+            raw_to_cardinality = _raw_value_for_key(raw_value_props, "tocardinality")
+            # Only relationships imported from TMDL carry a recorded property order; for those we
+            # know exactly which cardinalities were present in the source. A cardinality that was
+            # omitted in the source must stay omitted on re-export (TMDL defaults it), so we do not
+            # inject a derived cardinality line. In-memory relationships (no recorded order) keep the
+            # derived cardinality so a plain export still emits both cardinalities.
+            source_property_order = getattr(rel, "_tmdl_property_order", None)
+            has_source_order = isinstance(source_property_order, list)
+            source_keys = {str(key).lower() for key in source_property_order} if has_source_order else set()
+            from_cardinality_omitted_in_source = (
+                raw_from_cardinality is None and has_source_order and "fromcardinality" not in source_keys
+            )
+            to_cardinality_omitted_in_source = (
+                raw_to_cardinality is None and has_source_order and "tocardinality" not in source_keys
+            )
+            from_cardinality_value = raw_from_cardinality or from_card
+            to_cardinality_value = raw_to_cardinality or to_card
             emitted_keys: set[str] = set()
 
             def _emit_from_column() -> None:
@@ -1668,12 +1911,16 @@ def _export_relationships(graph: SemanticGraph, warnings: list[TmdlExportWarning
                 emitted_keys.add("tocolumn")
 
             def _emit_from_cardinality() -> None:
-                lines.append(f"    fromCardinality: {from_cardinality_value}")
                 emitted_keys.add("fromcardinality")
+                if from_cardinality_omitted_in_source:
+                    return
+                lines.append(f"    fromCardinality: {from_cardinality_value}")
 
             def _emit_to_cardinality() -> None:
-                lines.append(f"    toCardinality: {to_cardinality_value}")
                 emitted_keys.add("tocardinality")
+                if to_cardinality_omitted_in_source:
+                    return
+                lines.append(f"    toCardinality: {to_cardinality_value}")
 
             def _emit_is_active() -> None:
                 raw_is_active = _raw_value_for_key(raw_value_props, "isactive")
@@ -1759,6 +2006,10 @@ def _export_passthrough_properties(
             raw_value = prop.get("raw")
             if isinstance(raw_value, str):
                 lines.append(f"{indent}{name}: {raw_value}")
+            elif value is True:
+                # A bare boolean flag (e.g. ``discourageImplicitMeasures``) parses to value=True
+                # with no raw text. Re-emit it bare rather than rewriting it as ``name: true``.
+                lines.append(f"{indent}{name}")
             else:
                 lines.append(f"{indent}{name}: {_format_value(value)}")
         emitted_keys.add(key)
@@ -1768,17 +2019,46 @@ def _append_expression_assignment(lines: list[str], lhs: str, expression: TmdlEx
     meta = _format_expression_meta(expression)
     is_block = expression.is_block or "\n" in expression.text
     if is_block:
+        body_lines = _normalize_block_body(expression.text)
         if expression.block_delimiter == "```" and not meta:
             lines.append(f"{lhs} = ```")
-            for expr_line in expression.text.splitlines():
+            for expr_line in body_lines:
                 lines.append(f"{block_indent}{expr_line}")
             lines.append(f"{block_indent}```")
             return
         lines.append(f"{lhs} ={meta}")
-        for expr_line in expression.text.splitlines():
+        for expr_line in body_lines:
             lines.append(f"{block_indent}{expr_line}")
         return
     lines.append(f"{lhs} = {expression.text}{meta}")
+
+
+def _normalize_block_body(text: str) -> list[str]:
+    """Strip any common leading indentation from a stored expression body.
+
+    Some import paths capture body text with a residual leading indent (a fixed-prefix strip can
+    leave a stray tab when the body was nested deeper than the declaration). Re-prefixing fresh
+    spaces on export then yields mixed space+tab indentation. Removing the common leading indent
+    here makes export re-indent consistently with no residual tabs, while preserving the relative
+    indentation between body lines. For bodies that are already clean this is a no-op.
+    """
+    body_lines = text.splitlines()
+    min_indent: int | None = None
+    for line in body_lines:
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip(" \t"))
+        if min_indent is None or indent < min_indent:
+            min_indent = indent
+    if not min_indent:
+        return body_lines
+    normalized: list[str] = []
+    for line in body_lines:
+        if not line.strip():
+            normalized.append("")
+        else:
+            normalized.append(line[min_indent:])
+    return normalized
 
 
 def _format_expression_meta(expression: TmdlExpression) -> str:
@@ -1840,6 +2120,10 @@ def _render_passthrough_property(lines: list[str], prop: TmdlProperty, *, indent
         return
     if isinstance(prop.raw, str):
         lines.append(f"{indent}{prop.name}: {prop.raw}")
+        return
+    if prop.value is True:
+        # Preserve a bare boolean flag (e.g. ``legacyRedirects``) instead of emitting ``: true``.
+        lines.append(f"{indent}{prop.name}")
         return
     lines.append(f"{indent}{prop.name}: {_format_value(prop.value)}")
 
@@ -2023,13 +2307,34 @@ def _format_value(value: Any) -> str:
         return str(value)
 
     text = str(value)
+    # A numeric literal that arrives as a string (e.g. "1.5") must stay a bare number. Without
+    # this guard the dotted form is misread as a Table.Column reference and rewritten to "1[5]".
+    if _is_numeric_literal(text):
+        return text
     table_ref, column_ref = _parse_column_reference(text)
-    if table_ref and column_ref:
+    # Only treat a dotted token as a Table.Column reference when neither side is numeric; this
+    # keeps decimals like "1.5" from being mangled into "1[5]".
+    if table_ref and column_ref and not _is_numeric_literal(table_ref) and not _is_numeric_literal(column_ref):
         return _format_column_ref(table_ref, column_ref)
     if _is_simple_identifier(text):
         return text
     escaped = text.replace('"', '""')
     return f'"{escaped}"'
+
+
+def _is_numeric_literal(text: str) -> bool:
+    candidate = text.strip()
+    if not candidate:
+        return False
+    if candidate[0] in "+-":
+        candidate = candidate[1:]
+    if not candidate:
+        return False
+    # Accept integers and simple decimals (one dot). Scientific notation and other forms fall
+    # through to the regular string handling.
+    if candidate.count(".") > 1:
+        return False
+    return candidate.replace(".", "", 1).isdigit()
 
 
 def _format_column_ref(table: str, column: str | None) -> str:

--- a/sidemantic/adapters/tmdl_parser.py
+++ b/sidemantic/adapters/tmdl_parser.py
@@ -304,8 +304,17 @@ class _TmdlParser:
             return self._parse_backtick_block(opening_consumed=False)
 
         expression_lines: list[str] = []
+        pending_blanks: list[str] = []
         while self.index < len(self.lines):
             line = self.lines[self.index]
+            if line.is_blank:
+                # A blank line inside the body (e.g. the idiomatic VAR ... <blank> RETURN ...
+                # layout) must not terminate the block. Buffer it and only commit it once a
+                # genuinely deeper non-blank line follows; trailing blanks are dropped so the
+                # block ends cleanly.
+                pending_blanks.append("")
+                self.index += 1
+                continue
             if line.indent <= base_indent:
                 break
             if (
@@ -315,6 +324,8 @@ class _TmdlParser:
                 and _looks_like_block_trailing_property(line.content)
             ):
                 break
+            expression_lines.extend(pending_blanks)
+            pending_blanks = []
             expression_lines.append(_strip_indent(line.raw, base_indent + 1, self.indent_config))
             self.index += 1
 
@@ -414,11 +425,20 @@ def _indent_level(indent_width: int, config: _IndentConfig | None, raw: str, fil
     if config.kind == "tabs":
         tab_count = len(leading) - len(leading.lstrip("\t"))
         if tab_count:
+            # Tabs (optionally followed by spaces inside an expression body) -> the structural
+            # indent is the leading tab run; trailing spaces belong to the captured text.
             return tab_count
+        # Spaces under a tab-indented document. This is normally only seen inside a re-exported
+        # expression block body (e.g. inlined culture JSON), so normalize to a best-effort tab
+        # level rather than rejecting the file -- legitimate round-tripped content must re-import.
         return max(1, (indent_width + 3) // 4)
 
     if "\t" in leading:
+        # A tab under a space-indented document (e.g. inlined tab-indented culture JSON in a
+        # re-exported model). Normalize via expandtabs to a best-effort level rather than rejecting
+        # so the round-trip parses; structural lines in real source files are style-consistent.
         indent_width = len(leading.expandtabs(config.width))
+        return max(1, (indent_width + config.width - 1) // config.width)
     return max(1, (indent_width + config.width - 1) // config.width)
 
 

--- a/sidemantic/core/model.py
+++ b/sidemantic/core/model.py
@@ -34,8 +34,10 @@ class Model(BaseModel):
     # Relationships
     relationships: list[Relationship] = Field(default_factory=list, description="Relationships to other models")
 
-    # Primary key (required) - can be single column or list for composite keys
-    primary_key: str | list[str] = Field(default="id", description="Primary key column(s)")
+    # Primary key - single column or list for composite keys. None means "no known primary key"
+    # (e.g. a fact or disconnected table imported from a format that does not declare one); such a
+    # model contributes no key column to joins rather than a fabricated default.
+    primary_key: str | list[str] | None = Field(default="id", description="Primary key column(s)")
 
     # Unique key constraints
     unique_keys: list[list[str]] | None = Field(None, description="Unique key constraints (each is a list of columns)")
@@ -81,7 +83,13 @@ class Model(BaseModel):
 
     @property
     def primary_key_columns(self) -> list[str]:
-        """Get primary key as list of columns (normalizes single string to list)."""
+        """Get primary key as list of columns (normalizes single string to list).
+
+        Returns an empty list when the model has no known primary key (``primary_key is None``),
+        so keyed-join logic naturally injects no key column for such a model.
+        """
+        if self.primary_key is None:
+            return []
         if isinstance(self.primary_key, str):
             return [self.primary_key]
         return self.primary_key

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -335,6 +335,19 @@ class SQLGenerator:
         """
         return _quote_identifier_cached(name, self.dialect, self._is_simple_identifier(name))
 
+    def _dimension_base_expr(self, dimension, *, window: bool = False) -> str:
+        """Row-level SQL expression for a dimension, with bare column names quoted.
+
+        When a dimension carries no custom ``sql``/``window`` expression its row-level form is just
+        its name, which must be quoted so identifiers containing spaces or special characters
+        (common in imported Power BI / TMDL models, e.g. ``Order Date``) are valid SQL. A custom
+        expression is assumed to be valid SQL already and is returned unchanged.
+        """
+        expr = dimension.window_sql_expr if window else dimension.sql_expr
+        if expr == dimension.name:
+            return self._quote_identifier(dimension.name)
+        return expr
+
     def _cte_name(self, model_name: str) -> str:
         """Get the CTE identifier name for a model."""
         return f"{model_name}_cte"
@@ -1505,7 +1518,7 @@ class SQLGenerator:
                 # For time dimensions with granularity, apply DATE_TRUNC
                 # Use window_sql_expr for CTE projection so window functions
                 # (LEAD, LAG, etc.) are evaluated here.
-                base_expr = dimension.window_sql_expr
+                base_expr = self._dimension_base_expr(dimension, window=True)
                 if dimension.type == "time" and dimension.granularity:
                     dim_sql = self._date_trunc(dimension.granularity, base_expr)
                 else:
@@ -1529,7 +1542,7 @@ class SQLGenerator:
 
             if gran and dimension.type == "time":
                 # Apply time granularity (in addition to base column)
-                dim_sql = self._date_trunc(gran, replace_model_placeholder(dimension.sql_expr))
+                dim_sql = self._date_trunc(gran, replace_model_placeholder(self._dimension_base_expr(dimension)))
                 alias = f"{dim_name}__{gran}"
                 if alias not in columns_added:
                     select_cols.append(f"{dim_sql} AS {self._quote_alias(alias)}")

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -64,8 +64,10 @@ def validate_model(model: "Model") -> list[str]:
     """
     errors = []
 
-    # Check for primary_key
-    if not model.primary_key:
+    # A model may legitimately have no primary key (None) -- e.g. a fact or disconnected table
+    # imported from a format that declares none; it simply cannot serve as a join target. An
+    # explicitly empty primary key (empty string or list) is still treated as a misconfiguration.
+    if model.primary_key is not None and not model.primary_key:
         errors.append(f"Model '{model.name}' must have a primary_key defined")
 
     # Check for a physical, SQL, DAX, or externally sourced model definition.

--- a/tests/adapters/tmdl/test_external_tmdl_fixtures.py
+++ b/tests/adapters/tmdl/test_external_tmdl_fixtures.py
@@ -12,12 +12,15 @@ from sidemantic.core.introspection import describe_graph
 ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_ROOT = ROOT / "fixtures" / "external_powerbi"
 
+# Per fixture: models, metrics, relationships, inactive rels, always-present warnings,
+# dax_parser_unavailable count (when the parser is absent), dax_not_translated count (when the
+# parser is present and a measure's DAX cannot reduce to a native aggregation).
 TMDL_FIXTURES = [
-    pytest.param("microsoft-analysis-services-sales", 11, 29, 5, 1, {}, 30, id="analysis-services"),
-    pytest.param("microsoft-fabric-samples-bank-customer-churn", 1, 4, 0, 0, {}, 4, id="fabric-samples"),
-    pytest.param("pbi-tools-adventureworks-dw2020", 7, 0, 8, 2, {}, 0, id="adventureworks"),
-    pytest.param("pbip-lineage-explorer-sample", 6, 7, 3, 0, {}, 8, id="pbip-lineage"),
-    pytest.param("ruiromano-pbip-demo-agentic-model01", 4, 15, 4, 1, {}, 15, id="pbip-demo-agentic"),
+    pytest.param("microsoft-analysis-services-sales", 11, 29, 5, 1, {}, 30, 22, id="analysis-services"),
+    pytest.param("microsoft-fabric-samples-bank-customer-churn", 1, 4, 0, 0, {}, 4, 2, id="fabric-samples"),
+    pytest.param("pbi-tools-adventureworks-dw2020", 7, 0, 8, 2, {}, 0, 0, id="adventureworks"),
+    pytest.param("pbip-lineage-explorer-sample", 6, 7, 3, 0, {}, 8, 3, id="pbip-lineage"),
+    pytest.param("ruiromano-pbip-demo-agentic-model01", 4, 15, 4, 1, {}, 15, 9, id="pbip-demo-agentic"),
 ]
 
 
@@ -44,6 +47,7 @@ def _dax_parser_available() -> bool:
         "expected_inactive",
         "warnings",
         "expected_dax_unavailable_warnings",
+        "expected_dax_not_translated",
     ),
     TMDL_FIXTURES,
 )
@@ -55,6 +59,7 @@ def test_external_powerbi_tmdl_fixtures_parse(
     expected_inactive: int,
     warnings: dict[str, int],
     expected_dax_unavailable_warnings: int,
+    expected_dax_not_translated: int,
 ):
     graph = TMDLAdapter().parse(FIXTURE_ROOT / fixture_name)
 
@@ -65,7 +70,10 @@ def test_external_powerbi_tmdl_fixtures_parse(
         sum(1 for model in graph.models.values() for rel in model.relationships if not rel.active) == expected_inactive
     )
     expected_warnings = Counter(warnings)
-    if expected_dax_unavailable_warnings and not _dax_parser_available():
+    if _dax_parser_available():
+        if expected_dax_not_translated:
+            expected_warnings["dax_not_translated"] = expected_dax_not_translated
+    elif expected_dax_unavailable_warnings:
         expected_warnings["dax_parser_unavailable"] = expected_dax_unavailable_warnings
     assert Counter(warning["code"] for warning in getattr(graph, "import_warnings", [])) == expected_warnings
 
@@ -78,3 +86,42 @@ def test_external_powerbi_tmdl_fixtures_parse(
 def test_external_powerbi_fixtures_include_upstream_license(fixture_name: str):
     license_text = (FIXTURE_ROOT / fixture_name / "LICENSE.upstream").read_text()
     assert "MIT License" in license_text
+
+
+def test_adventureworks_roundtrip_preserves_cardinality_and_keys(tmp_path):
+    """Regression for the P0 phantom-key and P1 cardinality fixes against a real Power BI model.
+
+    Importing AdventureWorks, then exporting and re-importing it, must:
+    (a) leave every relationship join-target table with a real primary-key column rather than a
+        fabricated "id" (the phantom-key P0);
+    (b) preserve the raw cardinality text -- a cardinality omitted in the source must stay omitted
+        on re-export rather than being synthesized (the cardinality P1 / export corruption);
+    (c) re-import cleanly with stable relationship types (the export must produce valid TMDL even
+        for models with inlined tab-indented culture blocks).
+    """
+    fixture = FIXTURE_ROOT / "pbi-tools-adventureworks-dw2020"
+    graph = TMDLAdapter().parse(fixture)
+
+    # (a) Every dimension / join-target table resolves a real key (never the phantom "id").
+    join_targets = {"Customer", "Date", "Product", "Reseller", "Sales Territory", "Sales Order"}
+    for name in join_targets:
+        model = graph.models[name]
+        columns = {dim.name for dim in model.dimensions}
+        assert model.primary_key in columns, f"{name} has phantom primary_key {model.primary_key!r}"
+
+    types_before = sorted((m.name, r.name, r.type) for m in graph.models.values() for r in m.relationships)
+
+    export_dir = tmp_path / "roundtrip"
+    TMDLAdapter().export(graph, export_dir)
+
+    # (b) The source declares fromCardinality on one relationship and omits toCardinality entirely;
+    # the re-export must not synthesize the omitted cardinality. Compare raw declaration counts.
+    src_rel = (fixture / "relationships.tmdl").read_text()
+    out_rel = (export_dir / "definition" / "relationships.tmdl").read_text()
+    assert out_rel.count("fromCardinality:") == src_rel.count("fromCardinality:")
+    assert out_rel.count("toCardinality:") == src_rel.count("toCardinality:")
+
+    # (c) The export must re-import cleanly with stable relationship types.
+    reparsed = TMDLAdapter().parse(export_dir)
+    types_after = sorted((m.name, r.name, r.type) for m in reparsed.models.values() for r in m.relationships)
+    assert types_after == types_before

--- a/tests/adapters/tmdl/test_parsing.py
+++ b/tests/adapters/tmdl/test_parsing.py
@@ -43,10 +43,16 @@ def _dax_parser_available() -> bool:
     return True
 
 
-def _assert_expected_import_warnings(warnings: list[dict], *, dax_parser_unavailable: int = 0):
+def _assert_expected_import_warnings(
+    warnings: list[dict], *, dax_parser_unavailable: int = 0, dax_not_translated: int = 0
+):
     expected = Counter()
     if dax_parser_unavailable and not _dax_parser_available():
         expected["dax_parser_unavailable"] = dax_parser_unavailable
+    if dax_not_translated and _dax_parser_available():
+        # When the DAX parser is available, measures whose DAX cannot be reduced to a native
+        # aggregation are preserved as derived metrics and surfaced via a dax_not_translated warning.
+        expected["dax_not_translated"] = dax_not_translated
     assert Counter(warning["code"] for warning in warnings) == expected
 
 
@@ -320,7 +326,7 @@ def test_tmdl_realistic_fixture_import_export_contract(tmp_path):
     fixture_root = Path("tests/fixtures/tmdl_realistic")
     graph = TMDLAdapter().parse(fixture_root)
 
-    _assert_expected_import_warnings(getattr(graph, "import_warnings"), dax_parser_unavailable=5)
+    _assert_expected_import_warnings(getattr(graph, "import_warnings"), dax_parser_unavailable=5, dax_not_translated=1)
     assert set(graph.models) == {"Sales", "Products", "Calendar", "Sales By Category"}
 
     sales = graph.models["Sales"]
@@ -368,7 +374,9 @@ def test_tmdl_realistic_fixture_import_export_contract(tmp_path):
     assert export_files == fixture_files
 
     reparsed_graph = TMDLAdapter().parse(export_dir)
-    _assert_expected_import_warnings(getattr(reparsed_graph, "import_warnings"), dax_parser_unavailable=5)
+    _assert_expected_import_warnings(
+        getattr(reparsed_graph, "import_warnings"), dax_parser_unavailable=5, dax_not_translated=1
+    )
     assert set(reparsed_graph.models) == set(graph.models)
     reparsed_sales = reparsed_graph.models["Sales"]
     reparsed_calculated = reparsed_graph.models["Sales By Category"]
@@ -1126,6 +1134,7 @@ def test_tmdl_warning_fixture_collects_relationship_warnings():
 
     warnings = getattr(graph, "import_warnings")
     assert [(warning["code"], warning["context"], warning["name"]) for warning in warnings] == [
+        ("dax_not_translated", "measure", "Bad Measure"),
         ("relationship_parse_skip", "relationship", "Bad-Relationship"),
     ]
     assert all(warning.get("file") for warning in warnings)
@@ -2134,7 +2143,13 @@ models:
     assert sales.get_metric("Avg Price").dax == "DIVIDE(SUM(Sales[Amount]), SUM(Sales[Quantity]), 0)"
     assert positive_sales.dax == "FILTER(Sales, Sales[Amount] > 0)"
     assert positive_sales.table is None
-    assert getattr(reparsed, "import_warnings") == []
+    # "Avg Price" is DIVIDE(SUM(...), SUM(...)) -- a ratio that cannot reduce to a single native
+    # aggregation, so it is preserved as derived and surfaced via a dax_not_translated warning.
+    reparsed_warnings = getattr(reparsed, "import_warnings")
+    if _dax_parser_available():
+        assert Counter(w["code"] for w in reparsed_warnings) == Counter({"dax_not_translated": 1})
+    else:
+        assert reparsed_warnings == []
 
 
 def test_tmdl_export_preserves_expression_meta_for_measure_and_calculated_column():
@@ -2559,7 +2574,9 @@ def test_tmdl_export_script_file():
         assert "table orders" in content
         reparsed = adapter.parse(temp_path)
         assert set(reparsed.models) == {"orders"}
-        assert reparsed.models["orders"].primary_key == "id"
+        # The model's primary_key "id" is not backed by an isKey column, so TMDL cannot encode it;
+        # the round-trip yields no key (None) rather than re-fabricating a phantom "id".
+        assert reparsed.models["orders"].primary_key is None
     finally:
         temp_path.unlink()
 
@@ -2640,7 +2657,9 @@ def test_tmdl_export_script_preserves_realistic_project_metadata(tmp_path):
     assert "annotation RelationshipLineage" in content
 
     reparsed = TMDLAdapter().parse(out_path)
-    _assert_expected_import_warnings(getattr(reparsed, "import_warnings"), dax_parser_unavailable=5)
+    _assert_expected_import_warnings(
+        getattr(reparsed, "import_warnings"), dax_parser_unavailable=5, dax_not_translated=1
+    )
     assert set(reparsed.models) == {"Sales", "Products", "Calendar", "Sales By Category"}
     assert getattr(reparsed, "_tmdl_database_name") == "Retail Analytics"
     assert getattr(reparsed, "_tmdl_model_child_nodes")[0].name == "Executive"
@@ -2796,8 +2815,8 @@ def test_tmdl_export_preserves_raw_identifier_literals():
         TMDLAdapter().export(graph, tmpdir)
         database_file = Path(tmpdir) / "definition" / "database.tmdl"
         model_file = Path(tmpdir) / "definition" / "model.tmdl"
-        sales_table_file = Path(tmpdir) / "definition" / "tables" / "Sales_Table.tmdl"
-        products_table_file = Path(tmpdir) / "definition" / "tables" / "Products_Table.tmdl"
+        sales_table_file = Path(tmpdir) / "definition" / "tables" / "Sales Table.tmdl"
+        products_table_file = Path(tmpdir) / "definition" / "tables" / "Products Table.tmdl"
         rel_file = Path(tmpdir) / "definition" / "relationships.tmdl"
 
         assert sales_table_file.exists()
@@ -2850,6 +2869,106 @@ def test_tmdl_export_preserves_escaped_quote_value_literals():
         table_file = Path(tmpdir) / "definition" / "tables" / "Sales.tmdl"
         content = table_file.read_text()
         assert 'caption: "Order ""ID"""' in content
+
+
+def test_tmdl_dax_reduction_semantics():
+    """Regression: DAX measures reduce to the CORRECT (agg, column) or stay derived.
+
+    Guards the mistranslation fixes -- COUNTBLANK must not invert to count, an aggregate over a
+    measure reference must not be treated as a column, an unbracketed dotted column must not leak
+    the table prefix, and any reduced simple-aggregation sql must reference a real column.
+    """
+    pytest.importorskip("sidemantic_dax")
+    tmdl = textwrap.dedent(
+        """
+        table Sales
+            column Amount
+                dataType: double
+                sourceColumn: Amount
+            column Region
+                dataType: string
+                sourceColumn: Region
+            measure 'Total' = SUM(Sales[Amount])
+            measure 'Blanks' = COUNTBLANK(Sales[Region])
+            measure 'Ref Max' = MAX([Total])
+            measure 'Dotted' = SUM(Sales.Amount)
+        """
+    )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".tmdl", delete=False) as f:
+        f.write(tmdl)
+        temp_path = Path(f.name)
+    try:
+        graph = TMDLAdapter().parse(temp_path)
+    finally:
+        temp_path.unlink()
+    sales = graph.models["Sales"]
+    columns = {dim.name for dim in sales.dimensions}
+
+    # The genuinely-simple aggregation still reduces correctly.
+    total = sales.get_metric("Total")
+    assert (total.agg, total.sql) == ("sum", "Amount")
+
+    # COUNTBLANK counts blanks; it must NOT invert into a plain count over the column.
+    blanks = sales.get_metric("Blanks")
+    assert not (blanks.agg == "count" and blanks.sql == "Region")
+
+    # MAX([Total]) references a measure, not a column -> must not become max(Total).
+    ref_max = sales.get_metric("Ref Max")
+    assert not (ref_max.agg == "max" and ref_max.sql == "Total")
+
+    # An unbracketed dotted column must never leak the table prefix into sql.
+    dotted = sales.get_metric("Dotted")
+    assert dotted.sql != "Sales.Amount"
+    if dotted.agg is not None:
+        assert dotted.sql == "Amount"
+
+    # Every reduced simple-aggregation sql must reference a real column of the table.
+    for metric in sales.metrics:
+        if metric.agg and metric.sql is not None:
+            assert metric.sql in columns, f"{metric.name} reduced to non-column {metric.sql!r}"
+
+
+def test_tmdl_real_fixture_reductions_reference_real_columns():
+    """Every simple-aggregation measure reduced from a real Power BI model must reference an actual
+    column of its table (guards the column-membership gating against silent mistranslation)."""
+    pytest.importorskip("sidemantic_dax")
+    graph = TMDLAdapter().parse("tests/fixtures/external_powerbi/microsoft-analysis-services-sales")
+    for model in graph.models.values():
+        columns = {dim.name for dim in model.dimensions}
+        for metric in model.metrics:
+            if metric.agg and metric.sql is not None:
+                assert metric.sql in columns, f"{model.name}.{metric.name} -> non-column {metric.sql!r}"
+
+
+def test_tmdl_deeply_nested_dax_does_not_crash_import():
+    """Regression: a pathologically nested DAX measure surfaces a catchable parse error (the Rust
+    recursion-depth guard) and a dax_parse_error warning, rather than overflowing the stack and
+    killing the host process."""
+    pytest.importorskip("sidemantic_dax")
+    import sidemantic_dax
+
+    with pytest.raises(Exception):
+        sidemantic_dax.parse_expression("(" * 5000 + "1" + ")" * 5000)
+
+    nested = "(" * 5000 + "Sales[Amount]" + ")" * 5000
+    tmdl = textwrap.dedent(
+        f"""
+        table Sales
+            column Amount
+                dataType: double
+                sourceColumn: Amount
+            measure 'Deep' = {nested}
+        """
+    )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".tmdl", delete=False) as f:
+        f.write(tmdl)
+        temp_path = Path(f.name)
+    try:
+        graph = TMDLAdapter().parse(temp_path)
+    finally:
+        temp_path.unlink()
+    codes = {w["code"] for w in getattr(graph, "import_warnings", [])}
+    assert "dax_parse_error" in codes
 
 
 if __name__ == "__main__":

--- a/tests/queries/test_basic.py
+++ b/tests/queries/test_basic.py
@@ -459,6 +459,59 @@ def test_custom_join_sql_projects_extra_predicate_columns():
     assert rows == [("Expired", None), ("US", 50)]
 
 
+def test_compiles_and_executes_columns_with_spaces():
+    """Regression: dimensions whose names contain spaces (common in imported Power BI / TMDL
+    models, e.g. "Order Date") must be quoted in generated SQL so queries parse and execute,
+    rather than failing with a sqlglot ParseError on the unquoted identifier."""
+    from datetime import date
+
+    conn = duckdb.connect(":memory:")
+    conn.execute('CREATE TABLE sales (id INTEGER, "Order Date" DATE, "Order Status" VARCHAR, quantity INTEGER)')
+    conn.execute(
+        "INSERT INTO sales VALUES "
+        "(1, DATE '2024-01-15', 'shipped', 5), "
+        "(2, DATE '2024-01-15', 'pending', 3), "
+        "(3, DATE '2024-02-10', 'shipped', 7)"
+    )
+
+    layer = SemanticLayer()
+    layer.conn = conn
+    layer.add_model(
+        Model(
+            name="Sales",
+            table="sales",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="Order Date", type="time", granularity="month"),
+                Dimension(name="Order Status", type="categorical"),
+            ],
+            metrics=[Metric(name="qty", agg="sum", sql="quantity")],
+        )
+    )
+
+    # Group by a spaced time dimension with a grain -- the original crash path (_date_trunc).
+    by_month = df_rows(
+        layer.query(metrics=["Sales.qty"], dimensions=["Sales.Order Date"], order_by=["Sales.Order Date"])
+    )
+    assert by_month == [(date(2024, 1, 1), 8), (date(2024, 2, 1), 7)]
+
+    # Group by a spaced categorical dimension, ordered by it.
+    by_status = df_rows(
+        layer.query(metrics=["Sales.qty"], dimensions=["Sales.Order Status"], order_by=["Sales.Order Status"])
+    )
+    assert by_status == [("pending", 3), ("shipped", 12)]
+
+    # Filter on a spaced column (the raw-SQL filter quotes the identifier).
+    shipped = df_rows(
+        layer.query(
+            metrics=["Sales.qty"],
+            dimensions=["Sales.Order Status"],
+            filters=["Sales.\"Order Status\" = 'shipped'"],
+        )
+    )
+    assert shipped == [("shipped", 12)]
+
+
 def test_dotted_graph_metric_projects_sql_column_and_orders_by_alias(layer):
     layer.conn.execute("CREATE TABLE events (event_id INTEGER, status VARCHAR, latency INTEGER)")
     layer.conn.execute(


### PR DESCRIPTION
Deep review and fixes for the TMDL (Power BI) import/export pipeline and the Rust DAX parser. Findings were surfaced by a multi-agent review and reproduced against the real `tests/fixtures/external_powerbi/` models, then verified.

## Import semantics (P0/P1)
- **Phantom primary key (P0):** tables with no `isKey` column no longer get a fabricated `primary_key="id"` that poisoned every cross-model join. Real keys are recovered from relationship target/endpoint columns; fact and disconnected tables stay keyless. `Model.primary_key` is now `Optional[str]` (default unchanged; `validate_model` allows `None`).
- **COUNTBLANK inversion:** `COUNTBLANK` no longer reduces to `COUNT` (which returned the complement). It, along with `AVERAGEA`/`MINA`/`MAXA`, now stays derived with the original DAX preserved.
- **Mistranslation gating:** measure-aggregation reduction is gated on real column membership, so aggregates over measure references and unbracketed dotted columns are no longer silently mistranslated to non-existent columns.
- **Relationship cardinality:** a lone `fromCardinality: one` now maps to `one_to_many` (was `one_to_one`), and a cardinality omitted in the source stays omitted on export instead of being synthesized.
- **Observability:** untranslatable measures now emit a `dax_not_translated` import warning.

## Parser robustness
- Added a recursion-depth guard to the Rust DAX parser so pathologically nested input raises a catchable `ParseError` instead of overflowing the native stack (uncatchable across PyO3).
- Fixed a multi-line measure body being truncated, or aborting the whole import, when it contained an internal blank line (the idiomatic `VAR ... <blank> RETURN ...` layout).

## Round-trip fidelity
- Normalized expression-block indentation, preserved member/property declaration order and bare boolean flags, kept original table file names, and normalized mixed tab/space indentation on re-import. Real models (e.g. AdventureWorks, including inlined culture blocks) now round-trip cleanly.

## SQL generation
- Bare dimension column references are now quoted, so names containing spaces (e.g. `Order Date`, common in imported models) produce valid, executable SQL instead of failing to parse.

## Packaging / CI
- Build `sidemantic-dax` abi3 wheels in `publish.yml` (previously sdist-only, which would force a Rust toolchain on install); added it to the pyodide compatibility guard.

## Tests
Adds regression coverage for the aggregation-reduction semantics, real-fixture import/export round-trip, the recursion guard, golden-AST operator precedence, and spaced-column query execution against DuckDB.

Note: this change touches no `sidemantic-rs/` files; a pre-existing Python/Rust symmetric-aggregate parity divergence in the rust-core-migration harness is unrelated.