### PR TITLE
Define shared Sidemantic project resolution

### DIFF
--- a/sidemantic/project.py
+++ b/sidemantic/project.py
@@ -216,7 +216,7 @@ class ProjectContext:
 
         data_dirs = [self.root / "data"]
         if models is not None:
-            models_path = Path(models).resolve()
+            models_path = _resolve_cli_path(models, self.start_dir)
             if models_path.is_dir():
                 data_dirs.append(models_path / "data")
                 if models_path.name == "models":

--- a/sidemantic/project.py
+++ b/sidemantic/project.py
@@ -1,0 +1,245 @@
+"""Project discovery and CLI default resolution.
+
+This module keeps filesystem convention in one place so commands do not each
+invent a different meaning for ``.``.  It deliberately has no Typer dependency;
+the CLI can translate :class:`ProjectResolutionError` into its normal error UI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from sidemantic.config import SidemanticConfig, build_connection_string, find_config, get_init_sql, load_config
+
+
+class ProjectResolutionError(ValueError):
+    """Raised when project defaults are invalid or ambiguous."""
+
+
+@dataclass(frozen=True)
+class ResolvedConnection:
+    """A connection selected from CLI arguments, config, or project data."""
+
+    connection: str
+    source: str
+    database: Path | None = None
+    init_sql: list[str] | None = None
+
+
+def ensure_mutually_exclusive(
+    connection: str | None,
+    database: str | Path | None,
+    *,
+    connection_option: str = "--connection",
+    database_option: str = "--db",
+) -> None:
+    """Reject two command-line options that select the same resource."""
+
+    if connection is not None and database is not None:
+        raise ProjectResolutionError(f"{connection_option} and {database_option} are mutually exclusive")
+
+
+def _resolve_cli_path(path: str | Path, start_dir: Path) -> Path:
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = start_dir / candidate
+    return candidate.resolve()
+
+
+def _require_path(path: Path, description: str) -> Path:
+    if not path.exists():
+        raise ProjectResolutionError(f"{description} not found: {path}")
+    return path
+
+
+def _load_config_values(config_path: Path) -> dict[str, Any]:
+    if config_path.suffix.lower() == ".json":
+        import json
+
+        with config_path.open() as config_file:
+            values = json.load(config_file)
+    else:
+        import yaml
+
+        with config_path.open() as config_file:
+            values = yaml.safe_load(config_file)
+    return values if isinstance(values, dict) else {}
+
+
+def _find_conventional_root(start: Path) -> Path:
+    current = start
+    while True:
+        has_dashboard = any(
+            (current / name).is_file() for name in ("dashboard.yml", "dashboard.yaml", "dashboard.json")
+        )
+        has_database = any(
+            path.is_file() for pattern in ("*.db", "*.duckdb") for path in (current / "data").glob(pattern)
+        )
+        if (current / "models").is_dir() or has_dashboard or has_database:
+            return current
+        if current.parent == current:
+            return start
+        current = current.parent
+
+
+@dataclass(frozen=True)
+class ProjectContext:
+    """Discovered Sidemantic project and its shared command defaults."""
+
+    start_dir: Path
+    root: Path
+    config_path: Path | None = None
+    config: SidemanticConfig | None = None
+    config_values: dict[str, Any] | None = None
+
+    @classmethod
+    def discover(
+        cls,
+        start_dir: str | Path | None = None,
+        config_path: str | Path | None = None,
+    ) -> ProjectContext:
+        """Discover a project upward from ``start_dir``.
+
+        An explicitly requested config is authoritative: a missing or malformed
+        file is an error rather than a warning followed by unrelated defaults.
+        """
+
+        start = Path(start_dir or Path.cwd()).expanduser().resolve()
+        if not start.exists():
+            raise ProjectResolutionError(f"Start directory not found: {start}")
+        if start.is_file():
+            start = start.parent
+
+        if config_path is not None:
+            selected_config = _resolve_cli_path(config_path, start)
+            _require_path(selected_config, "Config file")
+        else:
+            selected_config = find_config(start)
+
+        if selected_config is None:
+            return cls(start_dir=start, root=_find_conventional_root(start))
+
+        try:
+            config = load_config(selected_config)
+        except Exception as exc:
+            raise ProjectResolutionError(f"Could not load config {selected_config}: {exc}") from exc
+
+        return cls(
+            start_dir=start,
+            root=selected_config.parent.resolve(),
+            config_path=selected_config.resolve(),
+            config=config,
+            config_values=_load_config_values(selected_config),
+        )
+
+    def resolve_models(self, explicit: str | Path | None = None) -> Path:
+        """Resolve models using CLI, config, ``models/``, then project root."""
+
+        if explicit is not None:
+            return _require_path(_resolve_cli_path(explicit, self.start_dir), "Models path")
+
+        if self.config is not None and "models_dir" in (self.config_values or {}):
+            # load_config() has already made this path relative to the config root.
+            return _require_path(Path(self.config.models_dir).resolve(), "Configured models path")
+
+        conventional = self.root / "models"
+        if conventional.is_dir():
+            return conventional.resolve()
+        return _require_path(self.root.resolve(), "Project root")
+
+    def resolve_dashboard(
+        self,
+        explicit: str | Path | None = None,
+        *,
+        required: bool = True,
+    ) -> Path | None:
+        """Resolve a dashboard spec, rejecting ambiguous conventional files."""
+
+        if explicit is not None:
+            return _require_path(_resolve_cli_path(explicit, self.start_dir), "Dashboard spec")
+
+        configured = (self.config_values or {}).get("dashboard")
+        if configured:
+            path = Path(configured).expanduser()
+            if not path.is_absolute():
+                path = self.root / path
+            return _require_path(path.resolve(), "Configured dashboard spec")
+
+        matches = [
+            path
+            for path in (self.root / "dashboard.yml", self.root / "dashboard.yaml", self.root / "dashboard.json")
+            if path.is_file()
+        ]
+        if len(matches) > 1:
+            choices = ", ".join(str(path) for path in matches)
+            raise ProjectResolutionError(f"Multiple dashboard specs found: {choices}; pass one explicitly")
+        if matches:
+            return matches[0].resolve()
+        if required:
+            raise ProjectResolutionError(
+                f"No dashboard spec found in {self.root}; expected dashboard.yml, dashboard.yaml, or dashboard.json"
+            )
+        return None
+
+    def resolve_connection(
+        self,
+        *,
+        connection: str | None = None,
+        database: str | Path | None = None,
+        models: str | Path | None = None,
+        required: bool = False,
+    ) -> ResolvedConnection | None:
+        """Resolve a connection using CLI, config, then exactly one ``data`` DB."""
+
+        ensure_mutually_exclusive(connection, database)
+        if connection is not None:
+            return ResolvedConnection(connection=connection, source="--connection")
+        if database is not None:
+            path = _require_path(_resolve_cli_path(database, self.start_dir), "Database")
+            return ResolvedConnection(connection=f"duckdb:///{path}", database=path, source="--db")
+
+        if self.config is not None and self.config.connection is not None:
+            database_path = None
+            connection_string = build_connection_string(self.config)
+            if connection_string.startswith("duckdb:///"):
+                raw_path = connection_string.removeprefix("duckdb:///")
+                if raw_path != ":memory:":
+                    database_path = Path(raw_path)
+            return ResolvedConnection(
+                connection=connection_string,
+                database=database_path,
+                init_sql=get_init_sql(self.config),
+                source="config",
+            )
+
+        data_dirs = [self.root / "data"]
+        if models is not None:
+            models_path = Path(models).resolve()
+            if models_path.is_dir():
+                data_dirs.append(models_path / "data")
+                if models_path.name == "models":
+                    data_dirs.append(models_path.parent / "data")
+        matches = sorted(
+            {
+                path.resolve()
+                for data_dir in data_dirs
+                for pattern in ("*.db", "*.duckdb")
+                for path in data_dir.glob(pattern)
+                if path.is_file()
+            },
+            key=lambda path: str(path),
+        )
+        if len(matches) > 1:
+            choices = ", ".join(str(path) for path in matches)
+            raise ProjectResolutionError(f"Multiple databases found: {choices}; pass --db or --connection")
+        if matches:
+            path = matches[0]
+            return ResolvedConnection(connection=f"duckdb:///{path}", database=path, source="project data")
+        if required:
+            locations = ", ".join(str(path) for path in dict.fromkeys(data_dirs))
+            raise ProjectResolutionError(
+                f"No database connection configured and no .db or .duckdb file found in: {locations}"
+            )
+        return None

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -121,6 +121,24 @@ def test_database_discovery_accepts_db_and_duckdb_and_rejects_ambiguity(tmp_path
         project.resolve_connection(required=True)
 
 
+def test_connection_models_path_is_relative_to_invocation_dir(tmp_path, monkeypatch):
+    invocation_dir = tmp_path / "invocation"
+    models_dir = invocation_dir / "local-models"
+    data_dir = models_dir / "data"
+    data_dir.mkdir(parents=True)
+    database = data_dir / "analytics.duckdb"
+    database.touch()
+    unrelated_cwd = tmp_path / "elsewhere"
+    unrelated_cwd.mkdir()
+    project = ProjectContext.discover(invocation_dir)
+
+    monkeypatch.chdir(unrelated_cwd)
+    resolved = project.resolve_connection(models="local-models", required=True)
+
+    assert resolved is not None
+    assert resolved.database == database
+
+
 def test_explicit_connection_and_database_are_mutually_exclusive(tmp_path):
     with pytest.raises(ProjectResolutionError, match="--connection and --db are mutually exclusive"):
         ProjectContext.discover(tmp_path).resolve_connection(connection="duckdb:///:memory:", database="data.db")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,146 @@
+from pathlib import Path
+
+import pytest
+
+from sidemantic.project import ProjectContext, ProjectResolutionError, ensure_mutually_exclusive
+
+
+def test_discovers_config_upward_and_resolves_config_paths_from_project_root(tmp_path):
+    (tmp_path / "models").mkdir()
+    (tmp_path / "data").mkdir()
+    database = tmp_path / "data" / "warehouse.duckdb"
+    database.touch()
+    (tmp_path / "sidemantic.yaml").write_text(
+        "models_dir: models\nconnection:\n  type: duckdb\n  path: data/warehouse.duckdb\n"
+    )
+    nested = tmp_path / "work" / "nested"
+    nested.mkdir(parents=True)
+
+    project = ProjectContext.discover(nested)
+
+    assert project.root == tmp_path
+    assert project.resolve_models() == tmp_path / "models"
+    resolved = project.resolve_connection(required=True)
+    assert resolved is not None
+    assert resolved.database == database
+    assert resolved.source == "config"
+
+
+def test_explicit_paths_override_config_and_are_relative_to_invocation_dir(tmp_path):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / "configured-models").mkdir()
+    (project_root / "sidemantic.yaml").write_text("models_dir: configured-models\n")
+    nested = project_root / "work"
+    nested.mkdir()
+    explicit_models = nested / "local-models"
+    explicit_models.mkdir()
+    explicit_database = nested / "local.duckdb"
+    explicit_database.touch()
+
+    project = ProjectContext.discover(nested)
+
+    assert project.resolve_models("local-models") == explicit_models
+    resolved = project.resolve_connection(database="local.duckdb")
+    assert resolved is not None
+    assert resolved.database == explicit_database
+    assert resolved.source == "--db"
+
+
+def test_models_convention_prefers_models_directory_then_root(tmp_path):
+    project = ProjectContext.discover(tmp_path)
+    assert project.resolve_models() == tmp_path
+
+    models = tmp_path / "models"
+    models.mkdir()
+    assert project.resolve_models() == models
+
+
+def test_conventional_project_is_discovered_upward_without_config(tmp_path):
+    models = tmp_path / "models"
+    nested = tmp_path / "work" / "nested"
+    models.mkdir()
+    nested.mkdir(parents=True)
+
+    project = ProjectContext.discover(nested)
+
+    assert project.root == tmp_path
+    assert project.resolve_models() == models
+
+
+def test_config_without_models_dir_uses_conventional_models_directory(tmp_path):
+    models = tmp_path / "models"
+    models.mkdir()
+    (tmp_path / "sidemantic.yaml").write_text("runtime:\n  engine: python\n")
+
+    assert ProjectContext.discover(tmp_path).resolve_models() == models
+
+
+@pytest.mark.parametrize("suffix", ["yml", "yaml", "json"])
+def test_dashboard_conventional_discovery(tmp_path, suffix):
+    dashboard = tmp_path / f"dashboard.{suffix}"
+    dashboard.write_text("{}")
+
+    assert ProjectContext.discover(tmp_path).resolve_dashboard() == dashboard
+
+
+def test_dashboard_discovery_rejects_ambiguity(tmp_path):
+    (tmp_path / "dashboard.yml").touch()
+    (tmp_path / "dashboard.json").touch()
+
+    with pytest.raises(ProjectResolutionError, match="Multiple dashboard specs found"):
+        ProjectContext.discover(tmp_path).resolve_dashboard()
+
+
+def test_dashboard_config_path_is_relative_to_config_root(tmp_path):
+    specs = tmp_path / "specs"
+    specs.mkdir()
+    dashboard = specs / "sales.yml"
+    dashboard.touch()
+    (tmp_path / "sidemantic.yaml").write_text("dashboard: specs/sales.yml\n")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+
+    assert ProjectContext.discover(nested).resolve_dashboard() == dashboard
+
+
+def test_database_discovery_accepts_db_and_duckdb_and_rejects_ambiguity(tmp_path):
+    data = tmp_path / "data"
+    data.mkdir()
+    first = data / "analytics.duckdb"
+    first.touch()
+    project = ProjectContext.discover(tmp_path)
+
+    resolved = project.resolve_connection(required=True)
+    assert resolved is not None
+    assert resolved.database == first
+    assert resolved.source == "project data"
+
+    (data / "warehouse.db").touch()
+    with pytest.raises(ProjectResolutionError, match="Multiple databases found"):
+        project.resolve_connection(required=True)
+
+
+def test_explicit_connection_and_database_are_mutually_exclusive(tmp_path):
+    with pytest.raises(ProjectResolutionError, match="--connection and --db are mutually exclusive"):
+        ProjectContext.discover(tmp_path).resolve_connection(connection="duckdb:///:memory:", database="data.db")
+
+    with pytest.raises(ProjectResolutionError, match="--connection and --database are mutually exclusive"):
+        ensure_mutually_exclusive("uri", Path("db"), database_option="--database")
+
+
+def test_explicit_missing_or_malformed_config_is_fatal(tmp_path):
+    with pytest.raises(ProjectResolutionError, match="Config file not found"):
+        ProjectContext.discover(tmp_path, "missing.yml")
+
+    malformed = tmp_path / "broken.yml"
+    malformed.write_text("models_dir: [")
+    with pytest.raises(ProjectResolutionError, match="Could not load config"):
+        ProjectContext.discover(tmp_path, malformed)
+
+
+def test_optional_resources_can_be_absent(tmp_path):
+    project = ProjectContext.discover(tmp_path)
+
+    assert project.resolve_dashboard(required=False) is None
+    assert project.resolve_connection(required=False) is None


### PR DESCRIPTION
Adds one deterministic project resolver for config, models, dashboard specs, databases, and connections. Establishes the zero-config project convention used by the CLI layers above it.