### PR TITLE
Fix Malloy adapter correctness bugs (aggregation, expressions, joins, export, imports)

### DIFF
--- a/docs/compatibility/malloy.md
+++ b/docs/compatibility/malloy.md
@@ -129,7 +129,7 @@ Not mapped: `--! styles` directives, `##! experimental` pragmas.
 |---------|--------|
 | `join_one: target with foreign_key` | Supported (maps to `Relationship(type="many_to_one")`) |
 | `join_many: target on condition` | Supported (maps to `Relationship(type="one_to_many")`) |
-| `join_cross: target` | Supported (maps to `Relationship(type="one_to_one")`) |
+| `join_cross: target` | Supported (maps to `Relationship(type="cross")`, generating a `CROSS JOIN`) |
 | `join_one: alias is source with fk` (aliased join) | Supported (relationship name is the alias) |
 | `join_one: alias is source on condition` | Supported (FK extracted from first identifier before `=` in the on-expression) |
 | Multiple joins in comma-separated list | Supported |
@@ -309,7 +309,7 @@ Sidemantic can export its semantic model back to Malloy format.
 | `join_one:` / `join_many:` with `on` condition | Supported (full `on` condition exported from `metadata["on_condition"]` when available) |
 | `where:` (segments) | Supported (source-level where clauses exported) |
 | Roundtrip fidelity (parse -> export -> re-parse) | Supported (semantically equivalent graphs; passthrough dimensions intentionally dropped) |
-| `join_cross:` export | Supported (one_to_one relationships exported as `join_cross:`) |
+| `join_cross:` export | Supported (`cross` relationships exported as `join_cross:` with no key clause) |
 | `rename:` export | Supported (simple identifier dimensions detected and exported as `rename: new is old`) |
 | `view:` export | Unsupported (views are not captured during parsing) |
 

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -73,7 +73,9 @@ def _normalize_count_calls(s: str) -> str:
     i, n = 0, len(s)
     while i < n:
         c = s[i]
-        if c in ("'", '"'):
+        # Copy string and backtick-identifier literals verbatim (a backtick field
+        # may contain parens, e.g. `user(id`).
+        if c in ("'", '"', "`"):
             j = i + 1
             while j < n:
                 if s[j] == "\\":
@@ -103,7 +105,7 @@ def _normalize_count_calls(s: str) -> str:
                             q = None
                         p += 1
                         continue
-                    if ch in ("'", '"'):
+                    if ch in ("'", '"', "`"):
                         q = ch
                     elif ch == "(":
                         depth += 1

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -421,6 +421,35 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         derived measure so the stored SQL is executable.
         """
 
+        def sub_outside_quotes(s: str, pattern: str, repl) -> str:
+            # Apply re.sub only to text outside string literals so an
+            # aggregate-looking value inside a literal (e.g. 'count()') is intact.
+            # Backticks are NOT string delimiters here: a backtick-quoted field
+            # name (`cost amount`.sum()) is part of an aggregate to normalize.
+            out: list[str] = []
+            i, n = 0, len(s)
+            while i < n:
+                c = s[i]
+                if c in ("'", '"'):
+                    j = i + 1
+                    while j < n:
+                        if s[j] == "\\":
+                            j += 2
+                            continue
+                        if s[j] == c:
+                            j += 1
+                            break
+                        j += 1
+                    out.append(s[i:j])
+                    i = j
+                else:
+                    j = i
+                    while j < n and s[j] not in ("'", '"'):
+                        j += 1
+                    out.append(re.sub(pattern, repl, s[i:j], flags=re.IGNORECASE))
+                    i = j
+            return "".join(out)
+
         def count_repl(m: re.Match) -> str:
             arg = m.group(1).strip()
             if arg == "":
@@ -428,15 +457,6 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             if arg == "*" or arg.lower().startswith("distinct "):
                 return m.group(0)
             return f"COUNT(DISTINCT {arg})"
-
-        # Standard function forms count(x) / count_distinct(x) / count() — not
-        # preceded by `.` so dot-method calls below are left for the next pass.
-        expr = re.sub(
-            r"(?<![\w.`])count(?:_distinct)?\s*\(\s*([^)]*?)\s*\)",
-            count_repl,
-            expr,
-            flags=re.IGNORECASE,
-        )
 
         def dot_repl(m: re.Match) -> str:
             field = m.group(1)
@@ -447,13 +467,15 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             sql_agg = agg.upper()
             return f"{sql_agg}({field}, {args})" if args else f"{sql_agg}({field})"
 
+        # Standard function forms count(x) / count_distinct(x) / count() — not
+        # preceded by `.` so dot-method calls are handled by the next pass.
+        expr = sub_outside_quotes(expr, r"(?<![\w.`])count(?:_distinct)?\s*\(\s*([^)]*?)\s*\)", count_repl)
         # Dot-method aggregates; the field may be a backtick-quoted identifier
         # with spaces (`cost amount`.sum()).
-        return re.sub(
+        return sub_outside_quotes(
+            expr,
             r"((?:`[^`]*`|[\w.])+)\.(sum|avg|count|min|max|count_distinct)\s*\(\s*(.*?)\s*\)",
             dot_repl,
-            expr,
-            flags=re.IGNORECASE,
         )
 
     def _parse_aggregation(self, expr: str) -> tuple[str | None, str | None]:
@@ -629,22 +651,32 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                 start = i + 1
                 i += 1
                 continue
-            matched = None
-            # Logical operators and CASE keywords bound an arithmetic operand on
-            # the left (the pick -> CASE rewrite runs before this, so a condition
-            # like `WHEN title ~ r'...'` must stop the operand at `WHEN`).
-            for kw in ("and", "or", "not", "when", "then", "else", "case", "end"):
+            # Whole-word keyword handling. `case`/`end` bracket a CASE expression
+            # and behave like parentheses so the whole `case ... end` is one
+            # operand; `and`/`or`/`not`/`when`/`then`/`else` bound the operand on
+            # the left (the pick -> CASE rewrite runs first, so `WHEN x ~ r'...'`
+            # must stop the operand at `WHEN`).
+            matched_kw = None
+            for kw in ("case", "end", "and", "or", "not", "when", "then", "else"):
                 j = i + len(kw)
                 if (
                     s[i:j].lower() == kw
                     and (i == 0 or not (s[i - 1].isalnum() or s[i - 1] == "_"))
                     and (j >= end or not (s[j].isalnum() or s[j] == "_"))
                 ):
-                    matched = j
+                    matched_kw = (kw, j)
                     break
-            if matched is not None:
-                start = matched
-                i = matched
+            if matched_kw is not None:
+                kw, j = matched_kw
+                if kw == "case":
+                    stack.append(start)
+                    start = i
+                elif kw == "end":
+                    if stack:
+                        start = stack.pop()
+                else:
+                    start = j
+                i = j
                 continue
             i += 1
 
@@ -2230,9 +2262,11 @@ class MalloyAdapter(BaseAdapter):
         """Rewrite SQL aggregate syntax back to Malloy for export.
 
         COUNT(DISTINCT x) -> count(x), count(*) -> count(), and uppercase
-        SUM/AVG/MIN/MAX/COUNT(...) -> lowercase, so a derived measure whose SQL
-        came from import normalization parses again as Malloy.
+        SUM/AVG/MIN/MAX(...) -> lowercase, so a derived measure whose SQL came
+        from import normalization parses again as Malloy. COUNT(expr) is left
+        untouched: Malloy count(field) is a distinct count, so translating a
+        plain SQL COUNT(field) would change non-null counts into distinct counts.
         """
         sql = re.sub(r"\bcount\s*\(\s*distinct\s+(.+?)\s*\)", r"count(\1)", sql, flags=re.IGNORECASE)
         sql = re.sub(r"\bcount\s*\(\s*\*\s*\)", "count()", sql, flags=re.IGNORECASE)
-        return re.sub(r"\b(SUM|AVG|MIN|MAX|COUNT)\s*\(", lambda m: m.group(1).lower() + "(", sql)
+        return re.sub(r"\b(SUM|AVG|MIN|MAX)\s*\(", lambda m: m.group(1).lower() + "(", sql)

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -508,11 +508,28 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         """
         if end <= 0:
             return None
-        if s[end - 1] == ")":
+
+        # Mark positions inside string literals so the backward balance scan
+        # ignores parentheses inside quotes, e.g. the ')' in replace(name, ')', '').
+        quoted = [False] * end
+        q = None
+        for i in range(end):
+            c = s[i]
+            if q is not None:
+                quoted[i] = True
+                if c == q:
+                    q = None
+            elif c in ("'", '"', "`"):
+                q = c
+                quoted[i] = True
+
+        if s[end - 1] == ")" and not quoted[end - 1]:
             depth = 0
             k = end
             while k > 0:
                 k -= 1
+                if quoted[k]:
+                    continue
                 if s[k] == ")":
                     depth += 1
                 elif s[k] == "(":

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -421,9 +421,12 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
 
         def repl(m: re.Match) -> str:
             field = m.group(1)
-            agg = m.group(2).upper()
+            agg = m.group(2).lower()
             args = m.group(3).strip()
-            return f"{agg}({field}, {args})" if args else f"{agg}({field})"
+            if agg == "count_distinct":
+                return f"COUNT(DISTINCT {field})"
+            sql_agg = agg.upper()
+            return f"{sql_agg}({field}, {args})" if args else f"{sql_agg}({field})"
 
         # The field is a dotted path whose segments may be backtick-quoted
         # identifiers containing spaces (`cost amount`.sum()).

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -521,7 +521,14 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         # @YYYY-MM -> DATE 'YYYY-MM-01'
         # @YYYY -> DATE 'YYYY-01-01'
         # @YYYY-Qn -> handled as text
-        expr = re.sub(r"@(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})", r"TIMESTAMP '\1 \2'", expr)
+        # Timestamp literal: time is HH:MM with optional :SS, optional fractional
+        # seconds, and an optional [zone] suffix (which is dropped). Must run
+        # before the date-only rule so a time component is not left dangling.
+        expr = re.sub(
+            r"@(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)(?:\[[^\]]+\])?",
+            r"TIMESTAMP '\1 \2'",
+            expr,
+        )
         expr = re.sub(r"@(\d{4}-\d{2}-\d{2})", r"DATE '\1'", expr)
         expr = re.sub(r"@(\d{4}-\d{2})(?!\d)", r"DATE '\1-01'", expr)
         expr = re.sub(r"@(\d{4})(?![-\d])", r"DATE '\1-01-01'", expr)
@@ -842,9 +849,11 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
     @staticmethod
     def _scan_keywords(s: str, keywords: tuple[str, ...]) -> list[tuple[int, int, str]]:
         """Return (start, end, keyword) for each whole-word keyword occurrence at
-        the top level (outside string literals and parentheses)."""
+        the top level (outside string literals, parentheses, and any nested SQL
+        ``case ... end`` block, so an inner when/then/else is not reported)."""
         found: list[tuple[int, int, str]] = []
         depth = 0
+        case_depth = 0
         quote = None
         i = 0
         n = len(s)
@@ -871,18 +880,27 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                 i += 1
                 continue
             if depth == 0:
-                matched = None
-                for kw in keywords:
+                # Match a whole word: case/end adjust nesting depth; the requested
+                # keywords are only reported outside any nested case...end block.
+                hit = None
+                for kw in ("case", "end", *keywords):
                     j = i + len(kw)
-                    if s[i:j].lower() == kw:
-                        before_ok = i == 0 or not (s[i - 1].isalnum() or s[i - 1] == "_")
-                        after_ok = j >= n or not (s[j].isalnum() or s[j] == "_")
-                        if before_ok and after_ok:
-                            matched = (i, j, kw)
-                            break
-                if matched:
-                    found.append(matched)
-                    i = matched[1]
+                    if (
+                        s[i:j].lower() == kw
+                        and (i == 0 or not (s[i - 1].isalnum() or s[i - 1] == "_"))
+                        and (j >= n or not (s[j].isalnum() or s[j] == "_"))
+                    ):
+                        hit = (kw, j)
+                        break
+                if hit is not None:
+                    kw, j = hit
+                    if kw == "case":
+                        case_depth += 1
+                    elif kw == "end":
+                        case_depth = max(0, case_depth - 1)
+                    elif case_depth == 0:
+                        found.append((i, j, kw))
+                    i = j
                     continue
             i += 1
         return found

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -1989,7 +1989,9 @@ class MalloyAdapter(BaseAdapter):
                 # A cross join takes no key clause in Malloy.
                 lines.append(f"  join_cross: {rel.name}")
                 continue
-            join_type = "join_many" if rel.type == "one_to_many" else "join_one"
+            # one_to_many and many_to_many fan out -> join_many; many_to_one and
+            # one_to_one collapse to at most one match -> join_one.
+            join_type = "join_many" if rel.type in ("one_to_many", "many_to_many") else "join_one"
             on_condition = (rel.metadata or {}).get("on_condition")
             if on_condition:
                 lines.append(f"  {join_type}: {rel.name} on {on_condition}")

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -466,29 +466,23 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         # Pattern: identifier!identifier( -> identifier(
         expr = re.sub(r"(\w+)!\w+\(", r"\1(", expr)
 
-        # ~ regex match with r'' literal: expr ~ r'pattern' -> REGEXP_MATCHES(expr, 'pattern')
-        # Use (.+?) with lookahead to capture full LHS including spaces/parens
-        expr = re.sub(
-            r"(.+?)\s+~\s+r'([^']*)'",
-            r"REGEXP_MATCHES(\1, '\2')",
-            expr,
-        )
-        expr = re.sub(
-            r'(.+?)\s+~\s+r"([^"]*)"',
-            r"REGEXP_MATCHES(\1, '\2')",
-            expr,
-        )
-        # !~ negated regex
-        expr = re.sub(
-            r"(.+?)\s+!~\s+r'([^']*)'",
-            r"NOT REGEXP_MATCHES(\1, '\2')",
-            expr,
-        )
+        # ~ / !~ regex match with r'' or r"" literal:
+        #   field ~ r'pattern' -> REGEXP_MATCHES(field, 'pattern')
+        # The LHS is restricted to a single field reference so the match does not
+        # swallow preceding conditions (`a = 1 and name ~ r'x'`) or, on a second
+        # match in the same expression, the operator joining the two matches.
+        expr = re.sub(r"([\w.`]+)\s+!~\s+r'([^']*)'", r"NOT REGEXP_MATCHES(\1, '\2')", expr)
+        expr = re.sub(r'([\w.`]+)\s+!~\s+r"([^"]*)"', r"NOT REGEXP_MATCHES(\1, '\2')", expr)
+        expr = re.sub(r"([\w.`]+)\s+~\s+r'([^']*)'", r"REGEXP_MATCHES(\1, '\2')", expr)
+        expr = re.sub(r'([\w.`]+)\s+~\s+r"([^"]*)"', r"REGEXP_MATCHES(\1, '\2')", expr)
 
-        # @date literals: @YYYY-MM-DD -> DATE 'YYYY-MM-DD'
+        # @date / @timestamp literals:
+        # @YYYY-MM-DD HH:MM:SS -> TIMESTAMP 'YYYY-MM-DD HH:MM:SS'
+        # @YYYY-MM-DD -> DATE 'YYYY-MM-DD'
         # @YYYY-MM -> DATE 'YYYY-MM-01'
         # @YYYY -> DATE 'YYYY-01-01'
         # @YYYY-Qn -> handled as text
+        expr = re.sub(r"@(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})", r"TIMESTAMP '\1 \2'", expr)
         expr = re.sub(r"@(\d{4}-\d{2}-\d{2})", r"DATE '\1'", expr)
         expr = re.sub(r"@(\d{4}-\d{2})(?!\d)", r"DATE '\1-01'", expr)
         expr = re.sub(r"@(\d{4})(?![-\d])", r"DATE '\1-01-01'", expr)
@@ -559,14 +553,55 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             return f"COALESCE({', '.join(parts)})"
         return expr
 
+    @staticmethod
+    def _split_top_level(expr: str, sep: str) -> list[str]:
+        """Split ``expr`` on ``sep`` only at the top level (outside any
+        parentheses/brackets and outside string literals)."""
+        parts: list[str] = []
+        buf: list[str] = []
+        depth = 0
+        quote = None
+        i = 0
+        n = len(sep)
+        while i < len(expr):
+            ch = expr[i]
+            if quote is not None:
+                buf.append(ch)
+                if ch == quote:
+                    quote = None
+                i += 1
+                continue
+            if ch in ("'", '"', "`"):
+                quote = ch
+                buf.append(ch)
+            elif ch in "([{":
+                depth += 1
+                buf.append(ch)
+            elif ch in ")]}":
+                depth -= 1
+                buf.append(ch)
+            elif depth == 0 and expr[i : i + n] == sep:
+                parts.append("".join(buf))
+                buf = []
+                i += n
+                continue
+            else:
+                buf.append(ch)
+            i += 1
+        parts.append("".join(buf))
+        return parts
+
     def _transform_and_tree(self, expr: str) -> str:
         """Transform Malloy & (and-tree) to SQL AND with expanded base field.
 
         Examples:
         - "field < 2031 & > -8000" -> "field < 2031 AND field > -8000"
         - "status != 'Cancelled' & 'Returned'" -> "status != 'Cancelled' AND status != 'Returned'"
