### PR TITLE
Ignore internal query history reads

### DIFF
--- a/sidemantic/db/bigquery.py
+++ b/sidemantic/db/bigquery.py
@@ -186,6 +186,7 @@ class BigQueryAdapter(BaseDatabaseAdapter):
           AND job_type = 'QUERY'
           AND state = 'DONE'
           AND error_result IS NULL
+          AND NOT REGEXP_CONTAINS(UPPER(query), r'INFORMATION_SCHEMA\\.JOBS_BY_PROJECT')
           {instrumentation_filter}
         ORDER BY creation_time DESC
         LIMIT {limit}

--- a/sidemantic/db/clickhouse.py
+++ b/sidemantic/db/clickhouse.py
@@ -232,6 +232,7 @@ class ClickHouseAdapter(BaseDatabaseAdapter):
         WHERE event_time >= now() - INTERVAL {days_back} DAY
           AND type = 'QueryFinish'
           AND exception = ''
+          AND lower(query) NOT LIKE '%system.query_log%'
           {instrumentation_filter}
         ORDER BY event_time DESC
         LIMIT {limit}

--- a/sidemantic/db/databricks.py
+++ b/sidemantic/db/databricks.py
@@ -193,6 +193,7 @@ class DatabricksAdapter(BaseDatabaseAdapter):
         FROM system.query.history
         WHERE start_time >= CURRENT_TIMESTAMP() - INTERVAL {days_back} DAYS
           AND status = 'FINISHED'
+          AND LOWER(statement_text) NOT LIKE '%system.query.history%'
           {instrumentation_filter}
         ORDER BY start_time DESC
         LIMIT {limit}

--- a/sidemantic/db/snowflake.py
+++ b/sidemantic/db/snowflake.py
@@ -241,6 +241,7 @@ class SnowflakeAdapter(BaseDatabaseAdapter):
             END_TIME_RANGE_START => DATEADD('day', -{days_back}, CURRENT_TIMESTAMP())
         ))
         WHERE execution_status = 'SUCCESS'
+          AND query_text NOT ILIKE '%INFORMATION_SCHEMA.QUERY_HISTORY%'
           {instrumentation_filter}
         ORDER BY start_time DESC
         LIMIT {limit}

--- a/tests/db/test_bigquery_adapter.py
+++ b/tests/db/test_bigquery_adapter.py
@@ -237,6 +237,7 @@ def test_bigquery_query_history_sql():
     assert "INTERVAL 4 DAY" in captured["sql"]
     assert "LIMIT 9" in captured["sql"]
     assert "error_result IS NULL" in captured["sql"]
+    assert "INFORMATION_SCHEMA\\.JOBS_BY_PROJECT" in captured["sql"]
     assert results == ["select 1 -- sidemantic: ok"]
 
     adapter.get_query_history(days_back=4, limit=9, instrumented_only=False)

--- a/tests/db/test_clickhouse_adapter.py
+++ b/tests/db/test_clickhouse_adapter.py
@@ -191,6 +191,7 @@ def test_clickhouse_query_history_sql():
     assert "system.query_log" in captured["sql"]
     assert "INTERVAL 3 DAY" in captured["sql"]
     assert "LIMIT 50" in captured["sql"]
+    assert "lower(query) NOT LIKE '%system.query_log%'" in captured["sql"]
     assert results == ["select 1 -- sidemantic: x"]
 
     adapter.get_query_history(days_back=3, limit=50, instrumented_only=False)

--- a/tests/db/test_databricks_adapter.py
+++ b/tests/db/test_databricks_adapter.py
@@ -172,6 +172,7 @@ def test_databricks_query_history_sql():
     assert "system.query.history" in captured["sql"]
     assert "INTERVAL 2 DAYS" in captured["sql"]
     assert "LIMIT 25" in captured["sql"]
+    assert "LOWER(statement_text) NOT LIKE '%system.query.history%'" in captured["sql"]
     assert results == ["select 1 -- sidemantic: z"]
 
     adapter.get_query_history(days_back=2, limit=25, instrumented_only=False)

--- a/tests/db/test_snowflake_adapter.py
+++ b/tests/db/test_snowflake_adapter.py
@@ -163,6 +163,7 @@ def test_snowflake_query_history_sql():
     assert "INFORMATION_SCHEMA.QUERY_HISTORY" in captured["sql"]
     assert "-5" in captured["sql"]
     assert "LIMIT 10" in captured["sql"]
+    assert "query_text NOT ILIKE '%INFORMATION_SCHEMA.QUERY_HISTORY%'" in captured["sql"]
     assert results == ["select 1 -- sidemantic: y"]
 
     adapter.get_query_history(days_back=5, limit=10, instrumented_only=False)


### PR DESCRIPTION
Prevents the migrator's warehouse-history lookup queries from being imported as user workload on repeated runs. Applies adapter-side exclusions for BigQuery, ClickHouse, Databricks, and Snowflake, with regression coverage for each.