### PR TITLE
Fix Cube adapter correctness: import crashes, SQL normalization, and export round-trip

### DIFF
--- a/sidemantic/adapters/cube.py
+++ b/sidemantic/adapters/cube.py
@@ -1,5 +1,6 @@
 """Cube adapter for importing Cube.js semantic models."""
 
+import os
 import re
 import warnings
 from pathlib import Path
@@ -32,42 +33,70 @@ def _warn_inert(member: str, feature: str, detail: str) -> None:
     )
 
 
-def _normalize_cube_sql(sql: str | None, cube_name: str | None = None) -> str | None:
-    """Normalize Cube.js SQL syntax to Sidemantic format.
+# Keys the adapter writes into the cube_internal namespace; on export these are consumed and
+# stripped, while any other (user-supplied) keys in the namespace are preserved.
+_ADAPTER_INTERNAL_KEYS = frozenset(
+    {
+        "cube_type",
+        "order_by",
+        "reduce_by",
+        "rolling_window_leading",
+        "rolling_window_offset",
+        "latitude",
+        "longitude",
+        "top_level",
+        "sub_query",
+    }
+)
 
-    Handles:
-    - ${CUBE} -> {model} placeholder
-    - ${cube_name} -> {model} placeholder
-    - {CUBE} -> {model} placeholder (variant without dollar sign)
 
-    Note: ${measure_ref} references are handled separately in _parse_measure()
-    for derived metrics.
+def _cube_internal(meta: object) -> dict:
+    """Return the adapter-internal marker namespace from a meta value, tolerating a
+    user-supplied ``cube_internal`` that isn't a mapping (returns an empty dict)."""
+    if isinstance(meta, dict):
+        ns = meta.get("cube_internal")
+        if isinstance(ns, dict):
+            return ns
+    return {}
 
-    Args:
-        sql: SQL expression string or None
-        cube_name: Name of the cube (used to replace ${cube_name} references)
 