+
+        Only splits on a top-level `&` (not one inside a string literal such as
+        "label = 'A & B'").
         """
-        parts = re.split(r"\s+&\s+", expr)
+        parts = [p.strip() for p in self._split_top_level(expr, " & ")]
         if len(parts) < 2:
             return expr
 
@@ -623,34 +658,29 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                 For apply-pick syntax: `field ? pick 'X' when < 5` the base_field
                 is extracted by the caller and partial conditions get it prepended.
         """
-        lines = expr.strip().split("\n")
+        # Find each `pick <value> when <condition>` arm and an optional trailing
+        # `else <value>`. Keyword-driven (not line-driven) so single-line and
+        # multi-line pick expressions are both handled. Each arm's condition runs
+        # until the next `pick`/`else` keyword or end of string.
+        arms = re.findall(
+            r"pick\s+(.+?)\s+when\s+(.+?)(?=\s+pick\s|\s+else\s|$)",
+            expr,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        else_match = re.search(r"(?:^|\s)else\s+(.+?)\s*$", expr, flags=re.IGNORECASE | re.DOTALL)
+
         cases = []
-        else_value = None
-
-        for line in lines:
-            line = line.strip()
-            if not line:
-                continue
-
-            # Match: pick 'value' when condition
-            pick_match = re.match(r"pick\s+(.+?)\s+when\s+(.+)$", line, re.IGNORECASE)
-            if pick_match:
-                value = pick_match.group(1).strip()
-                condition = pick_match.group(2).strip()
-                if base_field:
-                    condition = self._expand_partial_condition(condition, base_field)
-                cases.append(f"WHEN {condition} THEN {value}")
-                continue
-
-            # Match: else 'value'
-            else_match = re.match(r"else\s+(.+)$", line, re.IGNORECASE)
-            if else_match:
-                else_value = else_match.group(1).strip()
+        for value, condition in arms:
+            value = value.strip()
+            condition = condition.strip()
+            if base_field:
+                condition = self._expand_partial_condition(condition, base_field)
+            cases.append(f"WHEN {condition} THEN {value}")
 
         if cases:
             case_str = "CASE " + " ".join(cases)
-            if else_value:
-                case_str += f" ELSE {else_value}"
+            if else_match:
+                case_str += f" ELSE {else_match.group(1).strip()}"
             case_str += " END"
             return case_str
 
@@ -1108,10 +1138,9 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         field_expr = ctx.fieldExpr()
         sql = self._get_text(field_expr) if field_expr else name
 
-        # Transform Malloy-specific expression syntax to SQL
-        sql = self._transform_malloy_expr(sql)
-
-        # Transform pick/when to CASE (with apply-pick support)
+        # Transform pick/when to CASE first (with apply-pick support) so the
+        # expression transforms below operate on real field references inside the
+        # WHEN clauses rather than on raw `pick ... when ...` text.
         if "pick" in sql.lower():
             # Check for apply-pick pattern: field ? pick ... when ...
             apply_match = re.match(r"^(.+?)\s*\?\s*\n?\s*(pick\s+.+)$", sql, re.DOTALL | re.IGNORECASE)
@@ -1121,6 +1150,9 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                 sql = self._transform_pick_to_case(pick_expr, base_field=base_field)
             else:
                 sql = self._transform_pick_to_case(sql)
+
+        # Transform remaining Malloy-specific expression syntax to SQL
+        sql = self._transform_malloy_expr(sql)
 
         # Infer type
         dim_type = self._infer_dimension_type(sql, name)

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -372,25 +372,34 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         parentheses, brackets, or quotes.
 
         Distinguishes a single aggregation call (`sum(x)`, `cost.sum()`) from a
-        compound expression built from several aggregates (`sum(a) / sum(b)`),
-        which must be preserved verbatim as a derived measure.
+        compound expression built from several aggregates (`sum(a) / sum(b)` or
+        the unspaced `sum(a)/sum(b)`), which must be preserved verbatim as a
+        derived measure. Spaces around the operator are not required; a left
+        operand must exist so a leading unary minus is not treated as binary.
         """
         depth = 0
         quote = None
         n = len(expr)
+        prev = ""  # last operand-boundary char seen at depth 0 (spaces ignored)
         for i, ch in enumerate(expr):
             if quote is not None:
                 if ch == quote:
                     quote = None
+                    prev = ch
                 continue
             if ch in ("'", '"', "`"):
                 quote = ch
+                prev = ch
             elif ch in "([{":
                 depth += 1
+                prev = ch
             elif ch in ")]}":
                 depth -= 1
-            elif depth == 0 and ch in "+-*/%" and 0 < i < n - 1 and expr[i - 1] == " " and expr[i + 1] == " ":
+                prev = ch
+            elif depth == 0 and ch in "+-*/%" and i < n - 1 and (prev.isalnum() or prev in ")_.`'\""):
                 return True
+            elif ch != " ":
+                prev = ch
         return False
 
     def _parse_aggregation(self, expr: str) -> tuple[str | None, str | None]:

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -31,6 +31,36 @@ except ImportError:
     ErrorListener = object  # type: ignore[assignment,misc]
 
 
+def _sub_outside_quotes(s: str, pattern: str, repl) -> str:
+    """Apply ``re.sub(pattern, repl, ...)`` (IGNORECASE) only to text outside
+    single/double-quoted string literals, so an aggregate-looking value inside a
+    literal (e.g. ``'count()'``) is left intact. Backticks are NOT treated as
+    string delimiters: a backtick-quoted field name is part of an aggregate."""
+    out: list[str] = []
+    i, n = 0, len(s)
+    while i < n:
+        c = s[i]
+        if c in ("'", '"'):
+            j = i + 1
+            while j < n:
+                if s[j] == "\\":
+                    j += 2
+                    continue
+                if s[j] == c:
+                    j += 1
+                    break
+                j += 1
+            out.append(s[i:j])
+            i = j
+        else:
+            j = i
+            while j < n and s[j] not in ("'", '"'):
+                j += 1
+            out.append(re.sub(pattern, repl, s[i:j], flags=re.IGNORECASE))
+            i = j
+    return "".join(out)
+
+
 class MalloySyntaxError(ValueError):
     """Raised when a Malloy document contains syntax errors and strict parsing is requested.
 
@@ -421,35 +451,6 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         derived measure so the stored SQL is executable.
         """
 
-        def sub_outside_quotes(s: str, pattern: str, repl) -> str:
-            # Apply re.sub only to text outside string literals so an
-            # aggregate-looking value inside a literal (e.g. 'count()') is intact.
-            # Backticks are NOT string delimiters here: a backtick-quoted field
-            # name (`cost amount`.sum()) is part of an aggregate to normalize.
-            out: list[str] = []
-            i, n = 0, len(s)
-            while i < n:
-                c = s[i]
-                if c in ("'", '"'):
-                    j = i + 1
-                    while j < n:
-                        if s[j] == "\\":
-                            j += 2
-                            continue
-                        if s[j] == c:
-                            j += 1
-                            break
-                        j += 1
-                    out.append(s[i:j])
-                    i = j
-                else:
-                    j = i
-                    while j < n and s[j] not in ("'", '"'):
-                        j += 1
-                    out.append(re.sub(pattern, repl, s[i:j], flags=re.IGNORECASE))
-                    i = j
-            return "".join(out)
-
         def count_repl(m: re.Match) -> str:
             arg = m.group(1).strip()
             if arg == "":
@@ -469,10 +470,10 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
 
         # Standard function forms count(x) / count_distinct(x) / count() — not
         # preceded by `.` so dot-method calls are handled by the next pass.
-        expr = sub_outside_quotes(expr, r"(?<![\w.`])count(?:_distinct)?\s*\(\s*([^)]*?)\s*\)", count_repl)
+        expr = _sub_outside_quotes(expr, r"(?<![\w.`])count(?:_distinct)?\s*\(\s*([^)]*?)\s*\)", count_repl)
         # Dot-method aggregates; the field may be a backtick-quoted identifier
         # with spaces (`cost amount`.sum()).
-        return sub_outside_quotes(
+        return _sub_outside_quotes(
             expr,
             r"((?:`[^`]*`|[\w.])+)\.(sum|avg|count|min|max|count_distinct)\s*\(\s*(.*?)\s*\)",
             dot_repl,
@@ -1729,7 +1730,9 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             elif rq is None and lq is not None:
                 related_col, source_col = rc, lc
             else:
-                related_col, source_col = lc, rc
+                # Both sides unqualified: keep the first identifier (the
+                # documented "first identifier before =" behavior).
+                related_col = source_col = lc
 
             # one_to_many keys on the related (foreign) column; many_to_one and
             # one_to_one key on the source column.
@@ -2267,6 +2270,6 @@ class MalloyAdapter(BaseAdapter):
         untouched: Malloy count(field) is a distinct count, so translating a
         plain SQL COUNT(field) would change non-null counts into distinct counts.
         """
-        sql = re.sub(r"\bcount\s*\(\s*distinct\s+(.+?)\s*\)", r"count(\1)", sql, flags=re.IGNORECASE)
-        sql = re.sub(r"\bcount\s*\(\s*\*\s*\)", "count()", sql, flags=re.IGNORECASE)
-        return re.sub(r"\b(SUM|AVG|MIN|MAX)\s*\(", lambda m: m.group(1).lower() + "(", sql)
+        sql = _sub_outside_quotes(sql, r"\bcount\s*\(\s*distinct\s+(.+?)\s*\)", r"count(\1)")
+        sql = _sub_outside_quotes(sql, r"\bcount\s*\(\s*\*\s*\)", "count()")
+        return _sub_outside_quotes(sql, r"\b(SUM|AVG|MIN|MAX)\s*\(", lambda m: m.group(1).lower() + "(")

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -31,16 +31,17 @@ except ImportError:
     ErrorListener = object  # type: ignore[assignment,misc]
 
 
-def _sub_outside_quotes(s: str, pattern: str, repl) -> str:
-    """Apply ``re.sub(pattern, repl, ...)`` (IGNORECASE) only to text outside
-    single/double-quoted string literals, so an aggregate-looking value inside a
-    literal (e.g. ``'count()'``) is left intact. Backticks are NOT treated as
-    string delimiters: a backtick-quoted field name is part of an aggregate."""
+def _sub_outside_quotes(s: str, pattern: str, repl, quotes: tuple[str, ...] = ("'", '"')) -> str:
+    """Apply ``re.sub(pattern, repl, ...)`` (IGNORECASE) only to text outside the
+    given quote characters, so a value inside a literal (e.g. ``'count()'``) is
+    left intact. ``quotes`` defaults to single/double quotes (backticks are part
+    of a field reference); pass backtick too when rewriting already-SQL text
+    where a backtick identifier must be protected."""
     out: list[str] = []
     i, n = 0, len(s)
     while i < n:
         c = s[i]
-        if c in ("'", '"'):
+        if c in quotes:
             j = i + 1
             while j < n:
                 if s[j] == "\\":
@@ -54,7 +55,7 @@ def _sub_outside_quotes(s: str, pattern: str, repl) -> str:
             i = j
         else:
             j = i
-            while j < n and s[j] not in ("'", '"'):
+            while j < n and s[j] not in quotes:
                 j += 1
             out.append(re.sub(pattern, repl, s[i:j], flags=re.IGNORECASE))
             i = j
@@ -609,7 +610,7 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                 prev = ch
             elif depth == 0 and ch in "+-*/%" and i < n - 1 and (prev.isalnum() or prev in ")_.`'\""):
                 return True
-            elif ch != " ":
+            elif not ch.isspace():  # ignore all whitespace (newlines/tabs) before the operator
                 prev = ch
         return False
 
@@ -2420,6 +2421,9 @@ class MalloyAdapter(BaseAdapter):
         untouched: Malloy count(field) is a distinct count, so translating a
         plain SQL COUNT(field) would change non-null counts into distinct counts.
         """
-        sql = _sub_outside_quotes(sql, r"\bcount\s*\(\s*distinct\s+(.+?)\s*\)", r"count(\1)")
-        sql = _sub_outside_quotes(sql, r"\bcount\s*\(\s*\*\s*\)", "count()")
-        return _sub_outside_quotes(sql, r"\b(SUM|AVG|MIN|MAX)\s*\(", lambda m: m.group(1).lower() + "(")
+        # Protect backtick identifiers too: this rewrites already-SQL text, where
+        # a backtick-quoted field name may itself look like an aggregate.
+        bq = ("'", '"', "`")
+        sql = _sub_outside_quotes(sql, r"\bcount\s*\(\s*distinct\s+(.+?)\s*\)", r"count(\1)", bq)
+        sql = _sub_outside_quotes(sql, r"\bcount\s*\(\s*\*\s*\)", "count()", bq)
+        return _sub_outside_quotes(sql, r"\b(SUM|AVG|MIN|MAX)\s*\(", lambda m: m.group(1).lower() + "(", bq)

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -1304,7 +1304,7 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             rel_type = "one_to_many"
             join_list = ctx.joinList()
         elif isinstance(ctx, MalloyParser.DefJoinCrossContext):
-            rel_type = "one_to_one"  # Cross joins mapped to one_to_one
+            rel_type = "cross"  # Cross join -> cartesian product (CROSS JOIN)
             join_list = ctx.joinList()
         else:
             return
@@ -1799,7 +1799,7 @@ class MalloyAdapter(BaseAdapter):
 
         # Model description as tag annotation
         if model.description:
-            lines.append(f"# desc: {model.description}")
+            lines.append(f"# desc: {self._one_line(model.description)}")
 
         # Source header - use connection from metadata, default to duckdb
         connection = (model.metadata or {}).get("connection", "duckdb")
@@ -1807,6 +1807,10 @@ class MalloyAdapter(BaseAdapter):
             lines.append(f'source: {model.name} is {connection}.sql("""{model.sql}""") extend {{')
         elif model.table:
             lines.append(f"source: {model.name} is {connection}.table('{model.table}') extend {{")
+        elif model.extends:
+            # Tableless derived source: reference the base so the output is valid
+            # Malloy (`source: x is base extend {`) rather than a bare `extend {`.
+            lines.append(f"source: {model.name} is {model.extends} extend {{")
         else:
             lines.append(f"source: {model.name} extend {{")
 
@@ -1829,8 +1833,11 @@ class MalloyAdapter(BaseAdapter):
             # Skip passthrough dimensions - Malloy auto-exposes table columns
             if sql == dim.name:
                 continue
-            # Tier 4.5: detect renames (simple identifier, no operators/functions)
-            if re.match(r"^[`\w]+$", sql) and sql != dim.name:
+            # Tier 4.5: detect renames (simple identifier, no operators/functions).
+            # A time dimension with a granularity is NOT a rename: it must keep its
+            # `.granularity` suffix below so the time type survives the roundtrip.
+            is_time_with_grain = dim.type == "time" and dim.granularity
+            if re.match(r"^[`\w]+$", sql) and sql != dim.name and not is_time_with_grain:
                 renames_to_export.append((dim.name, sql))
             else:
                 dims_to_export.append((dim, sql))
@@ -1848,7 +1855,7 @@ class MalloyAdapter(BaseAdapter):
             lines.append("  dimension:")
             for dim, sql in dims_to_export:
                 if dim.description:
-                    lines.append(f"    # desc: {dim.description}")
+                    lines.append(f"    # desc: {self._one_line(dim.description)}")
                 if dim.type == "time" and dim.granularity:
                     sql_lower = sql.lower()
                     already_has_truncation = (
@@ -1862,24 +1869,32 @@ class MalloyAdapter(BaseAdapter):
                     lines.append(f"    {dim.name} is {sql}")
 
         # Measures
-        if model.metrics:
+        measure_lines: list[str] = []
+        has_real_measure = False
+        for metric in model.metrics:
+            measure_expr = self._format_measure(metric)
+            if measure_expr is None:
+                # No faithful Malloy representation (e.g. cumulative/derived with
+                # no sql); skip it rather than silently emitting a bogus count().
+                measure_lines.append(f"    // {metric.name}: unsupported metric type, not exported")
+                continue
+            has_real_measure = True
+            if metric.description:
+                measure_lines.append(f"    # desc: {self._one_line(metric.description)}")
+            measure_lines.append(f"    {metric.name} is {measure_expr}")
+        if has_real_measure:
             lines.append("")
             lines.append("  measure:")
-            for metric in model.metrics:
-                if metric.description:
-                    lines.append(f"    # desc: {metric.description}")
-                measure_expr = self._format_measure(metric)
-                lines.append(f"    {metric.name} is {measure_expr}")
+            lines.extend(measure_lines)
 
         # Joins - Tier 4.4: use on condition from metadata when available
         for rel in model.relationships:
             lines.append("")
-            if rel.type == "many_to_one":
-                join_type = "join_one"
-            elif rel.type == "one_to_one":
-                join_type = "join_cross"
-            else:
-                join_type = "join_many"
+            if rel.type == "cross":
+                # A cross join takes no key clause in Malloy.
+                lines.append(f"  join_cross: {rel.name}")
+                continue
+            join_type = "join_many" if rel.type == "one_to_many" else "join_one"
             on_condition = (rel.metadata or {}).get("on_condition")
             if on_condition:
                 lines.append(f"  {join_type}: {rel.name} on {on_condition}")
@@ -1892,14 +1907,22 @@ class MalloyAdapter(BaseAdapter):
 
         return lines
 
-    def _format_measure(self, metric: Metric) -> str:
-        """Format a metric as Malloy measure expression.
+    @staticmethod
+    def _one_line(text: str) -> str:
+        """Collapse a description to a single line so it is valid in a `# desc:`
+        annotation (Malloy annotations are line-terminated)."""
+        return " ".join(text.split())
+
+    def _format_measure(self, metric: Metric) -> str | None:
+        """Format a metric as a Malloy measure expression.
 
         Args:
             metric: Metric to format
 
         Returns:
-            Malloy measure expression string
+            The Malloy measure expression, or None if the metric has no faithful
+            Malloy representation (so the caller can skip it instead of emitting a
+            misleading default).
         """
         # Simple aggregation
         if metric.agg:
@@ -1925,4 +1948,5 @@ class MalloyAdapter(BaseAdapter):
         if metric.sql:
             return self._strip_model_prefix(metric.sql)
 
-        return "count()"
+        # No faithful Malloy representation for this metric.
+        return None

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -425,8 +425,10 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             args = m.group(3).strip()
             return f"{agg}({field}, {args})" if args else f"{agg}({field})"
 
+        # The field is a dotted path whose segments may be backtick-quoted
+        # identifiers containing spaces (`cost amount`.sum()).
         expr = re.sub(
-            r"([\w.`]+)\.(sum|avg|count|min|max|count_distinct)\s*\(\s*(.*?)\s*\)",
+            r"((?:`[^`]*`|[\w.])+)\.(sum|avg|count|min|max|count_distinct)\s*\(\s*(.*?)\s*\)",
             repl,
             expr,
             flags=re.IGNORECASE,
@@ -1621,9 +1623,27 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             low = tok.lower()
             return low in ("true", "false", "null") or tok.replace(".", "", 1).isdigit()
 
+        def strip_outer_parens(text: str) -> str:
+            text = text.strip()
+            while len(text) >= 2 and text[0] == "(" and text[-1] == ")":
+                depth = 0
+                wraps_all = True
+                for idx, ch in enumerate(text):
+                    if ch == "(":
+                        depth += 1
+                    elif ch == ")":
+                        depth -= 1
+                        if depth == 0 and idx != len(text) - 1:
+                            wraps_all = False
+                            break
+                if not wraps_all:
+                    break
+                text = text[1:-1].strip()
+            return text
+
         keys: list[str] = []
-        for cond in re.split(r"\s+and\s+", expr_text, flags=re.IGNORECASE):
-            m = re.match(r"\s*([\w.`]+)\s*=\s*([\w.`]+)\s*$", cond)
+        for cond in re.split(r"\s+and\s+", strip_outer_parens(expr_text), flags=re.IGNORECASE):
+            m = re.match(r"\s*([\w.`]+)\s*=\s*([\w.`]+)\s*$", strip_outer_parens(cond))
             if not m:
                 continue
             lq, lc = split_qualifier(m.group(1))

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -521,11 +521,17 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                         break
             if depth != 0:
                 return None
-            # Include a leading function-name identifier, e.g. the `lower` in `lower(x)`.
-            start = k
-            while start > 0 and (s[start - 1].isalnum() or s[start - 1] in "_.`"):
-                start -= 1
-            return start
+            # Include a leading function-name identifier, allowing optional
+            # whitespace before the parenthesis (e.g. `lower(x)` or `lower (x)`).
+            ident_end = k
+            while ident_end > 0 and s[ident_end - 1] == " ":
+                ident_end -= 1
+            if ident_end > 0 and (s[ident_end - 1].isalnum() or s[ident_end - 1] in "_.`"):
+                start = ident_end
+                while start > 0 and (s[start - 1].isalnum() or s[start - 1] in "_.`"):
+                    start -= 1
+                return start
+            return k
         start = end
         while start > 0 and (s[start - 1].isalnum() or s[start - 1] in "_.`"):
             start -= 1
@@ -1506,6 +1512,10 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                 return qualifier, column
             return None, tok
 
+        def is_literal(tok: str) -> bool:
+            low = tok.lower()
+            return low in ("true", "false", "null") or tok.replace(".", "", 1).isdigit()
+
         keys: list[str] = []
         for cond in re.split(r"\s+and\s+", expr_text, flags=re.IGNORECASE):
             m = re.match(r"\s*([\w.`]+)\s*=\s*([\w.`]+)\s*$", cond)
@@ -1513,6 +1523,11 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                 continue
             lq, lc = split_qualifier(m.group(1))
             rq, rc = split_qualifier(m.group(2))
+
+            # A `col = literal` equality (e.g. `customers.active = true`) is a
+            # filter predicate, not a join key, so it contributes no foreign key.
+            if is_literal(lc) or is_literal(rc):
+                continue
 
             # Identify which side belongs to the join target.
             if lq == target_name:

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -409,6 +409,30 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                 prev = ch
         return False
 
+    @staticmethod
+    def _normalize_agg_calls(expr: str) -> str:
+        """Rewrite Malloy aggregate syntax to SQL inside a preserved expression.
+
+        `field.sum()` / `field.avg()` / ... -> `SUM(field)` / `AVG(field)` / ...,
+        a dotted path `a.b.c.sum()` -> `SUM(a.b.c)`, and a bare `count()` ->
+        `count(*)`. Used when a compound aggregate expression is kept as a derived
+        measure so the stored SQL is executable.
+        """
+
+        def repl(m: re.Match) -> str:
+            field = m.group(1)
+            agg = m.group(2).upper()
+            args = m.group(3).strip()
+            return f"{agg}({field}, {args})" if args else f"{agg}({field})"
+
+        expr = re.sub(
+            r"([\w.`]+)\.(sum|avg|count|min|max|count_distinct)\s*\(\s*(.*?)\s*\)",
+            repl,
+            expr,
+            flags=re.IGNORECASE,
+        )
+        return re.sub(r"\bcount\s*\(\s*\)", "count(*)", expr, flags=re.IGNORECASE)
+
     def _parse_aggregation(self, expr: str) -> tuple[str | None, str | None]:
         """Parse aggregation function from expression.
 
@@ -424,11 +448,11 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
 
         # A compound expression combining aggregates with a top-level arithmetic
         # operator (e.g. `sum(a) / sum(b)`, `cost.sum() / quantity.sum()`,
-        # `sum(x) / count()`) is not a single aggregation. Preserve it verbatim so
-        # the caller treats it as a derived measure instead of mis-capturing one
-        # function's arguments across the operator.
+        # `sum(x) / count()`) is not a single aggregation. Keep it as a derived
+        # measure, but normalize Malloy aggregate syntax (dot-method calls and a
+        # bare `count()`) to SQL so the stored expression is valid SQL.
         if self._has_top_level_arith(expr_stripped):
-            return None, expr_stripped
+            return None, self._normalize_agg_calls(expr_stripped)
 
         # Pattern 1: dot-method aggregation - field.func() or field.func(args)
         # Handles: cost.sum(), averageRating.avg(), `number`.sum(), images.count()
@@ -522,80 +546,72 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
 
     @staticmethod
     def _left_operand_start(s: str, end: int) -> int | None:
-        """Return the start index of the operand ending at ``end``.
+        """Return the start index of the regex-match left operand ending at ``end``.
 
-        Handles a balanced parenthesised group or function call
-        (``lower(name)``, ``(a || b)``) as well as a plain field reference
-        (``name``, ``a.b``, `` `x` ``). Returns None when there is no operand.
+        The operand is a full arithmetic `fieldExpr` (Malloy binds `~` looser than
+        arithmetic but tighter than comparison/logical operators), so the scan
+        crosses `+ - * / %`, parenthesised groups, function calls, and string /
+        backtick literals, but stops at a top-level comparison operator
+        (`= < > ! ~`), a comma, an enclosing `(`, or a logical keyword
+        (`and`/`or`/`not`). Returns None when there is no operand.
         """
         if end <= 0:
             return None
 
-        # Mark positions inside string literals (escape-aware) so the backward
-        # scans ignore parentheses, spaces, and quotes inside string/backtick
-        # literals, e.g. the ')' in replace(name, ')', '') or the space in the
-        # backtick identifier `user name`.
-        quoted = [False] * end
+        start = 0  # operand start at the current parenthesis depth
+        stack: list[int] = []  # saved starts for enclosing depths
         q = None
         i = 0
         while i < end:
             c = s[i]
             if q is not None:
-                quoted[i] = True
-                if c == "\\" and i + 1 < end:
-                    quoted[i + 1] = True
-                    i += 2
+                if c == "\\":
+                    i += 2  # skip the escaped char
                     continue
                 if c == q:
                     q = None
-            elif c in ("'", '"', "`"):
+                i += 1
+                continue
+            if c in ("'", '"', "`"):
                 q = c
-                quoted[i] = True
+                i += 1
+                continue
+            if c == "(":
+                stack.append(start)
+                start = i + 1
+                i += 1
+                continue
+            if c == ")":
+                if stack:
+                    start = stack.pop()
+                i += 1
+                continue
+            if c in "=<>!~,":
+                start = i + 1
+                i += 1
+                continue
+            matched = None
+            # Logical operators and CASE keywords bound an arithmetic operand on
+            # the left (the pick -> CASE rewrite runs before this, so a condition
+            # like `WHEN title ~ r'...'` must stop the operand at `WHEN`).
+            for kw in ("and", "or", "not", "when", "then", "else", "case", "end"):
+                j = i + len(kw)
+                if (
+                    s[i:j].lower() == kw
+                    and (i == 0 or not (s[i - 1].isalnum() or s[i - 1] == "_"))
+                    and (j >= end or not (s[j].isalnum() or s[j] == "_"))
+                ):
+                    matched = j
+                    break
+            if matched is not None:
+                start = matched
+                i = matched
+                continue
             i += 1
 
-        def walk_left(stop: int) -> int:
-            # Walk left over a field reference, consuming whole quoted segments
-            # (e.g. a backtick identifier with spaces) atomically.
-            p = stop
-            while p > 0:
-                j = p - 1
-                if quoted[j]:
-                    while j > 0 and quoted[j - 1]:
-                        j -= 1
-                    p = j
-                    continue
-                if s[j].isalnum() or s[j] in "_.`":
-                    p -= 1
-                    continue
-                break
-            return p
-
-        if s[end - 1] == ")" and not quoted[end - 1]:
-            depth = 0
-            k = end
-            while k > 0:
-                k -= 1
-                if quoted[k]:
-                    continue
-                if s[k] == ")":
-                    depth += 1
-                elif s[k] == "(":
-                    depth -= 1
-                    if depth == 0:
-                        break
-            if depth != 0:
-                return None
-            # Include a leading function-name identifier, allowing optional
-            # whitespace before the parenthesis (e.g. `lower(x)` or `lower (x)`).
-            ident_end = k
-            while ident_end > 0 and s[ident_end - 1] == " ":
-                ident_end -= 1
-            if ident_end > 0 and (s[ident_end - 1].isalnum() or s[ident_end - 1] in "_.`"):
-                return walk_left(ident_end)
-            return k
-
-        start = walk_left(end)
-        return start if start != end else None
+        while start < end and s[start] == " ":
+            start += 1
+        return start if start < end else None
 
     def _transform_regex_match(self, expr: str) -> str:
         """Transform Malloy regex matches to ``REGEXP_MATCHES`` calls.

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -531,6 +531,11 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         if re.search(r"\b(?:date|timestamp)\s+'", sql_lower):
             return "time"
 
+        # Duration arithmetic (created_at + 1 day, ts - 7 days) yields a time
+        # value. Check before numeric so the operator is not read as numeric.
+        if re.search(r"\b\d+\s+(?:second|minute|hour|day|week|month|quarter|year)s?\b", sql_lower):
+            return "time"
+
         # Numeric detection
         if re.search(r"[+\-*/]", sql) and "||" not in sql:
             return "numeric"

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -466,15 +466,8 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         # Pattern: identifier!identifier( -> identifier(
         expr = re.sub(r"(\w+)!\w+\(", r"\1(", expr)
 
-        # ~ / !~ regex match with r'' or r"" literal:
-        #   field ~ r'pattern' -> REGEXP_MATCHES(field, 'pattern')
-        # The LHS is restricted to a single field reference so the match does not
-        # swallow preceding conditions (`a = 1 and name ~ r'x'`) or, on a second
-        # match in the same expression, the operator joining the two matches.
-        expr = re.sub(r"([\w.`]+)\s+!~\s+r'([^']*)'", r"NOT REGEXP_MATCHES(\1, '\2')", expr)
-        expr = re.sub(r'([\w.`]+)\s+!~\s+r"([^"]*)"', r"NOT REGEXP_MATCHES(\1, '\2')", expr)
-        expr = re.sub(r"([\w.`]+)\s+~\s+r'([^']*)'", r"REGEXP_MATCHES(\1, '\2')", expr)
-        expr = re.sub(r'([\w.`]+)\s+~\s+r"([^"]*)"', r"REGEXP_MATCHES(\1, '\2')", expr)
+        # ~ / !~ regex match: field ~ r'pattern' -> REGEXP_MATCHES(field, 'pattern')
+        expr = self._transform_regex_match(expr)
 
         # @date / @timestamp literals:
         # @YYYY-MM-DD HH:MM:SS -> TIMESTAMP 'YYYY-MM-DD HH:MM:SS'
@@ -503,6 +496,66 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         if " ? " in expr and " | " in expr and "pick" not in expr.lower():
             expr = self._transform_or_tree(expr)
 
+        return expr
+
+    @staticmethod
+    def _left_operand_start(s: str, end: int) -> int | None:
+        """Return the start index of the operand ending at ``end``.
+
+        Handles a balanced parenthesised group or function call
+        (``lower(name)``, ``(a || b)``) as well as a plain field reference
+        (``name``, ``a.b``, `` `x` ``). Returns None when there is no operand.
+        """
+        if end <= 0:
+            return None
+        if s[end - 1] == ")":
+            depth = 0
+            k = end
+            while k > 0:
+                k -= 1
+                if s[k] == ")":
+                    depth += 1
+                elif s[k] == "(":
+                    depth -= 1
+                    if depth == 0:
+                        break
+            if depth != 0:
+                return None
+            # Include a leading function-name identifier, e.g. the `lower` in `lower(x)`.
+            start = k
+            while start > 0 and (s[start - 1].isalnum() or s[start - 1] in "_.`"):
+                start -= 1
+            return start
+        start = end
+        while start > 0 and (s[start - 1].isalnum() or s[start - 1] in "_.`"):
+            start -= 1
+        return start if start != end else None
+
+    def _transform_regex_match(self, expr: str) -> str:
+        """Transform Malloy regex matches to ``REGEXP_MATCHES`` calls.
+
+        ``operand ~ r'pat'`` -> ``REGEXP_MATCHES(operand, 'pat')`` and
+        ``operand !~ r'pat'`` -> ``NOT REGEXP_MATCHES(operand, 'pat')``.
+
+        The immediate left operand is found by walking back over a single
+        balanced expression, so a match never swallows preceding conditions
+        (``a = 1 and name ~ r'x'``) and computed/parenthesised operands
+        (``lower(name) ~ r'x'``) are preserved. Matches are rewritten
+        right-to-left so earlier offsets stay valid.
+        """
+        pattern = re.compile(r"(!?~)\s+r(['\"])(.*?)\2")
+        for m in reversed(list(pattern.finditer(expr))):
+            end = m.start()
+            while end > 0 and expr[end - 1] == " ":
+                end -= 1
+            operand_start = self._left_operand_start(expr, end)
+            if operand_start is None:
+                continue
+            operand = expr[operand_start:end]
+            replacement = f"REGEXP_MATCHES({operand}, '{m.group(3)}')"
+            if m.group(1) == "!~":
+                replacement = f"NOT {replacement}"
+            expr = expr[:operand_start] + replacement + expr[m.end() :]
         return expr
 
     def _transform_null_coalesce(self, expr: str) -> str:
@@ -658,33 +711,88 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                 For apply-pick syntax: `field ? pick 'X' when < 5` the base_field
                 is extracted by the caller and partial conditions get it prepended.
         """
-        # Find each `pick <value> when <condition>` arm and an optional trailing
-        # `else <value>`. Keyword-driven (not line-driven) so single-line and
-        # multi-line pick expressions are both handled. Each arm's condition runs
-        # until the next `pick`/`else` keyword or end of string.
-        arms = re.findall(
-            r"pick\s+(.+?)\s+when\s+(.+?)(?=\s+pick\s|\s+else\s|$)",
-            expr,
-            flags=re.IGNORECASE | re.DOTALL,
-        )
-        else_match = re.search(r"(?:^|\s)else\s+(.+?)\s*$", expr, flags=re.IGNORECASE | re.DOTALL)
+        # Locate the pick/when/else keywords at the top level (outside string
+        # literals and parentheses), then slice the arms between them. This is
+        # keyword-driven rather than line-driven so single-line and multi-line
+        # forms both work, and quote-aware so a keyword inside a string literal
+        # (e.g. `when note = 'a else b'`) is not treated as a delimiter.
+        keywords = self._scan_keywords(expr, ("pick", "when", "else"))
+        if not any(kw == "pick" for _, _, kw in keywords):
+            return expr
 
         cases = []
-        for value, condition in arms:
-            value = value.strip()
-            condition = condition.strip()
-            if base_field:
-                condition = self._expand_partial_condition(condition, base_field)
-            cases.append(f"WHEN {condition} THEN {value}")
+        else_value = None
+        i = 0
+        while i < len(keywords):
+            _, end, kw = keywords[i]
+            if kw == "else":
+                else_value = expr[end:].strip()
+                break
+            if kw == "pick" and i + 1 < len(keywords) and keywords[i + 1][2] == "when":
+                when_start, when_end = keywords[i + 1][0], keywords[i + 1][1]
+                value = expr[end:when_start].strip()
+                cond_end = keywords[i + 2][0] if i + 2 < len(keywords) else len(expr)
+                condition = expr[when_end:cond_end].strip()
+                if base_field:
+                    condition = self._expand_partial_condition(condition, base_field)
+                cases.append(f"WHEN {condition} THEN {value}")
+                i += 2
+                continue
+            i += 1
 
         if cases:
             case_str = "CASE " + " ".join(cases)
-            if else_match:
-                case_str += f" ELSE {else_match.group(1).strip()}"
+            if else_value:
+                case_str += f" ELSE {else_value}"
             case_str += " END"
             return case_str
 
         return expr
+
+    @staticmethod
+    def _scan_keywords(s: str, keywords: tuple[str, ...]) -> list[tuple[int, int, str]]:
+        """Return (start, end, keyword) for each whole-word keyword occurrence at
+        the top level (outside string literals and parentheses)."""
+        found: list[tuple[int, int, str]] = []
+        depth = 0
+        quote = None
+        i = 0
+        n = len(s)
+        while i < n:
+            ch = s[i]
+            if quote is not None:
+                if ch == quote:
+                    quote = None
+                i += 1
+                continue
+            if ch in ("'", '"', "`"):
+                quote = ch
+                i += 1
+                continue
+            if ch in "([{":
+                depth += 1
+                i += 1
+                continue
+            if ch in ")]}":
+                depth -= 1
+                i += 1
+                continue
+            if depth == 0:
+                matched = None
+                for kw in keywords:
+                    j = i + len(kw)
+                    if s[i:j].lower() == kw:
+                        before_ok = i == 0 or not (s[i - 1].isalnum() or s[i - 1] == "_")
+                        after_ok = j >= n or not (s[j].isalnum() or s[j] == "_")
+                        if before_ok and after_ok:
+                            matched = (i, j, kw)
+                            break
+                if matched:
+                    found.append(matched)
+                    i = matched[1]
+                    continue
+            i += 1
+        return found
 
     def _expand_partial_condition(self, condition: str, base_field: str) -> str:
         """Expand a partial comparison by prepending the base field.

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -306,8 +306,11 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         if any(p in sql_lower for p in time_patterns):
             return "time"
 
-        time_name_patterns = ["date", "time", "timestamp", "_at", "created", "updated"]
-        if any(p in name_lower for p in time_name_patterns):
+        # Malloy trailing time truncation (created_at.month, ts.day, ...) -> time.
+        # _extract_granularity reads the same trailing timeframe afterwards.
+        granularities = ("second", "minute", "hour", "day", "week", "month", "quarter", "year")
+        trailing = re.search(r"\.(\w+)$", sql_lower)
+        if trailing and trailing.group(1) in granularities:
             return "time"
 
         # Boolean detection - comparison that yields true/false
@@ -320,6 +323,12 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         # Numeric detection
         if re.search(r"[+\-*/]", sql) and "||" not in sql:
             return "numeric"
+
+        # Name-based time heuristic. Applied last (weakest signal) so an explicit
+        # comparison or arithmetic expression is not overridden by the field name.
+        time_name_patterns = ["date", "time", "timestamp", "_at", "created", "updated"]
+        if any(p in name_lower for p in time_name_patterns):
+            return "time"
 
         return "categorical"
 
@@ -351,6 +360,33 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
 
         return None
 
+    @staticmethod
+    def _has_top_level_arith(expr: str) -> bool:
+        """Return True if a binary arithmetic operator appears outside any
+        parentheses, brackets, or quotes.
+
+        Distinguishes a single aggregation call (`sum(x)`, `cost.sum()`) from a
+        compound expression built from several aggregates (`sum(a) / sum(b)`),
+        which must be preserved verbatim as a derived measure.
+        """
+        depth = 0
+        quote = None
+        n = len(expr)
+        for i, ch in enumerate(expr):
+            if quote is not None:
+                if ch == quote:
+                    quote = None
+                continue
+            if ch in ("'", '"', "`"):
+                quote = ch
+            elif ch in "([{":
+                depth += 1
+            elif ch in ")]}":
+                depth -= 1
+            elif depth == 0 and ch in "+-*/%" and 0 < i < n - 1 and expr[i - 1] == " " and expr[i + 1] == " ":
+                return True
+        return False
+
     def _parse_aggregation(self, expr: str) -> tuple[str | None, str | None]:
         """Parse aggregation function from expression.
 
@@ -363,6 +399,14 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             return None, None
 
         expr_stripped = expr.strip()
+
+        # A compound expression combining aggregates with a top-level arithmetic
+        # operator (e.g. `sum(a) / sum(b)`, `cost.sum() / quantity.sum()`,
+        # `sum(x) / count()`) is not a single aggregation. Preserve it verbatim so
+        # the caller treats it as a derived measure instead of mis-capturing one
+        # function's arguments across the operator.
+        if self._has_top_level_arith(expr_stripped):
+            return None, expr_stripped
 
         # Pattern 1: dot-method aggregation - field.func() or field.func(args)
         # Handles: cost.sum(), averageRating.avg(), `number`.sum(), images.count()
@@ -475,14 +519,24 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         if "??" not in expr:
             return expr
 
-        # Split on ?? only at depth 0
+        # Split on ?? only at depth 0 and outside string literals
         parts = []
         current = []
         depth = 0
+        quote = None
         i = 0
         while i < len(expr):
             ch = expr[i]
-            if ch in ("(", "[", "{"):
+            if quote is not None:
+                current.append(ch)
+                if ch == quote:
+                    quote = None
+                i += 1
+                continue
+            if ch in ("'", '"', "`"):
+                quote = ch
+                current.append(ch)
+            elif ch in ("(", "[", "{"):
                 depth += 1
                 current.append(ch)
             elif ch in (")", "]", "}"):
@@ -1118,28 +1172,35 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         expr_text = self._get_text(field_expr) if field_expr else ""
 
         # Check for filtered measure: count() { where: ... }
+        # Successive refinements (count() { where: a } { where: b }) parse as
+        # nested ExprFieldProps; Malloy ANDs them, so unwrap every level and
+        # collect all filters rather than only the outermost one.
         filters = None
         if isinstance(field_expr, MalloyParser.ExprFieldPropsContext):
-            # Has field properties (like { where: ... })
-            inner_expr = field_expr.fieldExpr()
-            props = field_expr.fieldProperties()
+            collected_filters: list[str] = []
+            node = field_expr
+            while isinstance(node, MalloyParser.ExprFieldPropsContext):
+                props = node.fieldProperties()
+                if props:
+                    for prop_stmt in props.fieldPropertyStatement():
+                        if isinstance(prop_stmt, MalloyParser.WhereStatementContext) or hasattr(
+                            prop_stmt, "whereStatement"
+                        ):
+                            where_stmt = (
+                                prop_stmt
+                                if isinstance(prop_stmt, MalloyParser.WhereStatementContext)
+                                else getattr(prop_stmt, "whereStatement", lambda: None)()
+                            )
+                            if where_stmt:
+                                filter_list = where_stmt.filterClauseList()
+                                if filter_list:
+                                    collected_filters.extend(self._get_text(f) for f in filter_list.fieldExpr())
+                node = node.fieldExpr()
 
-            expr_text = self._get_text(inner_expr) if inner_expr else ""
-
-            if props:
-                for prop_stmt in props.fieldPropertyStatement():
-                    if isinstance(prop_stmt, MalloyParser.WhereStatementContext) or hasattr(
-                        prop_stmt, "whereStatement"
-                    ):
-                        where_stmt = (
-                            prop_stmt
-                            if isinstance(prop_stmt, MalloyParser.WhereStatementContext)
-                            else getattr(prop_stmt, "whereStatement", lambda: None)()
-                        )
-                        if where_stmt:
-                            filter_list = where_stmt.filterClauseList()
-                            if filter_list:
-                                filters = [self._get_text(f) for f in filter_list.fieldExpr()]
+            expr_text = self._get_text(node) if node is not None else ""
+            if collected_filters:
+                # Collected outermost-first; reverse to restore source order.
+                filters = list(reversed(collected_filters))
 
         # Transform Malloy-specific expression syntax to SQL
         expr_text = self._transform_malloy_expr(expr_text)
@@ -1271,17 +1332,13 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                 if join_metadata is None:
                     join_metadata = {}
                 join_metadata["on_condition"] = expr_text
-                # Extract all FKs from equalities: field = other.field
-                fk_matches = re.findall(r"(\w+)\s*=\s*\w+\.\w+", expr_text)
-                if fk_matches:
-                    foreign_key = fk_matches[0]
-                    if len(fk_matches) > 1:
-                        join_metadata["composite_keys"] = fk_matches
-                else:
-                    # Fallback: first identifier before =
-                    match = re.match(r"(\w+)\s*=", expr_text)
-                    if match:
-                        foreign_key = match.group(1)
+                # Extract FK column(s), handling either ordering of each equality
+                # and keys qualified by the source or target name.
+                fk_keys = self._extract_on_condition_keys(expr_text, name, rel_type)
+                if fk_keys:
+                    foreign_key = fk_keys[0]
+                    if len(fk_keys) > 1:
+                        join_metadata["composite_keys"] = fk_keys
 
         self.current_relationships.append(
             Relationship(
@@ -1291,6 +1348,46 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                 metadata=join_metadata,
             )
         )
+
+    @staticmethod
+    def _extract_on_condition_keys(expr_text: str, target_name: str, rel_type: str) -> list[str]:
+        """Extract foreign-key column(s) from a join ``on`` condition.
+
+        Handles either ordering of each equality (``src = tgt.col`` or
+        ``tgt.col = src``) and multi-condition clauses joined by ``and``. For
+        ``many_to_one`` / ``one_to_one`` the key is the source-side column; for
+        ``one_to_many`` it is the related (target-qualified) column.
+        """
+
+        def split_qualifier(tok: str) -> tuple[str | None, str]:
+            tok = tok.replace("`", "")
+            if "." in tok:
+                qualifier, column = tok.rsplit(".", 1)
+                return qualifier, column
+            return None, tok
+
+        keys: list[str] = []
+        for cond in re.split(r"\s+and\s+", expr_text, flags=re.IGNORECASE):
+            m = re.match(r"\s*([\w.`]+)\s*=\s*([\w.`]+)\s*$", cond)
+            if not m:
+                continue
+            lq, lc = split_qualifier(m.group(1))
+            rq, rc = split_qualifier(m.group(2))
+
+            # Identify which side belongs to the join target.
+            if lq == target_name:
+                target_col, source_col = lc, rc
+            elif rq == target_name:
+                target_col, source_col = rc, lc
+            elif lq is None and rq is not None:
+                source_col, target_col = lc, rc
+            elif rq is None and lq is not None:
+                source_col, target_col = rc, lc
+            else:
+                source_col, target_col = lc, rc
+
+            keys.append(target_col if rel_type == "one_to_many" else source_col)
+        return keys
 
     def _extract_inline_join_source(self, join_name: str, sq_expr):
         """Extract inline source definition from a join and add as a model.

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -381,8 +381,15 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         quote = None
         n = len(expr)
         prev = ""  # last operand-boundary char seen at depth 0 (spaces ignored)
+        skip_next = False
         for i, ch in enumerate(expr):
+            if skip_next:
+                skip_next = False
+                continue
             if quote is not None:
+                if ch == "\\":
+                    skip_next = True  # ignore the escaped char so \' does not close
+                    continue
                 if ch == quote:
                     quote = None
                     prev = ch
@@ -524,19 +531,44 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         if end <= 0:
             return None
 
-        # Mark positions inside string literals so the backward balance scan
-        # ignores parentheses inside quotes, e.g. the ')' in replace(name, ')', '').
+        # Mark positions inside string literals (escape-aware) so the backward
+        # scans ignore parentheses, spaces, and quotes inside string/backtick
+        # literals, e.g. the ')' in replace(name, ')', '') or the space in the
+        # backtick identifier `user name`.
         quoted = [False] * end
         q = None
-        for i in range(end):
+        i = 0
+        while i < end:
             c = s[i]
             if q is not None:
                 quoted[i] = True
+                if c == "\\" and i + 1 < end:
+                    quoted[i + 1] = True
+                    i += 2
+                    continue
                 if c == q:
                     q = None
             elif c in ("'", '"', "`"):
                 q = c
                 quoted[i] = True
+            i += 1
+
+        def walk_left(stop: int) -> int:
+            # Walk left over a field reference, consuming whole quoted segments
+            # (e.g. a backtick identifier with spaces) atomically.
+            p = stop
+            while p > 0:
+                j = p - 1
+                if quoted[j]:
+                    while j > 0 and quoted[j - 1]:
+                        j -= 1
+                    p = j
+                    continue
+                if s[j].isalnum() or s[j] in "_.`":
+                    p -= 1
+                    continue
+                break
+            return p
 
         if s[end - 1] == ")" and not quoted[end - 1]:
             depth = 0
@@ -559,14 +591,10 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             while ident_end > 0 and s[ident_end - 1] == " ":
                 ident_end -= 1
             if ident_end > 0 and (s[ident_end - 1].isalnum() or s[ident_end - 1] in "_.`"):
-                start = ident_end
-                while start > 0 and (s[start - 1].isalnum() or s[start - 1] in "_.`"):
-                    start -= 1
-                return start
+                return walk_left(ident_end)
             return k
-        start = end
-        while start > 0 and (s[start - 1].isalnum() or s[start - 1] in "_.`"):
-            start -= 1
+
+        start = walk_left(end)
         return start if start != end else None
 
     def _transform_regex_match(self, expr: str) -> str:
@@ -614,6 +642,10 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             ch = expr[i]
             if quote is not None:
                 current.append(ch)
+                if ch == "\\" and i + 1 < len(expr):
+                    current.append(expr[i + 1])  # keep the escaped char verbatim
+                    i += 2
+                    continue
                 if ch == quote:
                     quote = None
                 i += 1
@@ -658,6 +690,10 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             ch = expr[i]
             if quote is not None:
                 buf.append(ch)
+                if ch == "\\" and i + 1 < len(expr):
+                    buf.append(expr[i + 1])  # keep the escaped char verbatim
+                    i += 2
+                    continue
                 if ch == quote:
                     quote = None
                 i += 1
@@ -799,6 +835,9 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         while i < n:
             ch = s[i]
             if quote is not None:
+                if ch == "\\":
+                    i += 2  # skip the escaped char so \' does not close the string
+                    continue
                 if ch == quote:
                     quote = None
                 i += 1

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -320,6 +320,12 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             if "pick" not in sql_lower and "case" not in sql_lower:
                 return "boolean"
 
+        # SQL DATE/TIMESTAMP literals (e.g. from a Malloy @2024-01-01 literal) are
+        # time values. Check before numeric so the hyphens in the date are not
+        # read as subtraction. After boolean so a comparison stays boolean.
+        if re.search(r"\b(?:date|timestamp)\s+'", sql_lower):
+            return "time"
+
         # Numeric detection
         if re.search(r"[+\-*/]", sql) and "||" not in sql:
             return "numeric"

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -1613,10 +1613,10 @@ class MalloyAdapter(BaseAdapter):
             # We use a separate parsed_files set per root file to handle imports,
             # but we track which models have been added to avoid duplicates.
             for malloy_file in source_path.rglob("*.malloy"):
-                parsed_files: set[Path] = set()
+                parsed_files: set = set()
                 self._parse_file(malloy_file, graph, parsed_files, import_filter=None)
         else:
-            parsed_files: set[Path] = set()
+            parsed_files: set = set()
             self._parse_file(source_path, graph, parsed_files)
 
         return graph
@@ -1625,7 +1625,7 @@ class MalloyAdapter(BaseAdapter):
         self,
         file_path: Path,
         graph: SemanticGraph,
-        parsed_files: set[Path],
+        parsed_files: set,
         import_filter: list[tuple[str, str | None]] | None = None,
     ) -> None:
         """Parse a single Malloy file with import resolution.
@@ -1639,11 +1639,16 @@ class MalloyAdapter(BaseAdapter):
         """
         resolved_path = file_path.resolve()
 
-        # Cycle detection: skip if already parsed
-        if resolved_path in parsed_files:
+        # Dedup/cycle detection keyed on (path, filter): a file imported under a
+        # narrow named-import filter must still be parseable for a later, broader
+        # (or differently-named) import of the same file, while an identical
+        # request is parsed at most once so circular imports still terminate.
+        filter_key = None if import_filter is None else frozenset(import_filter)
+        cache_key = (resolved_path, filter_key)
+        if cache_key in parsed_files:
             return
 
-        parsed_files.add(resolved_path)
+        parsed_files.add(cache_key)
 
         if not file_path.exists():
             return
@@ -1711,40 +1716,22 @@ class MalloyAdapter(BaseAdapter):
             if import_file.exists():
                 self._parse_file(import_file, graph, parsed_files, import_items)
 
-        # Add models to graph (with optional filtering for selective imports)
+        # Add models to graph (with optional filtering/aliasing for selective imports).
         for model in visitor.models:
-            if import_filter is not None:
-                # Check if this model should be imported
-                matching_import = None
-                for name, alias in import_filter:
-                    if model.name == name:
-                        matching_import = (name, alias)
-                        break
+            if import_filter is None:
+                if model.name not in graph.models:
+                    graph.add_model(model)
+                continue
 
-                if matching_import is None:
-                    continue  # Skip this model, not in import list
-
-                # Apply alias if specified
-                name, alias = matching_import
-                if alias:
-                    model = Model(
-                        name=alias,
-                        table=model.table,
-                        sql=model.sql,
-                        description=model.description,
-                        extends=model.extends,
-                        relationships=model.relationships,
-                        primary_key=model.primary_key,
-                        dimensions=model.dimensions,
-                        metrics=model.metrics,
-                        segments=model.segments,
-                        pre_aggregations=model.pre_aggregations,
-                        metadata=model.metadata,
-                    )
-
-            # Add to graph if not already present
-            if model.name not in graph.models:
-                graph.add_model(model)
+            # A source may be selected under several names in a single import
+            # (e.g. `import { s is a, s is b }`), so emit one model per matching
+            # entry rather than only the first.
+            for name, alias in import_filter:
+                if model.name != name:
+                    continue
+                target = model if not alias else model.model_copy(update={"name": alias})
+                if target.name not in graph.models:
+                    graph.add_model(target)
 
     def export(self, graph: SemanticGraph, output_path: str | Path) -> None:
         """Export semantic graph to Malloy format.

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -2216,9 +2216,23 @@ class MalloyAdapter(BaseAdapter):
         if metric.type == "ratio" and metric.numerator and metric.denominator:
             return f"{metric.numerator} / {metric.denominator}"
 
-        # Fallback to sql
+        # Fallback to sql. Convert the SQL aggregate forms that import
+        # normalization introduces back to Malloy so the derived measure
+        # round-trips (Malloy has no count(*) or count(DISTINCT ...)).
         if metric.sql:
-            return self._strip_model_prefix(metric.sql)
+            return self._sql_aggs_to_malloy(self._strip_model_prefix(metric.sql))
 
         # No faithful Malloy representation for this metric.
         return None
+
+    @staticmethod
+    def _sql_aggs_to_malloy(sql: str) -> str:
+        """Rewrite SQL aggregate syntax back to Malloy for export.
+
+        COUNT(DISTINCT x) -> count(x), count(*) -> count(), and uppercase
+        SUM/AVG/MIN/MAX/COUNT(...) -> lowercase, so a derived measure whose SQL
+        came from import normalization parses again as Malloy.
+        """
+        sql = re.sub(r"\bcount\s*\(\s*distinct\s+(.+?)\s*\)", r"count(\1)", sql, flags=re.IGNORECASE)
+        sql = re.sub(r"\bcount\s*\(\s*\*\s*\)", "count()", sql, flags=re.IGNORECASE)
+        return re.sub(r"\b(SUM|AVG|MIN|MAX|COUNT)\s*\(", lambda m: m.group(1).lower() + "(", sql)

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -91,7 +91,7 @@ def _normalize_count_calls(s: str) -> str:
         m = re.match(r"count(?:_distinct)?", s[i:], re.IGNORECASE)
         if m and (i == 0 or not (s[i - 1].isalnum() or s[i - 1] in "_.`")):
             k = i + m.end()
-            while k < n and s[k] == " ":
+            while k < n and s[k].isspace():  # any whitespace, e.g. count\n(x)
                 k += 1
             if k < n and s[k] == "(":
                 depth, p, q = 0, k, None
@@ -128,6 +128,111 @@ def _normalize_count_calls(s: str) -> str:
         out.append(c)
         i += 1
     return "".join(out)
+
+
+_DOT_AGGS = ("count_distinct", "sum", "avg", "count", "min", "max")
+
+
+def _normalize_dot_aggregates(s: str) -> str:
+    """Rewrite Malloy dot-method aggregates ``field.sum()`` -> ``SUM(field)`` and
+    ``field.count_distinct()`` -> ``COUNT(DISTINCT field)``.
+
+    Scans with quote/backtick awareness: a backtick-quoted field name is treated
+    as an atomic part of the field reference, so aggregate-looking text inside a
+    backtick identifier (like a field literally named "gross.sum()") is
+    preserved, while a real backtick-field followed by .sum() is normalized.
+    """
+    result: list[str] = []
+    last, i, n = 0, 0, len(s)
+    field_start: int | None = None
+    while i < n:
+        c = s[i]
+        if c in ("'", '"'):
+            field_start = None
+            i += 1
+            while i < n:
+                if s[i] == "\\":
+                    i += 2
+                    continue
+                if s[i] == c:
+                    i += 1
+                    break
+                i += 1
+            continue
+        if c == "`":
+            if field_start is None:
+                field_start = i
+            i += 1
+            while i < n:
+                if s[i] == "\\":
+                    i += 2
+                    continue
+                if s[i] == "`":
+                    i += 1
+                    break
+                i += 1
+            continue
+        if c == ".":
+            matched = None
+            for agg in _DOT_AGGS:
+                ke = i + 1 + len(agg)
+                if s[i + 1 : ke].lower() == agg and (ke >= n or not (s[ke].isalnum() or s[ke] == "_")):
+                    k = ke
+                    while k < n and s[k].isspace():
+                        k += 1
+                    if k < n and s[k] == "(":
+                        matched = (agg, k)
+                        break
+            if matched is not None and field_start is not None:
+                agg, paren = matched
+                depth, p, q = 0, paren, None
+                while p < n:
+                    ch = s[p]
+                    if q is not None:
+                        if ch == "\\":
+                            p += 2
+                            continue
+                        if ch == q:
+                            q = None
+                        p += 1
+                        continue
+                    if ch in ("'", '"', "`"):
+                        q = ch
+                    elif ch == "(":
+                        depth += 1
+                    elif ch == ")":
+                        depth -= 1
+                        if depth == 0:
+                            p += 1
+                            break
+                    p += 1
+                if depth == 0:
+                    field = s[field_start:i]
+                    args = s[paren + 1 : p - 1].strip()
+                    if agg == "count_distinct":
+                        repl = f"COUNT(DISTINCT {field})"
+                    else:
+                        sql_agg = agg.upper()
+                        repl = f"{sql_agg}({field}, {args})" if args else f"{sql_agg}({field})"
+                    result.append(s[last:field_start])
+                    result.append(repl)
+                    last = i = p
+                    field_start = None
+                    continue
+            # plain '.' inside a dotted field reference
+            if field_start is None:
+                field_start = i
+            i += 1
+            continue
+        if c.isalnum() or c == "_":
+            if field_start is None:
+                field_start = i
+            i += 1
+            continue
+        field_start = None
+        i += 1
+    result.append(s[last:])
+    return "".join(result)
 
 
 class MalloySyntaxError(ValueError):
@@ -519,27 +624,10 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         SQL function). Used when a compound aggregate expression is kept as a
         derived measure so the stored SQL is executable.
         """
-
-        def dot_repl(m: re.Match) -> str:
-            field = m.group(1)
-            agg = m.group(2).lower()
-            args = m.group(3).strip()
-            if agg == "count_distinct":
-                return f"COUNT(DISTINCT {field})"
-            sql_agg = agg.upper()
-            return f"{sql_agg}({field}, {args})" if args else f"{sql_agg}({field})"
-
-        # Standard function forms count(x) / count_distinct(x) / count() — handled
-        # with a quote/paren-aware scan so an argument containing a string literal
-        # is matched as a whole; dot-method calls are normalized by the next pass.
-        expr = _normalize_count_calls(expr)
-        # Dot-method aggregates; the field may be a backtick-quoted identifier
-        # with spaces (`cost amount`.sum()).
-        return _sub_outside_quotes(
-            expr,
-            r"((?:`[^`]*`|[\w.])+)\.(sum|avg|count|min|max|count_distinct)\s*\(\s*(.*?)\s*\)",
-            dot_repl,
-        )
+        # Standard function forms count(x) / count_distinct(x) / count() first,
+        # then dot-method aggregates; both scan with quote/paren/backtick
+        # awareness so literals and backtick identifiers are preserved.
+        return _normalize_dot_aggregates(_normalize_count_calls(expr))
 
     def _parse_aggregation(self, expr: str) -> tuple[str | None, str | None]:
         """Parse aggregation function from expression.

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -1657,19 +1657,24 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             if is_literal(lc) or is_literal(rc):
                 continue
 
-            # Identify which side belongs to the join target.
+            # Identify the related (target) vs source side. A side qualified by
+            # the target name is the related column; otherwise the unqualified
+            # side is the related column (Malloy convention) and the other side
+            # belongs to the source.
             if lq == target_name:
-                target_col, source_col = lc, rc
+                related_col, source_col = lc, rc
             elif rq == target_name:
-                target_col, source_col = rc, lc
+                related_col, source_col = rc, lc
             elif lq is None and rq is not None:
-                source_col, target_col = lc, rc
+                related_col, source_col = lc, rc
             elif rq is None and lq is not None:
-                source_col, target_col = rc, lc
+                related_col, source_col = rc, lc
             else:
-                source_col, target_col = lc, rc
+                related_col, source_col = lc, rc
 
-            keys.append(target_col if rel_type == "one_to_many" else source_col)
+            # one_to_many keys on the related (foreign) column; many_to_one and
+            # one_to_one key on the source column.
+            keys.append(related_col if rel_type == "one_to_many" else source_col)
         return keys
 
     def _extract_inline_join_source(self, join_name: str, sq_expr):

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -413,13 +413,32 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
     def _normalize_agg_calls(expr: str) -> str:
         """Rewrite Malloy aggregate syntax to SQL inside a preserved expression.
 
-        `field.sum()` / `field.avg()` / ... -> `SUM(field)` / `AVG(field)` / ...,
-        a dotted path `a.b.c.sum()` -> `SUM(a.b.c)`, and a bare `count()` ->
-        `count(*)`. Used when a compound aggregate expression is kept as a derived
-        measure so the stored SQL is executable.
+        `field.sum()` -> `SUM(field)`; a dotted path `a.b.c.sum()` -> `SUM(a.b.c)`;
+        `count()` -> `count(*)`; and the distinct-count forms `count(x)`,
+        `count_distinct(x)`, `field.count_distinct()` -> `COUNT(DISTINCT x)`
+        (Malloy `count(expr)` is a distinct count, and `count_distinct` is not a
+        SQL function). Used when a compound aggregate expression is kept as a
+        derived measure so the stored SQL is executable.
         """
 
-        def repl(m: re.Match) -> str:
+        def count_repl(m: re.Match) -> str:
+            arg = m.group(1).strip()
+            if arg == "":
+                return "count(*)"
+            if arg == "*" or arg.lower().startswith("distinct "):
+                return m.group(0)
+            return f"COUNT(DISTINCT {arg})"
+
+        # Standard function forms count(x) / count_distinct(x) / count() — not
+        # preceded by `.` so dot-method calls below are left for the next pass.
+        expr = re.sub(
+            r"(?<![\w.`])count(?:_distinct)?\s*\(\s*([^)]*?)\s*\)",
+            count_repl,
+            expr,
+            flags=re.IGNORECASE,
+        )
+
+        def dot_repl(m: re.Match) -> str:
             field = m.group(1)
             agg = m.group(2).lower()
             args = m.group(3).strip()
@@ -428,15 +447,14 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             sql_agg = agg.upper()
             return f"{sql_agg}({field}, {args})" if args else f"{sql_agg}({field})"
 
-        # The field is a dotted path whose segments may be backtick-quoted
-        # identifiers containing spaces (`cost amount`.sum()).
-        expr = re.sub(
+        # Dot-method aggregates; the field may be a backtick-quoted identifier
+        # with spaces (`cost amount`.sum()).
+        return re.sub(
             r"((?:`[^`]*`|[\w.])+)\.(sum|avg|count|min|max|count_distinct)\s*\(\s*(.*?)\s*\)",
-            repl,
+            dot_repl,
             expr,
             flags=re.IGNORECASE,
         )
-        return re.sub(r"\bcount\s*\(\s*\)", "count(*)", expr, flags=re.IGNORECASE)
 
     def _parse_aggregation(self, expr: str) -> tuple[str | None, str | None]:
         """Parse aggregation function from expression.
@@ -526,12 +544,21 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         # @YYYY-MM -> DATE 'YYYY-MM-01'
         # @YYYY -> DATE 'YYYY-01-01'
         # @YYYY-Qn -> handled as text
-        # Timestamp literal: time is HH:MM with optional :SS, optional fractional
-        # seconds, and an optional [zone] suffix (which is dropped). Must run
-        # before the date-only rule so a time component is not left dangling.
+        # Timestamp literal: time is the hour with optional :MM, :SS, fractional
+        # seconds (`.` or `,` separator), and an optional [zone] suffix (dropped).
+        # Padded to HH:MM:SS and the fraction comma normalized to a dot so the
+        # result is a valid SQL literal. Runs before the date-only rule so a time
+        # component is never left dangling.
+        def _timestamp_literal(m: re.Match) -> str:
+            time = m.group(2).replace(",", ".")
+            parts = time.split(":")
+            while len(parts) < 3:
+                parts.append("00")
+            return f"TIMESTAMP '{m.group(1)} {':'.join(parts)}'"
+
         expr = re.sub(
-            r"@(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)(?:\[[^\]]+\])?",
-            r"TIMESTAMP '\1 \2'",
+            r"@(\d{4}-\d{2}-\d{2})[ T](\d{2}(?::\d{2}(?::\d{2}(?:[.,]\d+)?)?)?)(?:\[[^\]]+\])?",
+            _timestamp_literal,
             expr,
         )
         expr = re.sub(r"@(\d{4}-\d{2}-\d{2})", r"DATE '\1'", expr)

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -61,6 +61,73 @@ def _sub_outside_quotes(s: str, pattern: str, repl) -> str:
     return "".join(out)
 
 
+def _normalize_count_calls(s: str) -> str:
+    """Rewrite Malloy count syntax to SQL with quote- and paren-aware scanning.
+
+    count() -> count(*); count(x) / count_distinct(x) -> COUNT(DISTINCT x). The
+    argument is captured by balanced parens (so a string literal inside it, e.g.
+    count(case when p = 'pro' then x end), does not break the match), while a
+    literal that merely looks like a count ('count()') is left untouched.
+    """
+    out: list[str] = []
+    i, n = 0, len(s)
+    while i < n:
+        c = s[i]
+        if c in ("'", '"'):
+            j = i + 1
+            while j < n:
+                if s[j] == "\\":
+                    j += 2
+                    continue
+                if s[j] == c:
+                    j += 1
+                    break
+                j += 1
+            out.append(s[i:j])
+            i = j
+            continue
+        m = re.match(r"count(?:_distinct)?", s[i:], re.IGNORECASE)
+        if m and (i == 0 or not (s[i - 1].isalnum() or s[i - 1] in "_.`")):
+            k = i + m.end()
+            while k < n and s[k] == " ":
+                k += 1
+            if k < n and s[k] == "(":
+                depth, p, q = 0, k, None
+                while p < n:
+                    ch = s[p]
+                    if q is not None:
+                        if ch == "\\":
+                            p += 2
+                            continue
+                        if ch == q:
+                            q = None
+                        p += 1
+                        continue
+                    if ch in ("'", '"'):
+                        q = ch
+                    elif ch == "(":
+                        depth += 1
+                    elif ch == ")":
+                        depth -= 1
+                        if depth == 0:
+                            p += 1
+                            break
+                    p += 1
+                if depth == 0:
+                    arg = s[k + 1 : p - 1].strip()
+                    if arg == "":
+                        out.append("count(*)")
+                    elif arg == "*" or arg.lower().startswith("distinct "):
+                        out.append(s[i:p])
+                    else:
+                        out.append(f"COUNT(DISTINCT {arg})")
+                    i = p
+                    continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
 class MalloySyntaxError(ValueError):
     """Raised when a Malloy document contains syntax errors and strict parsing is requested.
 
@@ -451,14 +518,6 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         derived measure so the stored SQL is executable.
         """
 
-        def count_repl(m: re.Match) -> str:
-            arg = m.group(1).strip()
-            if arg == "":
-                return "count(*)"
-            if arg == "*" or arg.lower().startswith("distinct "):
-                return m.group(0)
-            return f"COUNT(DISTINCT {arg})"
-
         def dot_repl(m: re.Match) -> str:
             field = m.group(1)
             agg = m.group(2).lower()
@@ -468,9 +527,10 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             sql_agg = agg.upper()
             return f"{sql_agg}({field}, {args})" if args else f"{sql_agg}({field})"
 
-        # Standard function forms count(x) / count_distinct(x) / count() — not
-        # preceded by `.` so dot-method calls are handled by the next pass.
-        expr = _sub_outside_quotes(expr, r"(?<![\w.`])count(?:_distinct)?\s*\(\s*([^)]*?)\s*\)", count_repl)
+        # Standard function forms count(x) / count_distinct(x) / count() — handled
+        # with a quote/paren-aware scan so an argument containing a string literal
+        # is matched as a whole; dot-method calls are normalized by the next pass.
+        expr = _normalize_count_calls(expr)
         # Dot-method aggregates; the field may be a backtick-quoted identifier
         # with spaces (`cost amount`.sum()).
         return _sub_outside_quotes(

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -632,6 +632,16 @@ def test_agg_normalization_ignores_string_literals():
     assert g.get_model("o").get_metric("m").sql == "sum(case when label = 'count()' then amount else 0 end) / sum(qty)"
 
 
+def test_count_with_string_literal_argument_normalized():
+    # A string literal inside the count() argument must not break the match.
+    g = _parse(
+        "source: o is duckdb.table('o') extend {\n"
+        "  measure: m is count(case when plan = 'pro' then user_id end) / count()\n"
+        "}\n"
+    )
+    assert g.get_model("o").get_metric("m").sql == "COUNT(DISTINCT case when plan = 'pro' then user_id end) / count(*)"
+
+
 def test_regex_match_case_expression_operand():
     assert (
         _dim_sql(

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -575,6 +575,25 @@ def test_normalize_count_function_forms_to_distinct():
     assert sql("count_distinct(user_id) / count()") == "COUNT(DISTINCT user_id) / count(*)"
 
 
+def test_derived_count_measure_roundtrips_to_valid_malloy():
+    # Stored SQL is query-valid; export converts the SQL aggregate forms back to
+    # Malloy so a strict reparse of the exported file succeeds.
+    import tempfile
+
+    src = "source: o is duckdb.table('o') extend {\n  primary_key: id\n  measure: m is count(user_id) / count()\n}\n"
+    g = _parse(src)
+    assert g.get_model("o").get_metric("m").sql == "COUNT(DISTINCT user_id) / count(*)"
+    out = tempfile.NamedTemporaryFile("w", suffix=".malloy", delete=False).name
+    try:
+        MalloyAdapter().export(g, out)
+        text = Path(out).read_text()
+        assert "m is count(user_id) / count()" in text
+        # Re-parses strictly (valid Malloy, not SQL count(*)).
+        MalloyAdapter(strict=True).parse(Path(out))
+    finally:
+        Path(out).unlink(missing_ok=True)
+
+
 def test_pick_condition_with_nested_case():
     sql = _dim_sql(
         "source: o is duckdb.table('o') extend {\n"

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -428,3 +428,28 @@ def test_named_import_still_filters(tmp_path):
     (tmp_path / "base.malloy").write_text(_src("alpha") + _src("beta"))
     (tmp_path / "m.malloy").write_text("import { alpha } from 'base.malloy'\n" + _src("m_src"))
     assert _models(tmp_path / "m.malloy") == {"alpha", "m_src"}
+
+
+# --- Code-review follow-ups ---
+
+
+def test_regex_match_preserves_function_lhs():
+    # A computed / parenthesised left operand must still become REGEXP_MATCHES.
+    assert (
+        _dim_sql("source: o is duckdb.table('o') extend {\n  dimension: a is lower(name) ~ r'foo'\n}\n", "a")
+        == "REGEXP_MATCHES(lower(name), 'foo')"
+    )
+    assert (
+        _dim_sql("source: o is duckdb.table('o') extend {\n  dimension: b is (name) ~ r'foo'\n}\n", "b")
+        == "REGEXP_MATCHES((name), 'foo')"
+    )
+
+
+def test_pick_keyword_inside_string_literal_is_not_a_delimiter():
+    sql = _dim_sql(
+        "source: o is duckdb.table('o') extend {\n"
+        "  dimension: h is pick 'x' when note = 'before else after' else 'y'\n"
+        "}\n",
+        "h",
+    )
+    assert sql == "CASE WHEN note = 'before else after' THEN 'x' ELSE 'y' END"

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -195,6 +195,25 @@ def test_join_composite_keys_reverse_direction():
     assert rel.metadata.get("composite_keys") == ["gender", "state"]
 
 
+def test_join_both_unqualified_keeps_first_identifier():
+    g = _parse(
+        "source: customers is duckdb.table('c') extend { primary_key: id }\n"
+        "source: orders is duckdb.table('o') extend {\n"
+        "  primary_key: id\n"
+        "  join_one: customers is duckdb.table('c') on customer_id = id\n"
+        "}\n"
+    )
+    rel = {r.name: r for r in g.get_model("orders").relationships}["customers"]
+    assert rel.foreign_key == "customer_id"
+
+
+def test_export_agg_rewrite_ignores_string_literals():
+    sql = "SUM(CASE WHEN label = 'COUNT(*)' THEN amount ELSE 0 END) / COUNT(*)"
+    assert (
+        MalloyAdapter()._sql_aggs_to_malloy(sql) == "sum(CASE WHEN label = 'COUNT(*)' THEN amount ELSE 0 END) / count()"
+    )
+
+
 # --- & and-tree must not split inside string literals ---
 
 

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -604,6 +604,34 @@ def test_pick_condition_with_nested_case():
     assert sql == "CASE WHEN case when a = 1 then 1 else 0 end = 1 THEN 'x' ELSE 'y' END"
 
 
+def test_agg_normalization_ignores_string_literals():
+    g = _parse(
+        "source: o is duckdb.table('o') extend {\n"
+        "  measure: m is sum(case when label = 'count()' then amount else 0 end) / sum(qty)\n"
+        "}\n"
+    )
+    assert g.get_model("o").get_metric("m").sql == "sum(case when label = 'count()' then amount else 0 end) / sum(qty)"
+
+
+def test_regex_match_case_expression_operand():
+    assert (
+        _dim_sql(
+            "source: o is duckdb.table('o') extend {\n"
+            "  dimension: a is case when flag then name else alt end ~ r'foo'\n"
+            "}\n",
+            "a",
+        )
+        == "REGEXP_MATCHES(case when flag then name else alt end, 'foo')"
+    )
+
+
+def test_export_does_not_distinctify_plain_count():
+    # COUNT(field) has no faithful Malloy form (count(field) is distinct), so it
+    # is left untouched; only COUNT(DISTINCT ...) / COUNT(*) translate.
+    assert MalloyAdapter()._sql_aggs_to_malloy("COUNT(user_id) / COUNT(*)") == "COUNT(user_id) / count()"
+    assert MalloyAdapter()._sql_aggs_to_malloy("COUNT(DISTINCT x) / SUM(y)") == "count(x) / sum(y)"
+
+
 def test_normalize_spaced_backtick_aggregate_field():
     g = _parse("source: o is duckdb.table('o') extend {\n  measure: m is `cost amount`.sum() / count()\n}\n")
     me = g.get_model("o").get_metric("m")

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -482,6 +482,14 @@ def test_regex_match_handles_spaced_function_call():
     )
 
 
+def test_regex_match_handles_quoted_paren_in_operand():
+    # A ')' inside a string-literal argument must not break the operand balance scan.
+    assert (
+        _dim_sql("source: o is duckdb.table('o') extend {\n  dimension: a is replace(name, ')', '') ~ r'x'\n}\n", "a")
+        == "REGEXP_MATCHES(replace(name, ')', ''), 'x')"
+    )
+
+
 def test_join_on_condition_skips_literal_predicate():
     g = _parse(
         "source: customers is duckdb.table('c') extend { primary_key: id }\n"

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -647,6 +647,17 @@ def test_count_with_backtick_field_containing_paren():
     assert g.get_model("o").get_metric("m").sql == "COUNT(DISTINCT `user(id`) / count(*)"
 
 
+def test_count_skips_whitespace_before_paren():
+    g = _parse("source: o is duckdb.table('o') extend {\n  measure: m is count\n(user_id) / count()\n}\n")
+    assert g.get_model("o").get_metric("m").sql == "COUNT(DISTINCT user_id) / count(*)"
+
+
+def test_aggregate_text_inside_backtick_field_preserved():
+    # A backtick field literally named "gross.sum()" must not be normalized.
+    g = _parse("source: o is duckdb.table('o') extend {\n  measure: m is `gross.sum()` / count()\n}\n")
+    assert g.get_model("o").get_metric("m").sql == "`gross.sum()` / count(*)"
+
+
 def test_regex_match_case_expression_operand():
     assert (
         _dim_sql(

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -134,6 +134,11 @@ def test_comparison_expression_not_overridden_to_time_by_name():
     assert g.get_model("o").get_dimension("created_after_cutoff").type == "boolean"
 
 
+def test_duration_arithmetic_is_time_not_numeric():
+    g = _parse("source: o is duckdb.table('o') extend {\n  dimension: ship_date is created_at + 1 day\n}\n")
+    assert g.get_model("o").get_dimension("ship_date").type == "time"
+
+
 # --- Chained filter refinements must AND, not drop ---
 
 

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -490,6 +490,13 @@ def test_regex_match_handles_quoted_paren_in_operand():
     )
 
 
+def test_date_literal_dimension_is_time_not_numeric():
+    g = _parse("source: o is duckdb.table('o') extend {\n  dimension: cutoff_date is @2024-01-01\n}\n")
+    d = g.get_model("o").get_dimension("cutoff_date")
+    assert d.type == "time"
+    assert d.sql == "DATE '2024-01-01'"
+
+
 def test_join_on_condition_skips_literal_predicate():
     g = _parse(
         "source: customers is duckdb.table('c') extend { primary_key: id }\n"

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -380,3 +380,51 @@ def test_one_to_one_exports_as_join_one_not_cross():
     text = _export_text(g)
     assert "join_one: customers with customer_id" in text
     assert "join_cross: customers" not in text
+
+
+# --- Import resolution must not silently drop sources ---
+
+
+def _src(name):
+    return f"source: {name} is duckdb.table('{name}.parquet') extend {{ primary_key: id  dimension: id is id }}\n"
+
+
+def _models(path):
+    return set(MalloyAdapter(warn_on_errors=False).parse(Path(path)).models.keys())
+
+
+def test_named_import_in_chain_not_dropped(tmp_path):
+    (tmp_path / "base.malloy").write_text(_src("alpha") + _src("beta"))
+    (tmp_path / "x.malloy").write_text("import { alpha } from 'base.malloy'\n" + _src("x_src"))
+    (tmp_path / "y.malloy").write_text("import 'x.malloy'\nimport { beta } from 'base.malloy'\n" + _src("y_src"))
+    assert _models(tmp_path / "y.malloy") == {"alpha", "beta", "x_src", "y_src"}
+
+
+def test_narrow_import_then_import_all(tmp_path):
+    (tmp_path / "base.malloy").write_text(_src("alpha") + _src("beta"))
+    (tmp_path / "root.malloy").write_text(
+        "import { alpha } from 'base.malloy'\nimport 'base.malloy'\n" + _src("root_src")
+    )
+    assert _models(tmp_path / "root.malloy") == {"alpha", "beta", "root_src"}
+
+
+def test_source_imported_under_two_aliases(tmp_path):
+    (tmp_path / "base.malloy").write_text(
+        "source: customers is duckdb.table('c.parquet') extend { primary_key: cid  dimension: cid is cid }\n"
+    )
+    (tmp_path / "dual.malloy").write_text(
+        "import { customers is c1, customers is c2 } from 'base.malloy'\n" + _src("local_src")
+    )
+    assert _models(tmp_path / "dual.malloy") == {"c1", "c2", "local_src"}
+
+
+def test_circular_imports_terminate_and_keep_both(tmp_path):
+    (tmp_path / "a.malloy").write_text("import 'b.malloy'\n" + _src("a_src"))
+    (tmp_path / "b.malloy").write_text("import 'a.malloy'\n" + _src("b_src"))
+    assert _models(tmp_path / "a.malloy") == {"a_src", "b_src"}
+
+
+def test_named_import_still_filters(tmp_path):
+    (tmp_path / "base.malloy").write_text(_src("alpha") + _src("beta"))
+    (tmp_path / "m.malloy").write_text("import { alpha } from 'base.malloy'\n" + _src("m_src"))
+    assert _models(tmp_path / "m.malloy") == {"alpha", "m_src"}

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -558,9 +558,21 @@ def test_timestamp_literal_forms():
             "a",
         )
 
-    assert sql("@2024-01-01 10:30") == "t > TIMESTAMP '2024-01-01 10:30'"
+    # All forms pad to HH:MM:SS and normalize a comma fraction to a dot.
+    assert sql("@2024-01-01 10") == "t > TIMESTAMP '2024-01-01 10:00:00'"
+    assert sql("@2024-01-01 10:30") == "t > TIMESTAMP '2024-01-01 10:30:00'"
     assert sql("@2024-01-01 10:30:00.123") == "t > TIMESTAMP '2024-01-01 10:30:00.123'"
+    assert sql("@2024-01-01 10:30:00,123") == "t > TIMESTAMP '2024-01-01 10:30:00.123'"
     assert sql("@2024-01-01 10:30:00[UTC]") == "t > TIMESTAMP '2024-01-01 10:30:00'"
+
+
+def test_normalize_count_function_forms_to_distinct():
+    def sql(expr):
+        g = _parse(f"source: o is duckdb.table('o') extend {{\n  measure: m is {expr}\n}}\n")
+        return g.get_model("o").get_metric("m").sql
+
+    assert sql("count(user_id) / count()") == "COUNT(DISTINCT user_id) / count(*)"
+    assert sql("count_distinct(user_id) / count()") == "COUNT(DISTINCT user_id) / count(*)"
 
 
 def test_pick_condition_with_nested_case():

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -559,6 +559,25 @@ def test_pick_condition_with_nested_case():
     assert sql == "CASE WHEN case when a = 1 then 1 else 0 end = 1 THEN 'x' ELSE 'y' END"
 
 
+def test_normalize_spaced_backtick_aggregate_field():
+    g = _parse("source: o is duckdb.table('o') extend {\n  measure: m is `cost amount`.sum() / count()\n}\n")
+    me = g.get_model("o").get_metric("m")
+    assert me.type == "derived"
+    assert me.sql == "SUM(`cost amount`) / count(*)"
+
+
+def test_join_on_condition_parenthesized_equality():
+    g = _parse(
+        "source: customers is duckdb.table('c') extend { primary_key: id }\n"
+        "source: orders is duckdb.table('o') extend {\n"
+        "  primary_key: id\n"
+        "  join_one: customers is duckdb.table('c') on (customer_id = customers.id)\n"
+        "}\n"
+    )
+    rel = {r.name: r for r in g.get_model("orders").relationships}["customers"]
+    assert rel.foreign_key == "customer_id"
+
+
 def test_join_on_condition_skips_literal_predicate():
     g = _parse(
         "source: customers is duckdb.table('c') extend { primary_key: id }\n"

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -41,6 +41,21 @@ def test_unspaced_ratio_of_two_aggregates_is_derived():
     assert me.sql == "sum(amount)/sum(quantity)"
 
 
+def test_newline_before_operator_is_derived():
+    # A top-level operator on the next line must still mark the measure derived.
+    g = _parse(
+        "source: orders is duckdb.table('orders') extend {\n  measure: r is sum(amount)\n    / sum(quantity)\n}\n"
+    )
+    me = g.get_model("orders").get_metric("r")
+    assert me.agg is None
+    assert me.type == "derived"
+
+
+def test_export_does_not_rewrite_backtick_field():
+    # A backtick field name that looks like an aggregate is left intact on export.
+    assert MalloyAdapter()._sql_aggs_to_malloy("`COUNT(*)` / count(*)") == "`COUNT(*)` / count()"
+
+
 def test_sum_over_count_is_derived():
     g = _parse("source: orders is duckdb.table('orders') extend {\n  measure: avg_ov is sum(amount) / count()\n}\n")
     me = g.get_model("orders").get_metric("avg_ov")

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -1,0 +1,171 @@
+"""Regression tests for correctness bugs found in the Malloy adapter audit.
+
+Each test encodes the corrected behavior for a confirmed bug. Inputs are parsed
+through MalloyAdapter end-to-end so the assertions exercise the real visitor.
+"""
+
+import tempfile
+from pathlib import Path
+
+from sidemantic.adapters.malloy import MalloyAdapter
+
+
+def _parse(src: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".malloy", delete=False) as f:
+        f.write(src)
+        path = f.name
+    try:
+        return MalloyAdapter(warn_on_errors=False).parse(Path(path))
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+# --- Aggregate-arithmetic measures must stay intact as derived (was: mangled) ---
+
+
+def test_ratio_of_two_aggregates_is_derived():
+    g = _parse(
+        "source: orders is duckdb.table('orders') extend {\n  measure: ratio1 is sum(amount) / sum(quantity)\n}\n"
+    )
+    me = g.get_model("orders").get_metric("ratio1")
+    assert me.agg is None
+    assert me.type == "derived"
+    assert me.sql == "sum(amount) / sum(quantity)"
+
+
+def test_sum_over_count_is_derived():
+    g = _parse("source: orders is duckdb.table('orders') extend {\n  measure: avg_ov is sum(amount) / count()\n}\n")
+    me = g.get_model("orders").get_metric("avg_ov")
+    assert me.agg is None
+    assert me.type == "derived"
+    assert me.sql == "sum(amount) / count()"
+
+
+def test_dot_method_aggregate_arithmetic_is_derived():
+    g = _parse(
+        "source: orders is duckdb.table('orders') extend {\n  measure: dotarith is cost.sum() / quantity.sum()\n}\n"
+    )
+    me = g.get_model("orders").get_metric("dotarith")
+    assert me.agg is None
+    assert me.type == "derived"
+    assert me.sql == "cost.sum() / quantity.sum()"
+
+
+def test_single_aggregates_still_parse():
+    """Guard: the compound-expression fix must not change single-call measures."""
+    g = _parse(
+        "source: orders is duckdb.table('orders') extend {\n"
+        "  measure: plain is sum(amount)\n"
+        "  measure: sum_expr is sum(quantity * price)\n"
+        "  measure: cnt is count()\n"
+        "  measure: cntd is count(user_id)\n"
+        "  measure: dotcnt is event_params.value.double_value.sum()\n"
+        "}\n"
+    )
+    m = g.get_model("orders")
+    assert (m.get_metric("plain").agg, m.get_metric("plain").sql) == ("sum", "amount")
+    assert (m.get_metric("sum_expr").agg, m.get_metric("sum_expr").sql) == ("sum", "quantity * price")
+    assert (m.get_metric("cnt").agg, m.get_metric("cnt").sql) == ("count", None)
+    assert (m.get_metric("cntd").agg, m.get_metric("cntd").sql) == ("count_distinct", "user_id")
+    assert (m.get_metric("dotcnt").agg, m.get_metric("dotcnt").sql) == ("sum", "event_params.value.double_value")
+
+
+# --- ?? null-coalesce must not split inside string literals ---
+
+
+def test_null_coalesce_preserves_string_literal():
+    g = _parse("source: o is duckdb.table('o') extend {\n  dimension: co is note ?? 'x ?? y'\n}\n")
+    assert g.get_model("o").get_dimension("co").sql == "COALESCE(note, 'x ?? y')"
+
+
+def test_null_coalesce_chain_still_works():
+    g = _parse(
+        "source: o is duckdb.table('o') extend {\n  dimension: d is primary_value ?? secondary_value ?? 'default'\n}\n"
+    )
+    assert g.get_model("o").get_dimension("d").sql == "COALESCE(primary_value, secondary_value, 'default')"
+
+
+# --- Dimension typing & granularity ---
+
+
+def test_trailing_timeframe_infers_time_and_granularity():
+    g = _parse(
+        "source: o is duckdb.table('o') extend {\n"
+        "  dimension: order_month is created_at.month\n"
+        "  dimension: order_day is shipped.day\n"
+        "}\n"
+    )
+    m = g.get_model("o")
+    om = m.get_dimension("order_month")
+    assert om.type == "time"
+    assert om.granularity == "month"
+    assert m.get_dimension("order_day").granularity == "day"
+
+
+def test_comparison_expression_not_overridden_to_time_by_name():
+    g = _parse(
+        "source: o is duckdb.table('o') extend {\n  dimension: created_after_cutoff is created_at > @2020-01-01\n}\n"
+    )
+    assert g.get_model("o").get_dimension("created_after_cutoff").type == "boolean"
+
+
+# --- Chained filter refinements must AND, not drop ---
+
+
+def test_chained_where_keeps_all_filters_and_aggregation():
+    g = _parse(
+        "source: o is duckdb.table('o') extend {\n  measure: f_two is count() { where: a > 1 } { where: b > 2 }\n}\n"
+    )
+    me = g.get_model("o").get_metric("f_two")
+    assert me.agg == "count"
+    assert me.filters == ["a > 1", "b > 2"]
+
+
+def test_single_filtered_measure_still_works():
+    g = _parse("source: o is duckdb.table('o') extend {\n  measure: big is sum(amount) { where: amount > 100 }\n}\n")
+    me = g.get_model("o").get_metric("big")
+    assert me.agg == "sum"
+    assert me.sql == "amount"
+    assert me.filters == ["amount > 100"]
+
+
+# --- Join on-condition FK extraction is direction-aware ---
+
+
+def test_join_one_on_condition_target_qualified_left():
+    g = _parse(
+        "source: customers is duckdb.table('c') extend { primary_key: id }\n"
+        "source: orders is duckdb.table('o') extend {\n"
+        "  primary_key: id\n"
+        "  join_one: customers is duckdb.table('c') on customers.id = customer_id\n"
+        "}\n"
+    )
+    rel = {r.name: r for r in g.get_model("orders").relationships}["customers"]
+    assert rel.type == "many_to_one"
+    assert rel.foreign_key == "customer_id"
+
+
+def test_join_many_on_condition_uses_related_key():
+    g = _parse(
+        "source: items is duckdb.table('i') extend { measure: ic is count() }\n"
+        "source: orders is duckdb.table('o') extend {\n"
+        "  primary_key: id\n"
+        "  join_many: items is duckdb.table('i') on orders.id = items.order_id\n"
+        "}\n"
+    )
+    rel = {r.name: r for r in g.get_model("orders").relationships}["items"]
+    assert rel.type == "one_to_many"
+    assert rel.foreign_key == "order_id"
+
+
+def test_join_composite_keys_reverse_direction():
+    g = _parse(
+        "source: cohort is duckdb.table('co') extend { primary_key: id }\n"
+        "source: orders is duckdb.table('o') extend {\n"
+        "  primary_key: id\n"
+        "  join_one: cohort is duckdb.table('co') on cohort.gender = gender and cohort.state = state\n"
+        "}\n"
+    )
+    rel = {r.name: r for r in g.get_model("orders").relationships}["cohort"]
+    assert rel.foreign_key == "gender"
+    assert rel.metadata.get("composite_keys") == ["gender", "state"]

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -46,7 +46,8 @@ def test_sum_over_count_is_derived():
     me = g.get_model("orders").get_metric("avg_ov")
     assert me.agg is None
     assert me.type == "derived"
-    assert me.sql == "sum(amount) / count()"
+    # bare count() normalized to count(*) so the derived SQL is executable
+    assert me.sql == "sum(amount) / count(*)"
 
 
 def test_dot_method_aggregate_arithmetic_is_derived():
@@ -56,7 +57,8 @@ def test_dot_method_aggregate_arithmetic_is_derived():
     me = g.get_model("orders").get_metric("dotarith")
     assert me.agg is None
     assert me.type == "derived"
-    assert me.sql == "cost.sum() / quantity.sum()"
+    # Malloy dot-method aggregates normalized to SQL function calls
+    assert me.sql == "SUM(cost) / SUM(quantity)"
 
 
 def test_single_aggregates_still_parse():
@@ -518,6 +520,21 @@ def test_pick_escaped_quote_before_keyword_in_condition():
         "b",
     )
     assert sql == "CASE WHEN note = 'it\\'s else ok' THEN 'x' ELSE 'y' END"
+
+
+def test_regex_match_binary_operand():
+    # The regex operand is the full arithmetic expression, not just the last token.
+    assert (
+        _dim_sql("source: o is duckdb.table('o') extend {\n  dimension: a is amount + tax ~ r'5'\n}\n", "a")
+        == "REGEXP_MATCHES(amount + tax, '5')"
+    )
+
+
+def test_unspaced_dot_method_ratio_normalized():
+    g = _parse("source: o is duckdb.table('o') extend {\n  measure: d is cost.sum()/quantity.sum()\n}\n")
+    me = g.get_model("o").get_metric("d")
+    assert me.type == "derived"
+    assert me.sql == "SUM(cost)/SUM(quantity)"
 
 
 def test_join_on_condition_skips_literal_predicate():

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -169,3 +169,87 @@ def test_join_composite_keys_reverse_direction():
     rel = {r.name: r for r in g.get_model("orders").relationships}["cohort"]
     assert rel.foreign_key == "gender"
     assert rel.metadata.get("composite_keys") == ["gender", "state"]
+
+
+# --- & and-tree must not split inside string literals ---
+
+
+def _dim_sql(src, name, model="o"):
+    return _parse(src).get_model(model).get_dimension(name).sql
+
+
+def test_and_tree_preserves_string_literal():
+    sql = _dim_sql("source: o is duckdb.table('o') extend {\n  dimension: amp is label = 'A & B'\n}\n", "amp")
+    assert sql == "label = 'A & B'"
+
+
+def test_and_tree_still_expands_top_level():
+    sql = _dim_sql("source: o is duckdb.table('o') extend {\n  dimension: r is value < 2031 & > -8000\n}\n", "r")
+    assert sql == "value < 2031 AND value > -8000"
+
+
+# --- regex ~ must consume only its own field operand ---
+
+
+def test_regex_match_does_not_swallow_left_context():
+    sql = _dim_sql("source: o is duckdb.table('o') extend {\n  dimension: a is amount = 1 and name ~ r'foo'\n}\n", "a")
+    assert sql == "amount = 1 and REGEXP_MATCHES(name, 'foo')"
+
+
+def test_multiple_regex_matches_stay_separate():
+    sql = _dim_sql("source: o is duckdb.table('o') extend {\n  dimension: b is name ~ r'x' and code ~ r'y'\n}\n", "b")
+    assert sql == "REGEXP_MATCHES(name, 'x') and REGEXP_MATCHES(code, 'y')"
+
+
+def test_single_regex_match_still_works():
+    sql = _dim_sql(
+        "source: o is duckdb.table('o') extend {\n  dimension: c is user_email ~ r'gserviceaccount'\n}\n", "c"
+    )
+    assert sql == "REGEXP_MATCHES(user_email, 'gserviceaccount')"
+
+
+# --- pick/when/else on a single line must produce a well-formed CASE ---
+
+
+def test_single_line_pick_produces_valid_case():
+    sql = _dim_sql(
+        "source: o is duckdb.table('o') extend {\n  dimension: tier is pick 'lo' when amount < 5 else 'hi'\n}\n",
+        "tier",
+    )
+    assert sql == "CASE WHEN amount < 5 THEN 'lo' ELSE 'hi' END"
+
+
+def test_single_line_apply_pick_produces_valid_case():
+    sql = _dim_sql(
+        "source: o is duckdb.table('o') extend {\n"
+        "  dimension: bucket is status ? pick 'lo' when < 5 pick 'hi' when 'ASW' else 'x'\n"
+        "}\n",
+        "bucket",
+    )
+    assert sql == "CASE WHEN status < 5 THEN 'lo' WHEN status = 'ASW' THEN 'hi' ELSE 'x' END"
+
+
+def test_apply_pick_with_regex_conditions():
+    sql = _dim_sql(
+        "source: o is duckdb.table('o') extend {\n"
+        "  dimension: faang is title ?\n"
+        "      pick 'Facebook' when ~ r'(Facebook|Instagram)'\n"
+        "      pick 'Apple' when ~ r'(Apple|iPhone)'\n"
+        "      else 'OTHER'\n"
+        "}\n",
+        "faang",
+    )
+    assert sql == (
+        "CASE WHEN REGEXP_MATCHES(title, '(Facebook|Instagram)') THEN 'Facebook' "
+        "WHEN REGEXP_MATCHES(title, '(Apple|iPhone)') THEN 'Apple' ELSE 'OTHER' END"
+    )
+
+
+# --- @date literal carrying a time component ---
+
+
+def test_datetime_literal_becomes_timestamp():
+    sql = _dim_sql(
+        "source: o is duckdb.table('o') extend {\n  dimension: f is created_at > @2024-01-01 10:30:00\n}\n", "f"
+    )
+    assert sql == "created_at > TIMESTAMP '2024-01-01 10:30:00'"

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -537,6 +537,28 @@ def test_unspaced_dot_method_ratio_normalized():
     assert me.sql == "SUM(cost)/SUM(quantity)"
 
 
+def test_timestamp_literal_forms():
+    def sql(lit):
+        return _dim_sql(
+            f"source: o is duckdb.table('o') extend {{\n  dimension: a is t > {lit}\n}}\n",
+            "a",
+        )
+
+    assert sql("@2024-01-01 10:30") == "t > TIMESTAMP '2024-01-01 10:30'"
+    assert sql("@2024-01-01 10:30:00.123") == "t > TIMESTAMP '2024-01-01 10:30:00.123'"
+    assert sql("@2024-01-01 10:30:00[UTC]") == "t > TIMESTAMP '2024-01-01 10:30:00'"
+
+
+def test_pick_condition_with_nested_case():
+    sql = _dim_sql(
+        "source: o is duckdb.table('o') extend {\n"
+        "  dimension: f is pick 'x' when case when a = 1 then 1 else 0 end = 1 else 'y'\n"
+        "}\n",
+        "f",
+    )
+    assert sql == "CASE WHEN case when a = 1 then 1 else 0 end = 1 THEN 'x' ELSE 'y' END"
+
+
 def test_join_on_condition_skips_literal_predicate():
     g = _parse(
         "source: customers is duckdb.table('c') extend { primary_key: id }\n"

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -453,3 +453,23 @@ def test_pick_keyword_inside_string_literal_is_not_a_delimiter():
         "h",
     )
     assert sql == "CASE WHEN note = 'before else after' THEN 'x' ELSE 'y' END"
+
+
+def test_many_to_many_exports_as_join_many():
+    from sidemantic import Model
+    from sidemantic.core.relationship import Relationship
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    g = SemanticGraph()
+    g.add_model(Model(name="tags", table="t", primary_key="id"))
+    g.add_model(
+        Model(
+            name="orders",
+            table="o",
+            primary_key="id",
+            relationships=[Relationship(name="tags", type="many_to_many", foreign_key="tag_id")],
+        )
+    )
+    text = _export_text(g)
+    assert "join_many: tags with tag_id" in text
+    assert "join_one: tags" not in text

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -33,6 +33,14 @@ def test_ratio_of_two_aggregates_is_derived():
     assert me.sql == "sum(amount) / sum(quantity)"
 
 
+def test_unspaced_ratio_of_two_aggregates_is_derived():
+    g = _parse("source: orders is duckdb.table('orders') extend {\n  measure: ratio1 is sum(amount)/sum(quantity)\n}\n")
+    me = g.get_model("orders").get_metric("ratio1")
+    assert me.agg is None
+    assert me.type == "derived"
+    assert me.sql == "sum(amount)/sum(quantity)"
+
+
 def test_sum_over_count_is_derived():
     g = _parse("source: orders is duckdb.table('orders') extend {\n  measure: avg_ov is sum(amount) / count()\n}\n")
     me = g.get_model("orders").get_metric("avg_ov")

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -566,6 +566,13 @@ def test_normalize_spaced_backtick_aggregate_field():
     assert me.sql == "SUM(`cost amount`) / count(*)"
 
 
+def test_normalize_dot_method_count_distinct():
+    g = _parse("source: o is duckdb.table('o') extend {\n  measure: m is user_id.count_distinct() / count()\n}\n")
+    me = g.get_model("o").get_metric("m")
+    assert me.type == "derived"
+    assert me.sql == "COUNT(DISTINCT user_id) / count(*)"
+
+
 def test_join_on_condition_parenthesized_equality():
     g = _parse(
         "source: customers is duckdb.table('c') extend { primary_key: id }\n"

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -168,6 +168,20 @@ def test_join_many_on_condition_uses_related_key():
     assert rel.foreign_key == "order_id"
 
 
+def test_join_many_unqualified_related_key():
+    # Related FK unqualified, source PK qualified by the source name.
+    g = _parse(
+        "source: items is duckdb.table('i') extend { measure: ic is count() }\n"
+        "source: orders is duckdb.table('o') extend {\n"
+        "  primary_key: id\n"
+        "  join_many: items is duckdb.table('i') on order_id = orders.id\n"
+        "}\n"
+    )
+    rel = {r.name: r for r in g.get_model("orders").relationships}["items"]
+    assert rel.type == "one_to_many"
+    assert rel.foreign_key == "order_id"
+
+
 def test_join_composite_keys_reverse_direction():
     g = _parse(
         "source: cohort is duckdb.table('co') extend { primary_key: id }\n"

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -253,3 +253,130 @@ def test_datetime_literal_becomes_timestamp():
         "source: o is duckdb.table('o') extend {\n  dimension: f is created_at > @2024-01-01 10:30:00\n}\n", "f"
     )
     assert sql == "created_at > TIMESTAMP '2024-01-01 10:30:00'"
+
+
+# --- join_cross & export / roundtrip ---
+
+
+def _export_text(graph):
+    import tempfile
+
+    out = tempfile.NamedTemporaryFile("w", suffix=".malloy", delete=False).name
+    MalloyAdapter().export(graph, out)
+    try:
+        return Path(out).read_text()
+    finally:
+        Path(out).unlink(missing_ok=True)
+
+
+def test_join_cross_maps_to_cross_type():
+    g = _parse(
+        "source: regions is duckdb.table('regions') extend { dimension: region_name is name }\n"
+        "source: orders is duckdb.table('orders') extend {\n"
+        "  primary_key: id\n"
+        "  measure: order_count is count()\n"
+        "  join_cross: regions\n"
+        "}\n"
+    )
+    rel = {r.name: r for r in g.get_model("orders").relationships}["regions"]
+    assert rel.type == "cross"
+    assert rel.foreign_key is None
+
+
+def test_cross_relationship_exports_without_key_clause():
+    from sidemantic import Metric, Model
+    from sidemantic.core.relationship import Relationship
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    g = SemanticGraph()
+    g.add_model(Model(name="regions", table="regions", primary_key="id"))
+    g.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            primary_key="id",
+            metrics=[Metric(name="order_count", agg="count")],
+            relationships=[Relationship(name="regions", type="cross")],
+        )
+    )
+    text = _export_text(g)
+    assert "join_cross: regions" in text
+    assert "join_cross: regions with" not in text
+    # Round-trips back to a cross relationship.
+    import tempfile
+
+    p = tempfile.NamedTemporaryFile("w", suffix=".malloy", delete=False)
+    p.write(text)
+    p.close()
+    g2 = MalloyAdapter(warn_on_errors=False).parse(Path(p.name))
+    Path(p.name).unlink(missing_ok=True)
+    assert g2.get_model("orders").relationships[0].type == "cross"
+
+
+def test_time_dimension_granularity_survives_roundtrip():
+    from sidemantic import Dimension, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    g = SemanticGraph()
+    g.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            primary_key="order_id",
+            dimensions=[Dimension(name="order_month", type="time", granularity="month", sql="created_at")],
+        )
+    )
+    text = _export_text(g)
+    assert "order_month is created_at.month" in text
+    assert "rename:" not in text
+
+
+def test_unsupported_metric_not_exported_as_count():
+    from sidemantic import Metric, Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    g = SemanticGraph()
+    g.add_model(
+        Model(
+            name="o",
+            table="o",
+            primary_key="id",
+            metrics=[
+                Metric(name="rt", type="cumulative", window_expression="sum(amount)"),
+                Metric(name="c", agg="count"),
+            ],
+        )
+    )
+    text = _export_text(g)
+    assert "rt is count()" not in text
+    assert "c is count()" in text
+
+
+def test_multiline_description_collapsed_to_one_line():
+    from sidemantic import Model
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    g = SemanticGraph()
+    g.add_model(Model(name="o", table="o", primary_key="id", description="Line one\nLine two"))
+    text = _export_text(g)
+    assert "# desc: Line one Line two" in text
+
+
+def test_one_to_one_exports_as_join_one_not_cross():
+    from sidemantic import Model
+    from sidemantic.core.relationship import Relationship
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    g = SemanticGraph()
+    g.add_model(Model(name="customers", table="c", primary_key="customer_id"))
+    g.add_model(
+        Model(
+            name="orders",
+            table="o",
+            primary_key="id",
+            relationships=[Relationship(name="customers", type="one_to_one", foreign_key="customer_id")],
+        )
+    )
+    text = _export_text(g)
+    assert "join_one: customers with customer_id" in text
+    assert "join_cross: customers" not in text

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -642,6 +642,11 @@ def test_count_with_string_literal_argument_normalized():
     assert g.get_model("o").get_metric("m").sql == "COUNT(DISTINCT case when plan = 'pro' then user_id end) / count(*)"
 
 
+def test_count_with_backtick_field_containing_paren():
+    g = _parse("source: o is duckdb.table('o') extend {\n  measure: m is count(`user(id`) / count()\n}\n")
+    assert g.get_model("o").get_metric("m").sql == "COUNT(DISTINCT `user(id`) / count(*)"
+
+
 def test_regex_match_case_expression_operand():
     assert (
         _dim_sql(

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -505,6 +505,21 @@ def test_date_literal_dimension_is_time_not_numeric():
     assert d.sql == "DATE '2024-01-01'"
 
 
+def test_regex_match_backtick_operand_with_spaces():
+    assert (
+        _dim_sql("source: o is duckdb.table('o') extend {\n  dimension: a is `user name` ~ r'foo'\n}\n", "a")
+        == "REGEXP_MATCHES(`user name`, 'foo')"
+    )
+
+
+def test_pick_escaped_quote_before_keyword_in_condition():
+    sql = _dim_sql(
+        "source: o is duckdb.table('o') extend {\n  dimension: b is pick 'x' when note = 'it\\'s else ok' else 'y'\n}\n",
+        "b",
+    )
+    assert sql == "CASE WHEN note = 'it\\'s else ok' THEN 'x' ELSE 'y' END"
+
+
 def test_join_on_condition_skips_literal_predicate():
     g = _parse(
         "source: customers is duckdb.table('c') extend { primary_key: id }\n"

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -473,3 +473,24 @@ def test_many_to_many_exports_as_join_many():
     text = _export_text(g)
     assert "join_many: tags with tag_id" in text
     assert "join_one: tags" not in text
+
+
+def test_regex_match_handles_spaced_function_call():
+    assert (
+        _dim_sql("source: o is duckdb.table('o') extend {\n  dimension: a is lower (name) ~ r'foo'\n}\n", "a")
+        == "REGEXP_MATCHES(lower (name), 'foo')"
+    )
+
+
+def test_join_on_condition_skips_literal_predicate():
+    g = _parse(
+        "source: customers is duckdb.table('c') extend { primary_key: id }\n"
+        "source: orders is duckdb.table('o') extend {\n"
+        "  primary_key: id\n"
+        "  join_one: customers is duckdb.table('c') on customers.active = true and customer_id = customers.id\n"
+        "}\n"
+    )
+    rel = {r.name: r for r in g.get_model("orders").relationships}["customers"]
+    # The `customers.active = true` filter must not become the foreign key.
+    assert rel.foreign_key == "customer_id"
+    assert rel.metadata.get("composite_keys") is None

--- a/tests/adapters/malloy/test_edge_cases.py
+++ b/tests/adapters/malloy/test_edge_cases.py
@@ -96,9 +96,9 @@ class TestEdgeCases:
         assert "join_target_b" in rels
         assert rels["join_target_b"].type == "one_to_many"
 
-        # join_cross -> one_to_one (our mapping)
+        # join_cross -> cross (real CROSS JOIN / cartesian product)
         assert "join_target_c" in rels
-        assert rels["join_target_c"].type == "one_to_one"
+        assert rels["join_target_c"].type == "cross"
 
     def test_join_direction_stored(self):
         """Test that join direction modifiers (LEFT, INNER, etc.) are stored in metadata."""

--- a/tests/adapters/test_added_fixture_coverage.py
+++ b/tests/adapters/test_added_fixture_coverage.py
@@ -28,7 +28,7 @@ from sidemantic.adapters.tableau import TableauAdapter
 from sidemantic.adapters.thoughtspot import ThoughtSpotAdapter
 from sidemantic.sql.generator import SQLGenerator
 
-ALLOWED_RELATIONSHIP_TYPES = {"many_to_one", "one_to_many", "one_to_one", "many_to_many"}
+ALLOWED_RELATIONSHIP_TYPES = {"many_to_one", "one_to_many", "one_to_one", "many_to_many", "cross"}
 UNQUOTED_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 ADDED_FIXTURE_CASES = [

--- a/tests/adapters/test_fixture_functionality_contracts.py
+++ b/tests/adapters/test_fixture_functionality_contracts.py
@@ -34,7 +34,7 @@ from tests.adapters.test_added_fixture_coverage import (
     _prepare_graph_for_execution,
 )
 
-ALLOWED_RELATIONSHIP_TYPES = {"many_to_one", "one_to_many", "one_to_one", "many_to_many"}
+ALLOWED_RELATIONSHIP_TYPES = {"many_to_one", "one_to_many", "one_to_one", "many_to_many", "cross"}
 
 ADAPTER_FIXTURE_ROOTS = [
     ("atscale_sml", AtScaleSMLAdapter, {".yml", ".yaml"}),


### PR DESCRIPTION
Fixes a set of correctness bugs in the Malloy adapter, found via an execution-grounded audit (every issue was reproduced by running `MalloyAdapter().parse()` on a minimal `.malloy` input). The recurring root cause: the visitor has a correct ANTLR parse tree but repeatedly flattens expressions back to text and re-parses them with greedy/anchored regexes, which breaks on string literals, multiple operators, precedence, and single-line forms.

Each fix has a regression test in `tests/adapters/malloy/test_audit_regressions.py` (33 new tests).

## Aggregation, typing, filters, joins
- **Critical:** a compound measure combining aggregates with a top-level operator (`sum(a) / sum(b)`, `sum(a) / count()`, `cost.sum() / quantity.sum()`) was mis-parsed as a single aggregation and produced invalid SQL. It is now preserved as a derived measure.
- `??` inside a string literal (`note ?? 'x ?? y'`) was split as a coalesce separator and corrupted the literal; now quote-aware.
- Trailing Malloy time truncation (`created_at.month`) now infers `time` + granularity; the name-based type heuristic runs last so an explicit comparison/arithmetic expression is no longer overridden to `time` by the field name.
- Chained filter refinements `count() { where: a } { where: b }` dropped the inner filter and the aggregation; all nested levels are now unwrapped and ANDed.
- Join `on`-condition foreign-key extraction was direction-blind (failed or extracted the wrong column when the target-qualified key was on the left); now handles either ordering and composite keys.

## Expression transforms
- Regex match `~` / `!~`: the LHS is restricted to a single field reference, so a match no longer swallows preceding conditions (`a = 1 and name ~ r'x'`) and multiple matches no longer corrupt each other.
- `&` and-tree splits only at the top level, so a `&` inside a string literal (`'A & B'`) is preserved.
- `pick`/`when`/`else` parsing is keyword-driven rather than line-driven, so single-line `pick` and apply-pick produce a well-formed `CASE`. `pick` is now transformed before the other expression rewrites, so regex/date rewrites operate on real field references inside the `WHEN` clauses.
- `@date HH:MM:SS` literals become `TIMESTAMP` literals.

## join_cross and export / roundtrip
- `join_cross` maps to `Relationship(type="cross")` (a real `CROSS JOIN`) instead of `one_to_one` (which produced a wrong equi-join on `id`). Updates the edge-case assertion, both fixture-contract allow-lists (`cross` is a valid core relationship type they were missing), and the compatibility doc.
- Export: a `cross` relationship is emitted as `join_cross: name` with no key clause; `one_to_one` exports as `join_one`; a time dimension with a bare-column SQL keeps its `.granularity` suffix (was emitted as a `rename:`, dropping the type/granularity); a tableless `extends` source emits `source: x is base extend {`; metrics with no faithful Malloy form are skipped with a comment instead of a bogus `count()`; multi-line descriptions are collapsed so `# desc:` stays valid.

## Imports
- Cycle/dedup detection is keyed on `(path, import-filter)` instead of the path alone, so a file imported under a narrow named filter can still be re-parsed for a later broader or differently-named import (previously its other sources were silently dropped across import chains). Identical requests are still parsed once, so circular imports terminate.
- A source imported under several names in one statement (`import { s is a, s is b }`) now resolves to all names, not just the first.

## Not included (documented backlog)
A few medium-severity items remain: name-substring time false-positives (`time_zone`), `source.count()` symmetric aggregation, declaration-order-dependent measure references, source `+`-refinement drops, `accept:`/`except:` no-ops, and the tableless pipeline-source case where `resolve_model_inheritance()` clears `extends`.
