### PR TITLE
Document the project-first CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Sidemantic is an open-source semantic runtime. Define governed metrics once—or
 - **Run on your warehouse:** DuckDB, MotherDuck, PostgreSQL, BigQuery, Snowflake, ClickHouse, Databricks, Spark SQL, and ADBC sources
 - **Consume metrics anywhere:** semantic SQL, CLI, Python, HTTP/Arrow, PostgreSQL wire protocol, MCP, notebooks, TypeScript/WASM, and embedded analytics
 
-[Documentation](https://sidemantic.com) | [GitHub](https://github.com/sidequery/sidemantic) | [Docker Hub](https://hub.docker.com/repository/docker/sidequery/sidemantic) | [Discord](https://discord.com/invite/7MZ4UgSVvF) | [Demo](https://sidemantic.com/demo) (50+ MB data download, runs in your browser with Pyodide + DuckDB)
+[Documentation](https://sidemantic.com) | [CLI conventions](docs/cli.md) | [GitHub](https://github.com/sidequery/sidemantic) | [Docker Hub](https://hub.docker.com/repository/docker/sidequery/sidemantic) | [Discord](https://discord.com/invite/7MZ4UgSVvF) | [Demo](https://sidemantic.com/demo) (50+ MB data download, runs in your browser with Pyodide + DuckDB)
 
 ![Jupyter Widget Preview](preview.png)
 
@@ -41,14 +41,34 @@ models:
         agg: count
 ```
 
-Query it directly—no database setup or package installation required:
+Add `dashboard.yml` when you want the official browser dashboard:
+
+```yaml
+schema: sidemantic.dashboard.v1
+title: Orders
+tabs:
+  - id: overview
+    charts:
+      - id: revenue_by_status
+        type: bar
+        query:
+          metrics: [orders.revenue]
+          dimensions: [orders.status]
+        encoding:
+          x: orders.status
+          y: orders.revenue
+```
+
+Run from the project root. Sidemantic discovers `models/`, `dashboard.yml`, and a
+single `data/*.db` or `data/*.duckdb` automatically; explicit paths and connection
+flags are overrides:
 
 ```bash
+uvx sidemantic validate
 uvx sidemantic query \
   "SELECT orders.status, orders.revenue, orders.order_count
    FROM orders
-   ORDER BY orders.status" \
-  --models ./models
+   ORDER BY orders.status"
 ```
 
 ```csv
@@ -57,16 +77,21 @@ paid,200.00,2
 pending,50.00,1
 ```
 
-From here, inspect generated warehouse SQL or open an interactive explorer:
+Serve `dashboard.yml` in the official React application:
+
+```bash
+uvx --from "sidemantic[api]" sidemantic dashboard serve
+```
+
+From here, inspect generated warehouse SQL or open the terminal workbench:
 
 ```bash
 # Compile without executing
 uvx sidemantic query \
-  "SELECT orders.status, orders.revenue FROM orders" \
-  --models ./models --dry-run
+  "SELECT orders.status, orders.revenue FROM orders" --dry-run
 
 # Explore in the terminal
-uvx --from "sidemantic[workbench]" sidemantic workbench ./models
+uvx --from "sidemantic[workbench]" sidemantic workbench
 ```
 
 ## Choose your path
@@ -130,11 +155,13 @@ sidemantic query "SELECT revenue FROM orders" --db data.duckdb
 # Interactive workbench (TUI with SQL editor + charts)
 uvx --from "sidemantic[workbench]" sidemantic workbench models/ --db data.duckdb
 
-# PostgreSQL server (connect Tableau, DBeaver, etc.)
-uvx --from "sidemantic[serve]" sidemantic serve models/ --port 5433
+# Official browser dashboard (discovers dashboard.yml)
+uvx --from "sidemantic[api]" sidemantic dashboard serve
 
-# HTTP API server (JSON or Arrow)
-uvx --from "sidemantic[api]" sidemantic api-serve models/ --port 4400 --auth-token secret
+# Servers
+uvx --from "sidemantic[api]" sidemantic server api --port 4400 --auth-token secret
+uvx --from "sidemantic[serve]" sidemantic server postgres --port 5433
+uvx --from "sidemantic[mcp]" sidemantic server mcp
 
 # Validate definitions
 sidemantic validate models/
@@ -145,8 +172,13 @@ sidemantic info models/
 # Pre-aggregation recommendations
 sidemantic preagg recommend --db data.duckdb
 
-# Migrate SQL queries to semantic layer
-sidemantic migrator --queries legacy/ --generate-models output/
+# Generate models from queries, or check migration coverage
+sidemantic migrate generate legacy/ --output output/
+sidemantic migrate check legacy/
+
+# Generate typed clients and convert semantic formats
+sidemantic generate client --output sidemantic.generated.ts
+sidemantic convert lookml/ --to sidemantic --output converted.yml
 ```
 
 ## Demos
@@ -158,12 +190,12 @@ uvx --from "sidemantic[workbench]" sidemantic workbench --demo
 
 **PostgreSQL server** (connect Tableau, DBeaver, etc.):
 ```bash
-uvx --from "sidemantic[serve]" sidemantic serve --demo --port 5433
+uvx --from "sidemantic[serve]" sidemantic server postgres --demo --port 5433
 ```
 
 **HTTP API server** (JSON or Arrow):
 ```bash
-uvx --from "sidemantic[api]" sidemantic api-serve --demo --port 4400 --auth-token secret
+uvx --from "sidemantic[api]" sidemantic server api --demo --port 4400 --auth-token secret
 ```
 
 **Colab notebooks:**
@@ -284,7 +316,7 @@ For Cloudflare Worker + Container deployment, see [`examples/cloudflare_containe
 Start the API server:
 
 ```bash
-uvx --from "sidemantic[api]" sidemantic api-serve models/ --db data.duckdb --port 4400 --auth-token secret
+uvx --from "sidemantic[api]" sidemantic server api models/ --db data.duckdb --port 4400 --auth-token secret
 ```
 
 Compile a structured semantic query:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,78 @@
+# Command-line interface
+
+Sidemantic is project-first. Run commands from a project root and use path or connection options
+only to override discovery.
+
+## Project conventions
+
+```text
+analytics/
+├── sidemantic.yaml       # optional project configuration
+├── models/               # semantic YAML, SQL, and imported model formats
+├── queries/              # SQL used by migration commands
+├── dashboard.yml         # declarative official-UI dashboard
+└── data/
+    └── warehouse.duckdb  # one .db or .duckdb file is discovered automatically
+```
+
+Sidemantic searches upward for `sidemantic.yaml`, `sidemantic.yml`, or `sidemantic.json`. Without a
+config file it discovers the nearest conventional project root. A project may use
+`dashboard.yaml` or `dashboard.json` instead of `dashboard.yml`.
+
+Discovery rejects ambiguous dashboard specs or multiple database files. Resolve ambiguity with an
+explicit spec, `--db`, or `--connection`. To select a config outside the discovered project, put the
+global option before the command:
+
+```bash
+sidemantic --config path/to/sidemantic.yaml validate
+```
+
+## Everyday workflow
+
+```bash
+cd analytics
+sidemantic validate
+sidemantic info
+sidemantic query "SELECT orders.status, orders.revenue FROM orders"
+sidemantic dashboard validate
+sidemantic dashboard serve
+```
+
+`dashboard serve` loads the declarative spec into the official React application. The experimental
+cross-library renderers remain Python library examples; they are not a second CLI dashboard.
+
+## Command families
+
+| Command | Purpose |
+| --- | --- |
+| `validate [MODELS]` | Validate discovered or explicit semantic definitions |
+| `info [MODELS]` | Summarize models, dimensions, metrics, and relationships |
+| `query SQL` | Execute semantic SQL and emit CSV |
+| `rewrite SQL` | Compile semantic SQL without executing it |
+| `explain SQL` | Explain rewrite planning as JSON |
+| `dashboard validate [SPEC]` | Validate the discovered or explicit dashboard |
+| `dashboard serve [SPEC]` | Run the official dashboard application |
+| `dashboard types` | Generate dashboard-authoring TypeScript definitions |
+| `server api` | Run the HTTP/Arrow API and general explorer UI |
+| `server postgres` | Run the PostgreSQL wire-protocol server |
+| `server mcp` | Run the MCP server |
+| `generate client` | Generate a typed TypeScript query-client schema |
+| `generate sql [SOURCES]` | Generate bindings for semantic SQL literals |
+| `migrate generate [QUERIES]` | Generate models and rewritten SQL |
+| `migrate check [QUERIES]` | Check existing-model query coverage |
+| `convert [SOURCE]` | Convert semantic formats through the shared registry |
+| `preagg recommend` | Recommend pre-aggregations from query history |
+| `preagg apply` | Add recommendations to model files |
+| `preagg refresh` | Refresh materialized pre-aggregations |
+| `workbench [MODELS]` | Open the terminal workbench |
+| `lsp` | Run the semantic SQL language server |
+
+Use `sidemantic COMMAND --help` for command-specific overrides. Common overrides are `--models`,
+`--db`, and `--connection`; they do not replace the default project-root workflow.
+
+## Compatibility names
+
+Older releases exposed flat or differently grouped names such as `api-serve`, `serve`, `mcp-serve`,
+`gen`, `migrator`, `export-native`, and `explain-sql`. They are compatibility aliases where still
+available. New documentation and automation should use `server`, `generate`, `migrate`, `convert`,
+and `explain`.

--- a/docs/rust-native-runtime-roadmap.md
+++ b/docs/rust-native-runtime-roadmap.md
@@ -1007,24 +1007,13 @@ Every Python adapter should be able to answer:
 
 ### Migration Command
 
-Recommended CLI:
+Current normalized CLI:
 
 ```bash
-sidemantic migrator convert \
+sidemantic convert ./lookml_project \
   --from lookml \
-  --input ./lookml_project \
-  --output ./native_models \
-  --validate-with rust
-```
-
-Or:
-
-```bash
-sidemantic convert \
-  --from cube \
-  --input ./cube_models \
-  --output ./models \
-  --engine rust
+  --to sidemantic \
+  --output ./native_models.yml
 ```
 
 ### Adapter Compatibility Docs
@@ -1047,12 +1036,12 @@ Current Rust routing through environment variables is useful for internal testin
 
 ### CLI Modes
 
-Add explicit engine selection:
+Use explicit engine selection:
 
 ```bash
 sidemantic validate ./models --engine rust
-sidemantic query ./models --engine rust --metric orders.total_revenue
-sidemantic rewrite ./models --engine rust "select orders.total_revenue from metrics"
+sidemantic query "select orders.total_revenue from metrics" --models ./models --engine rust --dry-run
+sidemantic rewrite "select orders.total_revenue from metrics" --models ./models --engine rust
 ```
 
 ### Config Mode

--- a/docs/rust-runtime.md
+++ b/docs/rust-runtime.md
@@ -7,7 +7,7 @@ Use Python to import external semantic formats, then export or normalize them in
 Export adapter output to the native contract with:
 
 ```bash
-sidemantic export-native ./adapter-project --output sidemantic.yml --validate-rust
+sidemantic convert ./adapter-project --to sidemantic --output sidemantic.yml
 ```
 
 ## Supported Inputs
@@ -34,7 +34,9 @@ Rust does not parse these source formats directly:
 - Malloy
 - Omni
 
-When `sidemantic export-native` receives a file path, it loads that file's parent directory before writing native YAML. This preserves adjacent directory context used by inherited models, sibling SQL definitions, and source metadata. Use a dedicated directory for single-file exports when you need a narrow output.
+`sidemantic convert` uses the shared format registry and accepts a project, directory, or exact
+file. Pass `--from` only to override auto-detection and `--force` only when intentionally replacing
+an existing destination.
 - Superset
 - GoodData
 - Snowflake Cortex

--- a/docs/security.md
+++ b/docs/security.md
@@ -82,7 +82,7 @@ layer.compile(metrics=["orders.revenue"], filters=["orders.margin > 100"])  # Se
 
 ## Server enforcement
 
-### HTTP (`sidemantic api-serve`)
+### HTTP (`sidemantic server api`)
 
 User attributes come from a trusted header (default `X-Sidemantic-User`, a JSON object).
 The value is passed into every structured `/query` and `/compile` request, and the

--- a/docs/ui-architecture.md
+++ b/docs/ui-architecture.md
@@ -6,9 +6,9 @@ Sidemantic supports several HTML hosts through one React component implementatio
 
 | Concern | Canonical source | Other surfaces |
 | --- | --- | --- |
-| Product application shell, catalog, query orchestration, date controls, and interactive time series | `webapp/src/` | Built into the Python and Rust servers |
+| Product application shell, declarative dashboards, catalog, query orchestration, date controls, and interactive time series | `webapp/src/` | Built into the Python and Rust servers |
 | Reusable charts, leaderboards, previews, query debugging, and state primitives | `webapp/src/components/` via `webapp/src/ui.ts` | Built as React ESM and self-contained browser distributions |
-| Portable standalone charts and live crossfilter dashboards | `sidemantic/viz.py` | Used by `sidemantic chart` and `sidemantic dashboard serve` |
+| Experimental cross-library chart and crossfilter renderers | `sidemantic/viz.py` | Library APIs and examples only; not a product UI or CLI surface |
 | Notebook trait synchronization and mounting | `js/widget.js` and `sidemantic/widget/` | Mounts the canonical React distribution |
 | MCP Apps chart embedding | `sidemantic/apps/chart_widget.html` | Returned by the MCP `create_chart` tool |
 
@@ -17,6 +17,11 @@ The React webapp, static/WASM apps, and AnyWidget have separate lifecycle adapte
 The framework-free/WASM leaderboard is the visual champion for ranked cards: contiguous hairline panels, compact rows, lavender magnitude fills, full formatted values, and an understated expand affordance. The React `LeaderboardPanel` keeps ownership of querying, null handling, stale-result protection, and crossfilter behavior while rendering that presentation.
 
 The consolidated component gallery is available at `/components`. `scripts/build_ui_distribution.py` produces `sidemantic-ui.js`, `sidemantic-ui-static.js`, and `sidemantic-ui.css` directly from `webapp/src`; there are no parallel JSX, DOM-renderer, or CSS component sources.
+
+Declarative dashboard specs are loaded with `sidemantic dashboard serve` and rendered by the same
+React Explore components. `sidemantic dashboard validate` and `sidemantic dashboard types` remain
+authoring tools. The command serves the official application; there is no separate dashboard
+frontend.
 
 ## Generated and synchronized copies
 

--- a/examples/ecommerce/README.md
+++ b/examples/ecommerce/README.md
@@ -85,7 +85,7 @@ sidemantic query "SELECT order_items.net_revenue, products.category FROM order_i
 Start a server that BI tools can connect to:
 
 ```bash
-uvx --from "sidemantic[serve]" sidemantic serve examples/ecommerce/models \
+uvx --from "sidemantic[serve]" sidemantic server postgres examples/ecommerce/models \
   --db examples/ecommerce/data/ecommerce.db \
   --port 5433
 ```

--- a/examples/headless_dashboard/README.md
+++ b/examples/headless_dashboard/README.md
@@ -1,11 +1,11 @@
-# Headless Dashboard Example
+# Declarative Dashboard Example
 
-This example shows the declarative dashboard authoring path.
+This example shows the declarative dashboard authoring path in the canonical React application.
 
 The dashboard is defined in committed files:
 
 - `models.yml` defines the semantic model.
-- `dashboard.yml` defines the dashboard served by the Sidemantic CLI.
+- `dashboard.yml` configures the official Sidemantic web UI.
 - `dashboard.ts` shows the same dashboard shape with generated TypeScript field types.
 - `sidemantic.generated.ts` is generated from the semantic model and committed here so the typing contract is visible.
 
@@ -14,29 +14,28 @@ The dashboard is defined in committed files:
 ## Run It
 
 ```bash
-uv run examples/headless_dashboard/setup_data.py
-uv run sidemantic dashboard validate examples/headless_dashboard/dashboard.yml \
-  --models examples/headless_dashboard \
-  --db examples/headless_dashboard/data/orders.db
-uv run sidemantic dashboard serve examples/headless_dashboard/dashboard.yml \
-  --models examples/headless_dashboard \
-  --db examples/headless_dashboard/data/orders.db \
-  --port 8877
+cd examples/headless_dashboard
+uv run setup_data.py
+uv run sidemantic dashboard validate
+uv run sidemantic dashboard serve
 ```
 
 Then open:
 
 ```text
-http://127.0.0.1:8877/crossfilter.html
+http://127.0.0.1:4400/
 ```
 
 ## Regenerate TypeScript Types
 
 ```bash
 uv run sidemantic dashboard types \
-  --models examples/headless_dashboard \
-  --out examples/headless_dashboard/sidemantic.generated.ts
+  --out sidemantic.generated.ts
 ```
 
-The CLI serves YAML or JSON dashboard specs. The TypeScript file is for app authors who want editor-checked metric and dimension names while producing the same dashboard configuration shape.
+`dashboard serve` discovers the project model, database, and YAML or JSON dashboard spec, validates
+them, and serves the canonical React UI. The TypeScript file is for app authors who want
+editor-checked metric and dimension names while producing the same dashboard configuration shape.
 
+The cross-library renderers remain available as Python library examples under
+`examples/integrations/`; they are not a second dashboard product or CLI frontend.

--- a/examples/headless_dashboard/dashboard.ts
+++ b/examples/headless_dashboard/dashboard.ts
@@ -1,12 +1,9 @@
-import { defineDashboard, type DashboardRenderer } from "./sidemantic.generated";
-
-const renderer: DashboardRenderer = "vega-lite";
+import { defineDashboard } from "./sidemantic.generated";
 
 export default defineDashboard({
   schema: "sidemantic.dashboard.v1",
   title: "Revenue Performance Explorer",
   defaults: {
-    renderer,
     query: {
       interactionPreaggregations: true,
     },
@@ -55,4 +52,3 @@ export default defineDashboard({
     },
   ],
 });
-

--- a/examples/headless_dashboard/dashboard.yml
+++ b/examples/headless_dashboard/dashboard.yml
@@ -1,7 +1,6 @@
 schema: sidemantic.dashboard.v1
 title: Revenue Performance Explorer
 defaults:
-  renderer: vega-lite
   query:
     interaction_preaggregations: true
   interactions:
@@ -43,4 +42,3 @@ tabs:
               - orders.channel
               - orders.customer_tier
               - orders.product_line
-

--- a/examples/migrator/README.md
+++ b/examples/migrator/README.md
@@ -28,23 +28,23 @@ Generate model definitions and rewritten queries from your raw SQL:
 cd examples/migrator
 
 # Generate models and rewritten queries
-uv run sidemantic migrator --queries raw_queries/ --generate-models output/
+uv run sidemantic migrate generate raw_queries/ --output output/
 ```
 
 This will create:
 - `output/models/` - YAML model definitions for each table
-- `output/rewritten_queries/` - Python code showing how to query using the semantic layer
+- `output/rewritten_queries/` - semantic SQL rewrites
 
 ### Analyze Coverage
 
 If you already have a semantic layer, analyze which queries can be rewritten:
 
 ```bash
-# Compare queries against existing semantic layer
-uv run sidemantic migrator models/ --queries raw_queries/
+# Compare queries against an existing semantic layer
+uv run sidemantic migrate check raw_queries/ --models path/to/models/
 
 # Show detailed analysis for each query
-uv run sidemantic migrator models/ --queries raw_queries/ --verbose
+uv run sidemantic migrate check raw_queries/ --models path/to/models/ --verbose
 ```
 
 ## What Gets Generated

--- a/plugins/sidemantic/skills/modeler/SKILL.md
+++ b/plugins/sidemantic/skills/modeler/SKILL.md
@@ -36,13 +36,16 @@ models:
         agg: count
 YAML
 
-uv run sidemantic validate models/ --verbose
-uv run sidemantic info models/
-uv run sidemantic query models/ -c duckdb:///data.duckdb \
+uv run sidemantic validate --verbose
+uv run sidemantic info
+uv run sidemantic query \
   "SELECT revenue, status FROM orders ORDER BY revenue DESC LIMIT 5"
 ```
 
-Assumes an `orders` table already exists in `data.duckdb` with `status` and `order_amount` columns.
+Run these commands from the project root. Sidemantic discovers `models/`, an optional
+`sidemantic.yaml`, and exactly one `data/*.db` or `data/*.duckdb`. This example assumes an `orders`
+table already exists in that project database with `status` and `order_amount` columns. Use
+`--models`, `--db`, or `--connection` only to override project discovery.
 
 ### YAML (preferred for file-based models)
 
@@ -105,10 +108,10 @@ The fastest path when existing queries are available. The Migrator reverse-engin
 
 ```bash
 # Generate model YAML + rewritten queries from raw SQL
-sidemantic migrator --queries queries/ --generate-models output/
+sidemantic migrate generate queries/ --output output/
 
 # Check coverage: how well do existing models handle these queries?
-sidemantic migrator models/ --queries queries/ --verbose
+sidemantic migrate check queries/ --models models/ --verbose
 ```
 
 ### Python API (advanced/automation only)
@@ -251,21 +254,21 @@ For `many_to_many`, specify `through` (junction model), `through_foreign_key`, a
 
 ```bash
 # Validate definitions (checks for errors and warnings)
-sidemantic validate models/ --verbose
+sidemantic validate --verbose
 
 # Quick summary of what's defined
-sidemantic info models/
+sidemantic info
 ```
 
 ### Step 7: Test with queries
 
 ```bash
 # Validate and inspect without writing code
-uv run sidemantic validate models/ --verbose
-uv run sidemantic info models/
+uv run sidemantic validate --verbose
+uv run sidemantic info
 
 # Execute semantic SQL through CLI
-uv run sidemantic query models/ -c duckdb:///data.duckdb \
+uv run sidemantic query \
   "SELECT revenue, status FROM orders WHERE status = 'completed'"
 ```
 
@@ -306,7 +309,7 @@ models:
 Segments are model-scoped and used as `model.segment` references at query time:
 
 ```bash
-uv run sidemantic query models/ -c duckdb:///data.duckdb \
+uv run sidemantic query \
   "SELECT revenue, status FROM orders WHERE completed_orders"
 ```
 
@@ -366,20 +369,25 @@ result = layer.query(metrics=["orders.revenue"], parameters={"region": "US"})
 
 ## CLI Reference
 
-All commands are run as `sidemantic <command>`. Use `--config path/to/sidemantic.yaml` to load a config file with connection and model path settings.
+Run commands from the project root. Sidemantic discovers `sidemantic.yaml`, `models/`, `queries/`,
+`dashboard.yml`, and a single database under `data/`. Explicit paths and connection flags override
+those conventions. When selecting a non-discovered config, place the global option before the
+command: `sidemantic --config path/to/sidemantic.yaml validate`.
 
 | Command | Purpose |
 |---------|---------|
-| `validate [DIR] --verbose` | Validate definitions, show errors and warnings |
-| `info [DIR]` | Summary of models, dimensions, metrics, relationships |
-| `query [DIR] -c CONNECTION SQL` | Execute SQL through the semantic layer (`--format table/json/csv`, `--limit N`) |
-| `migrator [DIR] --queries PATH` | Coverage analysis: check how well models handle SQL queries |
-| `migrator --queries PATH --generate-models OUT` | Bootstrap: generate model YAML from SQL queries |
-| `preagg recommend [DIR]` | Recommend pre-aggregation tables from query patterns |
-| `preagg apply [DIR]` | Apply pre-aggregation recommendations |
-| `serve [DIR] -c CONNECTION` | Start PostgreSQL wire-protocol server |
-| `mcp-serve [DIR] -c CONNECTION` | Start MCP server for AI tool integration |
-| `workbench [DIR] -c CONNECTION` | Interactive TUI with SQL editor and charting |
+| `validate [MODELS] --verbose` | Validate definitions, show errors and warnings |
+| `info [MODELS]` | Summary of models, dimensions, metrics, relationships |
+| `query SQL [--models PATH] [--db PATH]` | Execute semantic SQL and emit CSV |
+| `rewrite SQL [--models PATH]` | Compile semantic SQL without executing it |
+| `migrate generate [QUERIES] [--output DIR]` | Bootstrap model YAML from SQL or configured history |
+| `migrate check [QUERIES] [--models PATH]` | Check how well models cover existing SQL |
+| `convert [SOURCE] --to FORMAT --output PATH` | Convert semantic definitions through the shared format registry |
+| `dashboard serve [SPEC]` | Serve a declarative dashboard in the official React UI |
+| `generate client` / `generate sql` | Generate typed TypeScript clients and query bindings |
+| `preagg recommend` / `apply` / `refresh` | Manage pre-aggregations |
+| `server api` / `postgres` / `mcp` | Run the HTTP, PostgreSQL, or MCP server |
+| `workbench [MODELS]` | Interactive TUI with SQL editor and charting |
 | `lsp` | Start LSP server for Sidemantic SQL files |
 
 ## Connection Strings

--- a/plugins/sidemantic/skills/modeler/references/generation.md
+++ b/plugins/sidemantic/skills/modeler/references/generation.md
@@ -15,8 +15,8 @@ When `connection` is provided, the Migrator queries `information_schema` for pri
 CLI-first for normal usage:
 
 ```bash
-sidemantic migrator --queries queries/ --generate-models output/
-sidemantic migrator models/ --queries queries/ --verbose
+sidemantic migrate generate queries/ --output output/
+sidemantic migrate check queries/ --models models/ --verbose
 ```
 
 ### Core Methods
@@ -116,7 +116,7 @@ Console coverage report: total/parseable/rewritable counts, missing models/dimen
 ### Bootstrap: generate models from queries
 
 ```bash
-sidemantic migrator --queries queries/ --generate-models output/
+sidemantic migrate generate queries/ --output output/
 ```
 
 Creates `output/models/` (YAML per model) and `output/rewritten_queries/` (semantic SQL).
@@ -124,19 +124,23 @@ Creates `output/models/` (YAML per model) and `output/rewritten_queries/` (seman
 ### Coverage analysis: check existing models against queries
 
 ```bash
-sidemantic migrator models/ --queries queries/ --verbose
+sidemantic migrate check queries/ --models models/ --verbose
 ```
 
 Reports which queries can be rewritten, which cannot, and what's missing.
 
 ### Parameters
 
-| Flag | Type | Description |
-|------|------|-------------|
-| `directory` | Path | Semantic layer files (default: `.`) |
-| `--queries / -q` | Path | Required. SQL file or directory |
-| `--verbose / -v` | bool | Per-query analysis details |
-| `--generate-models / -g` | Path | Output directory for generated models |
+Both commands discover `queries/` from the project root when `QUERIES` is omitted.
+
+| Command | Important options |
+|---------|-------------------|
+| `migrate generate [QUERIES]` | `--output/-o`, `--history`, `--connection`, `--days`, `--limit` |
+| `migrate check [QUERIES]` | `--models/-m`, `--history`, `--connection`, `--days`, `--limit`, `--verbose/-v` |
+
+`--history` reads warehouse query history through the configured connection. A command-line
+`--connection` is an override for `--history`, not a replacement for the project database used by
+ordinary semantic queries.
 
 ## Database Schema Introspection
 

--- a/plugins/sidemantic/skills/webapp-builder/SKILL.md
+++ b/plugins/sidemantic/skills/webapp-builder/SKILL.md
@@ -7,6 +7,17 @@ description: Build interactive analytics webapps, demos, dashboards, or embedded
 
 Build webapps around a validated Sidemantic semantic layer. Use the canonical built UI distribution, then wire runtime-specific data adapters to its documented props or mount functions.
 
+For a declarative Sidemantic dashboard, run the official application from the project root:
+
+```bash
+uv run sidemantic dashboard validate
+uv run sidemantic dashboard serve
+```
+
+Use `sidemantic dashboard validate` and `sidemantic dashboard types` for authoring. Do not create a
+separate crossfilter server or use the experimental cross-library renderers as a product surface;
+those APIs are retained for renderer examples and library experimentation only.
+
 In command examples, set `SIDEMANTIC_PLUGIN_ROOT` to the installed `sidemantic` plugin directory.
 
 ## Component-First Pattern
@@ -57,20 +68,21 @@ Use those static helpers before writing one-off DOM wiring. They are intentional
 
 ## Core Workflow
 
-1. Load-check the semantic layer before building UI. Use `info` and the inspector in noninteractive agent work. Use `validate` only when the current CLI exits cleanly in your environment:
+1. From the project root, validate and inspect the semantic layer before building UI:
 
 ```bash
-uv run sidemantic info path/to/models
-uv run ${SIDEMANTIC_PLUGIN_ROOT}/skills/webapp-builder/scripts/inspect_layer.py path/to/models \
-  --db path/to/data.duckdb \
+uv run sidemantic validate
+uv run sidemantic info
+uv run ${SIDEMANTIC_PLUGIN_ROOT}/skills/webapp-builder/scripts/inspect_layer.py models \
+  --db data/warehouse.duckdb \
   --require-execute
 ```
 
 2. Generate an app inventory:
 
 ```bash
-uv run ${SIDEMANTIC_PLUGIN_ROOT}/skills/webapp-builder/scripts/inspect_layer.py path/to/models \
-  --db path/to/data.duckdb \
+uv run ${SIDEMANTIC_PLUGIN_ROOT}/skills/webapp-builder/scripts/inspect_layer.py models \
+  --db data/warehouse.duckdb \
   --require-execute \
   --output docs/sidemantic-app-spec.json
 ```
@@ -105,7 +117,7 @@ The scaffold copies readable source from `assets/templates/static-dashboard/` an
 - Python-backed analytics app: use `sidemantic.api_server.create_app()` or `start_api_server()` when a FastAPI API is acceptable.
 - Browser-only demo: use the `sidemantic-wasm` npm package (Sidemantic Rust WASM) + DuckDB-WASM, or Pyodide + DuckDB-WASM, only for static demos or docs pages that must run without a backend.
 - Notebook or Python embedded view: use `sidemantic.widget.MetricsExplorer` instead of rebuilding the widget.
-- MCP app surface: use `sidemantic mcp-serve --apps --http --port 4100` and existing chart resources when the target is an MCP Apps-compatible host.
+- MCP app surface: use `sidemantic server mcp --apps --http --port 4100` and existing chart resources when the target is an MCP Apps-compatible host.
 
 5. Implement a narrow query contract. Prefer structured query payloads over ad hoc SQL strings:
 
@@ -132,9 +144,10 @@ If a control is visible, it must change the app state or data. Do not satisfy in
 7. Verify end to end:
 
 ```bash
-uv run sidemantic info path/to/models
-uv run ${SIDEMANTIC_PLUGIN_ROOT}/skills/webapp-builder/scripts/inspect_layer.py path/to/models --db path/to/data.duckdb --require-execute
-uv run sidemantic query "SELECT metric_name FROM model_name LIMIT 5" --models path/to/models --db path/to/data.duckdb
+uv run sidemantic validate
+uv run sidemantic info
+uv run ${SIDEMANTIC_PLUGIN_ROOT}/skills/webapp-builder/scripts/inspect_layer.py models --db data/warehouse.duckdb --require-execute
+uv run sidemantic query "SELECT metric_name FROM model_name LIMIT 5"
 uv run ${SIDEMANTIC_PLUGIN_ROOT}/skills/webapp-builder/scripts/verify_static_app.py dist/sidemantic-dashboard
 bunx --bun -p playwright node ${SIDEMANTIC_PLUGIN_ROOT}/skills/webapp-builder/scripts/verify_static_interactions.mjs --url http://127.0.0.1:5174/
 bun run build
@@ -181,7 +194,8 @@ Run DuckDB validation serially against a file database. Do not run the inspector
 
 ## API Modes
 
-When the app can call Python directly, prefer the existing HTTP API:
+When the app can call Python directly, start the existing HTTP API with
+`sidemantic server api` and use its stable endpoints:
 
 - `GET /health`
 - `GET /models`
@@ -238,7 +252,7 @@ Analytics webapps should feel work-focused:
 ## Common Failures
 
 - Building UI before the model validates. Validate first.
-- Running interactive validation in automation. If `sidemantic validate` requires `textual` or opens a TUI, use `sidemantic info` plus `inspect_layer.py` as the noninteractive check.
+- Skipping semantic validation. `sidemantic validate` is noninteractive; run it before the inspector and UI checks.
 - Trusting compiled SQL alone. Use `inspect_layer.py --require-execute` when possible so result columns and sample rows are checked and failures are nonzero.
 - Running parallel DuckDB checks against the same database file. Run them serially or use separate database copies.
 - Treating Python API examples as the default user path. Sidemantic is CLI-first; use API calls as app internals.


### PR DESCRIPTION
Updates onboarding, architecture notes, examples, and bundled skills to match the normalized project-first CLI and the official dashboard UI.