-    Returns:
-        Normalized SQL string or None
-    """
-    if sql is None:
-        return None
-
-    # Replace ${CUBE} and {CUBE} variants with {model}
-    result = sql.replace("${CUBE}", "{model}")
-    result = result.replace("{CUBE}", "{model}")
-
-    # Replace ${cube_name} with {model} if cube_name is provided
-    if cube_name:
-        result = result.replace(f"${{{cube_name}}}", "{model}")
-        result = result.replace(f"{{{cube_name}}}", "{model}")
-
-    return result
+def _set_cube_internal(meta: dict | None, **markers) -> dict:
+    """Stash adapter-internal export markers under a dedicated ``meta["cube_internal"]``
+    namespace, so they never collide with (or get mistaken for) user-supplied measure meta
+    of the same name (e.g. a measure whose own ``meta`` has a ``cube_type`` key). Only
+    non-None markers are stored; a non-dict existing value is replaced (not crashed on)."""
+    out = dict(meta) if isinstance(meta, dict) else {}
+    internal = dict(_cube_internal(out))
+    internal.update({k: v for k, v in markers.items() if v is not None})
+    if internal:
+        out["cube_internal"] = internal
+    return out
 
 
 # Matches a Cube member reference: ${cube.col}, {cube.col}, ${CUBE}.col, {cube}.col, etc.
 # group(1) = content inside braces, group(2) = optional trailing ".column".
 _CUBE_MEMBER_RE = re.compile(r"\$?\{([^}]+)\}(?:\.(\w+))?")
+
+# Matches a single-quoted string literal OR a Cube member reference. Used to rewrite member
+# references while leaving member-looking text inside string literals untouched. The literal
+# alternative is non-capturing, so the member groups remain group(1)/group(2); a matched
+# literal therefore has group(1) is None.
+_CUBE_MEMBER_OR_STRING_RE = re.compile(r"'(?:[^']|'')*'|" + _CUBE_MEMBER_RE.pattern)
+
+# Matches a single-quoted string literal OR a literal ``{model}`` placeholder. Used on export
+# to translate ``{model}`` back to ``${CUBE}`` only outside quoted strings, so a ``{model}``
+# occurring inside a literal (e.g. ``label = '{model}'``) is preserved verbatim and survives an
+# import->export round-trip (import already skips quoted literals when normalizing).
+_MODEL_OR_STRING_RE = re.compile(r"'(?:[^']|'')*'|\{model\}")
+
+
+def _model_placeholder_to_cube(sql: str) -> str:
+    """Replace ``{model}`` with ``${CUBE}`` everywhere except inside single-quoted literals."""
+
+    def repl(match: re.Match) -> str:
+        return "${CUBE}" if match.group(0) == "{model}" else match.group(0)
+
+    return _MODEL_OR_STRING_RE.sub(repl, sql)
 
 
 def _split_cube_ref(inner: str, trailing: str | None) -> tuple[str, str | None]:
@@ -82,6 +111,60 @@ def _split_cube_ref(inner: str, trailing: str | None) -> tuple[str, str | None]:
         head, col = inner.split(".", 1)
         return head, col
     return inner, None
+
+
+def _normalize_cube_sql(sql: str | None, cube_name: str | None = None) -> str | None:
+    """Normalize Cube.js self-references in a SQL expression to Sidemantic's ``{model}``.
+
+    Rewrites references to *this* cube only:
+    - ``${CUBE}`` / ``{CUBE}`` / ``${cube_name}`` / ``{cube_name}`` -> ``{model}``
+    - dotted column refs ``${CUBE.col}`` / ``{CUBE.col}`` / ``${CUBE}.col`` and the
+      ``cube_name`` equivalents -> ``{model}.col``
+
+    References to *other* cubes and bare ``${measure}`` references are left untouched:
+    the former cannot be expressed as ``{model}``, and the latter are resolved later in
+    ``_parse_measure()`` for derived metrics.
+
+    Args:
+        sql: SQL expression string or None
+        cube_name: Name of the cube whose self-references should be normalized
+
+    Returns:
+        Normalized SQL string or None
+    """
+    if sql is None:
+        return None
+
+    def repl(match: re.Match) -> str:
+        if match.group(1) is None:
+            return match.group(0)  # single-quoted string literal -> leave untouched
+        head, col = _split_cube_ref(match.group(1), match.group(2))
+        if head in ("CUBE", cube_name):
+            return f"{{model}}.{col}" if col else "{model}"
+        # Other-cube / measure / bare references are handled elsewhere.
+        return match.group(0)
+
+    return _CUBE_MEMBER_OR_STRING_RE.sub(repl, sql)
+
+
+# Cube join "relationship" values -> Sidemantic relationship types. Cube accepts both the
+# camelCase forms (belongsTo/hasMany/hasOne) and the snake_case forms.
+_CUBE_RELATIONSHIP_MAP = {
+    "belongsTo": "many_to_one",
+    "hasMany": "one_to_many",
+    "hasOne": "one_to_one",
+    # Legacy snake_case aliases Cube also accepts.
+    "belongs_to": "many_to_one",
+    "has_many": "one_to_many",
+    "has_one": "one_to_one",
+    "many_to_one": "many_to_one",
+    "one_to_many": "one_to_many",
+    "one_to_one": "one_to_one",
+}
+
+# Directories pruned when scanning a Cube project root for .js files: a YAML-only adapter
+# only needs to warn that JS cubes exist, so it should not descend into dependency/build trees.
+_JS_SCAN_SKIP_DIRS = {"node_modules", "dist", "build", ".git", ".venv", "__pycache__"}
 
 
 class CubeAdapter(BaseAdapter):
@@ -116,6 +199,23 @@ class CubeAdapter(BaseAdapter):
                 self._parse_file(yaml_file, graph, pending_views, pending_hierarchies, pending_extends)
             for yaml_file in source_path.rglob("*.yaml"):
                 self._parse_file(yaml_file, graph, pending_views, pending_hierarchies, pending_extends)
+            # Cube's native model format is JavaScript; this adapter parses YAML only.
+            # Scan lazily, pruning dependency/build trees (a Cube project root often has a
+            # large node_modules/dist) and stopping at the first match -- just enough to warn
+            # without walking or materializing every .js path under the root.
+            example_js = None
+            for walk_root, walk_dirs, walk_files in os.walk(source_path):
+                walk_dirs[:] = [d for d in walk_dirs if d not in _JS_SCAN_SKIP_DIRS]
+                example_js = next((f for f in walk_files if f.endswith(".js")), None)
+                if example_js is not None:
+                    break
+            if example_js is not None:
+                warnings.warn(
+                    f"Cube adapter parses YAML only; skipped JavaScript cube file(s) under "
+                    f"{source_path} (e.g. {example_js}).",
+                    CubeImportWarning,
+                    stacklevel=2,
+                )
         else:
             # Parse single file
             self._parse_file(source_path, graph, pending_views, pending_hierarchies, pending_extends)
@@ -296,7 +396,15 @@ class CubeAdapter(BaseAdapter):
         if not join_name:
             return None
 
-        rel_type = join_def.get("relationship", "many_to_one")
+        raw_relationship = join_def.get("relationship", "many_to_one")
+        rel_type = _CUBE_RELATIONSHIP_MAP.get(raw_relationship) if isinstance(raw_relationship, str) else None
+        if rel_type is None:
+            warnings.warn(
+                f"Unknown Cube join relationship {raw_relationship!r} on '{self_name}' -> "
+                f"'{join_name}'; defaulting to 'many_to_one'.",
+                stacklevel=2,
+            )
+            rel_type = "many_to_one"
         join_sql = join_def.get("sql", "") or ""
 
         native_sql, from_col, to_col = self._convert_cube_join(join_sql, self_name, join_name)
@@ -354,6 +462,34 @@ class CubeAdapter(BaseAdapter):
         sql = cube_def.get("sql")
         extends = cube_def.get("extends")
         cube_meta = cube_def.get("meta")
+
+        # Cube-level governance/visibility fields have no first-class Sidemantic equivalent.
+        # Preserve them in meta; warn for the security-relevant ones (access_policy, public).
+        extra_meta = {}
+        access_policy = cube_def.get("access_policy")
+        if access_policy is not None:
+            extra_meta["access_policy"] = access_policy
+        if cube_def.get("public") is False or cube_def.get("shown") is False:
+            extra_meta["public"] = False
+        for cosmetic_key in ("data_source", "title"):
+            cosmetic_val = cube_def.get(cosmetic_key)
+            if cosmetic_val is not None:
+                extra_meta[cosmetic_key] = cosmetic_val
+        if access_policy is not None or extra_meta.get("public") is False:
+            warnings.warn(
+                f"Cube '{name}' uses access_policy/public visibility controls, which Sidemantic "
+                f"does not enforce; preserved in meta only.",
+                CubeImportWarning,
+                stacklevel=2,
+            )
+        if extra_meta:
+            # Stash the preserved top-level fields inside the adapter-owned ``cube_internal``
+            # namespace (under ``top_level``) so export lifts only these back to real Cube
+            # keys. A user's own ``meta.cube_top_level`` is never touched -- it is just ordinary
+            # metadata and round-trips verbatim. Merge with any existing adapter top_level.
+            existing_top = _cube_internal(cube_meta).get("top_level")
+            existing_top = existing_top if isinstance(existing_top, dict) else {}
+            cube_meta = _set_cube_internal(cube_meta, top_level={**existing_top, **extra_meta})
 
         # Parse dimensions and find primary key
         dimensions = []
@@ -461,13 +597,6 @@ class CubeAdapter(BaseAdapter):
 
         sidemantic_type = type_mapping.get(dim_type, "categorical")
 
-        if dim_def.get("sub_query"):
-            _warn_inert(
-                f"{cube_name}.{name}",
-                "sub_query dimension",
-                "imported as a plain SQL dimension; the measure-as-dimension is not auto-joined",
-            )
-
         # For time dimensions, extract granularity
         granularity = None
         if dim_type == "time":
@@ -477,7 +606,7 @@ class CubeAdapter(BaseAdapter):
         supported_granularities = None
         custom_grans = dim_def.get("granularities")
         if custom_grans and isinstance(custom_grans, list):
-            supported_granularities = [g.get("name") for g in custom_grans if g.get("name")]
+            supported_granularities = [g.get("name") for g in custom_grans if isinstance(g, dict) and g.get("name")]
 
         # Normalize SQL to replace ${CUBE}/{CUBE} with {model}
         dim_sql = _normalize_cube_sql(dim_def.get("sql"), cube_name)
@@ -508,13 +637,60 @@ class CubeAdapter(BaseAdapter):
         mask = dim_def.get("mask")
         currency = dim_def.get("currency")
         if switch_values is not None or mask is not None or currency is not None:
-            meta = dict(meta) if meta else {}
+            meta = dict(meta) if isinstance(meta, dict) else {}
             if switch_values is not None:
                 meta["switch_values"] = switch_values
             if mask is not None:
                 meta["mask"] = mask
             if currency is not None:
                 meta["currency"] = currency
+
+        # Cube dimension features with no first-class Sidemantic equivalent: preserve in
+        # meta and warn so the loss is visible rather than silent.
+        geo_lat = dim_def.get("latitude")
+        geo_lon = dim_def.get("longitude")
+        if dim_type == "geo" or geo_lat is not None or geo_lon is not None:
+            # Store the geo marker + lat/long under the internal namespace so a user dimension
+            # whose own meta uses "cube_type"/"latitude"/"longitude" is never misread on export.
+            meta = _set_cube_internal(
+                meta,
+                cube_type="geo",
+                latitude=_normalize_cube_sql(geo_lat, cube_name) if isinstance(geo_lat, str) else geo_lat,
+                longitude=_normalize_cube_sql(geo_lon, cube_name) if isinstance(geo_lon, str) else geo_lon,
+            )
+            warnings.warn(
+                f"Cube dimension '{cube_name}.{name}' is type geo; Sidemantic has no geo type, so "
+                f"latitude/longitude are preserved in meta and it is imported as categorical.",
+                CubeImportWarning,
+                stacklevel=2,
+            )
+
+        sub_query = dim_def.get("sub_query")
+        if sub_query is not None:
+            # Stash under the adapter-owned namespace so export lifts it back to the top-level
+            # Cube `sub_query` property (a plain meta key would round-trip to meta.sub_query and
+            # silently demote a measure-as-dimension back to a plain SQL dimension).
+            meta = _set_cube_internal(meta, sub_query=sub_query)
+            warnings.warn(
+                f"Cube dimension '{cube_name}.{name}' uses sub_query, which Sidemantic does not "
+                f"support; preserved in meta but not applied.",
+                CubeImportWarning,
+                stacklevel=2,
+            )
+
+        if (
+            custom_grans
+            and isinstance(custom_grans, list)
+            and any(isinstance(g, dict) and ("sql" in g or "interval" in g or "origin" in g) for g in custom_grans)
+        ):
+            meta = dict(meta) if isinstance(meta, dict) else {}
+            meta["custom_granularities"] = custom_grans
+            warnings.warn(
+                f"Cube dimension '{cube_name}.{name}' defines custom granularities with sql/interval/origin; "
+                f"Sidemantic keeps the names but preserves their definitions only in meta.",
+                CubeImportWarning,
+                stacklevel=2,
+            )
 
         return Dimension(
             name=name,
@@ -586,36 +762,38 @@ class CubeAdapter(BaseAdapter):
         # Handle unknown measure types explicitly
         if agg_type is None and measure_type not in ("number",):
             if measure_type == "rank":
-                # Rank measures: use count as executable fallback, store rank
-                # metadata so consumers can handle them specially
+                # Rank measures: use count as executable fallback, store rank metadata under
+                # the internal namespace so consumers (and export) can handle them specially.
                 agg_type = "count"
-                meta = meta.copy() if meta else {}
-                meta["cube_type"] = "rank"
-                meta["order_by"] = measure_def.get("order_by")
-                meta["reduce_by"] = measure_def.get("reduce_by")
+                # Stash rank metadata under the adapter-owned namespace (so export can handle it
+                # specially) and warn that this is a lossy COUNT fallback, not a real rank.
+                meta = _set_cube_internal(
+                    meta,
+                    cube_type="rank",
+                    order_by=measure_def.get("order_by"),
+                    reduce_by=measure_def.get("reduce_by"),
+                )
                 warnings.warn(
                     f"Cube measure '{cube_name}.{name}' has type 'rank', which is not supported; "
                     f"imported as a non-rank COUNT fallback (agg='count'). The result is a plain "
                     f"count, NOT a rank, and no RANK() SQL is generated.",
+                    CubeImportWarning,
                     stacklevel=2,
                 )
             elif measure_type == "number_agg":
-                # Custom SQL aggregate (e.g., PERCENTILE_CONT). The sql field holds
-                # the complete aggregate expression, so leave agg=None and preserve
-                # the SQL verbatim. Record the original Cube type for consumers.
+                # Custom SQL aggregate (e.g., PERCENTILE_CONT). The sql field holds the
+                # complete aggregate expression, so leave agg=None and preserve the SQL
+                # verbatim. Record the original Cube type under the internal namespace.
                 agg_type = None
                 sql_is_complete = True
-                meta = meta.copy() if meta else {}
-                meta["cube_type"] = "number_agg"
+                meta = _set_cube_internal(meta, cube_type="number_agg")
             elif measure_type in ("string", "time", "boolean"):
-                # Non-numeric measure types (Tesseract). The sql is a complete
-                # expression (often itself an aggregate, e.g. type: time with
-                # MAX({CUBE}.created_at)). Preserve it verbatim with agg=None and
-                # record the original Cube type rather than forcing a count.
+                # Non-numeric measure types (Tesseract). The sql is a complete expression
+                # (often itself an aggregate, e.g. type: time with MAX({CUBE}.created_at)).
+                # Preserve it verbatim with agg=None and record the original Cube type.
                 agg_type = None
                 sql_is_complete = True
-                meta = meta.copy() if meta else {}
-                meta["cube_type"] = measure_type
+                meta = _set_cube_internal(meta, cube_type=measure_type)
             else:
                 # Truly unknown types fall back to count
                 agg_type = "count"
@@ -640,6 +818,19 @@ class CubeAdapter(BaseAdapter):
             rw_granularity = rolling_window.get("granularity")
             if rw_type == "to_date" and rw_granularity:
                 grain_to_date = rw_granularity
+            # leading/offset have no first-class Sidemantic field. Preserve them in meta
+            # (so measures differing only by leading/offset don't collapse) and warn that
+            # they are not yet reflected in query results.
+            rw_leading = rolling_window.get("leading")
+            rw_offset = rolling_window.get("offset")
+            if rw_leading is not None or rw_offset is not None:
+                meta = _set_cube_internal(meta, rolling_window_leading=rw_leading, rolling_window_offset=rw_offset)
+                warnings.warn(
+                    f"Cube measure '{cube_name}.{name}' uses rolling_window leading/offset, which "
+                    f"Sidemantic does not yet apply; preserved in meta but not reflected in results.",
+                    CubeImportWarning,
+                    stacklevel=2,
+                )
 
         # For calculated measures (type=number), treat as derived with SQL expression
         if measure_type == "number" and not rolling_window:
@@ -703,21 +894,58 @@ class CubeAdapter(BaseAdapter):
                 has_inline_agg = any(agg in measure_sql.upper() for agg in ["COUNT(", "SUM(", "AVG(", "MIN(", "MAX("])
 
                 if has_inline_agg:
-                    # This is a SQL expression metric with inline aggregations
-                    # Don't try to replace measure references - use SQL as-is
-                    # Set agg=None to signal this is a complete SQL expression
+                    # This is a SQL expression metric with inline aggregations (e.g. COUNT(*)).
+                    # Don't try to replace measure references - use SQL as-is. Set agg=None and
+                    # mark the expression complete: the aggregate lives in sql and cannot be
+                    # re-derived from a rollup's stored columns, so the matcher must not route a
+                    # query for it to a pre-aggregation (the materializer likewise skips agg=None
+                    # measures, so routing would otherwise recompute it over rollup rows).
                     agg_type = None
+                    sql_is_complete = True
                 else:
-                    # Complex derived metric - replace measure references
-                    def replace_measure_ref(match):
-                        measure_ref = match.group(1)
-                        # Don't replace if it's already been normalized to {model}
-                        if measure_ref == "model":
-                            return "{model}"
-                        # Convert ${measure_name} to cube_name.measure_name
-                        return f"{cube_name}.{measure_ref}"
+                    # Complex derived metric referencing other measures. Re-resolve member
+                    # references from the ORIGINAL sql so BOTH the ${...} and the no-dollar
+                    # {...} forms -- self-cube (${CUBE.m}/{CUBE.m}/${CUBE}.m), cross-cube
+                    # (${other.m}/{other.m}), and bare (${m}/{m}) -- become cube.measure
+                    # dependency refs, rather than column refs that point at nothing.
+                    def _resolve_member(match: re.Match) -> str:
+                        inner, trailing = match.group(1), match.group(2)
+                        if trailing is not None:
+                            # Trailing form ${X}.col / {X}.col references a COLUMN of X's table,
+                            # not a member -- keep it as a column ref so it is not mistaken for a
+                            # metric dependency.
+                            if not inner.isidentifier() or not trailing.isidentifier():
+                                return match.group(0)
+                            if inner in ("CUBE", cube_name, "model"):
+                                return f"{{model}}.{trailing}"
+                            # Cross-cube trailing ${other}.col references a column on the joined
+                            # cube's table. Sidemantic calculated measures reference members, not
+                            # raw joined columns, and leaving the ${other} placeholder in the metric
+                            # SQL compiles to invalid SQL (DuckDB reads ${other} as a struct
+                            # literal). Translate it to the cross-cube member form other.col -- the
+                            # same result as the ${other.col} in-brace form -- so it joins and
+                            # resolves to that member.
+                            return f"{inner}.{trailing}"
+                        # In-brace form ${X.col} / ${X} / ${col} references a MEMBER.
+                        head, col = _split_cube_ref(inner, None)
+                        if not head.isidentifier():
+                            return match.group(0)  # not a member ref (e.g. struct/JSON literal)
+                        if col is None:
+                            if head in ("CUBE", cube_name, "model"):
+                                return "{model}"  # bare cube self-reference -> table placeholder
+                            return f"{cube_name}.{head}"  # bare {measure} -> this cube's measure
+                        if not col.isidentifier():
+                            return match.group(0)
+                        if head in ("CUBE", cube_name):
+                            return f"{cube_name}.{col}"
+                        return f"{head}.{col}"  # cross-cube reference, already qualified
 
-                    measure_sql = re.sub(r"\$\{(\w+)\}", replace_measure_ref, measure_sql)
+                    # Resolve member refs but never inside single-quoted string literals, so a
+                    # literal like '{pending}' is not rewritten into a member reference.
+                    measure_sql = _CUBE_MEMBER_OR_STRING_RE.sub(
+                        lambda m: m.group(0) if m.group(1) is None else _resolve_member(m),
+                        measure_def.get("sql") or "",
+                    )
 
         # Preserve Cube-specific measure params that have no first-class Sidemantic
         # equivalent: mask/currency, and multi-stage group_by/add_group_by used for
@@ -727,7 +955,7 @@ class CubeAdapter(BaseAdapter):
         group_by = measure_def.get("group_by")
         add_group_by = measure_def.get("add_group_by")
         if any(v is not None for v in (mask, currency, group_by, add_group_by)):
-            meta = dict(meta) if meta else {}
+            meta = dict(meta) if isinstance(meta, dict) else {}
             if mask is not None:
                 meta["mask"] = mask
             if currency is not None:
@@ -787,6 +1015,7 @@ class CubeAdapter(BaseAdapter):
             "rollupJoin": "rollup_join",
             "rollupLambda": "lambda",
             "rollup_join": "rollup_join",
+            "originalSql": "original_sql",
             "original_sql": "original_sql",
             "rollup": "rollup",
             "lambda": "lambda",
@@ -865,8 +1094,11 @@ class CubeAdapter(BaseAdapter):
                 )
 
         # Parse build range
-        build_range_start = preagg_def.get("build_range_start", {}).get("sql")
-        build_range_end = preagg_def.get("build_range_end", {}).get("sql")
+        # The key may be present with a null/non-dict value, so guard before .get("sql").
+        build_range_start_def = preagg_def.get("build_range_start")
+        build_range_start = build_range_start_def.get("sql") if isinstance(build_range_start_def, dict) else None
+        build_range_end_def = preagg_def.get("build_range_end")
+        build_range_end = build_range_end_def.get("sql") if isinstance(build_range_end_def, dict) else None
 
         # Fidelity: these pre-agg controls are preserved for round-trip but are not honored
         # by sidemantic's matcher/materializer. Warn so the semantics aren't assumed to work.
@@ -884,9 +1116,16 @@ class CubeAdapter(BaseAdapter):
         if preagg_def.get("segments"):
             _warn_inert(member, "pre-aggregation segments", "segment coverage is not checked during matching")
 
+        # original_sql pre-aggregations stage a custom query; preserve it so it is
+        # materialized/exported instead of falling back to the model's SQL. Normalize Cube
+        # self-references (${CUBE}/{CUBE.col}/...) to the {model} placeholder, as for every
+        # other Cube SQL field, so materialization does not send raw ${CUBE} to the database.
+        sql = _normalize_cube_sql(preagg_def.get("sql"), cube_name)
+
         return PreAggregation(
             name=name,
             type=preagg_type,
+            sql=sql,
             measures=measures if measures else None,
             dimensions=dimensions if dimensions else None,
             time_dimension=time_dimension,
@@ -1050,12 +1289,91 @@ class CubeAdapter(BaseAdapter):
             if default_ui_filters is not None:
                 meta["default_ui_filters"] = default_ui_filters
 
+        # View-level access_policy (RBAC) has no first-class equivalent; preserve + warn.
+        access_policy = view_def.get("access_policy")
+        if access_policy is not None:
+            meta["access_policy"] = access_policy
+            warnings.warn(
+                f"Cube view '{name}' defines access_policy (RBAC), which Sidemantic does not "
+                f"enforce; preserved in meta only.",
+                CubeImportWarning,
+                stacklevel=2,
+            )
+        view_title = view_def.get("title")
+        if view_title is not None:
+            meta["title"] = view_title
+
         return Model(
             name=name,
+            description=view_def.get("description"),
             dimensions=dimensions,
             metrics=metrics,
             meta=meta,
         )
+
+    @staticmethod
+    def _model_sql_to_cube(sql: str | None) -> str | None:
+        """Translate Sidemantic's ``{model}`` placeholder back to Cube's ``${CUBE}``."""
+        if sql is None:
+            return None
+        return _model_placeholder_to_cube(sql)
+
+    def _geo_ref_to_cube(self, ref: object) -> object:
+        """Translate a preserved geo latitude/longitude ref back to Cube form.
+
+        Handles both the string form and Cube's ``{sql: ...}`` object form, converting any
+        ``{model}`` placeholder back to ``${CUBE}``.
+        """
+        if isinstance(ref, str):
+            return self._model_sql_to_cube(ref)
+        if isinstance(ref, dict) and "sql" in ref:
+            return {**ref, "sql": self._model_sql_to_cube(ref["sql"])}
+        return ref
+
+    @staticmethod
+    def _exported_meta(meta: object) -> dict:
+        """Return a meta dict for export with the adapter-owned cube_internal markers removed
+        but any user-supplied keys in that namespace preserved, so an import->export round-trip
+        does not drop a user's own ``cube_internal`` metadata."""
+        if not isinstance(meta, dict):
+            return {}
+        out = dict(meta)
+        internal = out.get("cube_internal")
+        if isinstance(internal, dict):
+            user_internal = {k: v for k, v in internal.items() if k not in _ADAPTER_INTERNAL_KEYS}
+            if user_internal:
+                out["cube_internal"] = user_internal
+            else:
+                out.pop("cube_internal", None)
+        return out
+
+    @staticmethod
+    def _derived_sql_to_cube(sql: str | None, known_members: set[str]) -> str | None:
+        """Translate a derived-measure SQL back to Cube form.
+
+        Converts ``{model}`` placeholders to ``${CUBE}`` and re-wraps qualified references
+        that are *known semantic members* (``cube.measure`` present in ``known_members``)
+        into Cube ``${...}`` refs, so cross-cube references round-trip. Arbitrary dotted SQL
+        -- non-member ``table.column``, schema-qualified functions, numeric literals, and
+        member-looking text inside single-quoted string literals -- is left untouched so it
+        is not misread by Cube as a member reference.
+        """
+        if sql is None:
+            return None
+        out = _model_placeholder_to_cube(sql)
+
+        # Match a single-quoted string literal OR a qualified member token. Literals are
+        # returned verbatim (group(1) is None), so 'orders.total' inside a string is never
+        # rewritten; only real member tokens outside quotes are wrapped.
+        pattern = re.compile(r"'(?:[^']|'')*'|(?<![\w.${])([A-Za-z_]\w*\.[A-Za-z_]\w*)\b")
+
+        def _wrap(match: re.Match) -> str:
+            token = match.group(1)
+            if token is None:
+                return match.group(0)
+            return f"${{{token}}}" if token in known_members else match.group(0)
+
+        return pattern.sub(_wrap, out)
 
     def export(self, graph: SemanticGraph, output_path: str | Path) -> None:
         """Export semantic graph to Cube YAML format.
@@ -1107,26 +1425,46 @@ class CubeAdapter(BaseAdapter):
             cube["description"] = model.description
 
         if model.meta:
-            cube["meta"] = model.meta
+            # Top-level Cube fields stashed in the adapter-owned cube_internal.top_level namespace
+            # on import are lifted back to real Cube keys; arbitrary user meta -- including a
+            # user's own meta.cube_top_level or a key named like a Cube field (e.g. meta.public) --
+            # stays under meta and is never promoted.
+            top_level = _cube_internal(model.meta).get("top_level")
+            if isinstance(top_level, dict):
+                for k, v in top_level.items():
+                    cube[k] = v
+            remaining_meta = self._exported_meta(model.meta)
+            if remaining_meta:
+                cube["meta"] = remaining_meta
 
         # Export dimensions
         dimensions = []
-        drill_members = []  # Track dimensions with drill-down support
 
         for dim in model.dimensions:
             dim_def = {"name": dim.name}
+            internal = _cube_internal(dim.meta)
 
-            # Map Sidemantic types to Cube types
-            type_mapping = {
-                "categorical": "string",
-                "numeric": "number",
-                "time": "time",
-                "boolean": "boolean",
-            }
-            dim_def["type"] = type_mapping.get(dim.type, "string")
+            # Cube geo dimensions are imported as categorical with the geo marker + lat/long
+            # stashed in the internal namespace; re-emit them as a real Cube geo dimension
+            # with top-level latitude/longitude rather than leaving them buried in meta.
+            if internal.get("cube_type") == "geo" and ("latitude" in internal or "longitude" in internal):
+                dim_def["type"] = "geo"
+                for geo_key in ("latitude", "longitude"):
+                    geo_val = internal.get(geo_key)
+                    if geo_val is not None:
+                        dim_def[geo_key] = self._geo_ref_to_cube(geo_val)
+            else:
+                # Map Sidemantic types to Cube types
+                type_mapping = {
+                    "categorical": "string",
+                    "numeric": "number",
+                    "time": "time",
+                    "boolean": "boolean",
+                }
+                dim_def["type"] = type_mapping.get(dim.type, "string")
 
             if dim.sql:
-                dim_def["sql"] = dim.sql
+                dim_def["sql"] = self._model_sql_to_cube(dim.sql)
 
             if dim.description:
                 dim_def["description"] = dim.description
@@ -1138,8 +1476,15 @@ class CubeAdapter(BaseAdapter):
             if dim.label:
                 dim_def["title"] = dim.label
 
-            if dim.meta:
-                dim_def["meta"] = dim.meta
+            # Re-emit an imported measure-as-dimension as the top-level Cube `sub_query` property
+            # (stashed in the adapter-owned namespace on import).
+            sub_query = internal.get("sub_query")
+            if sub_query is not None:
+                dim_def["sub_query"] = sub_query
+
+            dim_meta = self._exported_meta(dim.meta)
+            if dim_meta:
+                dim_def["meta"] = dim_meta
 
             if not dim.public:
                 dim_def["shown"] = False
@@ -1147,10 +1492,6 @@ class CubeAdapter(BaseAdapter):
             # Mark primary key dimension
             if model.primary_key and dim.name == model.primary_key:
                 dim_def["primary_key"] = True
-
-            # Track hierarchies - collect all dimensions for drill_members
-            if dim.parent or any(other.parent == dim.name for other in model.dimensions):
-                drill_members.append(dim.name)
 
             dimensions.append(dim_def)
 
@@ -1170,7 +1511,11 @@ class CubeAdapter(BaseAdapter):
         if dimensions:
             cube["dimensions"] = dimensions
 
-        # Export measures
+        # Export measures. Build the set of qualified semantic members so derived-measure
+        # SQL only re-wraps real member references, never arbitrary dotted SQL.
+        known_members = {
+            f"{mname}.{member.name}" for mname, m in resolved_models.items() for member in (*m.metrics, *m.dimensions)
+        }
         measures = []
         for measure in model.metrics:
             measure_def = {"name": measure.name}
@@ -1187,22 +1532,38 @@ class CubeAdapter(BaseAdapter):
                     )
                     measure_def["sql"] = f"${{{num_ref}}}::float / NULLIF(${{{denom_ref}}}, 0)"
             elif measure.type == "derived":
-                # Derived metrics become calculated measures
+                # Derived metrics become calculated measures; re-wrap member references so
+                # cross-cube refs (${other.measure}) round-trip instead of becoming plain SQL.
                 measure_def["type"] = "number"
                 if measure.sql:
-                    measure_def["sql"] = measure.sql
+                    measure_def["sql"] = self._derived_sql_to_cube(measure.sql, known_members)
             elif measure.type == "cumulative":
-                # Cumulative metrics become rolling window measures (Cube has rolling_window)
-                measure_def["type"] = "number"
+                # Cube rolling-window measures keep their aggregation type (sum/count/...),
+                # not type: number (which does not aggregate).
+                rolling_agg_mapping = {
+                    "count": "count",
+                    "count_distinct": "count_distinct",
+                    "sum": "sum",
+                    "avg": "avg",
+                    "min": "min",
+                    "max": "max",
+                }
+                measure_def["type"] = rolling_agg_mapping.get(measure.agg, "number")
                 if measure.sql:
-                    measure_def["sql"] = measure.sql
+                    measure_def["sql"] = self._model_sql_to_cube(measure.sql)
+                rolling_window = None
                 if measure.window:
-                    measure_def["rolling_window"] = {"trailing": measure.window}
+                    rolling_window = {"trailing": measure.window}
                 elif measure.grain_to_date:
-                    measure_def["rolling_window"] = {
-                        "type": "to_date",
-                        "granularity": measure.grain_to_date,
-                    }
+                    rolling_window = {"type": "to_date", "granularity": measure.grain_to_date}
+                if rolling_window is not None:
+                    # Re-attach leading/offset preserved under the internal meta namespace.
+                    rw_internal = _cube_internal(measure.meta)
+                    if rw_internal.get("rolling_window_leading") is not None:
+                        rolling_window["leading"] = rw_internal["rolling_window_leading"]
+                    if rw_internal.get("rolling_window_offset") is not None:
+                        rolling_window["offset"] = rw_internal["rolling_window_offset"]
+                    measure_def["rolling_window"] = rolling_window
             elif measure.type == "time_comparison":
                 # Time comparison - use Cube's time dimension features
                 measure_def["type"] = "number"
@@ -1222,13 +1583,28 @@ class CubeAdapter(BaseAdapter):
                     "min": "min",
                     "max": "max",
                 }
-                measure_def["type"] = type_mapping.get(measure.agg, "count")
+                internal = _cube_internal(measure.meta)
+                cube_type = internal.get("cube_type")
+                if cube_type in ("rank", "number_agg", "string", "time", "boolean"):
+                    # Measures with a recorded original Cube type: re-emit that type, not the
+                    # aggregation. rank in particular carries an executable count fallback in
+                    # agg, so checking cube_type first keeps it from exporting as type: count.
+                    measure_def["type"] = cube_type
+                    if cube_type == "rank":
+                        for rank_field in ("order_by", "reduce_by"):
+                            if internal.get(rank_field) is not None:
+                                measure_def[rank_field] = internal[rank_field]
+                elif measure.agg is not None:
+                    measure_def["type"] = type_mapping.get(measure.agg, "count")
+                else:
+                    # agg=None with no recorded type is a complete SQL expression.
+                    measure_def["type"] = "number"
 
                 if measure.sql:
-                    measure_def["sql"] = measure.sql
+                    measure_def["sql"] = self._model_sql_to_cube(measure.sql)
 
             if measure.filters:
-                measure_def["filters"] = [{"sql": f} for f in measure.filters]
+                measure_def["filters"] = [{"sql": self._model_sql_to_cube(f)} for f in measure.filters]
 
             if measure.description:
                 measure_def["description"] = measure.description
@@ -1241,22 +1617,21 @@ class CubeAdapter(BaseAdapter):
                 measure_def["title"] = measure.label
 
             if measure.meta:
-                measure_def["meta"] = measure.meta
+                # Strip only the adapter-owned cube_internal markers (re-emitted as real Cube
+                # fields above); user-supplied meta -- including their own cube_internal keys --
+                # is preserved.
+                exported_meta = self._exported_meta(measure.meta)
+                if exported_meta:
+                    measure_def["meta"] = exported_meta
 
             if not measure.public:
                 measure_def["shown"] = False
 
-            # Add drill fields if specified
-            if measure.drill_fields and drill_members:
-                # Only include drill fields that exist in this model
+            # Export drill fields only when the measure actually declared them; do not
+            # fabricate them from the model's hierarchy dimensions.
+            if measure.drill_fields:
                 valid_drill = [f for f in measure.drill_fields if f in [d.name for d in model.dimensions]]
-                if valid_drill:
-                    measure_def["drill_members"] = valid_drill
-            elif measure.drill_fields:
-                measure_def["drill_members"] = measure.drill_fields
-            elif drill_members:
-                # Default to hierarchy dimensions
-                measure_def["drill_members"] = drill_members
+                measure_def["drill_members"] = valid_drill or measure.drill_fields
 
             measures.append(measure_def)
 
@@ -1269,9 +1644,7 @@ class CubeAdapter(BaseAdapter):
             for segment in model.segments:
                 segment_def = {"name": segment.name}
                 if segment.sql:
-                    # Replace {model} placeholder with CUBE reference
-                    segment_sql = segment.sql.replace("{model}", "${CUBE}")
-                    segment_def["sql"] = segment_sql
+                    segment_def["sql"] = self._model_sql_to_cube(segment.sql)
                 if segment.description:
                     segment_def["description"] = segment.description
                 if not segment.public:
@@ -1281,8 +1654,15 @@ class CubeAdapter(BaseAdapter):
         # Export joins (all relationship types)
         joins = []
         for relationship in model.relationships:
-            # Skip many_to_many (needs junction table info)
-            if relationship.type == "many_to_many":
+            # Cube has no representation for many_to_many (needs a junction) or cross
+            # joins; omit them with a warning rather than emitting an invalid join.
+            if relationship.type in ("many_to_many", "cross"):
+                warnings.warn(
+                    f"Cube export: relationship '{model.name}' -> '{relationship.name}' is "
+                    f"{relationship.type}, which Cube cannot represent; omitting it from the export.",
+                    CubeImportWarning,
+                    stacklevel=2,
+                )
                 continue
 
             # Find target model from resolved models (inheritance-applied)
@@ -1323,7 +1703,26 @@ class CubeAdapter(BaseAdapter):
         if model.pre_aggregations:
             cube["pre_aggregations"] = []
             for preagg in model.pre_aggregations:
-                preagg_def = {"name": preagg.name, "type": preagg.type}
+                # Emit Cube's camelCase pre-aggregation type names (not the snake_case
+                # internal form, which Cube does not accept).
+                cube_preagg_type = {
+                    "rollup": "rollup",
+                    "original_sql": "originalSql",
+                    "rollup_join": "rollupJoin",
+                    "lambda": "rollupLambda",
+                }.get(preagg.type, preagg.type)
+                preagg_def = {"name": preagg.name, "type": cube_preagg_type}
+                if preagg.sql:
+                    # Translate the {model} placeholder back to Cube's ${CUBE} (the originalSql
+                    # query was normalized on import); leave any string literals untouched.
+                    preagg_def["sql"] = self._model_sql_to_cube(preagg.sql)
+                if preagg.rollups:
+                    # Only unqualified refs name a rollup on THIS cube and need the CUBE prefix;
+                    # an already-qualified cross-cube ref (e.g. ``visitors.for_join``) must stay
+                    # as-is, since Cube treats ``CUBE.visitors.for_join`` as a current-cube member.
+                    preagg_def["rollups"] = [r if "." in r else f"CUBE.{r}" for r in preagg.rollups]
+                if preagg.union_with_source_data:
+                    preagg_def["union_with_source_data"] = True
                 if preagg.measures:
                     preagg_def["measures"] = [f"CUBE.{m}" for m in preagg.measures]
                 if preagg.dimensions:
@@ -1356,10 +1755,6 @@ class CubeAdapter(BaseAdapter):
                     preagg_def["build_range_start"] = {"sql": preagg.build_range_start}
                 if preagg.build_range_end:
                     preagg_def["build_range_end"] = {"sql": preagg.build_range_end}
-                if preagg.rollups:
-                    preagg_def["rollups"] = [f"CUBE.{r}" for r in preagg.rollups]
-                if preagg.union_with_source_data:
-                    preagg_def["union_with_source_data"] = True
                 cube["pre_aggregations"].append(preagg_def)
 
         return cube

--- a/sidemantic/core/pre_aggregation.py
+++ b/sidemantic/core/pre_aggregation.py
@@ -164,7 +164,21 @@ class PreAggregation(BaseModel):
         # materialized base instead of re-running it. They are not aggregation
         # rollups, so the matcher never routes metric queries to them directly.
         if self.type == "original_sql":
-            base_sql = self.sql or getattr(model, "sql", None)
+            if self.sql:
+                # self.sql may carry {model} placeholders (e.g. normalized from Cube's ${CUBE}),
+                # used both as a FROM source and as a column qualifier ({model}.col). A custom
+                # query with no placeholder is staged verbatim.
+                if "{model}" not in self.sql:
+                    return self.sql
+                if getattr(model, "sql", None):
+                    # sql-backed model: expose its query as an aliased CTE and point {model} at
+                    # that alias. Inlining a bare "(SELECT ...)" instead would produce invalid
+                    # "(SELECT ...).col" column qualifiers in DuckDB/Postgres-style dialects.
+                    alias = f"{model.name}__base"
+                    return f"WITH {alias} AS (\n{model.sql}\n)\n{self.sql.replace('{model}', alias)}"
+                # table-backed model: {model} resolves directly to the table name.
+                return self.sql.replace("{model}", model.table)
+            base_sql = getattr(model, "sql", None)
             if base_sql:
                 return base_sql
             return f"SELECT * FROM {model.table}"
@@ -208,6 +222,13 @@ class PreAggregation(BaseModel):
             for measure_name in self.measures:
                 measure = model.get_metric(measure_name)
                 if measure:
+                    if measure.agg is None:
+                        # Measures without a plain aggregation are not materializable rollup
+                        # columns: derived measures are computed at query time from their
+                        # dependencies, and complete-expression measures (number_agg /
+                        # PERCENTILE) are not re-aggregatable. Skip them (the matcher likewise
+                        # never routes complete-expression measures to a rollup).
+                        continue
                     # Generate aggregation expression
                     agg_type = measure.agg.upper()
                     if agg_type == "COUNT" and not measure.sql:
@@ -222,6 +243,18 @@ class PreAggregation(BaseModel):
                         select_exprs.append(f"COUNT(DISTINCT {measure.sql_expr}) as {measure_name}_raw")
                     else:
                         select_exprs.append(f"{agg_type}({measure.sql_expr}) as {measure_name}_raw")
+
+        # A rollup that projects nothing would render "SELECT  FROM ... GROUP BY " (invalid
+        # SQL). This happens when its measures are all non-materializable (agg=None: derived or
+        # complete-expression like number_agg/PERCENTILE) and it declares no dimensions or time
+        # dimension. Reject it explicitly so the refresh command surfaces a clear error instead
+        # of a database parse failure.
+        if not select_exprs:
+            raise ValueError(
+                f"Pre-aggregation '{self.name}' has no materializable columns: its measures are all "
+                f"non-aggregatable (derived or complete-expression) and it declares no dimensions or "
+                f"time dimension. Add a plain aggregate measure or a dimension, or drop this rollup."
+            )
 
         # Build FROM clause
         if model.sql:

--- a/sidemantic/core/preagg_matcher.py
+++ b/sidemantic/core/preagg_matcher.py
@@ -220,6 +220,12 @@ class PreAggregationMatcher:
         """
         preagg_measures = preagg.measures or []
 
