### PR TITLE
Import query history in migrator

### DIFF
--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -230,6 +230,8 @@ def migrator(
     """
     from sidemantic.core.migrator import Migrator
 
+    source_dialect = "duckdb"
+
     if not queries and not connection:
         typer.echo("Error: Must specify --queries or --connection", err=True)
         typer.echo("Usage: sidemantic migrator [models_dir] (--queries <path> | --connection <url>)", err=True)
@@ -244,9 +246,11 @@ def migrator(
         raise typer.Exit(1)
 
     def load_queries_from_source() -> list[str] | None:
+        nonlocal source_dialect
         if connection:
             history_layer = SemanticLayer(connection=connection, auto_register=False)
             adapter = history_layer.adapter
+            source_dialect = adapter.dialect
             get_query_history = getattr(adapter, "get_query_history", None)
             if get_query_history is None:
                 raise ValueError(f"{adapter.dialect} does not support query-history import")
@@ -282,10 +286,9 @@ def migrator(
         try:
             # Create empty semantic layer for analysis
             layer = SemanticLayer(auto_register=False)
-            analyzer = Migrator(layer)
-
             # Analyze queries
             query_list = load_queries_from_source()
+            analyzer = Migrator(layer, dialect=source_dialect)
             if query_list is not None:
                 report = analyzer.analyze_queries(query_list)
             else:
@@ -336,11 +339,9 @@ def migrator(
                 typer.echo("Error: No models found in semantic layer", err=True)
                 raise typer.Exit(1)
 
-            # Create analyzer
-            analyzer = Migrator(layer)
-
             # Analyze queries
             query_list = load_queries_from_source()
+            analyzer = Migrator(layer, dialect=source_dialect)
             if query_list is not None:
                 report = analyzer.analyze_queries(query_list)
             else:

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -202,6 +202,13 @@ def migrator(
     queries: Path = typer.Option(
         None, "--queries", "-q", help="Path to file or folder containing SQL queries to analyze"
     ),
+    connection: str = typer.Option(
+        None,
+        "--connection",
+        help="Database connection string used to import warehouse query history",
+    ),
+    days_back: int = typer.Option(7, "--days", "-d", help="Days of query history to import (default: 7)"),
+    limit: int = typer.Option(1000, "--limit", "-l", help="Maximum history queries to import (default: 1000)"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed analysis for each query"),
     generate_models: Path = typer.Option(
         None,
@@ -218,18 +225,57 @@ def migrator(
 
     Examples:
       sidemantic migrator --queries queries/ --generate-models output/
+      sidemantic migrator --connection "snowflake://..." --days 7 --generate-models output/
       sidemantic migrator models/ --queries queries/ --verbose
     """
     from sidemantic.core.migrator import Migrator
 
-    if not queries:
-        typer.echo("Error: --queries is required", err=True)
-        typer.echo("Usage: sidemantic migrator [models_dir] --queries <path>", err=True)
+    if not queries and not connection:
+        typer.echo("Error: Must specify --queries or --connection", err=True)
+        typer.echo("Usage: sidemantic migrator [models_dir] (--queries <path> | --connection <url>)", err=True)
         raise typer.Exit(1)
 
-    if not queries.exists():
+    if queries and connection:
+        typer.echo("Error: --queries and --connection are mutually exclusive", err=True)
+        raise typer.Exit(1)
+
+    if queries and not queries.exists():
         typer.echo(f"Error: {queries} does not exist", err=True)
         raise typer.Exit(1)
+
+    def load_queries_from_source() -> list[str] | None:
+        if connection:
+            history_layer = SemanticLayer(connection=connection, auto_register=False)
+            adapter = history_layer.adapter
+            get_query_history = getattr(adapter, "get_query_history", None)
+            if get_query_history is None:
+                raise ValueError(f"{adapter.dialect} does not support query-history import")
+            typer.echo(
+                f"Importing up to {limit} queries from the last {days_back} day(s) of {adapter.dialect} history...",
+                err=True,
+            )
+            try:
+                try:
+                    imported = get_query_history(days_back=days_back, limit=limit, instrumented_only=False)
+                except TypeError as exc:
+                    if "instrumented_only" not in str(exc):
+                        raise
+                    raise ValueError(
+                        f"{adapter.dialect} adapter does not support unfiltered query-history import"
+                    ) from exc
+            finally:
+                close_adapter = getattr(adapter, "close", None)
+                if close_adapter:
+                    close_adapter()
+            queries_from_history = [query.strip() for query in imported if query and query.strip()]
+            typer.echo(f"Imported {len(queries_from_history)} queries from warehouse history", err=True)
+            if not queries_from_history:
+                raise ValueError("No queries found in warehouse history for the requested time range")
+            return queries_from_history
+
+        if queries and queries.is_file():
+            return [query.strip() for query in queries.read_text().split(";") if query.strip()]
+        return None
 
     # Bootstrap mode - generate models from queries
     if generate_models:
@@ -239,11 +285,11 @@ def migrator(
             analyzer = Migrator(layer)
 
             # Analyze queries
-            if queries.is_file():
-                query_list = queries.read_text().split(";")
-                query_list = [q.strip() for q in query_list if q.strip()]
+            query_list = load_queries_from_source()
+            if query_list is not None:
                 report = analyzer.analyze_queries(query_list)
             else:
+                assert queries is not None
                 report = analyzer.analyze_folder(str(queries))
 
             # Generate model definitions
@@ -294,13 +340,12 @@ def migrator(
             analyzer = Migrator(layer)
 
             # Analyze queries
-            if queries.is_file():
-                # Single file - load queries from it
-                query_list = queries.read_text().split(";")
-                query_list = [q.strip() for q in query_list if q.strip()]
+            query_list = load_queries_from_source()
+            if query_list is not None:
                 report = analyzer.analyze_queries(query_list)
             else:
                 # Directory - load all .sql files
+                assert queries is not None
                 report = analyzer.analyze_folder(str(queries))
 
             # Print report

--- a/sidemantic/core/migrator.py
+++ b/sidemantic/core/migrator.py
@@ -118,16 +118,18 @@ class Migrator:
     - How to rewrite queries using the semantic layer
     """
 
-    def __init__(self, layer: SemanticLayer, connection=None):
+    def __init__(self, layer: SemanticLayer, connection=None, dialect: str = "duckdb"):
         """Initialize analyzer.
 
         Args:
             layer: Semantic layer to analyze coverage for
             connection: Optional database connection for querying information_schema.
                        Should have an execute() method that returns results.
+            dialect: SQLGlot source dialect used to parse input queries.
         """
         self.layer = layer
         self.connection = connection
+        self.dialect = dialect
         self.analyses: list[QueryAnalysis] = []
 
         # Build mapping from table names to model names
@@ -244,7 +246,7 @@ class Migrator:
 
         try:
             # Parse SQL
-            parsed = sqlglot.parse_one(query, read="duckdb")
+            parsed = sqlglot.parse_one(query, read=self.dialect)
 
             # Extract components
             self._extract_tables(parsed, analysis)

--- a/sidemantic/db/bigquery.py
+++ b/sidemantic/db/bigquery.py
@@ -185,6 +185,7 @@ class BigQueryAdapter(BaseDatabaseAdapter):
         WHERE creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {days_back} DAY)
           AND job_type = 'QUERY'
           AND state = 'DONE'
+          AND error_result IS NULL
           {instrumentation_filter}
         ORDER BY creation_time DESC
         LIMIT {limit}

--- a/sidemantic/db/bigquery.py
+++ b/sidemantic/db/bigquery.py
@@ -164,7 +164,7 @@ class BigQueryAdapter(BaseDatabaseAdapter):
             )
         return columns
 
-    def get_query_history(self, days_back: int = 7, limit: int = 1000) -> list[str]:
+    def get_query_history(self, days_back: int = 7, limit: int = 1000, *, instrumented_only: bool = True) -> list[str]:
         """Fetch query history from BigQuery.
 
         Queries INFORMATION_SCHEMA.JOBS_BY_PROJECT to find queries with sidemantic instrumentation.
@@ -172,18 +172,20 @@ class BigQueryAdapter(BaseDatabaseAdapter):
         Args:
             days_back: Number of days of history to fetch (default: 7)
             limit: Maximum number of queries to return (default: 1000)
+            instrumented_only: Only return queries containing Sidemantic instrumentation comments
 
         Returns:
-            List of SQL query strings containing '-- sidemantic:' comments
+            List of SQL query strings. By default only Sidemantic-instrumented queries are returned.
         """
         days_back, limit = validate_query_history_params(days_back, limit)
+        instrumentation_filter = "AND query LIKE '%-- sidemantic:%'" if instrumented_only else ""
         sql = f"""
         SELECT query
         FROM `{self.project_id}.region-{self.client.location}.INFORMATION_SCHEMA.JOBS_BY_PROJECT`
         WHERE creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {days_back} DAY)
           AND job_type = 'QUERY'
           AND state = 'DONE'
-          AND query LIKE '%-- sidemantic:%'
+          {instrumentation_filter}
         ORDER BY creation_time DESC
         LIMIT {limit}
         """

--- a/sidemantic/db/clickhouse.py
+++ b/sidemantic/db/clickhouse.py
@@ -211,7 +211,7 @@ class ClickHouseAdapter(BaseDatabaseAdapter):
         result = self.client.query(sql, parameters={"schema": schema, "table": table_name})
         return [{"column_name": row[0], "data_type": row[1]} for row in result.result_rows]
 
-    def get_query_history(self, days_back: int = 7, limit: int = 1000) -> list[str]:
+    def get_query_history(self, days_back: int = 7, limit: int = 1000, *, instrumented_only: bool = True) -> list[str]:
         """Fetch query history from ClickHouse.
 
         Queries system.query_log to find queries with sidemantic instrumentation.
@@ -219,18 +219,20 @@ class ClickHouseAdapter(BaseDatabaseAdapter):
         Args:
             days_back: Number of days of history to fetch (default: 7)
             limit: Maximum number of queries to return (default: 1000)
+            instrumented_only: Only return queries containing Sidemantic instrumentation comments
 
         Returns:
-            List of SQL query strings containing '-- sidemantic:' comments
+            List of SQL query strings. By default only Sidemantic-instrumented queries are returned.
         """
         days_back, limit = validate_query_history_params(days_back, limit)
+        instrumentation_filter = "AND query LIKE '%-- sidemantic:%'" if instrumented_only else ""
         sql = f"""
         SELECT query
         FROM system.query_log
         WHERE event_time >= now() - INTERVAL {days_back} DAY
-          AND query LIKE '%-- sidemantic:%'
           AND type = 'QueryFinish'
           AND exception = ''
+          {instrumentation_filter}
         ORDER BY event_time DESC
         LIMIT {limit}
         """

--- a/sidemantic/db/databricks.py
+++ b/sidemantic/db/databricks.py
@@ -170,7 +170,7 @@ class DatabricksAdapter(BaseDatabaseAdapter):
         rows = result.fetchall()
         return [{"column_name": row[0], "data_type": row[1]} for row in rows]
 
-    def get_query_history(self, days_back: int = 7, limit: int = 1000) -> list[str]:
+    def get_query_history(self, days_back: int = 7, limit: int = 1000, *, instrumented_only: bool = True) -> list[str]:
         """Fetch query history from Databricks.
 
         Queries system.query.history (Unity Catalog) to find queries with sidemantic instrumentation.
@@ -178,20 +178,22 @@ class DatabricksAdapter(BaseDatabaseAdapter):
         Args:
             days_back: Number of days of history to fetch (default: 7)
             limit: Maximum number of queries to return (default: 1000)
+            instrumented_only: Only return queries containing Sidemantic instrumentation comments
 
         Returns:
-            List of SQL query strings containing '-- sidemantic:' comments
+            List of SQL query strings. By default only Sidemantic-instrumented queries are returned.
 
         Note:
             Requires Unity Catalog and appropriate permissions to query system.query.history
         """
         days_back, limit = validate_query_history_params(days_back, limit)
+        instrumentation_filter = "AND statement_text LIKE '%-- sidemantic:%'" if instrumented_only else ""
         sql = f"""
         SELECT statement_text
         FROM system.query.history
         WHERE start_time >= CURRENT_TIMESTAMP() - INTERVAL {days_back} DAYS
-          AND statement_text LIKE '%-- sidemantic:%'
           AND status = 'FINISHED'
+          {instrumentation_filter}
         ORDER BY start_time DESC
         LIMIT {limit}
         """

--- a/sidemantic/db/snowflake.py
+++ b/sidemantic/db/snowflake.py
@@ -220,7 +220,7 @@ class SnowflakeAdapter(BaseDatabaseAdapter):
         rows = result.fetchall()
         return [{"column_name": row[0], "data_type": row[1]} for row in rows]
 
-    def get_query_history(self, days_back: int = 7, limit: int = 1000) -> list[str]:
+    def get_query_history(self, days_back: int = 7, limit: int = 1000, *, instrumented_only: bool = True) -> list[str]:
         """Fetch query history from Snowflake.
 
         Queries INFORMATION_SCHEMA.QUERY_HISTORY to find queries with sidemantic instrumentation.
@@ -228,18 +228,20 @@ class SnowflakeAdapter(BaseDatabaseAdapter):
         Args:
             days_back: Number of days of history to fetch (default: 7, max: 7 for INFORMATION_SCHEMA)
             limit: Maximum number of queries to return (default: 1000)
+            instrumented_only: Only return queries containing Sidemantic instrumentation comments
 
         Returns:
-            List of SQL query strings containing '-- sidemantic:' comments
+            List of SQL query strings. By default only Sidemantic-instrumented queries are returned.
         """
         days_back, limit = validate_query_history_params(days_back, limit, max_days_back=7)
+        instrumentation_filter = "AND query_text LIKE '%-- sidemantic:%'" if instrumented_only else ""
         sql = f"""
         SELECT query_text
         FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY(
             END_TIME_RANGE_START => DATEADD('day', -{days_back}, CURRENT_TIMESTAMP())
         ))
-        WHERE query_text LIKE '%-- sidemantic:%'
-          AND execution_status = 'SUCCESS'
+        WHERE execution_status = 'SUCCESS'
+          {instrumentation_filter}
         ORDER BY start_time DESC
         LIMIT {limit}
         """

--- a/tests/db/test_bigquery_adapter.py
+++ b/tests/db/test_bigquery_adapter.py
@@ -238,6 +238,9 @@ def test_bigquery_query_history_sql():
     assert "LIMIT 9" in captured["sql"]
     assert results == ["select 1 -- sidemantic: ok"]
 
+    adapter.get_query_history(days_back=4, limit=9, instrumented_only=False)
+    assert "query LIKE '%-- sidemantic:%'" not in captured["sql"]
+
 
 def test_bigquery_result_fetchone_fetchall():
     class FakeRow:

--- a/tests/db/test_bigquery_adapter.py
+++ b/tests/db/test_bigquery_adapter.py
@@ -236,6 +236,7 @@ def test_bigquery_query_history_sql():
     assert "INFORMATION_SCHEMA.JOBS_BY_PROJECT" in captured["sql"]
     assert "INTERVAL 4 DAY" in captured["sql"]
     assert "LIMIT 9" in captured["sql"]
+    assert "error_result IS NULL" in captured["sql"]
     assert results == ["select 1 -- sidemantic: ok"]
 
     adapter.get_query_history(days_back=4, limit=9, instrumented_only=False)

--- a/tests/db/test_clickhouse_adapter.py
+++ b/tests/db/test_clickhouse_adapter.py
@@ -193,6 +193,9 @@ def test_clickhouse_query_history_sql():
     assert "LIMIT 50" in captured["sql"]
     assert results == ["select 1 -- sidemantic: x"]
 
+    adapter.get_query_history(days_back=3, limit=50, instrumented_only=False)
+    assert "query LIKE '%-- sidemantic:%'" not in captured["sql"]
+
 
 def test_clickhouse_result_ordering_and_exhaustion():
     result = ClickHouseResult(

--- a/tests/db/test_databricks_adapter.py
+++ b/tests/db/test_databricks_adapter.py
@@ -174,6 +174,9 @@ def test_databricks_query_history_sql():
     assert "LIMIT 25" in captured["sql"]
     assert results == ["select 1 -- sidemantic: z"]
 
+    adapter.get_query_history(days_back=2, limit=25, instrumented_only=False)
+    assert "statement_text LIKE '%-- sidemantic:%'" not in captured["sql"]
+
 
 def test_databricks_result_ordering_and_exhaustion():
     cursor = _FakeCursor(rows=[(1,), (2,)], description=[("a", None)])

--- a/tests/db/test_snowflake_adapter.py
+++ b/tests/db/test_snowflake_adapter.py
@@ -165,6 +165,9 @@ def test_snowflake_query_history_sql():
     assert "LIMIT 10" in captured["sql"]
     assert results == ["select 1 -- sidemantic: y"]
 
+    adapter.get_query_history(days_back=5, limit=10, instrumented_only=False)
+    assert "query_text LIKE '%-- sidemantic:%'" not in captured["sql"]
+
 
 def test_snowflake_result_ordering_and_exhaustion():
     cursor = _FakeCursor(rows=[(1,), (2,)], description=[("a", None)])

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -110,8 +110,8 @@ def test_migrator_generates_models_from_warehouse_query_history(monkeypatch, tmp
             self.adapter = FakeAdapter() if connection else None
 
     class FakeMigrator:
-        def __init__(self, _layer):
-            pass
+        def __init__(self, _layer, dialect="duckdb"):
+            captured["dialect"] = dialect
 
         def analyze_queries(self, queries):
             captured["queries"] = queries
@@ -156,6 +156,7 @@ def test_migrator_generates_models_from_warehouse_query_history(monkeypatch, tmp
 
     assert result.exit_code == 0, result.output
     assert captured["history_args"] == (30, 2500, False)
+    assert captured["dialect"] == "snowflake"
     assert captured["queries"] == ["SELECT status, SUM(amount) AS revenue FROM orders GROUP BY status"]
     assert captured["models_dir"] == str(output / "models")
     assert captured["rewritten_dir"] == str(output / "rewritten_queries")

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -95,6 +95,94 @@ models:
     assert "bad.yml" in result.output
 
 
+def test_migrator_generates_models_from_warehouse_query_history(monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeAdapter:
+        dialect = "snowflake"
+
+        def get_query_history(self, days_back=7, limit=1000, *, instrumented_only=True):
+            captured["history_args"] = (days_back, limit, instrumented_only)
+            return ["SELECT status, SUM(amount) AS revenue FROM orders GROUP BY status", "  ", None]
+
+    class FakeLayer:
+        def __init__(self, connection=None, **_kwargs):
+            self.adapter = FakeAdapter() if connection else None
+
+    class FakeMigrator:
+        def __init__(self, _layer):
+            pass
+
+        def analyze_queries(self, queries):
+            captured["queries"] = queries
+            return object()
+
+        def generate_models(self, _report):
+            return {"orders": object()}
+
+        def write_model_files(self, _models, output_dir):
+            captured["models_dir"] = output_dir
+
+        def generate_graph_metrics(self, _report, _models):
+            return {}
+
+        def write_graph_metrics_file(self, _metrics, _output_dir):
+            pass
+
+        def generate_rewritten_queries(self, _report):
+            return {"query_1": "SELECT orders.status, orders.revenue FROM orders"}
+
+        def write_rewritten_queries(self, _queries, output_dir):
+            captured["rewritten_dir"] = output_dir
+
+    monkeypatch.setattr(cli_module, "SemanticLayer", FakeLayer)
+    monkeypatch.setattr("sidemantic.core.migrator.Migrator", FakeMigrator)
+
+    output = tmp_path / "generated"
+    result = runner.invoke(
+        app,
+        [
+            "migrator",
+            "--connection",
+            "snowflake://example",
+            "--days",
+            "30",
+            "--limit",
+            "2500",
+            "--generate-models",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["history_args"] == (30, 2500, False)
+    assert captured["queries"] == ["SELECT status, SUM(amount) AS revenue FROM orders GROUP BY status"]
+    assert captured["models_dir"] == str(output / "models")
+    assert captured["rewritten_dir"] == str(output / "rewritten_queries")
+    assert "Imported 1 queries from warehouse history" in result.output
+
+
+def test_migrator_rejects_queries_and_connection_together(tmp_path):
+    query_file = tmp_path / "queries.sql"
+    query_file.write_text("SELECT 1")
+
+    result = runner.invoke(
+        app,
+        [
+            "migrator",
+            "--queries",
+            str(query_file),
+            "--connection",
+            "snowflake://example",
+            "--generate-models",
+            str(tmp_path / "output"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "mutually exclusive" in result.output
+
+
 def test_query_dry_run_emits_sql(tmp_path):
     _write_min_model(tmp_path)
 

--- a/tests/test_migrator_generation.py
+++ b/tests/test_migrator_generation.py
@@ -4,6 +4,27 @@ from sidemantic import SemanticLayer
 from sidemantic.core.migrator import Migrator
 
 
+def test_generate_models_parses_bigquery_history_with_source_dialect():
+    layer = SemanticLayer(auto_register=False)
+    analyzer = Migrator(layer, dialect="bigquery")
+
+    report = analyzer.analyze_queries(
+        [
+            """
+            SELECT status, SUM(amount) AS revenue
+            FROM `project.dataset.orders`
+            GROUP BY status
+            """
+        ]
+    )
+    models = analyzer.generate_models(report)
+
+    assert report.parseable_queries == 1
+    assert "orders" in models
+    assert models["orders"]["table"] == "orders"
+    assert {metric["name"] for metric in models["orders"]["metrics"]} == {"revenue"}
+
+
 def test_generate_models_from_queries():
     """Test generating model definitions from queries."""
     layer = SemanticLayer(auto_register=False)


### PR DESCRIPTION
Adds direct warehouse query-history ingestion to the migrator, so users can generate native semantic models and rewritten queries without first exporting SQL files.

The new `--connection`, `--days`, and `--limit` options support Snowflake, BigQuery, Databricks, and ClickHouse. Migrator imports unfiltered successful history while existing pre-aggregation consumers remain instrumented-only by default. File and directory corpora continue to work through `--queries`, and the two source modes are explicitly mutually exclusive.