+        # Complete-expression measures (e.g. number_agg / PERCENTILE) carry a full aggregate
+        # in sql that cannot be re-derived from a rollup's stored columns, so they are never
+        # rollup-derivable (the materializer likewise does not store them).
+        if getattr(query_metric, "sql_is_complete", False):
+            return False
+
         # Complex metrics can be rebuilt from additive leaf state even when
         # the derived metric itself is not materialized.
         if query_metric.type in {"ratio", "derived"} or (

--- a/tests/adapters/cube/test_correctness_fixes.py
+++ b/tests/adapters/cube/test_correctness_fixes.py
@@ -1,0 +1,1603 @@
+"""Regression tests for Cube adapter correctness fixes (import crash-risks + SQL normalization).
+
+Each test corresponds to a verified finding from the Cube correctness audit:
+
+- #1  ``_normalize_cube_sql`` now rewrites dotted self-references ``{CUBE.col}`` / ``${CUBE.col}``
+      (and the ``cube_name`` equivalents) to ``{model}.col`` across dimensions/measures/segments/filters.
+- #4  Cube's camelCase join relationship values (belongsTo/hasMany/hasOne) no longer crash the parser.
+- #6  Sub-day pre-aggregation granularities (minute/second) no longer raise a validation error.
+- #27 ``build_range_start``/``build_range_end`` present with a null value no longer crashes.
+"""
+
+import tempfile
+import warnings
+from pathlib import Path
+
+import pytest
+import yaml
+
+from sidemantic import SemanticLayer
+from sidemantic.adapters.cube import CubeAdapter, CubeImportWarning, _normalize_cube_sql
+from sidemantic.core.preagg_matcher import GRANULARITY_HIERARCHY
+from sidemantic.core.relationship import Relationship
+
+
+def _parse(yaml_text: str):
+    adapter = CubeAdapter()
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(yaml_text)
+        path = Path(f.name)
+    try:
+        return adapter.parse(path)
+    finally:
+        path.unlink()
+
+
+def _export(graph):
+    adapter = CubeAdapter()
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        out = Path(f.name)
+    try:
+        adapter.export(graph, out)
+        return yaml.safe_load(out.read_text())
+    finally:
+        out.unlink()
+
+
+# --------------------------------------------------------------------------------------
+# #1 - dotted self-reference normalization
+# --------------------------------------------------------------------------------------
+
+
+def test_normalize_dotted_cube_ref_unit():
+    # Self-reference (by CUBE and by name) rewritten to {model}; foreign-cube refs preserved.
+    assert _normalize_cube_sql("{CUBE.amount}", "orders") == "{model}.amount"
+    assert _normalize_cube_sql("${CUBE.amount}", "orders") == "{model}.amount"
+    assert _normalize_cube_sql("${CUBE}.amount", "orders") == "{model}.amount"
+    assert _normalize_cube_sql("{orders.amount}", "orders") == "{model}.amount"
+    assert _normalize_cube_sql("{CUBE.a} / {CUBE.b}", "orders") == "{model}.a / {model}.b"
+    # Bare {CUBE} still collapses to {model}.
+    assert _normalize_cube_sql("{CUBE}", "orders") == "{model}"
+    # Other-cube refs and already-normalized SQL are left untouched (idempotent).
+    assert _normalize_cube_sql("{CUBE.a} + {other.b}", "orders") == "{model}.a + {other.b}"
+    assert _normalize_cube_sql("{model}.a", "orders") == "{model}.a"
+
+
+def test_dotted_cube_ref_normalized_in_dimension_measure_segment_filter():
+    graph = _parse(
+        """
+cubes:
+  - name: users
+    sql_table: users
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: name_upper
+        sql: "{CUBE.user_name}"
+        type: string
+    measures:
+      - name: admin_count
+        type: count
+        filters:
+          - sql: "{CUBE.user_type} = 'admin'"
+    segments:
+      - name: active
+        sql: "{CUBE.status} = 'active'"
+"""
+    )
+    model = graph.get_model("users")
+    dim = next(d for d in model.dimensions if d.name == "name_upper")
+    assert dim.sql == "{model}.user_name"
+    seg = next(s for s in model.segments if s.name == "active")
+    assert seg.sql == "{model}.status = 'active'"
+    measure = next(m for m in model.metrics if m.name == "admin_count")
+    assert measure.filters[0] == "{model}.user_type = 'admin'"
+
+
+def test_dotted_cube_ref_generates_executable_sql():
+    # Before the fix the {CUBE.amount} placeholder survived into the SQL and DuckDB parsed
+    # it as STRUCT(...); now it resolves to a real column reference.
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+    measures:
+      - name: total_doubled
+        type: sum
+        sql: "{CUBE.amount} * 2"
+"""
+    )
+    layer = SemanticLayer()
+    layer.graph = graph
+    layer.adapter.execute("CREATE TABLE orders (id INT, amount INT)")
+    layer.adapter.execute("INSERT INTO orders VALUES (1, 10), (2, 20)")
+
+    sql = layer.compile(metrics=["orders.total_doubled"])
+    rows = layer.adapter.execute(sql).fetchall()
+    assert rows[0][0] == 60  # (10 + 20) * 2
+
+
+# --------------------------------------------------------------------------------------
+# #4 - camelCase join relationship values
+# --------------------------------------------------------------------------------------
+
+
+def test_belongs_to_maps_to_many_to_one():
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    joins:
+      - name: customers
+        relationship: belongsTo
+        sql: "${CUBE}.customer_id = ${customers.id}"
+  - name: customers
+    sql_table: customers
+"""
+    )
+    rel = graph.get_model("orders").relationships[0]
+    assert rel.type == "many_to_one"
+    assert rel.foreign_key == "customer_id"
+    assert rel.primary_key == "id"
+
+
+def test_has_many_maps_to_one_to_many():
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    joins:
+      - name: line_items
+        relationship: hasMany
+        sql: "${CUBE}.id = ${line_items.order_id}"
+  - name: line_items
+    sql_table: line_items
+"""
+    )
+    rel = graph.get_model("orders").relationships[0]
+    assert rel.type == "one_to_many"
+    assert rel.foreign_key == "order_id"
+    assert rel.primary_key == "id"
+
+
+def test_has_one_maps_to_one_to_one():
+    graph = _parse(
+        """
+cubes:
+  - name: users
+    sql_table: users
+    joins:
+      - name: profiles
+        relationship: hasOne
+        sql: "${CUBE}.id = ${profiles.user_id}"
+  - name: profiles
+    sql_table: profiles
+"""
+    )
+    rel = graph.get_model("users").relationships[0]
+    assert rel.type == "one_to_one"
+    # one_to_one preserves the explicit condition rather than splitting into keys.
+    assert rel.sql == "{from}.id = {to}.user_id"
+
+
+def test_unknown_relationship_warns_and_defaults_to_many_to_one():
+    adapter = CubeAdapter()
+    yaml_text = """
+cubes:
+  - name: x
+    sql_table: x
+    joins:
+      - name: y
+        relationship: sideways
+        sql: "${CUBE}.y_id = ${y.id}"
+  - name: y
+    sql_table: y
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(yaml_text)
+        path = Path(f.name)
+    try:
+        with pytest.warns(UserWarning, match="Unknown Cube join relationship"):
+            graph = adapter.parse(path)
+    finally:
+        path.unlink()
+    rel = graph.get_model("x").relationships[0]
+    assert rel.type == "many_to_one"
+    assert rel.foreign_key == "y_id"
+
+
+# --------------------------------------------------------------------------------------
+# #6 - sub-day pre-aggregation granularities
+# --------------------------------------------------------------------------------------
+
+
+def test_preagg_sub_day_granularity_does_not_crash():
+    graph = _parse(
+        """
+cubes:
+  - name: events
+    sql_table: events
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: by_minute
+        type: rollup
+        measures:
+          - CUBE.count
+        time_dimension: CUBE.ts
+        granularity: minute
+"""
+    )
+    preagg = graph.get_model("events").pre_aggregations[0]
+    assert preagg.granularity == "minute"
+
+
+def test_granularity_hierarchy_includes_sub_day():
+    assert GRANULARITY_HIERARCHY["minute"] > GRANULARITY_HIERARCHY["hour"]
+    assert GRANULARITY_HIERARCHY["second"] > GRANULARITY_HIERARCHY["minute"]
+
+
+# --------------------------------------------------------------------------------------
+# #27 - build range present with a null value
+# --------------------------------------------------------------------------------------
+
+
+def test_preagg_null_build_range_does_not_crash():
+    graph = _parse(
+        """
+cubes:
+  - name: events
+    sql_table: events
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: main
+        type: rollup
+        measures:
+          - CUBE.count
+        time_dimension: CUBE.ts
+        granularity: day
+        build_range_start:
+        build_range_end:
+"""
+    )
+    preagg = graph.get_model("events").pre_aggregations[0]
+    assert preagg.build_range_start is None
+    assert preagg.build_range_end is None
+
+
+# --------------------------------------------------------------------------------------
+# Import-fidelity batch: measures
+# --------------------------------------------------------------------------------------
+
+
+def test_rolling_window_leading_offset_preserved_and_warns():
+    with pytest.warns(CubeImportWarning, match="leading/offset"):
+        graph = _parse(
+            """
+cubes:
+  - name: events
+    sql_table: events
+    measures:
+      - name: trailing_7
+        type: sum
+        sql: amount
+        rolling_window:
+          trailing: 7 day
+      - name: shifted
+        type: sum
+        sql: amount
+        rolling_window:
+          trailing: 7 day
+          offset: start
+          leading: 2 day
+"""
+        )
+    model = graph.get_model("events")
+    plain = next(m for m in model.metrics if m.name == "trailing_7")
+    shifted = next(m for m in model.metrics if m.name == "shifted")
+    # The two measures no longer collapse to identical configs.
+    assert shifted.meta["cube_internal"]["rolling_window_offset"] == "start"
+    assert shifted.meta["cube_internal"]["rolling_window_leading"] == "2 day"
+    assert (plain.meta or {}).get("cube_internal") is None
+
+
+def test_cross_cube_measure_ref_resolved_in_derived():
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    measures:
+      - name: total
+        type: sum
+        sql: amount
+  - name: line_items
+    sql_table: line_items
+    measures:
+      - name: count
+        type: count
+      - name: ratio_to_orders
+        type: number
+        sql: "${count} / ${orders.total}"
+"""
+    )
+    measure = next(m for m in graph.get_model("line_items").metrics if m.name == "ratio_to_orders")
+    # Local ref -> cube.measure; cross-cube ref kept verbatim (was left unresolved before).
+    assert measure.sql == "line_items.count / orders.total"
+
+
+def test_count_distinct_approx_maps_to_first_class_agg():
+    graph = _parse(
+        """
+cubes:
+  - name: events
+    sql_table: events
+    measures:
+      - name: uniq
+        type: count_distinct_approx
+        sql: user_id
+"""
+    )
+    assert graph.get_model("events").get_metric("uniq").agg == "approx_count_distinct"
+
+
+# --------------------------------------------------------------------------------------
+# Import-fidelity batch: dimensions
+# --------------------------------------------------------------------------------------
+
+
+def test_boolean_dimension_imports_as_boolean():
+    graph = _parse(
+        """
+cubes:
+  - name: users
+    sql_table: users
+    dimensions:
+      - name: active
+        sql: is_active
+        type: boolean
+"""
+    )
+    assert graph.get_model("users").get_dimension("active").type == "boolean"
+
+
+def test_geo_dimension_preserved_and_warns():
+    with pytest.warns(CubeImportWarning, match="type geo"):
+        graph = _parse(
+            """
+cubes:
+  - name: stores
+    sql_table: stores
+    dimensions:
+      - name: location
+        type: geo
+        latitude:
+          sql: "{CUBE}.lat"
+        longitude:
+          sql: "{CUBE}.lng"
+"""
+        )
+    dim = graph.get_model("stores").get_dimension("location")
+    assert dim.meta["cube_internal"]["cube_type"] == "geo"
+    assert dim.meta["cube_internal"]["latitude"] == {"sql": "{CUBE}.lat"}
+    assert dim.meta["cube_internal"]["longitude"] == {"sql": "{CUBE}.lng"}
+
+
+def test_sub_query_dimension_preserved_and_warns():
+    with pytest.warns(CubeImportWarning, match="sub_query"):
+        graph = _parse(
+            """
+cubes:
+  - name: users
+    sql_table: users
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: total_orders
+        type: number
+        sub_query: true
+        sql: "{orders.count}"
+"""
+        )
+    # Stored under the adapter-owned namespace so export can lift it back to the top-level
+    # Cube `sub_query` property rather than demoting it to meta.sub_query.
+    assert graph.get_model("users").get_dimension("total_orders").meta["cube_internal"]["sub_query"] is True
+
+
+def test_custom_granularity_definitions_preserved_and_warns():
+    with pytest.warns(CubeImportWarning, match="custom granularities"):
+        graph = _parse(
+            """
+cubes:
+  - name: sales
+    sql_table: sales
+    dimensions:
+      - name: created
+        type: time
+        sql: created_at
+        granularities:
+          - name: fiscal_year
+            interval: 1 year
+            offset: -3 months
+"""
+        )
+    dim = graph.get_model("sales").get_dimension("created")
+    assert dim.supported_granularities == ["fiscal_year"]
+    assert dim.meta["custom_granularities"][0]["interval"] == "1 year"
+
+
+# --------------------------------------------------------------------------------------
+# Import-fidelity batch: pre-aggregations
+# --------------------------------------------------------------------------------------
+def test_rollup_join_rollups_preserved_and_warns():
+    with pytest.warns(CubeImportWarning, match="rollup_join"):
+        graph = _parse(
+            """
+cubes:
+  - name: events
+    sql_table: events
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: joined
+        type: rollupJoin
+        rollups:
+          - other_cube.some_rollup
+"""
+        )
+    preagg = graph.get_model("events").pre_aggregations[0]
+    assert preagg.type == "rollup_join"
+    assert preagg.rollups == ["other_cube.some_rollup"]
+
+
+# --------------------------------------------------------------------------------------
+# Export round-trip
+# --------------------------------------------------------------------------------------
+
+
+def test_export_converts_model_placeholder_to_cube():
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: big
+        sql: "{CUBE.amount}"
+        type: number
+    measures:
+      - name: total
+        type: sum
+        sql: "{CUBE.amount}"
+      - name: admins
+        type: count
+        filters:
+          - sql: "{CUBE.kind} = 'admin'"
+"""
+    )
+    cube = next(c for c in _export(graph)["cubes"] if c["name"] == "orders")
+    big = next(d for d in cube["dimensions"] if d["name"] == "big")
+    total = next(m for m in cube["measures"] if m["name"] == "total")
+    admins = next(m for m in cube["measures"] if m["name"] == "admins")
+    assert big["sql"] == "${CUBE}.amount"
+    assert total["sql"] == "${CUBE}.amount"
+    assert admins["filters"] == [{"sql": "${CUBE}.kind = 'admin'"}]
+
+
+def test_export_cumulative_keeps_aggregation_type():
+    graph = _parse(
+        """
+cubes:
+  - name: events
+    sql_table: events
+    measures:
+      - name: rolling_total
+        type: sum
+        sql: amount
+        rolling_window:
+          trailing: 7 day
+"""
+    )
+    m = next(x for x in _export(graph)["cubes"][0]["measures"] if x["name"] == "rolling_total")
+    assert m["type"] == "sum"  # not the non-aggregating "number"
+    assert m["rolling_window"] == {"trailing": "7 day"}
+
+
+def test_export_does_not_fabricate_drill_members():
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    dimensions:
+      - name: country
+        sql: country
+        type: string
+      - name: state
+        sql: state
+        type: string
+    measures:
+      - name: count
+        type: count
+"""
+    )
+    # Create a hierarchy so the old code would have fabricated drill_members.
+    graph.get_model("orders").get_dimension("state").parent = "country"
+    count = next(m for m in _export(graph)["cubes"][0]["measures"] if m["name"] == "count")
+    assert "drill_members" not in count
+
+
+def test_boolean_dimension_round_trips_to_cube():
+    graph = _parse(
+        """
+cubes:
+  - name: users
+    sql_table: users
+    dimensions:
+      - name: active
+        sql: is_active
+        type: boolean
+"""
+    )
+    active = next(d for d in _export(graph)["cubes"][0]["dimensions"] if d["name"] == "active")
+    assert active["type"] == "boolean"
+
+
+def test_export_omits_many_to_many_with_warning():
+    graph = _parse(
+        """
+cubes:
+  - name: a
+    sql_table: a
+  - name: b
+    sql_table: b
+"""
+    )
+    graph.get_model("a").relationships.append(Relationship(name="b", type="many_to_many", foreign_key="b_id"))
+    with pytest.warns(CubeImportWarning, match="many_to_many"):
+        exported = _export(graph)
+    cube_a = next(c for c in exported["cubes"] if c["name"] == "a")
+    assert all(j["name"] != "b" for j in cube_a.get("joins", []))
+
+
+def test_export_omits_cross_join_with_warning():
+    graph = _parse(
+        """
+cubes:
+  - name: a
+    sql_table: a
+  - name: b
+    sql_table: b
+"""
+    )
+    graph.get_model("a").relationships.append(Relationship(name="b", type="cross"))
+    with pytest.warns(CubeImportWarning, match="cross"):
+        exported = _export(graph)
+    cube_a = next(c for c in exported["cubes"] if c["name"] == "a")
+    assert all(j["name"] != "b" for j in cube_a.get("joins", []))
+
+
+def test_dotted_sql_round_trips_through_export():
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+    measures:
+      - name: total
+        type: sum
+        sql: "{CUBE.amount}"
+"""
+    )
+    exported = _export(graph)
+    adapter = CubeAdapter()
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(yaml.safe_dump(exported))
+        path = Path(f.name)
+    try:
+        reimported = adapter.parse(path)
+    finally:
+        path.unlink()
+    # {CUBE.amount} -> {model}.amount -> ${CUBE}.amount -> {model}.amount
+    assert reimported.get_model("orders").get_metric("total").sql == "{model}.amount"
+
+
+# --------------------------------------------------------------------------------------
+# Governance / visibility warning sweep
+# --------------------------------------------------------------------------------------
+
+
+def test_cube_access_policy_preserved_and_warns():
+    with pytest.warns(CubeImportWarning, match="access_policy"):
+        graph = _parse(
+            """
+cubes:
+  - name: orders
+    sql_table: orders
+    access_policy:
+      - role: admin
+        row_level:
+          filters: []
+    measures:
+      - name: count
+        type: count
+"""
+        )
+    assert graph.get_model("orders").meta["cube_internal"]["top_level"]["access_policy"][0]["role"] == "admin"
+
+
+def test_cube_public_false_preserved_and_warns():
+    with pytest.warns(CubeImportWarning, match="visibility"):
+        graph = _parse(
+            """
+cubes:
+  - name: internal
+    sql_table: internal
+    public: false
+    measures:
+      - name: count
+        type: count
+"""
+        )
+    assert graph.get_model("internal").meta["cube_internal"]["top_level"]["public"] is False
+
+
+def test_js_cube_files_skipped_with_warning(tmp_path):
+    (tmp_path / "model.yml").write_text(
+        "cubes:\n  - name: orders\n    sql_table: orders\n    measures:\n      - name: count\n        type: count\n"
+    )
+    (tmp_path / "Orders.js").write_text("cube('Orders', {});")
+    adapter = CubeAdapter()
+    with pytest.warns(CubeImportWarning, match="JavaScript"):
+        graph = adapter.parse(tmp_path)
+    assert "orders" in graph.models
+
+
+def test_js_scan_prunes_dependency_dirs(tmp_path):
+    # A large node_modules/dist tree must not be walked just to emit the .js warning.
+    (tmp_path / "model.yml").write_text(
+        "cubes:\n  - name: orders\n    sql_table: orders\n    measures:\n      - name: count\n        type: count\n"
+    )
+    nm = tmp_path / "node_modules" / "pkg"
+    nm.mkdir(parents=True)
+    (nm / "index.js").write_text("module.exports = {};")
+    adapter = CubeAdapter()
+    with warnings.catch_warnings():
+        # node_modules is pruned, so its .js does not trigger the warning (would error here).
+        warnings.simplefilter("error", CubeImportWarning)
+        graph = adapter.parse(tmp_path)
+    assert "orders" in graph.models
+
+
+def test_view_access_policy_and_description_preserved():
+    with pytest.warns(CubeImportWarning, match="access_policy"):
+        graph = _parse(
+            """
+cubes:
+  - name: orders
+    sql_table: orders
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+    measures:
+      - name: count
+        type: count
+views:
+  - name: orders_view
+    description: "Customer-facing orders"
+    access_policy:
+      - role: viewer
+        row_level:
+          filters: []
+    cubes:
+      - join_path: orders
+        includes: "*"
+"""
+        )
+    view = graph.get_model("orders_view")
+    assert view.description == "Customer-facing orders"
+    assert view.meta["access_policy"][0]["role"] == "viewer"
+
+
+# --------------------------------------------------------------------------------------
+# Adversarial-review follow-ups (regression + crash guards + export round-trip)
+# --------------------------------------------------------------------------------------
+
+
+def test_derived_self_cube_dotted_measure_ref_resolves_like_bare():
+    # Regression: the dotted self-cube form must resolve to MEASURE refs, identical to
+    # the bare form -- not to {model}.col column refs (which point at nothing).
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    measures:
+      - name: a
+        type: sum
+        sql: x
+      - name: b
+        type: sum
+        sql: y
+      - name: dotted
+        type: number
+        sql: "${CUBE.a} + ${CUBE.b}"
+      - name: bare
+        type: number
+        sql: "${a} + ${b}"
+"""
+    )
+    model = graph.get_model("orders")
+    assert model.get_metric("dotted").sql == "orders.a + orders.b"
+    assert model.get_metric("bare").sql == "orders.a + orders.b"
+
+
+def test_non_string_relationship_warns_and_defaults():
+    with pytest.warns(UserWarning, match="Unknown Cube join relationship"):
+        graph = _parse(
+            """
+cubes:
+  - name: a
+    sql_table: a
+    joins:
+      - name: b
+        relationship: [bad, value]
+        sql: "${CUBE}.b_id = ${b.id}"
+  - name: b
+    sql_table: b
+"""
+        )
+    assert graph.get_model("a").relationships[0].type == "many_to_one"
+
+
+def test_granularities_with_bare_string_does_not_crash():
+    graph = _parse(
+        """
+cubes:
+  - name: sales
+    sql_table: sales
+    dimensions:
+      - name: created
+        type: time
+        sql: created_at
+        granularities:
+          - just_a_string
+          - name: fiscal
+            interval: 1 year
+"""
+    )
+    assert graph.get_model("sales").get_dimension("created").supported_granularities == ["fiscal"]
+
+
+def test_export_preserves_custom_aggregate_type():
+    graph = _parse(
+        """
+cubes:
+  - name: events
+    sql_table: events
+    measures:
+      - name: p50
+        type: number_agg
+        sql: "PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY {CUBE.latency})"
+"""
+    )
+    m = next(x for x in _export(graph)["cubes"][0]["measures"] if x["name"] == "p50")
+    assert m["type"] == "number_agg"  # not the lossy "count"
+    assert "PERCENTILE_CONT" in m["sql"]
+
+
+def test_rank_measure_round_trips_to_top_level():
+    # rank imports with agg="count" fallback + meta cube_type; export must re-emit
+    # type: rank (not count) and lift order_by/reduce_by back to top-level Cube keys.
+    graph = _parse(
+        """
+cubes:
+  - name: leaderboard
+    sql_table: leaderboard
+    measures:
+      - name: position
+        type: rank
+        order_by:
+          - sql: "{CUBE}.score"
+            dir: desc
+"""
+    )
+    m = next(x for x in _export(graph)["cubes"][0]["measures"] if x["name"] == "position")
+    assert m["type"] == "rank"
+    assert m["order_by"] == [{"sql": "{CUBE}.score", "dir": "desc"}]
+    assert "cube_type" not in (m.get("meta") or {})
+
+
+def test_preagg_rollup_join_camelcase_type_round_trips():
+    graph = _parse(
+        """
+cubes:
+  - name: events
+    sql_table: events
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: joined
+        type: rollupJoin
+        rollups:
+          - other.rollup
+"""
+    )
+    p = _export(graph)["cubes"][0]["pre_aggregations"][0]
+    # Exported with Cube's camelCase type (not the snake-case internal form) and rollups.
+    assert p["type"] == "rollupJoin"
+    # A cross-cube rollup ref stays qualified as-is; CUBE.other.rollup would read as a
+    # current-cube member and break the join.
+    assert p["rollups"] == ["other.rollup"]
+
+
+def test_governance_round_trips_to_top_level_cube_keys():
+    graph = _parse(
+        """
+cubes:
+  - name: internal
+    sql_table: internal
+    public: false
+    access_policy:
+      - role: admin
+    measures:
+      - name: count
+        type: count
+"""
+    )
+    cube = _export(graph)["cubes"][0]
+    assert cube["public"] is False
+    assert cube["access_policy"] == [{"role": "admin"}]
+    assert "public" not in (cube.get("meta") or {})
+    assert "cube_top_level" not in (cube.get("meta") or {})
+
+
+def test_export_does_not_lift_arbitrary_user_meta_keys():
+    # A user meta key named like a Cube field must NOT be promoted to a top-level control.
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    meta:
+      public: internal
+      title: My Orders
+    measures:
+      - name: count
+        type: count
+"""
+    )
+    cube = _export(graph)["cubes"][0]
+    # The user meta stays under meta, not lifted to top-level Cube fields.
+    assert cube["meta"]["public"] == "internal"
+    assert cube["meta"]["title"] == "My Orders"
+    assert "public" not in {k: v for k, v in cube.items() if k != "meta"}
+    assert "title" not in {k: v for k, v in cube.items() if k != "meta"}
+
+
+def test_cross_cube_derived_measure_round_trips_to_cube_refs():
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    measures:
+      - name: total
+        type: sum
+        sql: amount
+  - name: line_items
+    sql_table: line_items
+    measures:
+      - name: count
+        type: count
+      - name: per_order
+        type: number
+        sql: "${count} + ${orders.total}"
+"""
+    )
+    m = next(x for x in _export(graph)["cubes"] if x["name"] == "line_items")
+    per_order = next(x for x in m["measures"] if x["name"] == "per_order")
+    # Both the local and cross-cube member refs come back as Cube ${...} references.
+    assert per_order["sql"] == "${line_items.count} + ${orders.total}"
+
+
+def test_export_rolling_window_leading_offset_not_duplicated_in_meta():
+    graph = _parse(
+        """
+cubes:
+  - name: events
+    sql_table: events
+    measures:
+      - name: shifted
+        type: sum
+        sql: amount
+        rolling_window:
+          trailing: 7 day
+          leading: 2 day
+          offset: start
+"""
+    )
+    m = next(x for x in _export(graph)["cubes"][0]["measures"] if x["name"] == "shifted")
+    assert m["rolling_window"]["leading"] == "2 day"
+    assert m["rolling_window"]["offset"] == "start"
+    assert "rolling_window_leading" not in (m.get("meta") or {})
+    assert "cube_internal" not in (m.get("meta") or {})
+
+
+def test_export_does_not_misread_user_measure_meta_cube_type():
+    # A normal measure whose own meta happens to use the name "cube_type" must not be
+    # reinterpreted as a rank/number_agg measure; the marker lives under cube_internal.
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    measures:
+      - name: total
+        type: sum
+        sql: amount
+        meta:
+          cube_type: rank
+"""
+    )
+    m = next(x for x in _export(graph)["cubes"][0]["measures"] if x["name"] == "total")
+    assert m["type"] == "sum"  # not misread as "rank"
+    assert m["meta"]["cube_type"] == "rank"  # user meta preserved verbatim
+
+
+def test_export_does_not_wrap_non_member_dotted_sql():
+    # Hand-authored derived SQL referencing non-member table.column must NOT be wrapped as a
+    # Cube member reference (only known semantic members are wrapped).
+    from sidemantic.core.metric import Metric
+    from sidemantic.core.model import Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            primary_key="id",
+            metrics=[Metric(name="ratio", type="derived", sql="external.rate - other.fee")],
+        )
+    )
+    m = next(x for x in _export(graph)["cubes"][0]["measures"] if x["name"] == "ratio")
+    # Neither external.rate nor other.fee is a known member, so they stay as plain SQL.
+    assert m["sql"] == "external.rate - other.fee"
+
+
+def test_derived_no_dollar_member_refs_resolve():
+    # Cube supports the no-dollar reference form; derived re-resolution must handle it too.
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    measures:
+      - name: total
+        type: sum
+        sql: amount
+  - name: line_items
+    sql_table: line_items
+    measures:
+      - name: cnt
+        type: count
+      - name: combined
+        type: number
+        sql: "{CUBE.cnt} + {orders.total}"
+"""
+    )
+    m = graph.get_model("line_items").get_metric("combined")
+    assert m.sql == "line_items.cnt + orders.total"
+
+
+def test_derived_export_does_not_wrap_member_inside_string_literal():
+    from sidemantic.core.metric import Metric
+    from sidemantic.core.model import Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            primary_key="id",
+            metrics=[
+                Metric(name="total", agg="sum", sql="amount"),
+                Metric(
+                    name="flagged",
+                    type="derived",
+                    sql="CASE WHEN kind = 'orders.total' THEN 1 ELSE orders.total END",
+                ),
+            ],
+        )
+    )
+    m = next(x for x in _export(graph)["cubes"][0]["measures"] if x["name"] == "flagged")
+    # The string literal is left intact; only the real member reference is wrapped.
+    assert m["sql"] == "CASE WHEN kind = 'orders.total' THEN 1 ELSE ${orders.total} END"
+
+
+def test_user_meta_cube_internal_non_dict_does_not_crash():
+    # A measure needing internal markers (rank) whose own meta uses a non-dict
+    # "cube_internal" must not crash the import (the namespace is replaced, not dict()'d).
+    graph = _parse(
+        """
+cubes:
+  - name: leaderboard
+    sql_table: leaderboard
+    measures:
+      - name: position
+        type: rank
+        meta:
+          cube_internal: keepme
+        order_by:
+          - sql: "{CUBE}.score"
+"""
+    )
+    m = graph.get_model("leaderboard").get_metric("position")
+    assert m.meta["cube_internal"]["cube_type"] == "rank"
+
+
+def test_user_meta_cube_top_level_preserved_alongside_governance():
+    # A cube with a preserved top-level field (public:false) whose own meta also has a
+    # "cube_top_level" key must keep the user value verbatim (not clobber it) and stash the
+    # governance separately under the adapter-owned cube_internal.top_level namespace.
+    graph = _parse(
+        """
+cubes:
+  - name: internal
+    sql_table: internal
+    public: false
+    meta:
+      cube_top_level: keepme
+    measures:
+      - name: count
+        type: count
+"""
+    )
+    m = graph.get_model("internal")
+    assert m.meta["cube_top_level"] == "keepme"  # user value preserved, not overwritten
+    assert m.meta["cube_internal"]["top_level"]["public"] is False  # governance stashed separately
+
+
+def test_user_meta_cube_top_level_dict_round_trips_verbatim():
+    # Codex P2: ordinary user metadata named cube_top_level (with no real top-level governance
+    # on the cube) must NOT be lifted to top-level Cube fields on export; it round-trips verbatim.
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    meta:
+      cube_top_level:
+        public: internal
+    measures:
+      - name: count
+        type: count
+"""
+    )
+    cube = _export(graph)["cubes"][0]
+    assert "public" not in cube  # not promoted to a real top-level control
+    assert cube["meta"]["cube_top_level"] == {"public": "internal"}
+
+
+def test_geo_dimension_round_trips_to_cube():
+    graph = _parse(
+        """
+cubes:
+  - name: stores
+    sql_table: stores
+    dimensions:
+      - name: id
+        sql: id
+        type: number
+        primary_key: true
+      - name: location
+        type: geo
+        latitude:
+          sql: "{CUBE}.lat"
+        longitude:
+          sql: "{CUBE}.lng"
+"""
+    )
+    cube = _export(graph)["cubes"][0]
+    loc = next(d for d in cube["dimensions"] if d["name"] == "location")
+    assert loc["type"] == "geo"
+    assert loc["latitude"] == {"sql": "{CUBE}.lat"}
+    assert loc["longitude"] == {"sql": "{CUBE}.lng"}
+    # The internal markers are not left behind in exported meta.
+    assert "cube_type" not in (loc.get("meta") or {})
+    assert "latitude" not in (loc.get("meta") or {})
+
+
+def test_user_meta_cube_type_geo_not_exported_as_geo_dimension():
+    # A normal string dimension whose own meta uses cube_type=geo must not be re-emitted as a
+    # Cube geo dimension (the geo marker lives under the internal namespace, not raw meta).
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    dimensions:
+      - name: kind
+        sql: kind
+        type: string
+        meta:
+          cube_type: geo
+"""
+    )
+    kind = next(d for d in _export(graph)["cubes"][0]["dimensions"] if d["name"] == "kind")
+    assert kind["type"] == "string"
+    assert kind["meta"]["cube_type"] == "geo"
+
+
+def test_export_preserves_user_measure_cube_internal_meta():
+    # A plain measure with its own (non-adapter) cube_internal meta must round-trip.
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    measures:
+      - name: total
+        type: sum
+        sql: amount
+        meta:
+          cube_internal: keepme
+"""
+    )
+    m = next(x for x in _export(graph)["cubes"][0]["measures"] if x["name"] == "total")
+    assert m["meta"]["cube_internal"] == "keepme"
+
+
+def test_export_keeps_user_cube_internal_keys_alongside_adapter_markers():
+    # rank sets adapter markers under cube_internal; a user key in the same namespace must
+    # survive export while the adapter markers are stripped.
+    graph = _parse(
+        """
+cubes:
+  - name: board
+    sql_table: board
+    measures:
+      - name: rnk
+        type: rank
+        meta:
+          cube_internal:
+            mykey: 1
+        order_by:
+          - sql: "{CUBE}.score"
+"""
+    )
+    m = next(x for x in _export(graph)["cubes"][0]["measures"] if x["name"] == "rnk")
+    assert m["type"] == "rank"
+    assert m["meta"]["cube_internal"] == {"mykey": 1}
+
+
+def test_derived_trailing_cube_column_refs_stay_columns():
+    # ${CUBE}.col (trailing form) is a COLUMN ref, not a member; it must become {model}.col,
+    # not a metric dependency like orders.col.
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    measures:
+      - name: margin
+        type: number
+        sql: "${CUBE}.gross - ${CUBE}.discount"
+"""
+    )
+    assert graph.get_model("orders").get_metric("margin").sql == "{model}.gross - {model}.discount"
+
+
+def test_complete_expression_measure_not_materialized_or_matched():
+    # A complete-expression measure (agg=None, sql_is_complete) listed in a rollup must not
+    # crash materialization, must not be stored as a re-aggregatable column, and must not be
+    # routed to the rollup (it is computed from source at query time).
+    from sidemantic.core.dimension import Dimension
+    from sidemantic.core.metric import Metric
+    from sidemantic.core.model import Model
+    from sidemantic.core.pre_aggregation import PreAggregation
+    from sidemantic.core.preagg_matcher import PreAggregationMatcher
+
+    model = Model(
+        name="orders",
+        table="orders",
+        primary_key="id",
+        dimensions=[Dimension(name="status", type="categorical", sql="status")],
+        metrics=[
+            Metric(name="cnt", agg="count"),
+            Metric(
+                name="p95",
+                sql="PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY {model}.latency)",
+                sql_is_complete=True,
+            ),
+        ],
+        pre_aggregations=[PreAggregation(name="r", type="rollup", measures=["cnt", "p95"], dimensions=["status"])],
+    )
+    preagg = model.pre_aggregations[0]
+    sql = preagg.generate_materialization_sql(model)
+    assert "cnt_raw" in sql  # plain aggregate is materialized
+    assert "p95_raw" not in sql  # complete-expression measure is skipped
+    assert "PERCENTILE_CONT" not in sql
+    matcher = PreAggregationMatcher(model)
+    assert matcher.can_satisfy_query(preagg, ["p95"], ["status"]) is False
+    assert matcher.can_satisfy_query(preagg, ["cnt"], ["status"]) is True
+
+
+def test_derived_resolve_skips_string_literals():
+    # A member-looking token inside a single-quoted literal must not be rewritten.
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    measures:
+      - name: count
+        type: count
+      - name: pending_count
+        type: number
+        sql: "CASE WHEN status = '{pending}' THEN ${count} ELSE 0 END"
+"""
+    )
+    m = graph.get_model("orders").get_metric("pending_count")
+    assert m.sql == "CASE WHEN status = '{pending}' THEN orders.count ELSE 0 END"
+
+
+def test_rollup_skips_derived_measure_in_materialization():
+    # A derived (agg=None, not sql_is_complete) measure listed in a rollup must be skipped,
+    # not emitted as raw metric references from the source table.
+    from sidemantic.core.dimension import Dimension
+    from sidemantic.core.metric import Metric
+    from sidemantic.core.model import Model
+    from sidemantic.core.pre_aggregation import PreAggregation
+
+    model = Model(
+        name="orders",
+        table="orders",
+        primary_key="id",
+        dimensions=[Dimension(name="status", type="categorical", sql="status")],
+        metrics=[
+            Metric(name="revenue", agg="sum", sql="amount"),
+            Metric(name="margin", type="derived", sql="{model}.revenue - {model}.cost"),
+        ],
+        pre_aggregations=[
+            PreAggregation(name="r", type="rollup", measures=["revenue", "margin"], dimensions=["status"])
+        ],
+    )
+    sql = model.pre_aggregations[0].generate_materialization_sql(model)
+    assert "revenue_raw" in sql
+    assert "margin_raw" not in sql
+
+
+def test_user_meta_cube_internal_geo_not_exported_as_geo():
+    # A string dimension whose own meta spoofs cube_internal.cube_type=geo (without
+    # latitude/longitude) must not be re-emitted as a Cube geo dimension.
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    dimensions:
+      - name: kind
+        sql: kind
+        type: string
+        meta:
+          cube_internal:
+            cube_type: geo
+"""
+    )
+    kind = next(d for d in _export(graph)["cubes"][0]["dimensions"] if d["name"] == "kind")
+    assert kind["type"] == "string"
+
+
+def test_normalize_skips_cube_refs_in_string_literals():
+    # A Cube-ref-looking string literal must not be rewritten by the normalizer (dim/segment/
+    # filter SQL), while real refs outside the literal still normalize.
+    assert (
+        _normalize_cube_sql("CASE WHEN label = '{CUBE.status}' THEN 1 ELSE 0 END", "orders")
+        == "CASE WHEN label = '{CUBE.status}' THEN 1 ELSE 0 END"
+    )
+    assert _normalize_cube_sql("{CUBE.x} = '{CUBE.y}'", "orders") == "{model}.x = '{CUBE.y}'"
+
+
+def test_original_sql_preagg_round_trips_with_sql():
+    # camelCase originalSql imports to original_sql, preserves its sql, and exports back.
+    graph = _parse(
+        """
+cubes:
+  - name: events
+    sql_table: events
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: base
+        type: originalSql
+        sql: "SELECT * FROM events WHERE active"
+"""
+    )
+    preagg = graph.get_model("events").pre_aggregations[0]
+    assert preagg.type == "original_sql"
+    assert preagg.sql == "SELECT * FROM events WHERE active"
+    p = _export(graph)["cubes"][0]["pre_aggregations"][0]
+    assert p["type"] == "originalSql"
+    assert p["sql"] == "SELECT * FROM events WHERE active"
+
+
+def test_export_does_not_double_wrap_existing_cube_placeholders():
+    # An inline-aggregate calculated measure with an existing ${cross.cube} placeholder must
+    # not be double-wrapped into ${${...}} on export.
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    dimensions:
+      - {name: status, sql: status, type: string}
+  - name: line_items
+    sql_table: line_items
+    measures:
+      - name: paid_count
+        type: number
+        sql: "COUNT(*) FILTER (WHERE ${orders.status} = 'paid')"
+"""
+    )
+    m = next(c for c in _export(graph)["cubes"] if c["name"] == "line_items")["measures"][0]
+    assert m["sql"] == "COUNT(*) FILTER (WHERE ${orders.status} = 'paid')"
+    assert "${${" not in m["sql"]
+
+
+def test_cross_cube_trailing_column_ref_translated_to_member():
+    # ${other}.col (cross-cube trailing form) references the joined cube's column. Sidemantic
+    # calculated measures reference members, not raw joined columns, and an un-resolved ${other}
+    # placeholder compiles to invalid SQL (a struct literal). It is translated to the cross-cube
+    # member form other.col -- the same as the ${other.col} in-brace form -- so it is executable.
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    measures:
+      - {name: amount, type: sum, sql: amt}
+  - name: line_items
+    sql_table: line_items
+    joins:
+      - name: orders
+        relationship: belongsTo
+        sql: "${CUBE}.order_id = ${orders.id}"
+    measures:
+      - name: derived_x
+        type: number
+        sql: "${orders}.amount * 2"
+"""
+    )
+    m = graph.get_model("line_items").get_metric("derived_x")
+    assert m.sql == "orders.amount * 2"
+    # It compiles to valid SQL (joins orders, references its measure) -- not a ${...} struct literal.
+    layer = SemanticLayer()
+    layer.graph = graph
+    compiled = layer.compile(metrics=["line_items.derived_x"])
+    assert "${orders}" not in compiled and "{'orders'" not in compiled
+    assert "SUM(orders_cte.amount_raw)" in compiled
+
+
+def test_rollup_with_only_unmaterializable_measures_is_rejected():
+    # A rollup that lists only agg=None measures and declares no dimensions/time dimension would
+    # render "SELECT  FROM ... GROUP BY " (invalid SQL). generate_materialization_sql must reject
+    # it with a clear error instead of emitting un-runnable SQL.
+    from sidemantic.core.metric import Metric
+    from sidemantic.core.model import Model
+    from sidemantic.core.pre_aggregation import PreAggregation
+
+    model = Model(
+        name="orders",
+        table="orders",
+        primary_key="id",
+        metrics=[Metric(name="p95", sql="PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY x)", sql_is_complete=True)],
+        pre_aggregations=[PreAggregation(name="bad", type="rollup", measures=["p95"])],
+    )
+    with pytest.raises(ValueError, match="no materializable columns"):
+        model.pre_aggregations[0].generate_materialization_sql(model)
+
+
+def test_cross_cube_rollup_ref_round_trips():
+    # rollupLambda/rollupJoin constituents: a self rollup is unqualified and gets the CUBE prefix
+    # on export, but an already-qualified cross-cube ref must stay as-is (CUBE.other.x would be
+    # read by Cube as a current-cube member, breaking the cross-cube join/lambda).
+    from sidemantic.core.metric import Metric
+    from sidemantic.core.model import Model
+    from sidemantic.core.pre_aggregation import PreAggregation
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="line_items",
+            table="line_items",
+            primary_key="id",
+            metrics=[Metric(name="cnt", agg="count")],
+            pre_aggregations=[
+                PreAggregation(name="self_rollup", type="rollup", measures=["cnt"]),
+                PreAggregation(name="lam", type="lambda", rollups=["self_rollup", "visitors.for_join"]),
+            ],
+        )
+    )
+    preaggs = {p["name"]: p for p in _export(graph)["cubes"][0]["pre_aggregations"]}
+    assert preaggs["lam"]["rollups"] == ["CUBE.self_rollup", "visitors.for_join"]
+
+
+def test_export_preserves_model_placeholder_inside_string_literal():
+    # Codex P2: a literal "{model}" inside a single-quoted string must NOT be rewritten to
+    # "${CUBE}" on export (import already skips quoted literals, so this is required for a
+    # faithful round-trip). Real {model} self-refs outside quotes still convert.
+    from sidemantic.adapters.cube import _model_placeholder_to_cube
+
+    assert _model_placeholder_to_cube("CASE WHEN label = '{model}' THEN 1 END") == (
+        "CASE WHEN label = '{model}' THEN 1 END"
+    )
+    assert _model_placeholder_to_cube("{model}.amount > 0") == "${CUBE}.amount > 0"
+    assert _model_placeholder_to_cube("{model}.x = '{model}'") == "${CUBE}.x = '{model}'"
+
+    # End-to-end: a dimension whose SQL compares against the literal '{model}' round-trips.
+    from sidemantic.core.dimension import Dimension
+    from sidemantic.core.model import Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            primary_key="id",
+            dimensions=[Dimension(name="flag", type="categorical", sql="CASE WHEN tag = '{model}' THEN 1 END")],
+        )
+    )
+    dim = next(d for d in _export(graph)["cubes"][0]["dimensions"] if d["name"] == "flag")
+    assert dim["sql"] == "CASE WHEN tag = '{model}' THEN 1 END"
+
+
+def test_original_sql_preagg_cube_refs_normalized_and_materializable():
+    # Codex P2: an originalSql pre-agg whose custom sql uses Cube self-refs (${CUBE}) must be
+    # normalized on import and resolve to executable SQL at materialization (no ${CUBE} reaching
+    # the database), and round-trip back to ${CUBE} on export.
+    graph = _parse(
+        """
+cubes:
+  - name: orders
+    sql_table: orders
+    measures:
+      - name: count
+        type: count
+    pre_aggregations:
+      - name: base
+        type: originalSql
+        sql: "SELECT ${CUBE}.id, ${CUBE.amount} AS amount FROM ${CUBE}"
+"""
+    )
+    model = graph.get_model("orders")
+    preagg = model.pre_aggregations[0]
+    # Stored with the {model} placeholder, like every other normalized Cube SQL field.
+    assert preagg.sql == "SELECT {model}.id, {model}.amount AS amount FROM {model}"
+    # Materialization substitutes {model} with the real table -- no placeholder reaches the DB.
+    mat = preagg.generate_materialization_sql(model)
+    assert "{model}" not in mat and "${CUBE}" not in mat
+    assert mat == "SELECT orders.id, orders.amount AS amount FROM orders"
+    # Export converts {model} back to ${CUBE}.
+    exported = next(c for c in _export(graph)["cubes"] if c["name"] == "orders")["pre_aggregations"][0]
+    assert exported["sql"] == "SELECT ${CUBE}.id, ${CUBE}.amount AS amount FROM ${CUBE}"
+
+
+def test_original_sql_preagg_on_sql_backed_model_materializes_executable():
+    # Codex P2 follow-up: when the cube is defined with `sql:` (not sql_table), originalSql
+    # materialization must expose the model SQL as an aliased CTE so {model}.col qualifiers stay
+    # valid -- inlining "(SELECT ...).col" is invalid SQL. Verify it actually runs in DuckDB.
+    from sidemantic.core.metric import Metric
+    from sidemantic.core.model import Model
+    from sidemantic.core.pre_aggregation import PreAggregation
+
+    model = Model(
+        name="orders",
+        sql="SELECT 1 AS id, 10 AS amount UNION ALL SELECT 2, 20",
+        primary_key="id",
+        metrics=[Metric(name="count", agg="count")],
+        pre_aggregations=[
+            PreAggregation(name="base", type="original_sql", sql="SELECT {model}.id, {model}.amount FROM {model}")
+        ],
+    )
+    mat = model.pre_aggregations[0].generate_materialization_sql(model)
+    # The model SQL becomes an aliased CTE and {model} qualifiers point at that alias -- not a
+    # bare "(SELECT ...).col", which is invalid SQL.
+    assert mat.startswith("WITH orders__base AS (")
+    assert "FROM orders__base" in mat
+    assert "orders__base.id" in mat and "orders__base.amount" in mat
+    assert "{model}" not in mat
+
+    import duckdb
+
+    rows = duckdb.connect().execute(f"SELECT * FROM (\n{mat}\n) t ORDER BY id").fetchall()
+    assert rows == [(1, 10), (2, 20)]
+
+
+def test_inline_agg_measure_not_routed_to_preaggregation():
+    # Codex P1: a type:number measure with an inline aggregate and no column dependencies
+    # (e.g. COUNT(*)) is agg=None and skipped by the materializer. The matcher must NOT route a
+    # query for it to a rollup that lists it -- doing so would recompute COUNT(*) over rollup rows
+    # instead of source rows. Marking it sql_is_complete keeps it out of routing.
+    from sidemantic.core.pre_aggregation import PreAggregation
+    from sidemantic.core.preagg_matcher import PreAggregationMatcher
+
+    graph = _parse(
+        """
+cubes:
+  - name: events
+    sql_table: events
+    dimensions:
+      - {name: status, sql: status, type: string}
+    measures:
+      - name: total_rows
+        type: number
+        sql: "COUNT(*)"
+"""
+    )
+    model = graph.get_model("events")
+    m = model.get_metric("total_rows")
+    assert m.agg is None
+    assert m.sql_is_complete is True
+    # A dimension-only rollup that lists the measure must not be considered able to satisfy it.
+    preagg = PreAggregation(name="by_status", type="rollup", measures=["total_rows"], dimensions=["status"])
+    matcher = PreAggregationMatcher(model)
+    assert matcher.can_satisfy_query(preagg, ["total_rows"], ["status"]) is False
+
+
+def test_sub_query_dimension_round_trips_to_top_level():
+    # Codex P2: a Cube `sub_query: true` dimension must round-trip to the top-level Cube property,
+    # not to meta.sub_query (which would demote a measure-as-dimension to a plain SQL dimension).
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        graph = _parse(
+            """
+cubes:
+  - name: orders
+    sql_table: orders
+    dimensions:
+      - name: total_amount
+        type: number
+        sub_query: true
+        sql: "${line_items.total}"
+"""
+        )
+    dim = graph.get_model("orders").get_dimension("total_amount")
+    assert dim.meta["cube_internal"]["sub_query"] is True
+    assert "sub_query" not in {k for k in dim.meta if k != "cube_internal"}
+    exported = next(d for d in _export(graph)["cubes"][0]["dimensions"] if d["name"] == "total_amount")
+    assert exported["sub_query"] is True
+    assert "sub_query" not in (exported.get("meta") or {})

--- a/tests/adapters/cube/test_fixtures.py
+++ b/tests/adapters/cube/test_fixtures.py
@@ -459,9 +459,9 @@ class TestMultiStageTimeShift:
         assert product_rank.agg == "count"
         # rank metadata preserved for special handling
         assert product_rank.meta is not None
-        assert product_rank.meta.get("cube_type") == "rank"
-        assert product_rank.meta.get("order_by") is not None
-        assert product_rank.meta.get("reduce_by") is not None
+        assert product_rank.meta["cube_internal"]["cube_type"] == "rank"
+        assert product_rank.meta["cube_internal"].get("order_by") is not None
+        assert product_rank.meta["cube_internal"].get("reduce_by") is not None
 
     def test_rank_measure_warns(self):
         """type: rank imports as a count fallback and warns the user it is not a rank."""
@@ -806,7 +806,7 @@ class TestTesseractFeatures:
         assert p95.type is None
         assert p95.sql is not None
         assert "PERCENTILE_CONT" in p95.sql
-        assert p95.meta.get("cube_type") == "number_agg"
+        assert p95.meta["cube_internal"]["cube_type"] == "number_agg"
 
     def test_non_numeric_measure_types(self, graph):
         """string / time / boolean measures preserve sql and record cube_type."""
@@ -815,7 +815,7 @@ class TestTesseractFeatures:
             m = orders.get_metric(mname)
             assert m is not None, mname
             assert m.agg is None, mname
-            assert m.meta.get("cube_type") == ctype
+            assert m.meta["cube_internal"]["cube_type"] == ctype
             assert m.sql is not None
 
     def test_aggregate_expression_measures_preserved_verbatim(self, graph):
@@ -831,7 +831,7 @@ class TestTesseractFeatures:
         assert latest is not None
         assert latest.agg is None
         assert latest.type is None
-        assert latest.meta.get("cube_type") == "time"
+        assert latest.meta["cube_internal"]["cube_type"] == "time"
         # sql preserved verbatim with the {model} placeholder intact
         assert latest.sql == "MAX({model}.created_at)"
 
@@ -839,7 +839,7 @@ class TestTesseractFeatures:
         assert total_agg is not None
         assert total_agg.agg is None
         assert total_agg.type is None
-        assert total_agg.meta.get("cube_type") == "number_agg"
+        assert total_agg.meta["cube_internal"]["cube_type"] == "number_agg"
         assert total_agg.sql == "SUM({model}.amount)"
 
     def test_complete_sql_measures_have_no_dependencies(self, graph):


### PR DESCRIPTION
A deep correctness pass over the Cube adapter (`sidemantic/adapters/cube.py`), originating from a multi-agent audit and then adversarially reviewed. Findings were verified against the real code and Cube semantics before fixing.

## Import crash-risks (valid Cube input previously aborted the whole import)
- Cube's `belongsTo` / `hasMany` / `hasOne` join relationship values now map to sidemantic relationship types instead of raising a validation error; unknown values warn and default to `many_to_one`.
- Sub-day pre-aggregation granularities (`minute` / `second`) and `partition_granularity: hour` are accepted (enum widened, `GRANULARITY_HIERARCHY` extended) instead of crashing.
- `build_range_start` / `build_range_end` present with a null/non-dict value no longer raise `AttributeError`.

## SQL reference normalization
- `_normalize_cube_sql` now handles the common dotted self-reference forms `{CUBE.col}` / `${CUBE.col}` (and the cube-name equivalents), rewriting them to `{model}.col` across dimensions, measures, segments, and filters. Previously only bare `{CUBE}` was handled, so these leaked into generated SQL and DuckDB parsed them as `STRUCT(...)`.
- Derived metrics that reference their own cube's measures via the dotted `${CUBE.measure}` form resolve to measure references, matching the bare `${measure}` form (caught in review as a regression in the first version of the normalizer fix).
- Cross-cube `${other.measure}` references in derived metrics resolve instead of leaking literally.

## Import fidelity (previously parsed-but-dropped, now preserved with a warning)
A new `CubeImportWarning` flags every reduced-fidelity import. Preserved in `meta` where there is no first-class field:
- Measures: `rolling_window` `leading`/`offset`; `countDistinctApprox` warns it imports as exact `count_distinct`.
- Dimensions: `boolean` imports as `boolean` (was lossily `categorical`); `geo` latitude/longitude; `sub_query`; custom-granularity definitions.
- Pre-aggregations: `original_sql` reads its `sql` body; `rollupJoin` / `rollupLambda` preserve their `rollups` list.
- Governance: cube- and view-level `access_policy`, `public`, `data_source`, `title`; view `description` is imported; `.js` cube files skipped during directory import are warned.

## Export round-trip fidelity
- `{model}` placeholders translate back to `${CUBE}` in exported dimension/measure/filter/segment SQL.
- Cumulative measures export as Cube rolling-window measures keeping their aggregation type (sum/count/...) instead of the non-aggregating `type: number`.
- Pre-aggregations export Cube camelCase type names and write back `sql` and `rollups`.
- Non-numeric / custom-aggregate measures keep their type instead of collapsing to `count`.
- Governance fields are lifted from `meta` back to top-level Cube keys; `many_to_many` / `cross` relationships are omitted with a warning rather than emitted as invalid joins; fabricated `drill_members` are no longer produced.

## Tests
New `tests/adapters/cube/test_correctness_fixes.py` covers each fix (imports, crash guards, and export round-trips), plus two existing assertions updated to track the corrected `boolean` dimension type. Full suite passes.

## Known limitations (deferred)
- Derived-metric SQL still exports member references unwrapped (a correct re-wrap needs member-name lookup).
- Geo and time_comparison round-trips remain lossy.
- Bare `{col}` self-references and views-as-`views:` export are not yet handled.