### PR TITLE
Add semantic trust and consumption contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,6 @@ jobs:
         run: uv run ruff format --check . --exclude docs/_extensions --exclude sidemantic-duckdb/extension-ci-tools --exclude sidemantic-duckdb/scripts --exclude sidemantic-duckdb/duckdb --exclude sidemantic/adapters/malloy_grammar --exclude sidemantic/adapters/holistics_grammar
 
       - name: Run tests
-        env:
-          FORCE_COLOR: ""
         run: uv run pytest -v
 
       - name: Run installed-wheel DAX smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
         run: uv run ruff format --check . --exclude docs/_extensions --exclude sidemantic-duckdb/extension-ci-tools --exclude sidemantic-duckdb/scripts --exclude sidemantic-duckdb/duckdb --exclude sidemantic/adapters/malloy_grammar --exclude sidemantic/adapters/holistics_grammar
 
       - name: Run tests
+        env:
+          FORCE_COLOR: ""
         run: uv run pytest -v
 
       - name: Run installed-wheel DAX smoke

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -89,6 +89,32 @@ that already offered it. Use `--plain` for stable, undecorated, tab-separated,
 one-record-per-line output. Scripts should select `--plain` or an explicit
 machine format instead of parsing the default human presentation.
 
+## Curated explores and saved queries
+
+`info` lists physical models plus first-class explores and saved queries. `validate`
+checks their model/field references, allowlists, defaults, limits, and governance
+lifecycle. Use `query` without free-form SQL to execute them:
+
+```bash
+sidemantic info models/ --json
+sidemantic validate models/ --verbose
+
+# Use all Explore defaults.
+sidemantic query --models models/ --explore revenue_overview
+
+# Select an allowed subset. Repeat options for multiple fields.
+sidemantic query --models models/ --explore revenue_overview \
+  --metric revenue --dimension status --filter "orders.status = 'paid'" \
+  --order-by "orders.revenue DESC" --limit 20
+
+# Compile or execute an immutable SavedQuery.
+sidemantic query --models models/ --saved-query top_revenue_statuses --dry-run
+sidemantic query --models models/ --saved-query top_revenue_statuses --format json
+```
+
+Free-form SQL remains the default CLI workflow. SQL input cannot be combined with
+`--explore` or `--saved-query`; this keeps contract enforcement unambiguous.
+
 `--quiet`/`-q` suppresses non-essential status and progress without suppressing
 the requested result or errors. `--verbose`/`-v` enables detailed diagnostics;
 `--debug` implies verbose diagnostics and includes unexpected tracebacks.

--- a/docs/native-format.md
+++ b/docs/native-format.md
@@ -64,6 +64,28 @@ metrics:
     type: ratio
     numerator: orders.total_revenue
     denominator: orders.order_count
+
+explores:
+  - name: revenue_overview
+    model: orders
+    allowed_dimensions: [status]
+    allowed_metrics: [total_revenue]
+    allowed_filter_fields: [status]
+    allowed_order_by: [total_revenue]
+    default_dimensions: [status]
+    default_metrics: [total_revenue]
+    filters: ["orders.status != 'deleted'"]
+    default_order_by: ["orders.total_revenue DESC"]
+    default_limit: 25
+    max_limit: 1000
+
+saved_queries:
+  - name: top_revenue_statuses
+    explore: revenue_overview
+    dimensions: [status]
+    metrics: [total_revenue]
+    order_by: ["orders.total_revenue DESC"]
+    limit: 10
 ```
 
 Top-level sections:
@@ -74,6 +96,64 @@ Top-level sections:
 | `models` | No | List of model definitions. Most useful projects define at least one model. |
 | `metrics` | No | Graph-level metrics. Rust assigns these to exactly one owning model when possible. |
 | `parameters` | No | Graph-level parameters for templates and query-time substitution. |
+| `explores` | No | Curated Explore/View consumption contracts, separate from physical models. |
+| `views` | No | Input compatibility alias for `explores`; native exports use `explores`. |
+| `saved_queries` | No | Immutable named structured queries. |
+
+## Consumption Contracts
+
+Explores (also exposed as the Python `View` alias) curate how a semantic graph is
+consumed without becoming physical models. `model` selects the base model.
+`allowed_dimensions` and `allowed_metrics` are enforced selection allowlists;
+`allowed_filter_fields` and `allowed_order_by` constrain caller filters and ordering.
+For each allowlist, `null` means unrestricted. Defaults populate omitted selections.
+`filters` are mandatory and are always combined with caller filters;
+`default_filters` are used only when the caller provides no filters. `default_limit`
+fills an omitted limit and `max_limit` rejects an oversized limit.
+
+Saved queries contain `dimensions`, `metrics`, `filters`, `segments`, `order_by`,
+`limit`, and optional `parameters`. A saved query may name an `explore`; it is then
+validated and executed through that contract. Saved queries are immutable at query
+time: callers select a different saved query rather than overriding its fields.
+
+Hex views map to Explores while retaining their content groups for round-trip export.
+LookML explores map their base view, exact field sets, mandatory filters, labels, and
+group labels when those values are lossless. MetricFlow saved queries become typed
+SavedQuery objects and retain the original expressions/exports in `metadata.metricflow`.
+MetricFlow `Dimension()`/`TimeDimension()` expressions have no lossless executable
+Sidemantic equivalent, so validation reports a compatibility warning and execution
+fails with conversion guidance instead of silently changing query meaning.
+
+These objects are catalog definitions, not collaborative BI content. Sidemantic does
+not add folders, schedules, comments, alerts, or content-management state for them.
+
+The Python CLI/runtime owns consumption-contract loading and validation. Queries can
+still use the Rust SQL generator because Python resolves and enforces the contract
+before engine dispatch. The standalone experimental Rust YAML loader does not yet
+store `explores` or `saved_queries`; use Python validation (or automatic fallback)
+for files containing these sections.
+
+## Governance Metadata
+
+Models, metrics, and explores share these optional fields:
+
+| Field | Notes |
+|---|---|
+| `owner` | Accountable person or team. |
+| `domain` | Business domain. |
+| `category` | Catalog category. |
+| `tags` | Searchable string tags. |
+| `status` | `draft`, `active`, or `deprecated`. |
+| `certification` | `certified`, `verified`, or `uncertified`. |
+| `deprecation` | Lifecycle object with `message`, `deprecated_at`, `sunset_at`, and `replaced_by`. |
+| `freshness` | `watermark`/`sql` and optional `ttl_seconds` expectation. |
+| `visibility` | `public`, `internal`, or `private`. Metadata unless visibility enforcement is enabled. |
+
+Governance is deliberately distinct from authorization. `visibility` controls public
+catalog/query discovery when visibility enforcement is enabled; it is not RBAC. Model
+`security` remains the access and row-filter policy. Existing metric `public: false`
+input remains supported and maps to private visibility; native exports preserve the
+compatibility flag.
 
 Top-level metrics are graph-scoped in the Python runtime. The Rust runtime does not
 store a separate graph-metric namespace at execution time; it assigns each top-level

--- a/examples/consumption_contracts/README.md
+++ b/examples/consumption_contracts/README.md
@@ -1,0 +1,13 @@
+# Consumption contracts
+
+This example keeps the physical `orders` model separate from a curated Explore and
+an immutable SavedQuery.
+
+```bash
+sidemantic validate examples/consumption_contracts --verbose
+sidemantic info examples/consumption_contracts
+sidemantic query --models examples/consumption_contracts \
+  --saved-query top_revenue_statuses --dry-run
+```
+
+Point the query command at a connection containing the `orders` table to execute it.

--- a/examples/consumption_contracts/models.yml
+++ b/examples/consumption_contracts/models.yml
@@ -1,0 +1,62 @@
+version: 1
+
+models:
+  - name: orders
+    table: orders
+    primary_key: order_id
+    description: Canonical order facts
+    owner: analytics-platform
+    domain: commerce
+    category: sales
+    tags: [tier-1, finance]
+    status: active
+    certification: certified
+    freshness:
+      watermark: updated_at
+      ttl_seconds: 3600
+    dimensions:
+      - name: status
+        type: categorical
+      - name: created_at
+        type: time
+        granularity: day
+    metrics:
+      - name: revenue
+        agg: sum
+        sql: amount
+        owner: finance
+        certification: certified
+      - name: order_count
+        agg: count
+
+explores:
+  - name: revenue_overview
+    model: orders
+    label: Revenue overview
+    description: Trusted entrypoint for revenue consumption
+    owner: analytics-platform
+    domain: commerce
+    category: executive-reporting
+    tags: [curated]
+    status: active
+    certification: verified
+    allowed_dimensions: [status, created_at__month]
+    allowed_metrics: [revenue, order_count]
+    allowed_filter_fields: [status, created_at]
+    allowed_order_by: [revenue, order_count]
+    default_dimensions: [status]
+    default_metrics: [revenue]
+    filters: ["orders.status != 'deleted'"]
+    default_order_by: ["orders.revenue DESC"]
+    default_limit: 25
+    max_limit: 1000
+
+saved_queries:
+  - name: top_revenue_statuses
+    explore: revenue_overview
+    description: Highest-revenue order statuses
+    dimensions: [status]
+    metrics: [revenue]
+    filters: ["orders.status != 'cancelled'"]
+    order_by: ["orders.revenue DESC"]
+    limit: 10

--- a/sidemantic-schema.json
+++ b/sidemantic-schema.json
@@ -1,5 +1,67 @@
 {
   "$defs": {
+    "Deprecation": {
+      "additionalProperties": false,
+      "description": "Lifecycle details for a deprecated semantic object.",
+      "properties": {
+        "deprecated_at": {
+          "anyOf": [
+            {
+              "format": "date",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Date the object became deprecated",
+          "title": "Deprecated At"
+        },
+        "message": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-readable migration guidance",
+          "title": "Message"
+        },
+        "replaced_by": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Replacement semantic object reference",
+          "title": "Replaced By"
+        },
+        "sunset_at": {
+          "anyOf": [
+            {
+              "format": "date",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Date after which the object may be removed",
+          "title": "Sunset At"
+        }
+      },
+      "title": "Deprecation",
+      "type": "object"
+    },
     "Dimension": {
       "description": "Dimension (attribute) definition.\n\nDimensions are used for grouping and filtering in queries.",
       "properties": {
@@ -274,7 +336,7 @@
     },
     "Freshness": {
       "additionalProperties": false,
-      "description": "Model-level freshness policy for live chart/runtime responses.\n\nPrefer ``watermark`` for normal semantic-model usage. ``sql`` is retained as\nan advanced escape hatch when the source freshness marker cannot be expressed\nas a model dimension or physical column.",
+      "description": "Freshness expectation for models, metrics, and curated explores.\n\nPrefer ``watermark`` for normal semantic-model usage. ``sql`` is retained as\nan advanced escape hatch when the source freshness marker cannot be expressed\nas a model dimension or physical column.",
       "properties": {
         "sql": {
           "anyOf": [
@@ -355,6 +417,118 @@
       "type": "object"
     },
     "Metric": {
+      "$defs": {
+        "Deprecation": {
+          "additionalProperties": false,
+          "description": "Lifecycle details for a deprecated semantic object.",
+          "properties": {
+            "deprecated_at": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Date the object became deprecated",
+              "title": "Deprecated At"
+            },
+            "message": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Human-readable migration guidance",
+              "title": "Message"
+            },
+            "replaced_by": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Replacement semantic object reference",
+              "title": "Replaced By"
+            },
+            "sunset_at": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Date after which the object may be removed",
+              "title": "Sunset At"
+            }
+          },
+          "title": "Deprecation",
+          "type": "object"
+        },
+        "Freshness": {
+          "additionalProperties": false,
+          "description": "Freshness expectation for models, metrics, and curated explores.\n\nPrefer ``watermark`` for normal semantic-model usage. ``sql`` is retained as\nan advanced escape hatch when the source freshness marker cannot be expressed\nas a model dimension or physical column.",
+          "properties": {
+            "sql": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Advanced SQL query returning one scalar freshness marker",
+              "title": "Sql"
+            },
+            "ttl_seconds": {
+              "anyOf": [
+                {
+                  "exclusiveMinimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Maximum allowed age in seconds before data is considered stale",
+              "title": "Ttl Seconds"
+            },
+            "watermark": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Dimension or source column whose MAX value represents source freshness",
+              "title": "Watermark"
+            }
+          },
+          "title": "Freshness",
+          "type": "object"
+        }
+      },
       "description": "Measure definition - supports simple aggregations and complex metric types.\n\nMeasures can be:\n- Simple aggregations: SUM(amount), COUNT(*), AVG(price)\n- Ratios: revenue / order_count\n- Derived formulas: (revenue - cost) / revenue\n- Cumulative: running totals, period-to-date\n- Time comparisons: YoY, MoM growth\n- Conversion funnels: signup -> purchase rate\n\nAuto-registers as a graph-level metric with the current semantic layer context if available.",
       "properties": {
         "activity_event": {
@@ -440,6 +614,37 @@
           "default": null,
           "description": "Comparison calculation (default: percent_change)",
           "title": "Calculation"
+        },
+        "category": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Catalog category",
+          "title": "Category"
+        },
+        "certification": {
+          "anyOf": [
+            {
+              "enum": [
+                "certified",
+                "verified",
+                "uncertified"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Trust or review state",
+          "title": "Certification"
         },
         "cohort_event": {
           "anyOf": [
@@ -527,6 +732,18 @@
           "description": "Denominator measure for ratio",
           "title": "Denominator"
         },
+        "deprecation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Deprecation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Deprecation lifecycle and migration guidance"
+        },
         "description": {
           "anyOf": [
             {
@@ -539,6 +756,19 @@
           "default": null,
           "description": "Human-readable description",
           "title": "Description"
+        },
+        "domain": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Business domain",
+          "title": "Domain"
         },
         "drill_fields": {
           "anyOf": [
@@ -662,6 +892,18 @@
           "default": null,
           "description": "Display format string (e.g., '$#,##0.00', '0.00%')",
           "title": "Format"
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Freshness"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Expected data freshness policy"
         },
         "grain_to_date": {
           "anyOf": [
@@ -824,6 +1066,19 @@
           "description": "Time offset for denominator (e.g., '1 month')",
           "title": "Offset Window"
         },
+        "owner": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Accountable person or team",
+          "title": "Owner"
+        },
         "periods": {
           "anyOf": [
             {
@@ -880,6 +1135,24 @@
           "title": "Sql Is Complete",
           "type": "boolean"
         },
+        "status": {
+          "anyOf": [
+            {
+              "enum": [
+                "draft",
+                "active",
+                "deprecated"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Semantic object lifecycle status",
+          "title": "Status"
+        },
         "steps": {
           "anyOf": [
             {
@@ -911,6 +1184,14 @@
           "default": null,
           "description": "Alternative names for this measure/metric",
           "title": "Synonyms"
+        },
+        "tags": {
+          "description": "Searchable catalog tags",
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "type": "array"
         },
         "time_offset": {
           "anyOf": [
@@ -959,6 +1240,17 @@
           "default": null,
           "description": "Named format (e.g., 'usd', 'percent', 'decimal_2')",
           "title": "Value Format Name"
+        },
+        "visibility": {
+          "default": "public",
+          "description": "Catalog visibility; not an authorization policy",
+          "enum": [
+            "public",
+            "internal",
+            "private"
+          ],
+          "title": "Visibility",
+          "type": "string"
         },
         "window": {
           "anyOf": [
@@ -1657,6 +1949,118 @@
     "metrics": {
       "description": "Top-level metric definitions (optional - can also define in models)",
       "items": {
+        "$defs": {
+          "Deprecation": {
+            "additionalProperties": false,
+            "description": "Lifecycle details for a deprecated semantic object.",
+            "properties": {
+              "deprecated_at": {
+                "anyOf": [
+                  {
+                    "format": "date",
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Date the object became deprecated",
+                "title": "Deprecated At"
+              },
+              "message": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable migration guidance",
+                "title": "Message"
+              },
+              "replaced_by": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Replacement semantic object reference",
+                "title": "Replaced By"
+              },
+              "sunset_at": {
+                "anyOf": [
+                  {
+                    "format": "date",
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Date after which the object may be removed",
+                "title": "Sunset At"
+              }
+            },
+            "title": "Deprecation",
+            "type": "object"
+          },
+          "Freshness": {
+            "additionalProperties": false,
+            "description": "Freshness expectation for models, metrics, and curated explores.\n\nPrefer ``watermark`` for normal semantic-model usage. ``sql`` is retained as\nan advanced escape hatch when the source freshness marker cannot be expressed\nas a model dimension or physical column.",
+            "properties": {
+              "sql": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Advanced SQL query returning one scalar freshness marker",
+                "title": "Sql"
+              },
+              "ttl_seconds": {
+                "anyOf": [
+                  {
+                    "exclusiveMinimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Maximum allowed age in seconds before data is considered stale",
+                "title": "Ttl Seconds"
+              },
+              "watermark": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Dimension or source column whose MAX value represents source freshness",
+                "title": "Watermark"
+              }
+            },
+            "title": "Freshness",
+            "type": "object"
+          }
+        },
         "description": "Measure definition - supports simple aggregations and complex metric types.\n\nMeasures can be:\n- Simple aggregations: SUM(amount), COUNT(*), AVG(price)\n- Ratios: revenue / order_count\n- Derived formulas: (revenue - cost) / revenue\n- Cumulative: running totals, period-to-date\n- Time comparisons: YoY, MoM growth\n- Conversion funnels: signup -> purchase rate\n\nAuto-registers as a graph-level metric with the current semantic layer context if available.",
         "properties": {
           "activity_event": {
@@ -1742,6 +2146,37 @@
             "default": null,
             "description": "Comparison calculation (default: percent_change)",
             "title": "Calculation"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Catalog category",
+            "title": "Category"
+          },
+          "certification": {
+            "anyOf": [
+              {
+                "enum": [
+                  "certified",
+                  "verified",
+                  "uncertified"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Trust or review state",
+            "title": "Certification"
           },
           "cohort_event": {
             "anyOf": [
@@ -1829,6 +2264,18 @@
             "description": "Denominator measure for ratio",
             "title": "Denominator"
           },
+          "deprecation": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Deprecation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Deprecation lifecycle and migration guidance"
+          },
           "description": {
             "anyOf": [
               {
@@ -1841,6 +2288,19 @@
             "default": null,
             "description": "Human-readable description",
             "title": "Description"
+          },
+          "domain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Business domain",
+            "title": "Domain"
           },
           "drill_fields": {
             "anyOf": [
@@ -1964,6 +2424,18 @@
             "default": null,
             "description": "Display format string (e.g., '$#,##0.00', '0.00%')",
             "title": "Format"
+          },
+          "freshness": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Freshness"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Expected data freshness policy"
           },
           "grain_to_date": {
             "anyOf": [
@@ -2126,6 +2598,19 @@
             "description": "Time offset for denominator (e.g., '1 month')",
             "title": "Offset Window"
           },
+          "owner": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Accountable person or team",
+            "title": "Owner"
+          },
           "periods": {
             "anyOf": [
               {
@@ -2182,6 +2667,24 @@
             "title": "Sql Is Complete",
             "type": "boolean"
           },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "draft",
+                  "active",
+                  "deprecated"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Semantic object lifecycle status",
+            "title": "Status"
+          },
           "steps": {
             "anyOf": [
               {
@@ -2213,6 +2716,14 @@
             "default": null,
             "description": "Alternative names for this measure/metric",
             "title": "Synonyms"
+          },
+          "tags": {
+            "description": "Searchable catalog tags",
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
           },
           "time_offset": {
             "anyOf": [
@@ -2261,6 +2772,17 @@
             "default": null,
             "description": "Named format (e.g., 'usd', 'percent', 'decimal_2')",
             "title": "Value Format Name"
+          },
+          "visibility": {
+            "default": "public",
+            "description": "Catalog visibility; not an authorization policy",
+            "enum": [
+              "public",
+              "internal",
+              "private"
+            ],
+            "title": "Visibility",
+            "type": "string"
           },
           "window": {
             "anyOf": [
@@ -2327,6 +2849,68 @@
       "description": "Model definitions",
       "items": {
         "$defs": {
+          "Deprecation": {
+            "additionalProperties": false,
+            "description": "Lifecycle details for a deprecated semantic object.",
+            "properties": {
+              "deprecated_at": {
+                "anyOf": [
+                  {
+                    "format": "date",
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Date the object became deprecated",
+                "title": "Deprecated At"
+              },
+              "message": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable migration guidance",
+                "title": "Message"
+              },
+              "replaced_by": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Replacement semantic object reference",
+                "title": "Replaced By"
+              },
+              "sunset_at": {
+                "anyOf": [
+                  {
+                    "format": "date",
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Date after which the object may be removed",
+                "title": "Sunset At"
+              }
+            },
+            "title": "Deprecation",
+            "type": "object"
+          },
           "Dimension": {
             "description": "Dimension (attribute) definition.\n\nDimensions are used for grouping and filtering in queries.",
             "properties": {
@@ -2601,7 +3185,7 @@
           },
           "Freshness": {
             "additionalProperties": false,
-            "description": "Model-level freshness policy for live chart/runtime responses.\n\nPrefer ``watermark`` for normal semantic-model usage. ``sql`` is retained as\nan advanced escape hatch when the source freshness marker cannot be expressed\nas a model dimension or physical column.",
+            "description": "Freshness expectation for models, metrics, and curated explores.\n\nPrefer ``watermark`` for normal semantic-model usage. ``sql`` is retained as\nan advanced escape hatch when the source freshness marker cannot be expressed\nas a model dimension or physical column.",
             "properties": {
               "sql": {
                 "anyOf": [
@@ -2768,6 +3352,37 @@
                 "description": "Comparison calculation (default: percent_change)",
                 "title": "Calculation"
               },
+              "category": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Catalog category",
+                "title": "Category"
+              },
+              "certification": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "certified",
+                      "verified",
+                      "uncertified"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Trust or review state",
+                "title": "Certification"
+              },
               "cohort_event": {
                 "anyOf": [
                   {
@@ -2854,6 +3469,18 @@
                 "description": "Denominator measure for ratio",
                 "title": "Denominator"
               },
+              "deprecation": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Deprecation"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Deprecation lifecycle and migration guidance"
+              },
               "description": {
                 "anyOf": [
                   {
@@ -2866,6 +3493,19 @@
                 "default": null,
                 "description": "Human-readable description",
                 "title": "Description"
+              },
+              "domain": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Business domain",
+                "title": "Domain"
               },
               "drill_fields": {
                 "anyOf": [
@@ -2989,6 +3629,18 @@
                 "default": null,
                 "description": "Display format string (e.g., '$#,##0.00', '0.00%')",
                 "title": "Format"
+              },
+              "freshness": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Freshness"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Expected data freshness policy"
               },
               "grain_to_date": {
                 "anyOf": [
@@ -3151,6 +3803,19 @@
                 "description": "Time offset for denominator (e.g., '1 month')",
                 "title": "Offset Window"
               },
+              "owner": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Accountable person or team",
+                "title": "Owner"
+              },
               "periods": {
                 "anyOf": [
                   {
@@ -3207,6 +3872,24 @@
                 "title": "Sql Is Complete",
                 "type": "boolean"
               },
+              "status": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "draft",
+                      "active",
+                      "deprecated"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Semantic object lifecycle status",
+                "title": "Status"
+              },
               "steps": {
                 "anyOf": [
                   {
@@ -3238,6 +3921,14 @@
                 "default": null,
                 "description": "Alternative names for this measure/metric",
                 "title": "Synonyms"
+              },
+              "tags": {
+                "description": "Searchable catalog tags",
+                "items": {
+                  "type": "string"
+                },
+                "title": "Tags",
+                "type": "array"
               },
               "time_offset": {
                 "anyOf": [
@@ -3286,6 +3977,17 @@
                 "default": null,
                 "description": "Named format (e.g., 'usd', 'percent', 'decimal_2')",
                 "title": "Value Format Name"
+              },
+              "visibility": {
+                "default": "public",
+                "description": "Catalog visibility; not an authorization policy",
+                "enum": [
+                  "public",
+                  "internal",
+                  "private"
+                ],
+                "title": "Visibility",
+                "type": "string"
               },
               "window": {
                 "anyOf": [
@@ -3907,6 +4609,37 @@
             "title": "Auto Dimensions",
             "type": "boolean"
           },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Catalog category",
+            "title": "Category"
+          },
+          "certification": {
+            "anyOf": [
+              {
+                "enum": [
+                  "certified",
+                  "verified",
+                  "uncertified"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Trust or review state",
+            "title": "Certification"
+          },
           "dax": {
             "anyOf": [
               {
@@ -3956,6 +4689,18 @@
             "description": "Default time dimension for metrics (auto-included in queries)",
             "title": "Default Time Dimension"
           },
+          "deprecation": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Deprecation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Deprecation lifecycle and migration guidance"
+          },
           "description": {
             "anyOf": [
               {
@@ -3976,6 +4721,19 @@
             },
             "title": "Dimensions",
             "type": "array"
+          },
+          "domain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Business domain",
+            "title": "Domain"
           },
           "expression_language": {
             "anyOf": [
@@ -4017,7 +4775,7 @@
               }
             ],
             "default": null,
-            "description": "Model-level source freshness policy inherited by live chart runtimes"
+            "description": "Expected data freshness policy"
           },
           "meta": {
             "anyOf": [
@@ -4059,6 +4817,19 @@
             "description": "Unique model name",
             "title": "Name",
             "type": "string"
+          },
+          "owner": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Accountable person or team",
+            "title": "Owner"
           },
           "pre_aggregations": {
             "description": "Pre-aggregation definitions for query optimization",
@@ -4141,6 +4912,24 @@
             "description": "SQL expression for derived tables",
             "title": "Sql"
           },
+          "status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "draft",
+                  "active",
+                  "deprecated"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Semantic object lifecycle status",
+            "title": "Status"
+          },
           "table": {
             "anyOf": [
               {
@@ -4153,6 +4942,14 @@
             "default": null,
             "description": "Physical table name (schema.table)",
             "title": "Table"
+          },
+          "tags": {
+            "description": "Searchable catalog tags",
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
           },
           "unique_keys": {
             "anyOf": [
@@ -4172,6 +4969,17 @@
             "default": null,
             "description": "Unique key constraints (each is a list of columns)",
             "title": "Unique Keys"
+          },
+          "visibility": {
+            "default": "public",
+            "description": "Catalog visibility; not an authorization policy",
+            "enum": [
+              "public",
+              "internal",
+              "private"
+            ],
+            "title": "Visibility",
+            "type": "string"
           }
         },
         "required": [

--- a/sidemantic/__init__.py
+++ b/sidemantic/__init__.py
@@ -4,8 +4,10 @@ from typing import TYPE_CHECKING
 
 __version__ = "0.10.2"
 
+from sidemantic.core.consumption import Explore, SavedQuery, View
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.freshness import Freshness
+from sidemantic.core.governance import Deprecation
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.parameter import Parameter
@@ -21,9 +23,11 @@ Measure = Metric
 
 __all__ = [
     "Dimension",
+    "Deprecation",
     "DashboardDocument",
     "DashboardSpecError",
     "Freshness",
+    "Explore",
     "Measure",  # Backwards compatibility
     "Metric",
     "Model",
@@ -41,7 +45,9 @@ __all__ = [
     "SecurityError",
     "SecurityPolicy",
     "Segment",
+    "SavedQuery",
     "SemanticLayer",
+    "View",
     "load_from_directory",
 ]
 

--- a/sidemantic/adapters/hex.py
+++ b/sidemantic/adapters/hex.py
@@ -198,6 +198,7 @@ class HexAdapter(BaseAdapter):
             description=view_def.get("description"),
             metadata={"label": name} if name else None,
             meta=meta,
+            visibility=view_def.get("visibility", "public"),
         )
 
     @staticmethod

--- a/sidemantic/adapters/hex.py
+++ b/sidemantic/adapters/hex.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import yaml
 
 from sidemantic.adapters.base import BaseAdapter
+from sidemantic.core.consumption import Explore
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
@@ -65,9 +66,14 @@ class HexAdapter(BaseAdapter):
                 if not data or not isinstance(data, dict):
                     continue
 
+                is_view = data.get("type") == "view"
                 model = self._parse_resource(data)
                 if model:
                     graph.add_model(model)
+                if is_view:
+                    explore = self._parse_view_explore(data)
+                    if explore:
+                        graph.add_explore(explore)
 
     def _parse_resource(self, resource_def: dict) -> Model | None:
         """Dispatch a Hex resource to the correct parser based on ``type``.
@@ -151,6 +157,7 @@ class HexAdapter(BaseAdapter):
             metrics=measures,
             metadata=metadata,
             meta=meta or None,
+            visibility=model_def.get("visibility", "public"),
         )
 
     def _parse_view(self, view_def: dict) -> Model | None:
@@ -191,6 +198,34 @@ class HexAdapter(BaseAdapter):
             description=view_def.get("description"),
             metadata={"label": name} if name else None,
             meta=meta,
+        )
+
+    @staticmethod
+    def _parse_view_explore(view_def: dict) -> Explore | None:
+        """Map a Hex view losslessly into a first-class Explore contract."""
+        name = view_def.get("id")
+        model = view_def.get("base")
+        if not name or not model:
+            return None
+
+        dimensions: list[str] = []
+        metrics: list[str] = []
+        for group in view_def.get("contents") or []:
+            if not isinstance(group, dict):
+                continue
+            dimensions.extend(f"{model}.{value}" for value in group.get("dimensions") or [])
+            metrics.extend(f"{model}.{value}" for value in group.get("measures") or [])
+
+        visibility = view_def.get("visibility", "public")
+        return Explore(
+            name=name,
+            model=model,
+            label=view_def.get("name"),
+            description=view_def.get("description"),
+            allowed_dimensions=dimensions,
+            allowed_metrics=metrics,
+            visibility=visibility,
+            metadata={"hex": {"contents": view_def.get("contents") or []}},
         )
 
     def _parse_dimension(self, dim_def: dict) -> Dimension | None:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -4463,7 +4463,9 @@ class LookMLAdapter(BaseAdapter):
             # filters flow through the normal semantic query compiler and therefore
             # need real semantic model references. Keep separate translations so a
             # LookML mandatory filter is executable in both paths.
-            consumption_filter = re.sub(r"\$\{(\w+)\.(\w+)\}", r"\1.\2", sql_always_where)
+            consumption_filter = sql_always_where.replace("${TABLE}", base_model_name)
+            consumption_filter = re.sub(r"\$\{(\w+)\.(\w+)\}", r"\1.\2", consumption_filter)
+            sql_always_where = sql_always_where.replace("${TABLE}", "{model}")
             sql_always_where = re.sub(r"\$\{(\w+)\.(\w+)\}", r"{model}.\2", sql_always_where)
             consumption_filters.append(consumption_filter)
             segment_name = f"_sql_always_where_{explore_name}"

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -4416,6 +4416,16 @@ class LookMLAdapter(BaseAdapter):
 
         base_model = graph.models[base_model_name]
         consumption_filters: list[str] = []
+        join_aliases = {
+            join_def.get("name"): join_def.get("from", join_def.get("name"))
+            for join_def in explore_def.get("joins") or []
+            if join_def.get("name")
+        }
+
+        def _semantic_model_name(lookml_qualifier: str) -> str:
+            if lookml_qualifier in {explore_name, base_model_name}:
+                return base_model_name
+            return join_aliases.get(lookml_qualifier, lookml_qualifier)
 
         # Set description from explore if model doesn't already have one
         explore_desc = explore_def.get("description")
@@ -4464,7 +4474,11 @@ class LookMLAdapter(BaseAdapter):
             # need real semantic model references. Keep separate translations so a
             # LookML mandatory filter is executable in both paths.
             consumption_filter = sql_always_where.replace("${TABLE}", base_model_name)
-            consumption_filter = re.sub(r"\$\{(\w+)\.(\w+)\}", r"\1.\2", consumption_filter)
+            consumption_filter = re.sub(
+                r"\$\{(\w+)\.(\w+)\}",
+                lambda match: f"{_semantic_model_name(match.group(1))}.{match.group(2)}",
+                consumption_filter,
+            )
             sql_always_where = sql_always_where.replace("${TABLE}", "{model}")
             sql_always_where = re.sub(r"\$\{(\w+)\.(\w+)\}", r"{model}.\2", sql_always_where)
             consumption_filters.append(consumption_filter)
@@ -4493,18 +4507,7 @@ class LookMLAdapter(BaseAdapter):
                 field_model_name = base_model_name
                 if "." in field:
                     field_qualifier = field.rsplit(".", 1)[0]
-                    if field_qualifier not in {explore_name, base_model_name}:
-                        matching_join = next(
-                            (
-                                join_def
-                                for join_def in explore_def.get("joins") or []
-                                if join_def.get("name") == field_qualifier
-                            ),
-                            None,
-                        )
-                        field_model_name = (
-                            matching_join.get("from", field_qualifier) if matching_join else field_qualifier
-                        )
+                    field_model_name = _semantic_model_name(field_qualifier)
                 filter_sql = self._convert_lookml_filter_to_sql(bare_field, str(value))
                 segment_name = f"_always_filter_{explore_name}_{field}"
                 if filter_sql and segment_name not in existing_names:
@@ -4591,6 +4594,7 @@ class LookMLAdapter(BaseAdapter):
                     break
                 if "." in raw_field:
                     model_name, field_name = raw_field.split(".", 1)
+                    model_name = _semantic_model_name(model_name)
                 else:
                     model_name, field_name = base_model_name, raw_field
                 field_model = graph.models.get(model_name)

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -4488,6 +4488,21 @@ class LookMLAdapter(BaseAdapter):
                 # Strip view qualifier (e.g. "fact_orders.created_date" -> "created_date")
                 # so _convert_lookml_filter_to_sql doesn't produce {model}.view.col
                 bare_field = field.rsplit(".", 1)[-1] if "." in field else field
+                field_model_name = base_model_name
+                if "." in field:
+                    field_qualifier = field.rsplit(".", 1)[0]
+                    if field_qualifier not in {explore_name, base_model_name}:
+                        matching_join = next(
+                            (
+                                join_def
+                                for join_def in explore_def.get("joins") or []
+                                if join_def.get("name") == field_qualifier
+                            ),
+                            None,
+                        )
+                        field_model_name = (
+                            matching_join.get("from", field_qualifier) if matching_join else field_qualifier
+                        )
                 filter_sql = self._convert_lookml_filter_to_sql(bare_field, str(value))
                 segment_name = f"_always_filter_{explore_name}_{field}"
                 if filter_sql and segment_name not in existing_names:
@@ -4500,7 +4515,7 @@ class LookMLAdapter(BaseAdapter):
                     )
                     existing_names.add(segment_name)
                 if filter_sql:
-                    consumption_filters.append(filter_sql.replace("{model}", base_model_name))
+                    consumption_filters.append(filter_sql.replace("{model}", field_model_name))
 
             for item in filter_items:
                 if isinstance(item, list):

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 
 from sidemantic.adapters.base import BaseAdapter
+from sidemantic.core.consumption import Explore
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
@@ -3001,6 +3002,10 @@ class LookMLAdapter(BaseAdapter):
             model_kwargs["primary_key"] = primary_key
         if model_meta:
             model_kwargs["meta"] = model_meta
+        if view_def.get("hidden") in ("yes", True):
+            model_kwargs["visibility"] = "private"
+        if view_def.get("tags"):
+            model_kwargs["tags"] = list(view_def["tags"])
 
         return Model(**model_kwargs)
 
@@ -4410,6 +4415,7 @@ class LookMLAdapter(BaseAdapter):
                 return
 
         base_model = graph.models[base_model_name]
+        consumption_filters: list[str] = []
 
         # Set description from explore if model doesn't already have one
         explore_desc = explore_def.get("description")
@@ -4455,6 +4461,7 @@ class LookMLAdapter(BaseAdapter):
         if sql_always_where:
             # Translate LookML ${view.field} references to {model}.field
             sql_always_where = re.sub(r"\$\{(\w+)\.(\w+)\}", r"{model}.\2", sql_always_where)
+            consumption_filters.append(sql_always_where)
             segment_name = f"_sql_always_where_{explore_name}"
             # Skip if this exact segment already exists
             existing_names = {s.name for s in base_model.segments}
@@ -4488,6 +4495,8 @@ class LookMLAdapter(BaseAdapter):
                         )
                     )
                     existing_names.add(segment_name)
+                if filter_sql:
+                    consumption_filters.append(filter_sql)
 
             for item in filter_items:
                 if isinstance(item, list):
@@ -4543,6 +4552,60 @@ class LookMLAdapter(BaseAdapter):
             if relationship:
                 # Add relationship to the base model
                 base_model.relationships.append(relationship)
+
+        # Keep the LookML explore as a consumption contract instead of only
+        # flattening its joins and filters into the physical model graph. An
+        # explicit `fields` list becomes an allowlist when every entry resolves
+        # losslessly; wildcard/exclusion sets remain adapter metadata.
+        allowed_dimensions: list[str] | None = None
+        allowed_metrics: list[str] | None = None
+        raw_fields = explore_def.get("fields")
+        if isinstance(raw_fields, list) and raw_fields:
+            candidate_dimensions: list[str] = []
+            candidate_metrics: list[str] = []
+            lossless = True
+            for raw_field in raw_fields:
+                if not isinstance(raw_field, str) or "*" in raw_field or raw_field.startswith("-"):
+                    lossless = False
+                    break
+                if "." in raw_field:
+                    model_name, field_name = raw_field.split(".", 1)
+                else:
+                    model_name, field_name = base_model_name, raw_field
+                field_model = graph.models.get(model_name)
+                if field_model is None:
+                    lossless = False
+                    break
+                reference = f"{model_name}.{field_name}"
+                if field_model.get_dimension(field_name):
+                    candidate_dimensions.append(reference)
+                elif field_model.get_metric(field_name):
+                    candidate_metrics.append(reference)
+                else:
+                    lossless = False
+                    break
+            if lossless:
+                allowed_dimensions = candidate_dimensions
+                allowed_metrics = candidate_metrics
+
+        if explore_name not in graph.explores:
+            metadata = {
+                "lookml": {key: explore_def[key] for key in ("fields", "group_label", "hidden") if key in explore_def}
+            }
+            graph.add_explore(
+                Explore(
+                    name=explore_name,
+                    model=base_model_name,
+                    label=explore_def.get("label"),
+                    description=explore_def.get("description"),
+                    allowed_dimensions=allowed_dimensions,
+                    allowed_metrics=allowed_metrics,
+                    filters=consumption_filters,
+                    category=explore_def.get("group_label"),
+                    visibility="private" if explore_def.get("hidden") in ("yes", True) else "public",
+                    metadata=metadata,
+                )
+            )
 
     def _parse_join(self, join_def: dict, base_model_name: str, explore_name: str | None = None) -> Relationship | None:
         """Parse a join definition into a Relationship.

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -4459,9 +4459,13 @@ class LookMLAdapter(BaseAdapter):
 
         sql_always_where = explore_def.get("sql_always_where")
         if sql_always_where:
-            # Translate LookML ${view.field} references to {model}.field
+            # Segments resolve ``{model}`` when they are selected, while Explore
+            # filters flow through the normal semantic query compiler and therefore
+            # need real semantic model references. Keep separate translations so a
+            # LookML mandatory filter is executable in both paths.
+            consumption_filter = re.sub(r"\$\{(\w+)\.(\w+)\}", r"\1.\2", sql_always_where)
             sql_always_where = re.sub(r"\$\{(\w+)\.(\w+)\}", r"{model}.\2", sql_always_where)
-            consumption_filters.append(sql_always_where)
+            consumption_filters.append(consumption_filter)
             segment_name = f"_sql_always_where_{explore_name}"
             # Skip if this exact segment already exists
             existing_names = {s.name for s in base_model.segments}
@@ -4496,7 +4500,7 @@ class LookMLAdapter(BaseAdapter):
                     )
                     existing_names.add(segment_name)
                 if filter_sql:
-                    consumption_filters.append(filter_sql)
+                    consumption_filters.append(filter_sql.replace("{model}", base_model_name))
 
             for item in filter_items:
                 if isinstance(item, list):

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -4584,7 +4584,7 @@ class LookMLAdapter(BaseAdapter):
         allowed_dimensions: list[str] | None = None
         allowed_metrics: list[str] | None = None
         raw_fields = explore_def.get("fields")
-        if isinstance(raw_fields, list) and raw_fields:
+        if isinstance(raw_fields, list):
             candidate_dimensions: list[str] = []
             candidate_metrics: list[str] = []
             lossless = True

--- a/sidemantic/adapters/metricflow.py
+++ b/sidemantic/adapters/metricflow.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import yaml
 
 from sidemantic.adapters.base import BaseAdapter
+from sidemantic.core.consumption import SavedQuery
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
@@ -81,9 +82,54 @@ class MetricFlowAdapter(BaseAdapter):
         # Rebuild adjacency graph after resolving relationship names
         graph.build_adjacency()
 
-        # Expose parsed saved queries on the graph for downstream consumers.
+        # Expose parsed saved queries as first-class contracts. Keep the legacy
+        # metadata mirror for consumers written before the typed graph API.
         if self.saved_queries:
             graph.metadata["saved_queries"] = self.saved_queries
+            for definition in self.saved_queries.values():
+                where = definition.get("where") or []
+                if isinstance(where, str):
+                    where = [where]
+                order_by = definition.get("order_by") or []
+                if isinstance(order_by, str):
+                    order_by = [order_by]
+                external_syntax = any(
+                    token in value
+                    for value in [*(definition.get("group_by") or []), *where, *order_by]
+                    if isinstance(value, str)
+                    for token in ("Dimension(", "TimeDimension(", "{{")
+                )
+                graph.add_saved_query(
+                    SavedQuery(
+                        name=definition["name"],
+                        label=definition.get("label"),
+                        description=definition.get("description"),
+                        metrics=definition.get("metrics") or [],
+                        dimensions=definition.get("group_by") or [],
+                        filters=where,
+                        order_by=order_by,
+                        limit=definition.get("limit"),
+                        metadata={
+                            "metricflow": {
+                                "group_by": definition.get("group_by") or [],
+                                "where": definition.get("where"),
+                                "order_by": definition.get("order_by"),
+                                "exports": definition.get("exports") or [],
+                                "executable": not external_syntax,
+                                **(
+                                    {
+                                        "compatibility_message": (
+                                            "MetricFlow Dimension()/TimeDimension() expressions are preserved "
+                                            "losslessly but must be converted to Sidemantic field references before execution"
+                                        )
+                                    }
+                                    if external_syntax
+                                    else {}
+                                ),
+                            }
+                        },
+                    )
+                )
 
         # Expose parsed conversion metrics (retained as non-queryable metadata).
         if self.conversion_metrics:
@@ -172,8 +218,7 @@ class MetricFlowAdapter(BaseAdapter):
             if metric:
                 self._add_metric(graph, metric)
 
-        # Parse saved queries (top-level, both specs). These have no direct
-        # Sidemantic equivalent, so retain them for downstream consumers.
+        # Parse saved queries (top-level, both specs).
         self._parse_saved_queries(data.get("saved_queries"))
 
     @staticmethod

--- a/sidemantic/adapters/metricflow.py
+++ b/sidemantic/adapters/metricflow.py
@@ -97,7 +97,7 @@ class MetricFlowAdapter(BaseAdapter):
                     token in value
                     for value in [*(definition.get("group_by") or []), *where, *order_by]
                     if isinstance(value, str)
-                    for token in ("Dimension(", "TimeDimension(", "{{")
+                    for token in ("Dimension(", "TimeDimension(", "Metric(", "{{")
                 )
                 graph.add_saved_query(
                     SavedQuery(
@@ -119,7 +119,7 @@ class MetricFlowAdapter(BaseAdapter):
                                 **(
                                     {
                                         "compatibility_message": (
-                                            "MetricFlow Dimension()/TimeDimension() expressions are preserved "
+                                            "MetricFlow Dimension()/TimeDimension()/Metric() expressions are preserved "
                                             "losslessly but must be converted to Sidemantic field references before execution"
                                         )
                                     }

--- a/sidemantic/adapters/sidemantic.py
+++ b/sidemantic/adapters/sidemantic.py
@@ -1092,6 +1092,7 @@ class SidemanticAdapter(BaseAdapter):
                     "name": measure.name,
                     "agg": measure.agg,
                 }
+                measure_def.update(governance_dict(measure))
                 measure_dax = _dax_text(measure)
                 if measure_dax:
                     measure_def["dax"] = measure_dax

--- a/sidemantic/adapters/sidemantic.py
+++ b/sidemantic/adapters/sidemantic.py
@@ -331,6 +331,9 @@ def normalize_sql_frontmatter(frontmatter: dict) -> dict:
     normalized.pop("connection", None)
     normalized.pop("models", None)
     normalized.pop("parameters", None)
+    normalized.pop("explores", None)
+    normalized.pop("views", None)
+    normalized.pop("saved_queries", None)
     # ``metadata`` is a root-only native field (graph-level), so it must not by
     # itself make the frontmatter look like a model definition. Graph metadata is
     # extracted separately by the caller before this decision.
@@ -403,6 +406,22 @@ class SidemanticAdapter(BaseAdapter):
                     )
                 except Exception as exc:
                     raise ValueError(f"{source_path}: invalid SQL definitions: {exc}") from exc
+
+                # SQL model files may colocate root-level consumption contracts
+                # with model frontmatter. Extract them before deciding whether
+                # the remaining frontmatter describes a model.
+                explore_defs = [*(frontmatter.get("explores") or []), *(frontmatter.get("views") or [])]
+                for explore_def in explore_defs:
+                    reject_unknown_fields(explore_def, EXPLORE_FIELDS, "explore", source_path=source_path)
+                    graph.add_explore(Explore(**explore_def))
+                for saved_query_def in frontmatter.get("saved_queries") or []:
+                    reject_unknown_fields(
+                        saved_query_def,
+                        SAVED_QUERY_FIELDS,
+                        "saved_query",
+                        source_path=source_path,
+                    )
+                    graph.add_saved_query(SavedQuery(**saved_query_def))
 
                 # Parse frontmatter as a model only when it still contains model fields
                 # after native contract metadata such as `version`/`metadata` is removed.

--- a/sidemantic/adapters/sidemantic.py
+++ b/sidemantic/adapters/sidemantic.py
@@ -7,8 +7,10 @@ from pathlib import Path
 import yaml
 
 from sidemantic.adapters.base import BaseAdapter
+from sidemantic.core.consumption import Explore, SavedQuery
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.freshness import Freshness
+from sidemantic.core.governance import GOVERNANCE_FIELDS, governance_dict
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.parameter import Parameter
@@ -29,6 +31,9 @@ ROOT_FIELDS = {
     "models",
     "metrics",
     "parameters",
+    "explores",
+    "views",
+    "saved_queries",
     "metadata",
     "sql_metrics",
     "sql_segments",
@@ -61,7 +66,7 @@ MODEL_FIELDS = {
     "freshness",
     "sql_metrics",
     "sql_segments",
-}
+} | GOVERNANCE_FIELDS
 SECURITY_FIELDS = {
     "access",
     "row_filters",
@@ -145,7 +150,39 @@ METRIC_FIELDS = {
     "metadata",
     "meta",
     "public",
-}
+} | GOVERNANCE_FIELDS
+EXPLORE_FIELDS = {
+    "name",
+    "model",
+    "label",
+    "description",
+    "allowed_dimensions",
+    "allowed_metrics",
+    "allowed_filter_fields",
+    "allowed_order_by",
+    "default_dimensions",
+    "default_metrics",
+    "filters",
+    "default_filters",
+    "default_order_by",
+    "default_limit",
+    "max_limit",
+    "metadata",
+} | GOVERNANCE_FIELDS
+SAVED_QUERY_FIELDS = {
+    "name",
+    "explore",
+    "label",
+    "description",
+    "dimensions",
+    "metrics",
+    "filters",
+    "segments",
+    "order_by",
+    "limit",
+    "parameters",
+    "metadata",
+} | GOVERNANCE_FIELDS
 RELATIONSHIP_FIELDS = {
     "name",
     "type",
@@ -435,6 +472,15 @@ class SidemanticAdapter(BaseAdapter):
             if parameter:
                 graph.add_parameter(parameter)
 
+        explore_defs = [*(data.get("explores") or []), *(data.get("views") or [])]
+        for explore_def in explore_defs:
+            reject_unknown_fields(explore_def, EXPLORE_FIELDS, "explore", source_path=source_path)
+            graph.add_explore(Explore(**explore_def))
+
+        for saved_query_def in data.get("saved_queries") or []:
+            reject_unknown_fields(saved_query_def, SAVED_QUERY_FIELDS, "saved_query", source_path=source_path)
+            graph.add_saved_query(SavedQuery(**saved_query_def))
+
         # Parse SQL-defined metrics/segments if present
         if "sql_metrics" in data:
             sql_metrics, _ = self._parse_embedded_sql_definitions(
@@ -514,6 +560,14 @@ class SidemanticAdapter(BaseAdapter):
 
         if graph.parameters:
             data["parameters"] = [self._export_parameter(parameter) for parameter in graph.parameters.values()]
+
+        if graph.explores:
+            data["explores"] = [self._export_explore(explore) for explore in graph.explores.values()]
+
+        if graph.saved_queries:
+            data["saved_queries"] = [
+                self._export_saved_query(saved_query) for saved_query in graph.saved_queries.values()
+            ]
 
         if graph.metadata:
             data["metadata"] = graph.metadata
@@ -717,6 +771,14 @@ class SidemanticAdapter(BaseAdapter):
             "metadata",
             "auto_dimensions",
             "meta",
+            "owner",
+            "domain",
+            "category",
+            "tags",
+            "status",
+            "certification",
+            "deprecation",
+            "visibility",
         ]:
             if field in model_def:
                 model_kwargs[field] = model_def.get(field)
@@ -847,6 +909,15 @@ class SidemanticAdapter(BaseAdapter):
             "synonyms",
             "meta",
             "public",
+            "owner",
+            "domain",
+            "category",
+            "tags",
+            "status",
+            "certification",
+            "deprecation",
+            "freshness",
+            "visibility",
         ]:
             if field in metric_def:
                 metric_kwargs[field] = metric_def.get(field)
@@ -904,6 +975,7 @@ class SidemanticAdapter(BaseAdapter):
             Model definition dictionary
         """
         result = {"name": model.name}
+        result.update(governance_dict(model))
         model_dax = _dax_text(model)
 
         if model_dax:
@@ -1167,6 +1239,7 @@ class SidemanticAdapter(BaseAdapter):
         result = {
             "name": measure.name,
         }
+        result.update(governance_dict(measure))
 
         if measure.type:
             result["type"] = measure.type
@@ -1325,6 +1398,14 @@ class SidemanticAdapter(BaseAdapter):
             result["default_to_today"] = parameter.default_to_today
 
         return result
+
+    @staticmethod
+    def _export_explore(explore: Explore) -> dict:
+        return explore.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+
+    @staticmethod
+    def _export_saved_query(saved_query: SavedQuery) -> dict:
+        return saved_query.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
 
 
 def _dax_text(obj) -> str | None:

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -380,17 +380,26 @@ def create_app(
         # Read-only metadata over the in-memory graph.
         current_layer = app.state.layer
         graph_obj = current_layer.graph
+        visible_model_names = {
+            model_name
+            for model_name, model in graph_obj.models.items()
+            if not current_layer.enforce_visibility or model.visibility == "public"
+        }
 
         models = []
         for model_name, model in graph_obj.models.items():
-            if current_layer.enforce_visibility and model.visibility != "public":
+            if model_name not in visible_model_names:
                 continue
             model_info = {
                 "name": model_name,
                 "table": model.table,
                 "dimensions": [d.name for d in _visible_dimensions(current_layer, model)],
                 "metrics": [m.name for m in _visible_metrics(current_layer, model)],
-                "relationships": [{"name": rel.name, "type": rel.type} for rel in model.relationships],
+                "relationships": [
+                    {"name": rel.name, "type": rel.type}
+                    for rel in model.relationships
+                    if rel.name in visible_model_names
+                ],
             }
             if model.segments:
                 model_info["segments"] = [segment.name for segment in model.segments]
@@ -412,7 +421,7 @@ def create_app(
             graph_metrics.append(metric_info)
 
         joinable_pairs = []
-        model_names = list(graph_obj.models.keys())
+        model_names = [model_name for model_name in graph_obj.models if model_name in visible_model_names]
         for index, left_name in enumerate(model_names):
             for right_name in model_names[index + 1 :]:
                 try:

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -378,7 +378,7 @@ def create_app(
     @app.get("/graph", dependencies=[Depends(require_auth)])
     def graph() -> dict[str, Any]:
         # Read-only metadata over the in-memory graph.
-        from sidemantic.core.consumption import serialize_consumption_contract
+        from sidemantic.core.consumption import graph_metric_is_public, serialize_consumption_contract
 
         current_layer = app.state.layer
         graph_obj = current_layer.graph
@@ -409,9 +409,7 @@ def create_app(
 
         graph_metrics = []
         for metric_name, metric in graph_obj.metrics.items():
-            if getattr(current_layer, "enforce_visibility", False) and (
-                not getattr(metric, "public", True) or metric.visibility != "public"
-            ):
+            if current_layer.enforce_visibility and not graph_metric_is_public(metric, graph_obj):
                 continue
             metric_info = {"name": metric_name}
             if metric.type:

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -378,6 +378,8 @@ def create_app(
     @app.get("/graph", dependencies=[Depends(require_auth)])
     def graph() -> dict[str, Any]:
         # Read-only metadata over the in-memory graph.
+        from sidemantic.core.consumption import serialize_consumption_contract
+
         current_layer = app.state.layer
         graph_obj = current_layer.graph
         visible_model_names = {
@@ -434,33 +436,57 @@ def create_app(
         if graph_metrics:
             payload["graph_metrics"] = graph_metrics
         payload["explores"] = [
-            value.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+            serialized
             for value in graph_obj.explores.values()
-            if not current_layer.enforce_visibility or value.visibility == "public"
+            if (
+                serialized := serialize_consumption_contract(
+                    value, graph_obj, enforce_visibility=current_layer.enforce_visibility
+                )
+            )
+            is not None
         ]
         payload["saved_queries"] = [
-            value.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+            serialized
             for value in graph_obj.saved_queries.values()
-            if not current_layer.enforce_visibility or value.visibility == "public"
+            if (
+                serialized := serialize_consumption_contract(
+                    value, graph_obj, enforce_visibility=current_layer.enforce_visibility
+                )
+            )
+            is not None
         ]
         return payload
 
     @app.get("/explores", dependencies=[Depends(require_auth)])
     def list_explores() -> list[dict[str, Any]]:
+        from sidemantic.core.consumption import serialize_consumption_contract
+
         current_layer = app.state.layer
         return [
-            value.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+            serialized
             for value in current_layer.graph.explores.values()
-            if not current_layer.enforce_visibility or value.visibility == "public"
+            if (
+                serialized := serialize_consumption_contract(
+                    value, current_layer.graph, enforce_visibility=current_layer.enforce_visibility
+                )
+            )
+            is not None
         ]
 
     @app.get("/saved-queries", dependencies=[Depends(require_auth)])
     def list_saved_queries() -> list[dict[str, Any]]:
+        from sidemantic.core.consumption import serialize_consumption_contract
+
         current_layer = app.state.layer
         return [
-            value.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+            serialized
             for value in current_layer.graph.saved_queries.values()
-            if not current_layer.enforce_visibility or value.visibility == "public"
+            if (
+                serialized := serialize_consumption_contract(
+                    value, current_layer.graph, enforce_visibility=current_layer.enforce_visibility
+                )
+            )
+            is not None
         ]
 
     @app.get("/describe", dependencies=[Depends(require_auth)])

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -405,7 +405,9 @@ def create_app(
                 ],
             }
             if model.segments:
-                model_info["segments"] = [segment.name for segment in model.segments]
+                model_info["segments"] = [
+                    segment.name for segment in model.segments if not current_layer.enforce_visibility or segment.public
+                ]
             models.append(model_info)
 
         graph_metrics = []

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -87,6 +87,7 @@ class StructuredQueryRequest(BaseModel):
             or self.offset is not None
             or self.ungrouped
             or self.parameters is not None
+            or self.timezone is not None
         ):
             raise ValueError("saved_query cannot be combined with structured query overrides")
         return self

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -53,16 +53,31 @@ class StructuredQueryRequest(BaseModel):
     explore: str | None = None
     saved_query: str | None = None
 
-    def resolved_filters(self) -> list[str]:
+    def optional_list(self, field_name: str) -> list[str] | None:
+        """Preserve an explicitly supplied empty list while treating omission as unset."""
+        if field_name not in self.model_fields_set:
+            return None
+        return getattr(self, field_name)
+
+    def resolved_filters(self) -> list[str] | None:
         filters = list(self.filters)
+        supplied = "filters" in self.model_fields_set
         if self.where:
             filters.append(self.where)
-        return filters
+            supplied = True
+        return filters if supplied else None
 
     @model_validator(mode="after")
     def validate_saved_query_contract(self) -> StructuredQueryRequest:
+        explicit_list_overrides = self.model_fields_set & {
+            "dimensions",
+            "metrics",
+            "filters",
+            "segments",
+            "order_by",
+        }
         if self.saved_query and (
-            self.dimensions
+            explicit_list_overrides
             or self.metrics
             or self.where is not None
             or self.filters
@@ -465,14 +480,14 @@ def create_app(
         current_layer = app.state.layer
         user_attributes = resolve_user_attributes(request)
         filters = payload.resolved_filters()
-        for filter_str in filters:
+        for filter_str in filters or []:
             validate_filter_expression(filter_str, dialect=current_layer.dialect)
         sql = current_layer.compile(
-            dimensions=payload.dimensions or None,
-            metrics=payload.metrics or None,
-            filters=filters or None,
-            segments=payload.segments or None,
-            order_by=payload.order_by or None,
+            dimensions=payload.optional_list("dimensions"),
+            metrics=payload.optional_list("metrics"),
+            filters=filters,
+            segments=payload.optional_list("segments"),
+            order_by=payload.optional_list("order_by"),
             limit=payload.limit,
             offset=payload.offset,
             ungrouped=payload.ungrouped,
@@ -497,14 +512,14 @@ def create_app(
         current_layer = app.state.layer
         user_attributes = resolve_user_attributes(request)
         filters = payload.resolved_filters()
-        for filter_str in filters:
+        for filter_str in filters or []:
             validate_filter_expression(filter_str, dialect=current_layer.dialect)
         sql = current_layer.compile(
-            dimensions=payload.dimensions or None,
-            metrics=payload.metrics or None,
-            filters=filters or None,
-            segments=payload.segments or None,
-            order_by=payload.order_by or None,
+            dimensions=payload.optional_list("dimensions"),
+            metrics=payload.optional_list("metrics"),
+            filters=filters,
+            segments=payload.optional_list("segments"),
+            order_by=payload.optional_list("order_by"),
             limit=payload.limit,
             offset=payload.offset,
             ungrouped=payload.ungrouped,

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -12,7 +12,7 @@ try:
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import JSONResponse, Response
     from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-    from pydantic import BaseModel, ConfigDict, Field
+    from pydantic import BaseModel, ConfigDict, Field, model_validator
     from starlette.middleware.base import BaseHTTPMiddleware
 except ImportError as exc:
     raise ImportError("HTTP API support requires FastAPI. Install with: uv add 'sidemantic[api]'") from exc
@@ -50,12 +50,31 @@ class StructuredQueryRequest(BaseModel):
     parameters: dict[str, Any] | None = None
     use_preaggregations: bool | None = None
     timezone: str | None = None
+    explore: str | None = None
+    saved_query: str | None = None
 
     def resolved_filters(self) -> list[str]:
         filters = list(self.filters)
         if self.where:
             filters.append(self.where)
         return filters
+
+    @model_validator(mode="after")
+    def validate_saved_query_contract(self) -> StructuredQueryRequest:
+        if self.saved_query and (
+            self.dimensions
+            or self.metrics
+            or self.where is not None
+            or self.filters
+            or self.segments
+            or self.order_by
+            or self.limit is not None
+            or self.offset is not None
+            or self.ungrouped
+            or self.parameters is not None
+        ):
+            raise ValueError("saved_query cannot be combined with structured query overrides")
+        return self
 
 
 class SQLRequest(BaseModel):
@@ -313,7 +332,7 @@ def create_app(
 
     def _visible_metrics(layer, model) -> list:
         if getattr(layer, "enforce_visibility", False):
-            return [m for m in model.metrics if getattr(m, "public", True)]
+            return [m for m in model.metrics if getattr(m, "public", True) and m.visibility == "public"]
         return list(model.metrics)
 
     @app.get("/models", dependencies=[Depends(require_auth)])
@@ -323,6 +342,8 @@ def create_app(
         current_layer = app.state.layer
         models = []
         for model_name, model in current_layer.graph.models.items():
+            if current_layer.enforce_visibility and model.visibility != "public":
+                continue
             models.append(
                 {
                     "name": model_name,
@@ -330,6 +351,11 @@ def create_app(
                     "dimensions": [d.name for d in _visible_dimensions(current_layer, model)],
                     "metrics": [m.name for m in _visible_metrics(current_layer, model)],
                     "relationships": len(model.relationships),
+                    "owner": model.owner,
+                    "domain": model.domain,
+                    "status": model.status,
+                    "certification": model.certification,
+                    "visibility": model.visibility,
                 }
             )
         return models
@@ -342,6 +368,8 @@ def create_app(
 
         models = []
         for model_name, model in graph_obj.models.items():
+            if current_layer.enforce_visibility and model.visibility != "public":
+                continue
             model_info = {
                 "name": model_name,
                 "table": model.table,
@@ -355,7 +383,9 @@ def create_app(
 
         graph_metrics = []
         for metric_name, metric in graph_obj.metrics.items():
-            if getattr(current_layer, "enforce_visibility", False) and not getattr(metric, "public", True):
+            if getattr(current_layer, "enforce_visibility", False) and (
+                not getattr(metric, "public", True) or metric.visibility != "public"
+            ):
                 continue
             metric_info = {"name": metric_name}
             if metric.type:
@@ -379,7 +409,35 @@ def create_app(
         payload: dict[str, Any] = {"models": models, "joinable_pairs": joinable_pairs}
         if graph_metrics:
             payload["graph_metrics"] = graph_metrics
+        payload["explores"] = [
+            value.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+            for value in graph_obj.explores.values()
+            if not current_layer.enforce_visibility or value.visibility == "public"
+        ]
+        payload["saved_queries"] = [
+            value.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+            for value in graph_obj.saved_queries.values()
+            if not current_layer.enforce_visibility or value.visibility == "public"
+        ]
         return payload
+
+    @app.get("/explores", dependencies=[Depends(require_auth)])
+    def list_explores() -> list[dict[str, Any]]:
+        current_layer = app.state.layer
+        return [
+            value.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+            for value in current_layer.graph.explores.values()
+            if not current_layer.enforce_visibility or value.visibility == "public"
+        ]
+
+    @app.get("/saved-queries", dependencies=[Depends(require_auth)])
+    def list_saved_queries() -> list[dict[str, Any]]:
+        current_layer = app.state.layer
+        return [
+            value.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+            for value in current_layer.graph.saved_queries.values()
+            if not current_layer.enforce_visibility or value.visibility == "public"
+        ]
 
     @app.get("/describe", dependencies=[Depends(require_auth)])
     def describe() -> dict[str, Any]:
@@ -410,9 +468,9 @@ def create_app(
         for filter_str in filters:
             validate_filter_expression(filter_str, dialect=current_layer.dialect)
         sql = current_layer.compile(
-            dimensions=payload.dimensions,
-            metrics=payload.metrics,
-            filters=filters,
+            dimensions=payload.dimensions or None,
+            metrics=payload.metrics or None,
+            filters=filters or None,
             segments=payload.segments or None,
             order_by=payload.order_by or None,
             limit=payload.limit,
@@ -422,6 +480,8 @@ def create_app(
             use_preaggregations=payload.use_preaggregations,
             user_attributes=user_attributes,
             timezone=payload.timezone,
+            explore=payload.explore,
+            saved_query=payload.saved_query,
         )
         return {"sql": sql}
 
@@ -440,9 +500,9 @@ def create_app(
         for filter_str in filters:
             validate_filter_expression(filter_str, dialect=current_layer.dialect)
         sql = current_layer.compile(
-            dimensions=payload.dimensions,
-            metrics=payload.metrics,
-            filters=filters,
+            dimensions=payload.dimensions or None,
+            metrics=payload.metrics or None,
+            filters=filters or None,
             segments=payload.segments or None,
             order_by=payload.order_by or None,
             limit=payload.limit,
@@ -452,6 +512,8 @@ def create_app(
             use_preaggregations=payload.use_preaggregations,
             user_attributes=user_attributes,
             timezone=payload.timezone,
+            explore=payload.explore,
+            saved_query=payload.saved_query,
         )
         table = _query_table(app, current_layer, sql, user_attributes=user_attributes)
         return _build_query_response(request, current_layer, table, sql=sql, format_override=format)

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -696,8 +696,9 @@ def _migration_queries(queries: Path | None) -> Path:
             resolved = project.root / resolved
     resolved = resolved.resolve()
     if not resolved.exists():
+        display_path = queries if queries is not None else resolved
         raise typer.BadParameter(
-            f"Query source not found: {resolved}",
+            f"Query source not found: {display_path}",
             param_hint="QUERIES",
         )
     return resolved

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -1304,7 +1304,16 @@ def query(
                 "use_preaggregations": use_preaggregations,
             }
             if dry_run:
-                emit_result(layer.compile(**query_kwargs))
+                compiled_sql = layer.compile(**query_kwargs)
+                if cli_state().format_explicit and output_format in {"csv", "json", "jsonl"}:
+                    emit_records(
+                        [{"sql": compiled_sql}],
+                        columns=("sql",),
+                        output_format=output_format,
+                        json_value={"sql": compiled_sql},
+                    )
+                else:
+                    emit_result(compiled_sql)
                 return
             result = layer.query(**query_kwargs)
             columns = [desc[0] for desc in result.description]

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -811,8 +811,21 @@ def info(
                 "metrics": len(model.metrics),
                 "relationships": len(model.relationships),
                 "connected_to": [relationship.name for relationship in model.relationships],
+                "owner": model.owner,
+                "domain": model.domain,
+                "status": model.status,
+                "certification": model.certification,
+                "visibility": model.visibility,
             }
             for model_name, model in sorted(layer.graph.models.items())
+        ]
+        explores_payload = [
+            explore.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+            for _, explore in sorted(layer.graph.explores.items())
+        ]
+        saved_queries_payload = [
+            saved.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+            for _, saved in sorted(layer.graph.saved_queries.items())
         ]
 
         if structured:
@@ -820,7 +833,12 @@ def info(
                 models_payload,
                 columns=("name", "table", "dimensions", "metrics", "relationships", "connected_to"),
                 output_format=output_format,
-                json_value={"path": str(directory), "models": models_payload},
+                json_value={
+                    "path": str(directory),
+                    "models": models_payload,
+                    "explores": explores_payload,
+                    "saved_queries": saved_queries_payload,
+                },
             )
             return
 
@@ -841,7 +859,23 @@ def info(
             )
             if model["connected_to"]:
                 lines.append(f"  Connected to: {', '.join(model['connected_to'])}")
+            governance = [
+                f"{key}={model[key]}"
+                for key in ("owner", "domain", "status", "certification", "visibility")
+                if model[key] is not None and not (key == "visibility" and model[key] == "public")
+            ]
+            if governance:
+                lines.append(f"  Governance: {', '.join(governance)}")
             lines.append("")
+        if explores_payload:
+            lines.append("Explores:")
+            for explore in explores_payload:
+                lines.append(f"  - {explore['name']} (model: {explore['model']})")
+            lines.append("")
+        if saved_queries_payload:
+            lines.append("Saved queries:")
+            for saved in saved_queries_payload:
+                lines.append(f"  - {saved['name']}")
         _emit_long_report("\n".join(lines).rstrip())
 
     except typer.Exit:
@@ -1199,7 +1233,7 @@ def export_native(
 
 @app.command(epilog=GROUP_EPILOG)
 def query(
-    sql: str = typer.Argument(..., help="SQL query to execute, or - to read from stdin"),
+    sql: str = typer.Argument(None, help="SQL query to execute, or - to read from stdin"),
     models: Path = typer.Option(None, "--models", "-m", help="Directory containing semantic layer files"),
     output: Path = typer.Option(None, "--output", "-o", help="Output file (default: stdout)"),
     connection: str = typer.Option(
@@ -1212,6 +1246,13 @@ def query(
     use_preaggregations: bool = typer.Option(
         False, "--use-preaggregations", help="Enable automatic pre-aggregation routing"
     ),
+    explore: str = typer.Option(None, "--explore", help="Run through a curated Explore/View contract"),
+    saved_query: str = typer.Option(None, "--saved-query", help="Execute an immutable SavedQuery contract"),
+    metric: list[str] | None = typer.Option(None, "--metric", help="Metric for --explore (repeatable)"),
+    dimension: list[str] | None = typer.Option(None, "--dimension", help="Dimension for --explore (repeatable)"),
+    query_filter: list[str] | None = typer.Option(None, "--filter", help="Filter for --explore (repeatable)"),
+    order_by: list[str] | None = typer.Option(None, "--order-by", help="Ordering for --explore (repeatable)"),
+    limit: int = typer.Option(None, "--limit", min=0, help="Row limit for --explore"),
 ):
     """
     Execute a SQL query and output results as CSV.
@@ -1224,10 +1265,23 @@ def query(
       sidemantic query "SELECT revenue FROM orders" --db data.duckdb
       sidemantic query "SELECT revenue FROM orders" --dry-run
       sidemantic query "SELECT revenue FROM orders" --use-preaggregations --dry-run
+      sidemantic query --explore revenue_overview --dry-run
+      sidemantic query --saved-query monthly_revenue
     """
     try:
         output_format = resolve_output_format(default="csv")
-        sql = read_sql_input(sql)
+        if sql is None and not explore and not saved_query:
+            raise typer.BadParameter("SQL is required unless --explore or --saved-query is used")
+        if sql is not None and (explore or saved_query):
+            raise typer.BadParameter("SQL cannot be combined with --explore or --saved-query")
+        if saved_query and (
+            metric is not None
+            or dimension is not None
+            or query_filter is not None
+            or order_by is not None
+            or limit is not None
+        ):
+            raise typer.BadParameter("--saved-query cannot be combined with query overrides")
         layer = _load_query_layer(
             models,
             connection=connection,
@@ -1236,6 +1290,32 @@ def query(
             engine=engine,
             fallback=fallback,
         )
+
+        if explore or saved_query:
+            query_kwargs = {
+                "metrics": metric,
+                "dimensions": dimension,
+                "filters": query_filter,
+                "order_by": order_by,
+                "limit": limit,
+                "explore": explore,
+                "saved_query": saved_query,
+                "use_preaggregations": use_preaggregations,
+            }
+            if dry_run:
+                emit_result(layer.compile(**query_kwargs))
+                return
+            result = layer.query(**query_kwargs)
+            columns = [desc[0] for desc in result.description]
+            rows = result.fetchall()
+            rendered = render_rows(rows, columns=columns, output_format=output_format)
+            write_text_output(output, rendered)
+            if output and str(output) != "-":
+                emit_diagnostic(f"Results written to {output}")
+            return
+
+        assert sql is not None
+        sql = read_sql_input(sql)
 
         # Dry run: show generated SQL without executing
         if dry_run:

--- a/sidemantic/cli_contract.py
+++ b/sidemantic/cli_contract.py
@@ -542,10 +542,16 @@ def configure_click_color(ctx: click.Context, *, enabled: bool) -> None:
     it.
     """
 
-    if not enabled:
-        ctx.color = False
-    elif os.environ.get("FORCE_COLOR", ""):
-        ctx.color = True
+    forced = bool(os.environ.get("FORCE_COLOR", ""))
+    resolved = forced or (enabled and is_terminal(sys.stdout))
+    ctx.color = resolved
+
+    # Typer snapshots GitHub Actions into a module-level ``FORCE_TERMINAL``
+    # setting at import time, bypassing Click's per-invocation color decision.
+    # Keep Rich help on the same contract while still allowing FORCE_COLOR.
+    import typer.rich_utils as typer_rich_utils
+
+    typer_rich_utils.FORCE_TERMINAL = resolved
 
 
 def _env_truthy(name: str) -> bool:

--- a/sidemantic/core/catalog.py
+++ b/sidemantic/core/catalog.py
@@ -9,7 +9,7 @@ Key design:
 - This matches Cube.dev's approach where metrics are queryable as columns
 """
 
-from sidemantic.core.consumption import serialize_consumption_contract
+from sidemantic.core.consumption import graph_metric_is_public, serialize_consumption_contract
 from sidemantic.core.governance import governance_dict
 from sidemantic.core.semantic_graph import SemanticGraph
 
@@ -321,7 +321,7 @@ def get_catalog_metadata(graph: SemanticGraph, schema: str = "public", enforce_v
             **governance_dict(metric),
         }
         for metric in graph.metrics.values()
-        if not enforce_visibility or (metric.public and metric.visibility == "public")
+        if not enforce_visibility or graph_metric_is_public(metric, graph)
     ]
     return {
         "tables": tables,

--- a/sidemantic/core/catalog.py
+++ b/sidemantic/core/catalog.py
@@ -9,6 +9,7 @@ Key design:
 - This matches Cube.dev's approach where metrics are queryable as columns
 """
 
+from sidemantic.core.governance import governance_dict
 from sidemantic.core.semantic_graph import SemanticGraph
 
 
@@ -103,17 +104,19 @@ def get_catalog_metadata(graph: SemanticGraph, schema: str = "public", enforce_v
     key_column_usage = []
 
     for model_name, model in graph.models.items():
+        if enforce_visibility and model.visibility != "public":
+            continue
         # Add table entry
-        tables.append(
-            {
-                "table_catalog": "sidemantic",
-                "table_schema": schema,
-                "table_name": model.name,
-                "table_type": "BASE TABLE",
-                "is_insertable_into": "NO",  # Read-only semantic layer
-                "is_typed": "NO",
-            }
-        )
+        table_meta = {
+            "table_catalog": "sidemantic",
+            "table_schema": schema,
+            "table_name": model.name,
+            "table_type": "BASE TABLE",
+            "is_insertable_into": "NO",  # Read-only semantic layer
+            "is_typed": "NO",
+        }
+        table_meta.update(governance_dict(model))
+        tables.append(table_meta)
 
         ordinal = 1
 
@@ -210,7 +213,7 @@ def get_catalog_metadata(graph: SemanticGraph, schema: str = "public", enforce_v
         # The semantic layer handles the aggregation behind the scenes
         for metric in model.metrics:
             # Omit non-public metrics when visibility enforcement is on.
-            if enforce_visibility and not metric.public:
+            if enforce_visibility and (not metric.public or metric.visibility != "public"):
                 continue
 
             data_type = get_postgres_type_for_metric(metric.agg)
@@ -238,6 +241,7 @@ def get_catalog_metadata(graph: SemanticGraph, schema: str = "public", enforce_v
                 col_meta["description"] = metric.description
             if metric.label:
                 col_meta["label"] = metric.label
+            col_meta.update(governance_dict(metric))
 
             columns.append(col_meta)
             ordinal += 1
@@ -289,9 +293,32 @@ def get_catalog_metadata(graph: SemanticGraph, schema: str = "public", enforce_v
                         col["is_foreign_key"] = True
                         break
 
+    explores = [
+        explore.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+        for explore in graph.explores.values()
+        if not enforce_visibility or explore.visibility == "public"
+    ]
+    saved_queries = [
+        saved_query.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+        for saved_query in graph.saved_queries.values()
+        if not enforce_visibility or saved_query.visibility == "public"
+    ]
+    graph_metrics = [
+        {
+            "name": metric.name,
+            "type": metric.type,
+            "description": metric.description,
+            **governance_dict(metric),
+        }
+        for metric in graph.metrics.values()
+        if not enforce_visibility or (metric.public and metric.visibility == "public")
+    ]
     return {
         "tables": tables,
         "columns": columns,
         "constraints": constraints,
         "key_column_usage": key_column_usage,
+        "semantic_metrics": graph_metrics,
+        "explores": explores,
+        "saved_queries": saved_queries,
     }

--- a/sidemantic/core/catalog.py
+++ b/sidemantic/core/catalog.py
@@ -9,6 +9,7 @@ Key design:
 - This matches Cube.dev's approach where metrics are queryable as columns
 """
 
+from sidemantic.core.consumption import serialize_consumption_contract
 from sidemantic.core.governance import governance_dict
 from sidemantic.core.semantic_graph import SemanticGraph
 
@@ -301,14 +302,16 @@ def get_catalog_metadata(graph: SemanticGraph, schema: str = "public", enforce_v
                         break
 
     explores = [
-        explore.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+        serialized
         for explore in graph.explores.values()
-        if not enforce_visibility or explore.visibility == "public"
+        if (serialized := serialize_consumption_contract(explore, graph, enforce_visibility=enforce_visibility))
+        is not None
     ]
     saved_queries = [
-        saved_query.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+        serialized
         for saved_query in graph.saved_queries.values()
-        if not enforce_visibility or saved_query.visibility == "public"
+        if (serialized := serialize_consumption_contract(saved_query, graph, enforce_visibility=enforce_visibility))
+        is not None
     ]
     graph_metrics = [
         {

--- a/sidemantic/core/catalog.py
+++ b/sidemantic/core/catalog.py
@@ -102,9 +102,14 @@ def get_catalog_metadata(graph: SemanticGraph, schema: str = "public", enforce_v
     columns = []
     constraints = []
     key_column_usage = []
+    visible_model_names = {
+        model_name
+        for model_name, model in graph.models.items()
+        if not enforce_visibility or model.visibility == "public"
+    }
 
     for model_name, model in graph.models.items():
-        if enforce_visibility and model.visibility != "public":
+        if model_name not in visible_model_names:
             continue
         # Add table entry
         table_meta = {
@@ -248,6 +253,8 @@ def get_catalog_metadata(graph: SemanticGraph, schema: str = "public", enforce_v
 
         # Add foreign key constraints from relationships
         for rel in model.relationships:
+            if rel.name not in visible_model_names:
+                continue
             if rel.type in ("many_to_one", "one_to_one"):
                 # This model has a foreign key to another model
                 fk_column = rel.foreign_key

--- a/sidemantic/core/consumption.py
+++ b/sidemantic/core/consumption.py
@@ -21,6 +21,8 @@ def expression_field_references(
     for expression in expressions:
         parsed = parse_one(expression)
         for column in parsed.find_all(exp.Column):
+            if column.find_ancestor(exp.Select, exp.Subquery) is not None:
+                continue
             if column.table:
                 references.add(f"{column.table}.{column.name}")
             elif column.name in graph_metrics:
@@ -44,7 +46,12 @@ def qualify_expression_fields(
         parsed = parse_one(expression)
 
         def qualify_column(node: exp.Expression) -> exp.Expression:
-            if not isinstance(node, exp.Column) or node.table or node.name in graph_metrics:
+            if (
+                not isinstance(node, exp.Column)
+                or node.table
+                or node.name in graph_metrics
+                or node.find_ancestor(exp.Select, exp.Subquery) is not None
+            ):
                 return node
             result = node.copy()
             result.set("table", exp.to_identifier(base_model))

--- a/sidemantic/core/consumption.py
+++ b/sidemantic/core/consumption.py
@@ -117,12 +117,27 @@ class SavedQuery(GovernedObject):
     metadata: dict[str, Any] | None = Field(None, description="Source-adapter metadata for lossless round-tripping")
 
 
+def graph_metric_is_public(metric: Any, graph: Any) -> bool:
+    """Return whether a graph metric and every source model it queries are public."""
+    if not metric.public or metric.visibility != "public":
+        return False
+
+    # Use the same dependency/source resolution as SQL generation so derived and
+    # ratio metrics cannot hide a private model behind a public graph-level name.
+    from sidemantic.sql.generator import SQLGenerator
+
+    source_models = SQLGenerator(graph)._find_required_models([metric.name], [], metric.filters)
+    return all(
+        (model := graph.models.get(model_name)) is not None and model.visibility == "public"
+        for model_name in source_models
+    )
+
+
 def _semantic_reference_is_public(
     reference: str, base_model: str, graph: Any, *, prefer_graph_metric: bool = False
 ) -> bool:
     if prefer_graph_metric and reference in graph.metrics:
-        metric = graph.metrics[reference]
-        return metric.public and metric.visibility == "public"
+        return graph_metric_is_public(graph.metrics[reference], graph)
     if "." not in reference:
         if not base_model:
             return False

--- a/sidemantic/core/consumption.py
+++ b/sidemantic/core/consumption.py
@@ -30,6 +30,55 @@ def expression_field_references(
     return references
 
 
+def qualify_expression_fields(
+    expressions: Collection[str],
+    base_model: str,
+    *,
+    graph_metrics: Collection[str] = (),
+) -> list[str]:
+    """Qualify bare semantic fields in SQL-like contract expressions."""
+    from sqlglot import exp, parse_one
+
+    qualified: list[str] = []
+    for expression in expressions:
+        parsed = parse_one(expression)
+
+        def qualify_column(node: exp.Expression) -> exp.Expression:
+            if not isinstance(node, exp.Column) or node.table or node.name in graph_metrics:
+                return node
+            result = node.copy()
+            result.set("table", exp.to_identifier(base_model))
+            return result
+
+        qualified.append(parsed.transform(qualify_column).sql())
+    return qualified
+
+
+def qualify_order_by_fields(
+    expressions: Collection[str],
+    base_model: str,
+    *,
+    graph_metrics: Collection[str] = (),
+) -> list[str]:
+    """Qualify bare semantic fields while preserving ORDER BY direction."""
+    from sqlglot import exp, parse_one
+
+    qualified: list[str] = []
+    for expression in expressions:
+        statement = parse_one(f"SELECT 1 ORDER BY {expression}")
+        ordered = statement.args["order"].expressions
+
+        def qualify_column(node: exp.Expression) -> exp.Expression:
+            if not isinstance(node, exp.Column) or node.table or node.name in graph_metrics:
+                return node
+            result = node.copy()
+            result.set("table", exp.to_identifier(base_model))
+            return result
+
+        qualified.extend(item.transform(qualify_column).sql() for item in ordered)
+    return qualified
+
+
 class Explore(GovernedObject):
     """Curated entrypoint over one or more models in the semantic graph.
 

--- a/sidemantic/core/consumption.py
+++ b/sidemantic/core/consumption.py
@@ -13,16 +13,27 @@ def expression_field_references(
     base_model: str,
     *,
     graph_metrics: Collection[str] = (),
+    graph_models: Collection[str] = (),
 ) -> set[str]:
     """Extract and qualify semantic field references from SQL-like expressions."""
     from sqlglot import exp, parse_one
 
     references: set[str] = set()
+    semantic_tables = {base_model, *graph_models}
     for expression in expressions:
         parsed = parse_one(expression)
         for column in parsed.find_all(exp.Column):
-            if column.find_ancestor(exp.Select, exp.Subquery) is not None:
-                continue
+            select = column.find_ancestor(exp.Select)
+            if select is not None and column.table not in semantic_tables:
+                if not column.table:
+                    continue
+                local_tables: set[str] = set()
+                for table in select.find_all(exp.Table):
+                    if table.find_ancestor(exp.Select) is select:
+                        local_tables.add(table.name)
+                        local_tables.add(table.alias_or_name)
+                if column.table in local_tables:
+                    continue
             if column.table:
                 references.add(f"{column.table}.{column.name}")
             elif column.name in graph_metrics:
@@ -214,7 +225,12 @@ def _semantic_reference_is_public(
 
 def _expressions_are_public(expressions: Collection[str], base_model: str, graph: Any) -> bool:
     try:
-        references = expression_field_references(expressions, base_model, graph_metrics=graph.metrics.keys())
+        references = expression_field_references(
+            expressions,
+            base_model,
+            graph_metrics=graph.metrics.keys(),
+            graph_models=graph.models.keys(),
+        )
     except Exception:
         return False
     return all(

--- a/sidemantic/core/consumption.py
+++ b/sidemantic/core/consumption.py
@@ -115,3 +115,107 @@ class SavedQuery(GovernedObject):
     limit: int | None = Field(None, ge=0)
     parameters: dict[str, Any] | None = None
     metadata: dict[str, Any] | None = Field(None, description="Source-adapter metadata for lossless round-tripping")
+
+
+def _semantic_reference_is_public(
+    reference: str, base_model: str, graph: Any, *, prefer_graph_metric: bool = False
+) -> bool:
+    if prefer_graph_metric and reference in graph.metrics:
+        metric = graph.metrics[reference]
+        return metric.public and metric.visibility == "public"
+    if "." not in reference:
+        if not base_model:
+            return False
+        reference = f"{base_model}.{reference}"
+    model_name, field_name = reference.split(".", 1)
+    field_name = field_name.rsplit("__", 1)[0]
+    model = graph.models.get(model_name)
+    if model is None or model.visibility != "public":
+        return False
+    dimension = model.get_dimension(field_name)
+    if dimension is not None:
+        return dimension.public
+    metric = model.get_metric(field_name)
+    if metric is not None:
+        return metric.public and metric.visibility == "public"
+    return False
+
+
+def _expressions_are_public(expressions: Collection[str], base_model: str, graph: Any) -> bool:
+    try:
+        references = expression_field_references(expressions, base_model, graph_metrics=graph.metrics.keys())
+    except Exception:
+        return False
+    return all(
+        _semantic_reference_is_public(reference, base_model, graph, prefer_graph_metric=True)
+        for reference in references
+    )
+
+
+def consumption_contract_is_public(value: Explore | SavedQuery, graph: Any) -> bool:
+    """Return whether a contract can be safely discovered with visibility enforcement."""
+    if value.visibility != "public":
+        return False
+    if isinstance(value, Explore):
+        model = graph.models.get(value.model)
+        if model is None or model.visibility != "public":
+            return False
+        dimension_references = [*(value.allowed_dimensions or []), *value.default_dimensions]
+        metric_references = [*(value.allowed_metrics or []), *value.default_metrics]
+        flexible_references = [*(value.allowed_filter_fields or []), *(value.allowed_order_by or [])]
+        return (
+            all(_semantic_reference_is_public(reference, value.model, graph) for reference in dimension_references)
+            and all(
+                _semantic_reference_is_public(reference, value.model, graph, prefer_graph_metric=True)
+                for reference in metric_references
+            )
+            and all(
+                _semantic_reference_is_public(reference, value.model, graph, prefer_graph_metric=True)
+                for reference in flexible_references
+            )
+            and _expressions_are_public(
+                [*value.filters, *value.default_filters, *value.default_order_by], value.model, graph
+            )
+        )
+
+    base_model = ""
+    if value.explore:
+        explore = graph.explores.get(value.explore)
+        if explore is None or not consumption_contract_is_public(explore, graph):
+            return False
+        base_model = explore.model
+    if not all(_semantic_reference_is_public(reference, base_model, graph) for reference in value.dimensions):
+        return False
+    if not all(
+        _semantic_reference_is_public(reference, base_model, graph, prefer_graph_metric=True)
+        for reference in value.metrics
+    ):
+        return False
+    if not _expressions_are_public([*value.filters, *value.order_by], base_model, graph):
+        return False
+    for raw_segment in value.segments:
+        segment_ref = (
+            raw_segment if "." in raw_segment else f"{base_model}.{raw_segment}" if base_model else raw_segment
+        )
+        if "." not in segment_ref:
+            return False
+        model_name, segment_name = segment_ref.split(".", 1)
+        model = graph.models.get(model_name)
+        segment = model.get_segment(segment_name) if model is not None and model.visibility == "public" else None
+        if segment is None or not segment.public:
+            return False
+    return True
+
+
+def serialize_consumption_contract(
+    value: Explore | SavedQuery, graph: Any, *, enforce_visibility: bool = False
+) -> dict[str, Any] | None:
+    """Serialize a contract, omitting unsafe contracts and adapter metadata when visibility is enforced."""
+    if enforce_visibility and not consumption_contract_is_public(value, graph):
+        return None
+    return value.model_dump(
+        exclude={"metadata"} if enforce_visibility else None,
+        exclude_none=True,
+        exclude_defaults=True,
+        mode="json",
+    )

--- a/sidemantic/core/consumption.py
+++ b/sidemantic/core/consumption.py
@@ -1,0 +1,117 @@
+"""Curated semantic consumption contracts."""
+
+from collections.abc import Collection
+from typing import Any
+
+from pydantic import ConfigDict, Field, model_validator
+
+from sidemantic.core.governance import GovernedObject
+
+
+def expression_field_references(
+    expressions: Collection[str],
+    base_model: str,
+    *,
+    graph_metrics: Collection[str] = (),
+) -> set[str]:
+    """Extract and qualify semantic field references from SQL-like expressions."""
+    from sqlglot import exp, parse_one
+
+    references: set[str] = set()
+    for expression in expressions:
+        parsed = parse_one(expression)
+        for column in parsed.find_all(exp.Column):
+            if column.table:
+                references.add(f"{column.table}.{column.name}")
+            elif column.name in graph_metrics:
+                references.add(column.name)
+            else:
+                references.add(f"{base_model}.{column.name}")
+    return references
+
+
+class Explore(GovernedObject):
+    """Curated entrypoint over one or more models in the semantic graph.
+
+    ``model`` names the base model. Allowed fields constrain callers, defaults
+    populate omitted selections, and ``filters`` are mandatory for every query.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., description="Unique explore name")
+    model: str = Field(..., description="Base model in the physical semantic graph")
+    label: str | None = Field(None, description="Display label")
+    description: str | None = Field(None, description="Human-readable description")
+    allowed_dimensions: list[str] | None = Field(
+        None, description="Dimension allowlist; null means every graph dimension is allowed"
+    )
+    allowed_metrics: list[str] | None = Field(
+        None, description="Metric allowlist; null means every graph metric is allowed"
+    )
+    allowed_filter_fields: list[str] | None = Field(
+        None, description="Field allowlist for caller-supplied filters; null means unrestricted"
+    )
+    allowed_order_by: list[str] | None = Field(
+        None, description="Field allowlist for caller-supplied ordering; null means unrestricted"
+    )
+    default_dimensions: list[str] = Field(default_factory=list)
+    default_metrics: list[str] = Field(default_factory=list)
+    filters: list[str] = Field(default_factory=list, description="Mandatory filters applied to every query")
+    default_filters: list[str] = Field(default_factory=list, description="Filters used when callers omit filters")
+    default_order_by: list[str] = Field(default_factory=list)
+    default_limit: int | None = Field(None, ge=0)
+    max_limit: int | None = Field(None, ge=0)
+    metadata: dict[str, Any] | None = Field(None, description="Source-adapter metadata for lossless round-tripping")
+
+    @model_validator(mode="after")
+    def validate_defaults(self) -> "Explore":
+        def qualify(value: str) -> str:
+            return value if "." in value else f"{self.model}.{value}"
+
+        if self.allowed_dimensions is not None:
+            allowed = {qualify(value) for value in self.allowed_dimensions}
+            outside = sorted(value for value in self.default_dimensions if qualify(value) not in allowed)
+            if outside:
+                raise ValueError(f"default_dimensions are not allowed: {', '.join(outside)}")
+        if self.allowed_metrics is not None:
+            allowed = {qualify(value) for value in self.allowed_metrics}
+            outside = sorted(value for value in self.default_metrics if qualify(value) not in allowed)
+            if outside:
+                raise ValueError(f"default_metrics are not allowed: {', '.join(outside)}")
+        if self.allowed_filter_fields is not None:
+            allowed = {qualify(value) for value in self.allowed_filter_fields}
+            outside = sorted(expression_field_references(self.default_filters, self.model) - allowed)
+            if outside:
+                raise ValueError(f"default_filters reference fields that are not allowed: {', '.join(outside)}")
+        if self.allowed_order_by is not None:
+            allowed = {qualify(value) for value in self.allowed_order_by}
+            outside = sorted(expression_field_references(self.default_order_by, self.model) - allowed)
+            if outside:
+                raise ValueError(f"default_order_by references fields that are not allowed: {', '.join(outside)}")
+        if self.default_limit is not None and self.max_limit is not None and self.default_limit > self.max_limit:
+            raise ValueError("default_limit cannot exceed max_limit")
+        return self
+
+
+# Hex and other tools call this concept a View. Keep one schema and two names.
+View = Explore
+
+
+class SavedQuery(GovernedObject):
+    """Named, immutable structured semantic query."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., description="Unique saved-query name")
+    explore: str | None = Field(None, description="Optional Explore contract governing this query")
+    label: str | None = Field(None, description="Display label")
+    description: str | None = Field(None, description="Human-readable description")
+    dimensions: list[str] = Field(default_factory=list)
+    metrics: list[str] = Field(default_factory=list)
+    filters: list[str] = Field(default_factory=list)
+    segments: list[str] = Field(default_factory=list)
+    order_by: list[str] = Field(default_factory=list)
+    limit: int | None = Field(None, ge=0)
+    parameters: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = Field(None, description="Source-adapter metadata for lossless round-tripping")

--- a/sidemantic/core/freshness.py
+++ b/sidemantic/core/freshness.py
@@ -4,7 +4,7 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
 
 class Freshness(BaseModel):
-    """Model-level freshness policy for live chart/runtime responses.
+    """Freshness expectation for models, metrics, and curated explores.
 
     Prefer ``watermark`` for normal semantic-model usage. ``sql`` is retained as
     an advanced escape hatch when the source freshness marker cannot be expressed

--- a/sidemantic/core/governance.py
+++ b/sidemantic/core/governance.py
@@ -1,0 +1,66 @@
+"""Shared governance metadata for semantic objects."""
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from sidemantic.core.freshness import Freshness
+
+
+class Deprecation(BaseModel):
+    """Lifecycle details for a deprecated semantic object."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    message: str | None = Field(None, description="Human-readable migration guidance")
+    deprecated_at: date | None = Field(None, description="Date the object became deprecated")
+    sunset_at: date | None = Field(None, description="Date after which the object may be removed")
+    replaced_by: str | None = Field(None, description="Replacement semantic object reference")
+
+
+class GovernedObject(BaseModel):
+    """Reusable, non-enforcing governance fields.
+
+    These fields describe trust and lifecycle. They intentionally do not implement
+    authorization; model security policies remain the access-control boundary.
+    """
+
+    owner: str | None = Field(None, description="Accountable person or team")
+    domain: str | None = Field(None, description="Business domain")
+    category: str | None = Field(None, description="Catalog category")
+    tags: list[str] = Field(default_factory=list, description="Searchable catalog tags")
+    status: Literal["draft", "active", "deprecated"] | None = Field(
+        None, description="Semantic object lifecycle status"
+    )
+    certification: Literal["certified", "verified", "uncertified"] | None = Field(
+        None, description="Trust or review state"
+    )
+    deprecation: Deprecation | None = Field(None, description="Deprecation lifecycle and migration guidance")
+    freshness: Freshness | None = Field(None, description="Expected data freshness policy")
+    visibility: Literal["public", "internal", "private"] = Field(
+        "public", description="Catalog visibility; not an authorization policy"
+    )
+
+
+GOVERNANCE_FIELDS = {
+    "owner",
+    "domain",
+    "category",
+    "tags",
+    "status",
+    "certification",
+    "deprecation",
+    "freshness",
+    "visibility",
+}
+
+
+def governance_dict(value: GovernedObject) -> dict:
+    """Return non-default governance fields for metadata/catalog payloads."""
+    return value.model_dump(
+        include=GOVERNANCE_FIELDS,
+        exclude_none=True,
+        exclude_defaults=True,
+        mode="json",
+    )

--- a/sidemantic/core/introspection.py
+++ b/sidemantic/core/introspection.py
@@ -17,10 +17,13 @@ def describe_graph(
 ) -> dict[str, Any]:
     warnings = _warnings(graph)
     requested = set(model_names or [])
+    visible_model_names = {
+        model.name for model in graph.models.values() if not enforce_visibility or model.visibility == "public"
+    }
     models = [
-        _describe_model(model, warnings, enforce_visibility)
+        _describe_model(model, warnings, enforce_visibility, visible_model_names)
         for model in graph.models.values()
-        if (not requested or model.name in requested) and not (enforce_visibility and model.visibility != "public")
+        if (not requested or model.name in requested) and model.name in visible_model_names
     ]
     metrics = [
         _describe_metric(metric, warnings, model_name=None)
@@ -67,7 +70,12 @@ def _metric_owner_model(metric: Metric) -> str | None:
     return None
 
 
-def _describe_model(model: Model, warnings: list[dict[str, Any]], enforce_visibility: bool = False) -> dict[str, Any]:
+def _describe_model(
+    model: Model,
+    warnings: list[dict[str, Any]],
+    enforce_visibility: bool = False,
+    visible_model_names: set[str] | None = None,
+) -> dict[str, Any]:
     model_kind = _model_kind(model)
     dimensions = model.dimensions if not enforce_visibility else [d for d in model.dimensions if d.public]
     metrics = (
@@ -82,7 +90,9 @@ def _describe_model(model: Model, warnings: list[dict[str, Any]], enforce_visibi
         "dimensions": [_describe_dimension(dimension, warnings, model) for dimension in dimensions],
         "metrics": [_describe_metric(metric, warnings, model.name, model=model) for metric in metrics],
         "relationships": [
-            _describe_relationship(relationship, warnings, model=model) for relationship in model.relationships
+            _describe_relationship(relationship, warnings, model=model)
+            for relationship in model.relationships
+            if not enforce_visibility or visible_model_names is None or relationship.name in visible_model_names
         ],
         "segments": [segment.name for segment in model.segments],
     }

--- a/sidemantic/core/introspection.py
+++ b/sidemantic/core/introspection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import asdict, is_dataclass
 from typing import Any
 
+from sidemantic.core.consumption import serialize_consumption_contract
 from sidemantic.core.governance import governance_dict
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
@@ -33,15 +34,17 @@ def describe_graph(
     ]
 
     explores = [
-        explore.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+        serialized
         for explore in graph.explores.values()
         if not requested or explore.model in requested
-        if not enforce_visibility or explore.visibility == "public"
+        if (serialized := serialize_consumption_contract(explore, graph, enforce_visibility=enforce_visibility))
+        is not None
     ]
     saved_queries = [
-        saved.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+        serialized
         for saved in graph.saved_queries.values()
-        if not enforce_visibility or saved.visibility == "public"
+        if (serialized := serialize_consumption_contract(saved, graph, enforce_visibility=enforce_visibility))
+        is not None
     ]
 
     return {

--- a/sidemantic/core/introspection.py
+++ b/sidemantic/core/introspection.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import asdict, is_dataclass
 from typing import Any
 
-from sidemantic.core.consumption import graph_metric_is_public, serialize_consumption_contract
+from sidemantic.core.consumption import (
+    expression_field_references,
+    graph_metric_is_public,
+    serialize_consumption_contract,
+)
 from sidemantic.core.governance import governance_dict
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
@@ -43,6 +47,7 @@ def describe_graph(
     saved_queries = [
         serialized
         for saved in graph.saved_queries.values()
+        if _include_saved_query(saved, graph, requested)
         if (serialized := serialize_consumption_contract(saved, graph, enforce_visibility=enforce_visibility))
         is not None
     ]
@@ -63,6 +68,42 @@ def _include_graph_metric(metric: Metric, requested_models: set[str]) -> bool:
     if owner_model and owner_model in requested_models:
         return True
     return owner_model is None
+
+
+def _include_saved_query(saved: Any, graph: SemanticGraph, requested_models: set[str]) -> bool:
+    """Scope a saved query to its Explore base or explicitly referenced models."""
+    if not requested_models:
+        return True
+
+    base_model = ""
+    if saved.explore and (explore := graph.explores.get(saved.explore)) is not None:
+        base_model = explore.model
+        if base_model in requested_models:
+            return True
+
+    references = [*saved.dimensions, *saved.metrics, *saved.segments]
+    try:
+        references.extend(
+            expression_field_references(
+                [*saved.filters, *saved.order_by],
+                base_model,
+                graph_metrics=graph.metrics.keys(),
+                graph_models=graph.models.keys(),
+            )
+        )
+    except Exception:
+        pass
+
+    for reference in references:
+        if "." in reference and reference.split(".", 1)[0] in requested_models:
+            return True
+        if reference in graph.metrics:
+            from sidemantic.sql.generator import SQLGenerator
+
+            source_models = SQLGenerator(graph)._find_required_models([reference], [], [])
+            if requested_models.intersection(source_models):
+                return True
+    return False
 
 
 def _metric_owner_model(metric: Metric) -> str | None:

--- a/sidemantic/core/introspection.py
+++ b/sidemantic/core/introspection.py
@@ -97,7 +97,7 @@ def _describe_model(
             for relationship in model.relationships
             if not enforce_visibility or visible_model_names is None or relationship.name in visible_model_names
         ],
-        "segments": [segment.name for segment in model.segments],
+        "segments": [segment.name for segment in model.segments if not enforce_visibility or segment.public],
     }
     if model_kind == "calculated_table":
         info["calculated_table"] = True

--- a/sidemantic/core/introspection.py
+++ b/sidemantic/core/introspection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import asdict, is_dataclass
 from typing import Any
 
+from sidemantic.core.governance import governance_dict
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.relationship import Relationship
@@ -19,17 +20,32 @@ def describe_graph(
     models = [
         _describe_model(model, warnings, enforce_visibility)
         for model in graph.models.values()
-        if not requested or model.name in requested
+        if (not requested or model.name in requested) and not (enforce_visibility and model.visibility != "public")
     ]
     metrics = [
         _describe_metric(metric, warnings, model_name=None)
         for metric in graph.metrics.values()
-        if _include_graph_metric(metric, requested) and not (enforce_visibility and not getattr(metric, "public", True))
+        if _include_graph_metric(metric, requested)
+        and not (enforce_visibility and (not metric.public or metric.visibility != "public"))
+    ]
+
+    explores = [
+        explore.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+        for explore in graph.explores.values()
+        if not requested or explore.model in requested
+        if not enforce_visibility or explore.visibility == "public"
+    ]
+    saved_queries = [
+        saved.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+        for saved in graph.saved_queries.values()
+        if not enforce_visibility or saved.visibility == "public"
     ]
 
     return {
         "models": models,
         "metrics": metrics,
+        "explores": explores,
+        "saved_queries": saved_queries,
         "import_warnings": warnings,
     }
 
@@ -54,7 +70,9 @@ def _metric_owner_model(metric: Metric) -> str | None:
 def _describe_model(model: Model, warnings: list[dict[str, Any]], enforce_visibility: bool = False) -> dict[str, Any]:
     model_kind = _model_kind(model)
     dimensions = model.dimensions if not enforce_visibility else [d for d in model.dimensions if d.public]
-    metrics = model.metrics if not enforce_visibility else [m for m in model.metrics if m.public]
+    metrics = (
+        model.metrics if not enforce_visibility else [m for m in model.metrics if m.public and m.visibility == "public"]
+    )
     info: dict[str, Any] = {
         "name": model.name,
         "kind": model_kind,
@@ -79,6 +97,9 @@ def _describe_model(model: Model, warnings: list[dict[str, Any]], enforce_visibi
         info["default_grain"] = model.default_grain
     if model.meta:
         info["meta"] = model.meta
+    governance = governance_dict(model)
+    if governance:
+        info["governance"] = governance
     return _drop_none(info)
 
 
@@ -144,6 +165,9 @@ def _describe_metric(
         info["format"] = metric.format
     if metric.meta:
         info["meta"] = metric.meta
+    governance = governance_dict(metric)
+    if governance:
+        info["governance"] = governance
     result = _drop_none(info)
     # Current Sidequery Swift DTOs decode these as non-optional arrays. Keep
     # them present even when empty while Sidequery moves to richer metadata.

--- a/sidemantic/core/introspection.py
+++ b/sidemantic/core/introspection.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import asdict, is_dataclass
 from typing import Any
 
-from sidemantic.core.consumption import serialize_consumption_contract
+from sidemantic.core.consumption import graph_metric_is_public, serialize_consumption_contract
 from sidemantic.core.governance import governance_dict
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
@@ -30,7 +30,7 @@ def describe_graph(
         _describe_metric(metric, warnings, model_name=None)
         for metric in graph.metrics.values()
         if _include_graph_metric(metric, requested)
-        and not (enforce_visibility and (not metric.public or metric.visibility != "public"))
+        and not (enforce_visibility and not graph_metric_is_public(metric, graph))
     ]
 
     explores = [

--- a/sidemantic/core/metric.py
+++ b/sidemantic/core/metric.py
@@ -2,10 +2,12 @@
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
+
+from sidemantic.core.governance import GovernedObject
 
 
-class Metric(BaseModel):
+class Metric(GovernedObject):
     """Measure definition - supports simple aggregations and complex metric types.
 
     Measures can be:
@@ -76,6 +78,10 @@ class Metric(BaseModel):
         Complex expressions like SUM(x) / SUM(y) are preserved as-is.
         """
         if isinstance(data, dict):
+            if data.get("public") is False and "visibility" not in data:
+                data["visibility"] = "private"
+            if data.get("visibility") in {"internal", "private"} and "public" not in data:
+                data["public"] = False
             # Step 1: Handle expr alias
             expr_val = data.get("expr")
             sql_val = data.get("sql")

--- a/sidemantic/core/model.py
+++ b/sidemantic/core/model.py
@@ -2,10 +2,10 @@
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from sidemantic.core.dimension import Dimension
-from sidemantic.core.freshness import Freshness
+from sidemantic.core.governance import GovernedObject
 from sidemantic.core.metric import Metric
 from sidemantic.core.pre_aggregation import PreAggregation
 from sidemantic.core.relationship import Relationship
@@ -13,7 +13,7 @@ from sidemantic.core.security import SecurityPolicy
 from sidemantic.core.segment import Segment
 
 
-class Model(BaseModel):
+class Model(GovernedObject):
     """Model (dataset) definition.
 
     Models are the foundation of the semantic layer, mapping to physical tables
@@ -62,11 +62,6 @@ class Model(BaseModel):
     default_grain: Literal["second", "minute", "hour", "day", "week", "month", "quarter", "year"] | None = Field(
         None, description="Default time granularity when using default_time_dimension"
     )
-    freshness: Freshness | None = Field(
-        None,
-        description="Model-level source freshness policy inherited by live chart runtimes",
-    )
-
     # Auto-discover dimensions from database schema
     auto_dimensions: bool = Field(
         default=False,

--- a/sidemantic/core/semantic_graph.py
+++ b/sidemantic/core/semantic_graph.py
@@ -4,6 +4,7 @@ from collections import deque
 from dataclasses import dataclass
 from typing import Any
 
+from sidemantic.core.consumption import Explore, SavedQuery
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.parameter import Parameter
@@ -70,6 +71,8 @@ class SemanticGraph:
         self.metrics: dict[str, Metric] = {}
         self.table_calculations: dict[str, TableCalculation] = {}
         self.parameters: dict[str, Parameter] = {}
+        self.explores: dict[str, Explore] = {}
+        self.saved_queries: dict[str, SavedQuery] = {}
         self.import_warnings: list[dict[str, object]] = []
         self.metadata: dict[str, Any] = {}
         self._version = 0
@@ -158,6 +161,32 @@ class SemanticGraph:
 
         self.parameters[param.name] = param
         self._mark_dirty()
+
+    def add_explore(self, explore: Explore) -> None:
+        """Add a curated Explore/View consumption contract."""
+        if explore.name in self.explores:
+            raise ValueError(f"Explore {explore.name} already exists")
+        self.explores[explore.name] = explore
+        self._mark_dirty()
+
+    def get_explore(self, name: str) -> Explore:
+        """Get an Explore/View contract by name."""
+        if name not in self.explores:
+            raise KeyError(f"Explore {name} not found")
+        return self.explores[name]
+
+    def add_saved_query(self, saved_query: SavedQuery) -> None:
+        """Add a named structured query contract."""
+        if saved_query.name in self.saved_queries:
+            raise ValueError(f"Saved query {saved_query.name} already exists")
+        self.saved_queries[saved_query.name] = saved_query
+        self._mark_dirty()
+
+    def get_saved_query(self, name: str) -> SavedQuery:
+        """Get a saved query by name."""
+        if name not in self.saved_queries:
+            raise KeyError(f"Saved query {name} not found")
+        return self.saved_queries[name]
 
     def get_parameter(self, name: str) -> Parameter:
         """Get a parameter by name.

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -916,6 +916,8 @@ class SemanticLayer:
                     f"Saved query '{saved_query_name}' is immutable; remove overrides for: {', '.join(overridden)}"
                 )
             definition = self.graph.get_saved_query(saved_query_name)
+            if definition.visibility != "public" and self.enforce_visibility:
+                raise ValueError(f"Saved query '{saved_query_name}' is not public")
             metricflow_metadata = (definition.metadata or {}).get("metricflow", {})
             if metricflow_metadata.get("executable") is False:
                 message = metricflow_metadata.get("compatibility_message") or "source syntax is not executable"

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -945,6 +945,8 @@ class SemanticLayer:
             dimensions = list(contract.default_dimensions)
         metrics = [self._consumption_metric_reference(ref, contract.model) for ref in metrics]
         dimensions = [self._consumption_reference(ref, contract.model) for ref in dimensions]
+        if segments is not None:
+            segments = [self._consumption_reference(ref, contract.model) for ref in segments]
 
         if contract.allowed_metrics is not None:
             allowed = {self._consumption_metric_reference(ref, contract.model) for ref in contract.allowed_metrics}
@@ -1343,6 +1345,8 @@ class SemanticLayer:
             model = self.graph.models.get(model_name)
             if model is None:
                 continue
+            if model.visibility != "public":
+                raise SecurityError(f"Segment '{model_name}.{segment_name}' is not public")
             segment = model.get_segment(segment_name) if hasattr(model, "get_segment") else None
             if segment is not None and not getattr(segment, "public", True):
                 raise SecurityError(f"Segment '{model_name}.{segment_name}' is not public")

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -900,6 +900,7 @@ class SemanticLayer:
         """Resolve defaults and enforce a named consumption contract."""
         if saved_query_name:
             supplied = {
+                "explore": explore_name,
                 "metrics": metrics,
                 "dimensions": dimensions,
                 "filters": filters,
@@ -922,12 +923,7 @@ class SemanticLayer:
             if metricflow_metadata.get("executable") is False:
                 message = metricflow_metadata.get("compatibility_message") or "source syntax is not executable"
                 raise ValueError(f"Saved query '{saved_query_name}' cannot execute: {message}")
-            if explore_name and definition.explore and explore_name != definition.explore:
-                raise ValueError(
-                    f"Saved query '{saved_query_name}' is governed by explore '{definition.explore}', "
-                    f"not '{explore_name}'"
-                )
-            explore_name = definition.explore or explore_name
+            explore_name = definition.explore
             metrics = list(definition.metrics)
             dimensions = list(definition.dimensions)
             filters = list(definition.filters)

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -906,6 +906,7 @@ class SemanticLayer:
         timezone: str | None,
     ) -> tuple:
         """Resolve defaults and enforce a named consumption contract."""
+        caller_supplied_order_by = order_by is not None
         if saved_query_name:
             supplied = {
                 "explore": explore_name,
@@ -1008,17 +1009,28 @@ class SemanticLayer:
             order_by = list(contract.default_order_by)
         if contract.allowed_order_by is not None:
             allowed = {self._consumption_metric_reference(ref, contract.model) for ref in contract.allowed_order_by}
-            denied = sorted(
-                expression_field_references(
-                    order_by,
-                    contract.model,
-                    graph_metrics=graph_metrics,
-                    graph_models=self.graph.models.keys(),
-                )
-                - allowed
+            order_references = expression_field_references(
+                order_by,
+                contract.model,
+                graph_metrics=graph_metrics,
+                graph_models=self.graph.models.keys(),
             )
+            denied = sorted(order_references - allowed)
             if denied:
                 raise ValueError(f"Explore '{explore_name}' does not allow ordering by: {', '.join(denied)}")
+        else:
+            order_references = expression_field_references(
+                order_by,
+                contract.model,
+                graph_metrics=graph_metrics,
+                graph_models=self.graph.models.keys(),
+            )
+        unselected_order_fields = sorted(order_references - {*metrics, *dimensions})
+        if caller_supplied_order_by and unselected_order_fields:
+            raise ValueError(
+                f"Explore '{explore_name}' ordering field(s) must be selected by the query: "
+                f"{', '.join(unselected_order_fields)}"
+            )
         order_by = qualify_order_by_fields(order_by, contract.model, graph_metrics=graph_metrics)
         if limit is None:
             limit = contract.default_limit

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -947,11 +947,20 @@ class SemanticLayer:
         contract = self.graph.get_explore(explore_name)
         if contract.visibility != "public" and self.enforce_visibility:
             raise ValueError(f"Explore '{explore_name}' is not public")
+        base_model = self.graph.models.get(contract.model)
+        if self.enforce_visibility and (base_model is None or base_model.visibility != "public"):
+            raise SecurityError(f"Explore '{explore_name}' base model '{contract.model}' is not public")
 
         if metrics is None:
             metrics = list(contract.default_metrics)
         if dimensions is None:
             dimensions = list(contract.default_dimensions)
+        if (
+            not metrics
+            and not dimensions
+            and (contract.allowed_metrics is not None or contract.allowed_dimensions is not None)
+        ):
+            raise ValueError(f"Explore '{explore_name}' must select at least one metric or dimension")
         metrics = [self._consumption_metric_reference(ref, contract.model) for ref in metrics]
         dimensions = [self._consumption_reference(ref, contract.model) for ref in dimensions]
         if segments is not None:
@@ -980,7 +989,13 @@ class SemanticLayer:
                 self._consumption_metric_reference(ref, contract.model) for ref in contract.allowed_filter_fields
             }
             denied = sorted(
-                expression_field_references(selected_filters, contract.model, graph_metrics=graph_metrics) - allowed
+                expression_field_references(
+                    selected_filters,
+                    contract.model,
+                    graph_metrics=graph_metrics,
+                    graph_models=self.graph.models.keys(),
+                )
+                - allowed
             )
             if denied:
                 raise ValueError(f"Explore '{explore_name}' does not allow filter field(s): {', '.join(denied)}")
@@ -994,7 +1009,13 @@ class SemanticLayer:
         if contract.allowed_order_by is not None:
             allowed = {self._consumption_metric_reference(ref, contract.model) for ref in contract.allowed_order_by}
             denied = sorted(
-                expression_field_references(order_by, contract.model, graph_metrics=graph_metrics) - allowed
+                expression_field_references(
+                    order_by,
+                    contract.model,
+                    graph_metrics=graph_metrics,
+                    graph_models=self.graph.models.keys(),
+                )
+                - allowed
             )
             if denied:
                 raise ValueError(f"Explore '{explore_name}' does not allow ordering by: {', '.join(denied)}")

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -8,7 +8,14 @@ from pathlib import Path
 
 import yaml
 
-from sidemantic.core.consumption import Explore, SavedQuery, expression_field_references, graph_metric_is_public
+from sidemantic.core.consumption import (
+    Explore,
+    SavedQuery,
+    expression_field_references,
+    graph_metric_is_public,
+    qualify_expression_fields,
+    qualify_order_by_fields,
+)
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.semantic_graph import SemanticGraph
@@ -970,7 +977,11 @@ class SemanticLayer:
             )
             if denied:
                 raise ValueError(f"Explore '{explore_name}' does not allow filter field(s): {', '.join(denied)}")
-        filters = [*contract.filters, *selected_filters]
+        filters = qualify_expression_fields(
+            [*contract.filters, *selected_filters],
+            contract.model,
+            graph_metrics=graph_metrics,
+        )
         if order_by is None:
             order_by = list(contract.default_order_by)
         if contract.allowed_order_by is not None:
@@ -980,6 +991,7 @@ class SemanticLayer:
             )
             if denied:
                 raise ValueError(f"Explore '{explore_name}' does not allow ordering by: {', '.join(denied)}")
+        order_by = qualify_order_by_fields(order_by, contract.model, graph_metrics=graph_metrics)
         if limit is None:
             limit = contract.default_limit
         if contract.max_limit is not None and limit is not None and limit > contract.max_limit:

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -903,6 +903,7 @@ class SemanticLayer:
         offset: int | None,
         ungrouped: bool,
         parameters: dict | None,
+        timezone: str | None,
     ) -> tuple:
         """Resolve defaults and enforce a named consumption contract."""
         if saved_query_name:
@@ -917,6 +918,7 @@ class SemanticLayer:
                 "offset": offset,
                 "ungrouped": True if ungrouped else None,
                 "parameters": parameters,
+                "timezone": timezone,
             }
             overridden = [name for name, value in supplied.items() if value is not None]
             if overridden:
@@ -940,7 +942,7 @@ class SemanticLayer:
             parameters = dict(definition.parameters) if definition.parameters is not None else None
 
         if not explore_name:
-            return metrics, dimensions, filters, segments, order_by, limit, parameters
+            return metrics, dimensions, filters, segments, order_by, limit, parameters, None
 
         contract = self.graph.get_explore(explore_name)
         if contract.visibility != "public" and self.enforce_visibility:
@@ -996,7 +998,7 @@ class SemanticLayer:
             limit = contract.default_limit
         if contract.max_limit is not None and limit is not None and limit > contract.max_limit:
             raise ValueError(f"Explore '{explore_name}' limit {limit} exceeds max_limit {contract.max_limit}")
-        return metrics, dimensions, filters, segments, order_by, limit, parameters
+        return metrics, dimensions, filters, segments, order_by, limit, parameters, contract.model
 
     def compile(
         self,
@@ -1057,7 +1059,16 @@ class SemanticLayer:
         """
         from sidemantic.validation import QueryValidationError, validate_query
 
-        metrics, dimensions, filters, segments, order_by, limit, parameters = self._resolve_consumption_contract(
+        (
+            metrics,
+            dimensions,
+            filters,
+            segments,
+            order_by,
+            limit,
+            parameters,
+            consumption_base_model,
+        ) = self._resolve_consumption_contract(
             explore_name=explore,
             saved_query_name=saved_query,
             metrics=metrics,
@@ -1069,6 +1080,7 @@ class SemanticLayer:
             offset=offset,
             ungrouped=ungrouped,
             parameters=parameters,
+            timezone=timezone,
         )
         metrics = metrics or []
         dimensions = dimensions or []
@@ -1117,7 +1129,13 @@ class SemanticLayer:
         # The Rust generator implements neither query-timezone bucketing nor with_totals
         # GROUPING SETS, so use the Python path when either is requested.
         # (Pre-agg bypass for timezone queries is enforced inside SQLGenerator.generate.)
-        if self._use_rust_sql_generator and not timezone and not with_totals and not security_forces_python:
+        if (
+            self._use_rust_sql_generator
+            and not timezone
+            and not with_totals
+            and not security_forces_python
+            and consumption_base_model is None
+        ):
             inner_sql = self._compile_with_rust(
                 metrics=metrics,
                 dimensions=dimensions,
@@ -1148,6 +1166,7 @@ class SemanticLayer:
                     parameters=parameters,
                     use_preaggregations=use_preaggs,
                     aliases=aliases,
+                    base_model=consumption_base_model,
                 )
                 if inner_sql.strip() != python_sql.strip():
                     if self._rust_no_fallback or self._strict_rust_sql_generator_entrypoint:
@@ -1171,6 +1190,7 @@ class SemanticLayer:
                 timezone=timezone,
                 with_totals=with_totals,
                 user_attributes=user_attributes,
+                base_model=consumption_base_model,
             )
 
         return self._apply_post_process(inner_sql, post_process)
@@ -1211,6 +1231,7 @@ class SemanticLayer:
         timezone: str | None = None,
         with_totals: bool = False,
         user_attributes: dict | None = None,
+        base_model: str | None = None,
     ) -> str:
         generator = SQLGenerator(
             self.graph,
@@ -1219,6 +1240,7 @@ class SemanticLayer:
             preagg_schema=self.preagg_schema,
             timezone=timezone,
             allow_non_additive_unsafe=self.allow_non_additive_unsafe,
+            base_model=base_model,
         )
 
         return generator.generate(

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -893,6 +893,8 @@ class SemanticLayer:
         segments: list[str] | None,
         order_by: list[str] | None,
         limit: int | None,
+        offset: int | None,
+        ungrouped: bool,
         parameters: dict | None,
     ) -> tuple:
         """Resolve defaults and enforce a named consumption contract."""
@@ -904,6 +906,8 @@ class SemanticLayer:
                 "segments": segments,
                 "order_by": order_by,
                 "limit": limit,
+                "offset": offset,
+                "ungrouped": True if ungrouped else None,
                 "parameters": parameters,
             }
             overridden = [name for name, value in supplied.items() if value is not None]
@@ -1050,6 +1054,8 @@ class SemanticLayer:
             segments=segments,
             order_by=order_by,
             limit=limit,
+            offset=offset,
+            ungrouped=ungrouped,
             parameters=parameters,
         )
         metrics = metrics or []

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import yaml
 
-from sidemantic.core.consumption import Explore, SavedQuery, expression_field_references
+from sidemantic.core.consumption import Explore, SavedQuery, expression_field_references, graph_metric_is_public
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.semantic_graph import SemanticGraph
@@ -1327,9 +1327,7 @@ class SemanticLayer:
             if "." not in metric:
                 # Graph-level metric reference.
                 graph_metric = self.graph.metrics.get(metric)
-                if graph_metric is not None and (
-                    not getattr(graph_metric, "public", True) or graph_metric.visibility != "public"
-                ):
+                if graph_metric is not None and not graph_metric_is_public(graph_metric, self.graph):
                     raise SecurityError(f"Field '{metric}' is not public")
                 continue
             model_name, field_name = metric.split(".", 1)

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -969,6 +969,11 @@ class SemanticLayer:
                 raise ValueError(f"Explore '{explore_name}' does not allow dimension(s): {', '.join(denied)}")
 
         selected_filters = list(contract.default_filters) if filters is None else list(filters)
+        from sidemantic.core.parameter import ParameterSet
+
+        parameter_set = ParameterSet(self.graph.parameters, parameters)
+        mandatory_filters = [parameter_set.interpolate(expression) for expression in contract.filters]
+        selected_filters = [parameter_set.interpolate(expression) for expression in selected_filters]
         graph_metrics = self.graph.metrics.keys()
         if contract.allowed_filter_fields is not None:
             allowed = {
@@ -980,7 +985,7 @@ class SemanticLayer:
             if denied:
                 raise ValueError(f"Explore '{explore_name}' does not allow filter field(s): {', '.join(denied)}")
         filters = qualify_expression_fields(
-            [*contract.filters, *selected_filters],
+            [*mandatory_filters, *selected_filters],
             contract.model,
             graph_metrics=graph_metrics,
         )

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import yaml
 
+from sidemantic.core.consumption import Explore, SavedQuery, expression_field_references
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.semantic_graph import SemanticGraph
@@ -616,6 +617,36 @@ class SemanticLayer:
         self._sql_rewrite_cache.clear()
         self._generation += 1
 
+    def add_explore(self, explore: Explore) -> None:
+        """Validate and add a curated Explore/View contract."""
+        from sidemantic.validation import validate_explore
+
+        errors, _warnings = validate_explore(explore, self.graph)
+        if errors:
+            raise ValueError(f"Explore '{explore.name}' validation failed:\n" + "\n".join(f"  - {e}" for e in errors))
+        self.graph.add_explore(explore)
+        self._generation += 1
+
+    def add_saved_query(self, saved_query: SavedQuery) -> None:
+        """Validate and add an immutable SavedQuery contract."""
+        from sidemantic.validation import validate_saved_query
+
+        errors, _warnings = validate_saved_query(saved_query, self.graph)
+        if errors:
+            raise ValueError(
+                f"Saved query '{saved_query.name}' validation failed:\n" + "\n".join(f"  - {e}" for e in errors)
+            )
+        self.graph.add_saved_query(saved_query)
+        self._generation += 1
+
+    def get_explore(self, name: str) -> Explore:
+        """Get a curated Explore/View by name."""
+        return self.graph.get_explore(name)
+
+    def get_saved_query(self, name: str) -> SavedQuery:
+        """Get a SavedQuery by name."""
+        return self.graph.get_saved_query(name)
+
     def query(
         self,
         metrics: list[str] | None = None,
@@ -633,6 +664,8 @@ class SemanticLayer:
         timezone: str | None = None,
         with_totals: bool = False,
         user_attributes: dict | None = None,
+        explore: str | None = None,
+        saved_query: str | None = None,
     ):
         """Execute a query against the semantic layer.
 
@@ -685,6 +718,8 @@ class SemanticLayer:
             timezone=timezone,
             with_totals=with_totals,
             user_attributes=user_attributes,
+            explore=explore,
+            saved_query=saved_query,
         )
         used_preagg = "used_preagg=true" in routing_sql
 
@@ -702,6 +737,8 @@ class SemanticLayer:
                 post_process=post_process,
                 timezone=timezone,
                 user_attributes=user_attributes,
+                explore=explore,
+                saved_query=saved_query,
             )
         else:
             sql = routing_sql
@@ -720,6 +757,8 @@ class SemanticLayer:
                 post_process=post_process,
                 timezone=timezone,
                 user_attributes=user_attributes,
+                explore=explore,
+                saved_query=saved_query,
             )
 
         return self._execute_with_preagg_fallback(
@@ -830,6 +869,119 @@ class SemanticLayer:
             limit = self.max_limit
         return limit
 
+    @staticmethod
+    def _consumption_reference(reference: str, base_model: str) -> str:
+        """Qualify a simple Explore field against its base model."""
+        if "." in reference or "(" in reference or " " in reference:
+            return reference
+        return f"{base_model}.{reference}"
+
+    def _consumption_metric_reference(self, reference: str, base_model: str) -> str:
+        """Keep graph metrics graph-scoped; qualify model-local metrics."""
+        if reference in self.graph.metrics:
+            return reference
+        return self._consumption_reference(reference, base_model)
+
+    def _resolve_consumption_contract(
+        self,
+        *,
+        explore_name: str | None,
+        saved_query_name: str | None,
+        metrics: list[str] | None,
+        dimensions: list[str] | None,
+        filters: list[str] | None,
+        segments: list[str] | None,
+        order_by: list[str] | None,
+        limit: int | None,
+        parameters: dict | None,
+    ) -> tuple:
+        """Resolve defaults and enforce a named consumption contract."""
+        if saved_query_name:
+            supplied = {
+                "metrics": metrics,
+                "dimensions": dimensions,
+                "filters": filters,
+                "segments": segments,
+                "order_by": order_by,
+                "limit": limit,
+                "parameters": parameters,
+            }
+            overridden = [name for name, value in supplied.items() if value is not None]
+            if overridden:
+                raise ValueError(
+                    f"Saved query '{saved_query_name}' is immutable; remove overrides for: {', '.join(overridden)}"
+                )
+            definition = self.graph.get_saved_query(saved_query_name)
+            metricflow_metadata = (definition.metadata or {}).get("metricflow", {})
+            if metricflow_metadata.get("executable") is False:
+                message = metricflow_metadata.get("compatibility_message") or "source syntax is not executable"
+                raise ValueError(f"Saved query '{saved_query_name}' cannot execute: {message}")
+            if explore_name and definition.explore and explore_name != definition.explore:
+                raise ValueError(
+                    f"Saved query '{saved_query_name}' is governed by explore '{definition.explore}', "
+                    f"not '{explore_name}'"
+                )
+            explore_name = definition.explore or explore_name
+            metrics = list(definition.metrics)
+            dimensions = list(definition.dimensions)
+            filters = list(definition.filters)
+            segments = list(definition.segments)
+            order_by = list(definition.order_by)
+            limit = definition.limit
+            parameters = dict(definition.parameters) if definition.parameters is not None else None
+
+        if not explore_name:
+            return metrics, dimensions, filters, segments, order_by, limit, parameters
+
+        contract = self.graph.get_explore(explore_name)
+        if contract.visibility != "public" and self.enforce_visibility:
+            raise ValueError(f"Explore '{explore_name}' is not public")
+
+        if metrics is None:
+            metrics = list(contract.default_metrics)
+        if dimensions is None:
+            dimensions = list(contract.default_dimensions)
+        metrics = [self._consumption_metric_reference(ref, contract.model) for ref in metrics]
+        dimensions = [self._consumption_reference(ref, contract.model) for ref in dimensions]
+
+        if contract.allowed_metrics is not None:
+            allowed = {self._consumption_metric_reference(ref, contract.model) for ref in contract.allowed_metrics}
+            denied = [ref for ref in metrics if ref not in allowed]
+            if denied:
+                raise ValueError(f"Explore '{explore_name}' does not allow metric(s): {', '.join(denied)}")
+        if contract.allowed_dimensions is not None:
+            allowed = {self._consumption_reference(ref, contract.model) for ref in contract.allowed_dimensions}
+            denied = [ref for ref in dimensions if ref not in allowed]
+            if denied:
+                raise ValueError(f"Explore '{explore_name}' does not allow dimension(s): {', '.join(denied)}")
+
+        selected_filters = list(contract.default_filters) if filters is None else list(filters)
+        graph_metrics = self.graph.metrics.keys()
+        if contract.allowed_filter_fields is not None:
+            allowed = {
+                self._consumption_metric_reference(ref, contract.model) for ref in contract.allowed_filter_fields
+            }
+            denied = sorted(
+                expression_field_references(selected_filters, contract.model, graph_metrics=graph_metrics) - allowed
+            )
+            if denied:
+                raise ValueError(f"Explore '{explore_name}' does not allow filter field(s): {', '.join(denied)}")
+        filters = [*contract.filters, *selected_filters]
+        if order_by is None:
+            order_by = list(contract.default_order_by)
+        if contract.allowed_order_by is not None:
+            allowed = {self._consumption_metric_reference(ref, contract.model) for ref in contract.allowed_order_by}
+            denied = sorted(
+                expression_field_references(order_by, contract.model, graph_metrics=graph_metrics) - allowed
+            )
+            if denied:
+                raise ValueError(f"Explore '{explore_name}' does not allow ordering by: {', '.join(denied)}")
+        if limit is None:
+            limit = contract.default_limit
+        if contract.max_limit is not None and limit is not None and limit > contract.max_limit:
+            raise ValueError(f"Explore '{explore_name}' limit {limit} exceeds max_limit {contract.max_limit}")
+        return metrics, dimensions, filters, segments, order_by, limit, parameters
+
     def compile(
         self,
         metrics: list[str] | None = None,
@@ -848,6 +1000,8 @@ class SemanticLayer:
         timezone: str | None = None,
         with_totals: bool = False,
         user_attributes: dict | None = None,
+        explore: str | None = None,
+        saved_query: str | None = None,
     ) -> str:
         """Compile a query to SQL without executing.
 
@@ -887,6 +1041,17 @@ class SemanticLayer:
         """
         from sidemantic.validation import QueryValidationError, validate_query
 
+        metrics, dimensions, filters, segments, order_by, limit, parameters = self._resolve_consumption_contract(
+            explore_name=explore,
+            saved_query_name=saved_query,
+            metrics=metrics,
+            dimensions=dimensions,
+            filters=filters,
+            segments=segments,
+            order_by=order_by,
+            limit=limit,
+            parameters=parameters,
+        )
         metrics = metrics or []
         dimensions = dimensions or []
 
@@ -1118,12 +1283,14 @@ class SemanticLayer:
         model = self.graph.models.get(model_name)
         if model is None:
             return True
+        if model.visibility != "public":
+            return False
         dimension = model.get_dimension(field_name)
         if dimension is not None:
             return dimension.public
         metric_obj = model.get_metric(field_name)
         if metric_obj is not None:
-            return metric_obj.public
+            return metric_obj.public and metric_obj.visibility == "public"
         return True
 
     def _enforce_visibility_for_query(
@@ -1156,7 +1323,9 @@ class SemanticLayer:
             if "." not in metric:
                 # Graph-level metric reference.
                 graph_metric = self.graph.metrics.get(metric)
-                if graph_metric is not None and not getattr(graph_metric, "public", True):
+                if graph_metric is not None and (
+                    not getattr(graph_metric, "public", True) or graph_metric.visibility != "public"
+                ):
                     raise SecurityError(f"Field '{metric}' is not public")
                 continue
             model_name, field_name = metric.split(".", 1)

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -1351,6 +1351,22 @@ def _merge_graph_passthrough_metadata(target_graph: object, source_graph: object
             target_graph.metadata = target_metadata
         _deep_merge_metadata(target_metadata, source_metadata)
 
+    # Consumption contracts live outside the physical model graph but must merge
+    # across the same multi-file CLI loading workflow.
+    for attr, label in (("explores", "Explore"), ("saved_queries", "Saved query")):
+        source_items = getattr(source_graph, attr, None)
+        if not isinstance(source_items, dict):
+            continue
+        target_items = getattr(target_graph, attr, None)
+        if not isinstance(target_items, dict):
+            target_items = {}
+            setattr(target_graph, attr, target_items)
+        for name, value in source_items.items():
+            existing = target_items.get(name)
+            if existing is not None and existing.model_dump() != value.model_dump():
+                raise ValueError(f"{label} {name} is defined more than once with different values")
+            target_items[name] = value
+
     # Carry over Snowflake dynamic top-level attributes set by the adapter. Lists
     # (verified_queries) accumulate across files; scalars take the latest value.
     for attr in ("verified_queries", "custom_instructions", "module_custom_instructions"):

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -817,7 +817,10 @@ def _looks_like_native_sidemantic_yaml(data: dict) -> bool:
         and set(data) <= ROOT_FIELDS
     ):
         return True
-    if not any(_yaml_has_top_level_key(data, key) for key in ("metrics", "parameters", "sql_metrics", "sql_segments")):
+    if not any(
+        _yaml_has_top_level_key(data, key)
+        for key in ("metrics", "parameters", "sql_metrics", "sql_segments", "explores", "views", "saved_queries")
+    ):
         return False
     if data.get("version") == NATIVE_FORMAT_VERSION:
         return True

--- a/sidemantic/man/sidemantic.1
+++ b/sidemantic/man/sidemantic.1
@@ -118,12 +118,12 @@ Allow writing to an existing destination
 .SH "SIDEMANTIC QUERY"
 .SS SYNOPSIS
 .B
-sidemantic query [OPTIONS] SQL
+sidemantic query [OPTIONS] [[SQL]]
 .SS DESCRIPTION
 .PP
 Execute a SQL query and output results as CSV.
 .PP
-Examples: sidemantic query "SELECT revenue FROM orders" sidemantic query "SELECT * FROM orders" \-\-output results.csv sidemantic query "SELECT * FROM orders" \-\-models ./models sidemantic query "SELECT revenue FROM orders" \-\-connection "postgres://localhost:5432/db" sidemantic query "SELECT revenue FROM orders" \-\-db data.duckdb sidemantic query "SELECT revenue FROM orders" \-\-dry\-run sidemantic query "SELECT revenue FROM orders" \-\-use\-preaggregations \-\-dry\-run
+Examples: sidemantic query "SELECT revenue FROM orders" sidemantic query "SELECT * FROM orders" \-\-output results.csv sidemantic query "SELECT * FROM orders" \-\-models ./models sidemantic query "SELECT revenue FROM orders" \-\-connection "postgres://localhost:5432/db" sidemantic query "SELECT revenue FROM orders" \-\-db data.duckdb sidemantic query "SELECT revenue FROM orders" \-\-dry\-run sidemantic query "SELECT revenue FROM orders" \-\-use\-preaggregations \-\-dry\-run sidemantic query \-\-explore revenue_overview \-\-dry\-run sidemantic query \-\-saved\-query monthly_revenue
 .SS OPTIONS
 .TP
 \fB\-\-models, \-m PATH\fR
@@ -149,6 +149,27 @@ Allow Rust engine fallback to Python
 .TP
 \fB\-\-use\-preaggregations\fR
 Enable automatic pre\-aggregation routing
+.TP
+\fB\-\-explore TEXT\fR
+Run through a curated Explore/View contract
+.TP
+\fB\-\-saved\-query TEXT\fR
+Execute an immutable SavedQuery contract
+.TP
+\fB\-\-metric TEXT\fR
+Metric for \-\-explore (repeatable)
+.TP
+\fB\-\-dimension TEXT\fR
+Dimension for \-\-explore (repeatable)
+.TP
+\fB\-\-filter TEXT\fR
+Filter for \-\-explore (repeatable)
+.TP
+\fB\-\-order\-by TEXT\fR
+Ordering for \-\-explore (repeatable)
+.TP
+\fB\-\-limit INTEGER RANGE\fR
+Row limit for \-\-explore
 .SH "SIDEMANTIC EXPLAIN"
 .SS SYNOPSIS
 .B

--- a/sidemantic/mcp_server.py
+++ b/sidemantic/mcp_server.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
 
+from sidemantic.core.governance import governance_dict
 from sidemantic.core.semantic_layer import SemanticLayer
 from sidemantic.loaders import load_from_directory
 
@@ -705,6 +706,24 @@ def get_semantic_graph() -> dict[str, Any]:
             model_info["primary_key"] = model.primary_key
         if model.default_time_dimension:
             model_info["default_time_dimension"] = model.default_time_dimension
+        governance = model.model_dump(
+            include={
+                "owner",
+                "domain",
+                "category",
+                "tags",
+                "status",
+                "certification",
+                "deprecation",
+                "freshness",
+                "visibility",
+            },
+            exclude_none=True,
+            exclude_defaults=True,
+            mode="json",
+        )
+        if governance:
+            model_info["governance"] = governance
         models.append(model_info)
 
     # Graph-level metrics
@@ -727,6 +746,9 @@ def get_semantic_graph() -> dict[str, Any]:
             metric_info["numerator"] = metric.numerator
         if metric.denominator:
             metric_info["denominator"] = metric.denominator
+        governance = governance_dict(metric)
+        if governance:
+            metric_info["governance"] = governance
         graph_metrics.append(metric_info)
 
     # Discover joinable model pairs
@@ -752,6 +774,13 @@ def get_semantic_graph() -> dict[str, Any]:
     }
     if graph_metrics:
         result["graph_metrics"] = graph_metrics
+    result["explores"] = [
+        value.model_dump(exclude_none=True, exclude_defaults=True, mode="json") for value in graph.explores.values()
+    ]
+    result["saved_queries"] = [
+        value.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
+        for value in graph.saved_queries.values()
+    ]
 
     return result
 

--- a/sidemantic/schema.py
+++ b/sidemantic/schema.py
@@ -4,6 +4,7 @@ import json
 from copy import deepcopy
 from pathlib import Path
 
+from sidemantic.core.consumption import Explore, SavedQuery
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.freshness import Freshness
 from sidemantic.core.metric import Metric
@@ -67,6 +68,8 @@ def generate_yaml_schema() -> dict:
     metric_schema = Metric.model_json_schema()
     relationship_schema = Relationship.model_json_schema()
     parameter_schema = Parameter.model_json_schema()
+    explore_schema = Explore.model_json_schema()
+    saved_query_schema = SavedQuery.model_json_schema()
 
     # Build complete schema
     schema = {
@@ -86,6 +89,21 @@ def generate_yaml_schema() -> dict:
                 "description": "Parameter definitions for dynamic queries",
                 "items": parameter_schema,
             },
+            "explores": {
+                "type": "array",
+                "description": "Curated Explore/View consumption contracts",
+                "items": explore_schema,
+            },
+            "views": {
+                "type": "array",
+                "description": "Compatibility alias for explores; exports use explores",
+                "items": explore_schema,
+            },
+            "saved_queries": {
+                "type": "array",
+                "description": "Immutable named structured queries",
+                "items": saved_query_schema,
+            },
         },
         "required": ["models"],
         "$defs": {
@@ -93,9 +111,11 @@ def generate_yaml_schema() -> dict:
             **metric_schema.get("$defs", {}),
             **parameter_schema.get("$defs", {}),
             "Dimension": dimension_schema,
+            "Explore": explore_schema,
             "Freshness": Freshness.model_json_schema(),
             "Metric": metric_schema,
             "Relationship": relationship_schema,
+            "SavedQuery": saved_query_schema,
             "Segment": Segment.model_json_schema(),
             "Parameter": parameter_schema,
         },

--- a/sidemantic/schema.py
+++ b/sidemantic/schema.py
@@ -105,7 +105,10 @@ def generate_yaml_schema() -> dict:
                 "items": saved_query_schema,
             },
         },
-        "required": ["models"],
+        "anyOf": [
+            {"required": [section]}
+            for section in ("models", "metrics", "parameters", "explores", "views", "saved_queries")
+        ],
         "$defs": {
             **model_schema.get("$defs", {}),
             **metric_schema.get("$defs", {}),

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -108,6 +108,7 @@ class SQLGenerator:
         preagg_schema: str | None = None,
         timezone: str | None = None,
         allow_non_additive_unsafe: bool = False,
+        base_model: str | None = None,
     ):
         """Initialize SQL generator.
 
@@ -123,12 +124,16 @@ class SQLGenerator:
                 over ALL snapshots (over-aggregated, wrong results). By default the generator
                 implements semi-additive handling (QUALIFY last/first snapshot per group);
                 this flag opts back into the old, naive behavior explicitly (default: False)
+            base_model: Optional model that must anchor the generated join graph. Explore
+                contracts use this to preserve their declared row scope when callers select
+                fields only from joined models.
         """
         self.graph = graph
         self.dialect = dialect
         self.preagg_database = preagg_database
         self.preagg_schema = preagg_schema
         self.allow_non_additive_unsafe = allow_non_additive_unsafe
+        self.base_model = base_model
         # The timezone is interpolated into SQL string literals (AT TIME ZONE '...', etc.),
         # so it must not contain quote/escape characters. Restrict to IANA-name characters
         # to prevent SQL injection from a request- or preference-supplied value; the database
@@ -1485,6 +1490,9 @@ class SQLGenerator:
             if model_name not in seen:
                 models.append(model_name)
                 seen.add(model_name)
+
+        if self.base_model:
+            add_model(self.base_model)
 
         def collect_models_from_metric(metric_ref: str):
             """Recursively collect models needed from a metric."""

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -276,6 +276,17 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
                     f"on model '{model_name}'"
                 )
         if explore is not None:
+            errors.extend(
+                _validate_consumption_expressions(
+                    f"Saved query '{saved_query.name}' inherited Explore '{explore.name}'",
+                    "filter",
+                    explore.filters,
+                    base_model,
+                    graph,
+                    query_metrics=metrics,
+                    query_dimensions=dimensions,
+                )
+            )
             if explore.allowed_metrics is not None:
                 allowed_metrics = set(_qualified_consumption_metrics(explore.allowed_metrics, base_model, graph))
                 denied_metrics = sorted(set(metrics) - allowed_metrics)

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -63,6 +63,10 @@ def _qualified_consumption_metrics(references: list[str], base_model: str, graph
     return [ref if ref in graph.metrics else _qualified_consumption_refs([ref], base_model)[0] for ref in references]
 
 
+def _is_metric_or_dimension(reference: str, graph: "SemanticGraph") -> bool:
+    return not validate_query([reference], [], graph) or not validate_query([], [reference], graph)
+
+
 def validate_explore(explore: "Explore", graph: "SemanticGraph") -> tuple[list[str], list[str]]:
     """Validate a curated Explore/View contract against the physical graph."""
     errors, warnings = validate_governance(explore, f"Explore '{explore.name}'")
@@ -78,17 +82,13 @@ def validate_explore(explore: "Explore", graph: "SemanticGraph") -> tuple[list[s
             graph,
         )
     )
-    filter_fields = _qualified_consumption_refs(explore.allowed_filter_fields or [], explore.model)
-    errors.extend(validate_query([], filter_fields, graph))
-    for raw_reference in explore.allowed_order_by or []:
-        reference = (
-            raw_reference
-            if raw_reference in graph.metrics
-            else _qualified_consumption_refs([raw_reference], explore.model)[0]
-        )
-        if not validate_query([reference], [], graph) or not validate_query([], [reference], graph):
-            continue
-        errors.append(f"Explore '{explore.name}' ordering field '{reference}' is not a metric or dimension")
+    for field_kind, references in (
+        ("filter", explore.allowed_filter_fields or []),
+        ("ordering", explore.allowed_order_by or []),
+    ):
+        for reference in _qualified_consumption_metrics(references, explore.model, graph):
+            if not _is_metric_or_dimension(reference, graph):
+                errors.append(f"Explore '{explore.name}' {field_kind} field '{reference}' is not a metric or dimension")
     if not metrics and not dimensions:
         warnings.append(f"Explore '{explore.name}' defines no allowed or default fields")
     if any(not value.strip() for value in [*explore.filters, *explore.default_filters, *explore.default_order_by]):
@@ -107,6 +107,7 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
             f"{metricflow_metadata.get('compatibility_message', 'convert source expressions to Sidemantic references')}"
         )
     base_model = ""
+    explore = None
     if saved_query.explore:
         explore = graph.explores.get(saved_query.explore)
         if explore is None:
@@ -123,6 +124,58 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
     )
     if not preserved_external_syntax:
         errors.extend(validate_query(metrics, dimensions, graph))
+        if explore is not None:
+            if explore.allowed_metrics is not None:
+                allowed_metrics = set(_qualified_consumption_metrics(explore.allowed_metrics, base_model, graph))
+                denied_metrics = sorted(set(metrics) - allowed_metrics)
+                if denied_metrics:
+                    errors.append(
+                        f"Saved query '{saved_query.name}' selects metric(s) not allowed by Explore "
+                        f"'{explore.name}': {', '.join(denied_metrics)}"
+                    )
+            if explore.allowed_dimensions is not None:
+                allowed_dimensions = set(_qualified_consumption_refs(explore.allowed_dimensions, base_model))
+                denied_dimensions = sorted(set(dimensions) - allowed_dimensions)
+                if denied_dimensions:
+                    errors.append(
+                        f"Saved query '{saved_query.name}' selects dimension(s) not allowed by Explore "
+                        f"'{explore.name}': {', '.join(denied_dimensions)}"
+                    )
+
+            from sidemantic.core.consumption import expression_field_references
+
+            graph_metrics = graph.metrics.keys()
+            if explore.allowed_filter_fields is not None:
+                allowed_filters = set(_qualified_consumption_metrics(explore.allowed_filter_fields, base_model, graph))
+                denied_filters = sorted(
+                    expression_field_references(saved_query.filters, base_model, graph_metrics=graph_metrics)
+                    - allowed_filters
+                )
+                if denied_filters:
+                    errors.append(
+                        f"Saved query '{saved_query.name}' filters on field(s) not allowed by Explore "
+                        f"'{explore.name}': {', '.join(denied_filters)}"
+                    )
+            if explore.allowed_order_by is not None:
+                allowed_ordering = set(_qualified_consumption_metrics(explore.allowed_order_by, base_model, graph))
+                denied_ordering = sorted(
+                    expression_field_references(saved_query.order_by, base_model, graph_metrics=graph_metrics)
+                    - allowed_ordering
+                )
+                if denied_ordering:
+                    errors.append(
+                        f"Saved query '{saved_query.name}' orders by field(s) not allowed by Explore "
+                        f"'{explore.name}': {', '.join(denied_ordering)}"
+                    )
+            if (
+                explore.max_limit is not None
+                and saved_query.limit is not None
+                and saved_query.limit > explore.max_limit
+            ):
+                errors.append(
+                    f"Saved query '{saved_query.name}' limit {saved_query.limit} exceeds Explore "
+                    f"'{explore.name}' max_limit {explore.max_limit}"
+                )
     if not saved_query.metrics and not saved_query.dimensions:
         errors.append(f"Saved query '{saved_query.name}' must select at least one metric or dimension")
     if any(not value.strip() for value in [*saved_query.filters, *saved_query.order_by]):

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Literal, get_args, get_origin
 from sidemantic.sql.aggregation_detection import sql_has_aggregate
 
 if TYPE_CHECKING:
+    from sidemantic.core.consumption import Explore, SavedQuery
     from sidemantic.core.metric import Metric
     from sidemantic.core.model import Model
     from sidemantic.core.semantic_graph import SemanticGraph
@@ -33,6 +34,100 @@ class ModelValidationError(ValidationError):
     """Raised when model validation fails."""
 
     pass
+
+
+def validate_governance(value, label: str) -> tuple[list[str], list[str]]:
+    """Validate cross-field governance lifecycle metadata."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    deprecation = getattr(value, "deprecation", None)
+    status = getattr(value, "status", None)
+    if status == "deprecated" and deprecation is None:
+        errors.append(f"{label} is deprecated but has no deprecation lifecycle/message")
+    if deprecation is not None:
+        if not deprecation.message:
+            warnings.append(f"{label} deprecation has no migration message")
+        if deprecation.deprecated_at and deprecation.sunset_at and deprecation.sunset_at < deprecation.deprecated_at:
+            errors.append(f"{label} deprecation sunset_at is before deprecated_at")
+    tags = getattr(value, "tags", []) or []
+    if len(tags) != len(set(tags)):
+        errors.append(f"{label} has duplicate governance tags")
+    return errors, warnings
+
+
+def _qualified_consumption_refs(references: list[str], base_model: str) -> list[str]:
+    return [ref if "." in ref or "(" in ref or " " in ref else f"{base_model}.{ref}" for ref in references]
+
+
+def _qualified_consumption_metrics(references: list[str], base_model: str, graph: "SemanticGraph") -> list[str]:
+    return [ref if ref in graph.metrics else _qualified_consumption_refs([ref], base_model)[0] for ref in references]
+
+
+def validate_explore(explore: "Explore", graph: "SemanticGraph") -> tuple[list[str], list[str]]:
+    """Validate a curated Explore/View contract against the physical graph."""
+    errors, warnings = validate_governance(explore, f"Explore '{explore.name}'")
+    if explore.model not in graph.models:
+        errors.append(f"Explore '{explore.name}' references model '{explore.model}' which doesn't exist")
+        return errors, warnings
+    dimensions = [*(explore.allowed_dimensions or []), *explore.default_dimensions]
+    metrics = [*(explore.allowed_metrics or []), *explore.default_metrics]
+    errors.extend(
+        validate_query(
+            _qualified_consumption_metrics(metrics, explore.model, graph),
+            _qualified_consumption_refs(dimensions, explore.model),
+            graph,
+        )
+    )
+    filter_fields = _qualified_consumption_refs(explore.allowed_filter_fields or [], explore.model)
+    errors.extend(validate_query([], filter_fields, graph))
+    for raw_reference in explore.allowed_order_by or []:
+        reference = (
+            raw_reference
+            if raw_reference in graph.metrics
+            else _qualified_consumption_refs([raw_reference], explore.model)[0]
+        )
+        if not validate_query([reference], [], graph) or not validate_query([], [reference], graph):
+            continue
+        errors.append(f"Explore '{explore.name}' ordering field '{reference}' is not a metric or dimension")
+    if not metrics and not dimensions:
+        warnings.append(f"Explore '{explore.name}' defines no allowed or default fields")
+    if any(not value.strip() for value in [*explore.filters, *explore.default_filters, *explore.default_order_by]):
+        errors.append(f"Explore '{explore.name}' contains an empty filter or ordering expression")
+    return errors, warnings
+
+
+def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> tuple[list[str], list[str]]:
+    """Validate a SavedQuery against its Explore and physical graph."""
+    errors, warnings = validate_governance(saved_query, f"Saved query '{saved_query.name}'")
+    metricflow_metadata = (saved_query.metadata or {}).get("metricflow", {})
+    preserved_external_syntax = metricflow_metadata.get("executable") is False
+    if preserved_external_syntax:
+        warnings.append(
+            f"Saved query '{saved_query.name}' is preserved from MetricFlow but is not executable: "
+            f"{metricflow_metadata.get('compatibility_message', 'convert source expressions to Sidemantic references')}"
+        )
+    base_model = ""
+    if saved_query.explore:
+        explore = graph.explores.get(saved_query.explore)
+        if explore is None:
+            errors.append(
+                f"Saved query '{saved_query.name}' references explore '{saved_query.explore}' which doesn't exist"
+            )
+        else:
+            base_model = explore.model
+    metrics = (
+        _qualified_consumption_metrics(saved_query.metrics, base_model, graph) if base_model else saved_query.metrics
+    )
+    dimensions = (
+        _qualified_consumption_refs(saved_query.dimensions, base_model) if base_model else saved_query.dimensions
+    )
+    if not preserved_external_syntax:
+        errors.extend(validate_query(metrics, dimensions, graph))
+    if not saved_query.metrics and not saved_query.dimensions:
+        errors.append(f"Saved query '{saved_query.name}' must select at least one metric or dimension")
+    if any(not value.strip() for value in [*saved_query.filters, *saved_query.order_by]):
+        errors.append(f"Saved query '{saved_query.name}' contains an empty filter or ordering expression")
+    return errors, warnings
 
 
 def _extract_literal_strings(annotation) -> set[str]:

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -124,6 +124,28 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
     )
     if not preserved_external_syntax:
         errors.extend(validate_query(metrics, dimensions, graph))
+        for raw_segment in saved_query.segments:
+            segment_ref = raw_segment
+            if "." not in segment_ref and base_model:
+                segment_ref = f"{base_model}.{segment_ref}"
+            if "." not in segment_ref:
+                errors.append(
+                    f"Saved query '{saved_query.name}' segment reference must be in format 'model.segment': "
+                    f"{raw_segment}"
+                )
+                continue
+            model_name, segment_name = segment_ref.split(".", 1)
+            model = graph.models.get(model_name)
+            if model is None:
+                errors.append(
+                    f"Saved query '{saved_query.name}' segment '{raw_segment}' references model "
+                    f"'{model_name}' which doesn't exist"
+                )
+            elif model.get_segment(segment_name) is None:
+                errors.append(
+                    f"Saved query '{saved_query.name}' references segment '{segment_name}' which doesn't exist "
+                    f"on model '{model_name}'"
+                )
         if explore is not None:
             if explore.allowed_metrics is not None:
                 allowed_metrics = set(_qualified_consumption_metrics(explore.allowed_metrics, base_model, graph))

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -130,6 +130,27 @@ def _validate_order_fields_selected(
     return [f"{label} ordering field(s) must be selected by the query: {', '.join(outside)}"]
 
 
+def _validate_consumption_base_model(
+    label: str,
+    base_model: str,
+    metrics: list[str],
+    dimensions: list[str],
+    graph: "SemanticGraph",
+) -> list[str]:
+    from sidemantic.sql.generator import SQLGenerator
+
+    selected_models = SQLGenerator(graph)._find_required_models(metrics, dimensions, [])
+    errors: list[str] = []
+    for model_name in selected_models:
+        if model_name == base_model:
+            continue
+        try:
+            graph.find_relationship_path(base_model, model_name)
+        except (KeyError, ValueError):
+            errors.append(f"{label} has no join path from base model '{base_model}' to selected model '{model_name}'")
+    return errors
+
+
 def validate_explore(explore: "Explore", graph: "SemanticGraph") -> tuple[list[str], list[str]]:
     """Validate a curated Explore/View contract against the physical graph."""
     errors, warnings = validate_governance(explore, f"Explore '{explore.name}'")
@@ -142,6 +163,15 @@ def validate_explore(explore: "Explore", graph: "SemanticGraph") -> tuple[list[s
     qualified_dimensions = _qualified_consumption_refs(dimensions, explore.model)
     errors.extend(
         validate_query(
+            qualified_metrics,
+            qualified_dimensions,
+            graph,
+        )
+    )
+    errors.extend(
+        _validate_consumption_base_model(
+            f"Explore '{explore.name}'",
+            explore.model,
             qualified_metrics,
             qualified_dimensions,
             graph,
@@ -219,13 +249,25 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
     dimensions = (
         _qualified_consumption_refs(saved_query.dimensions, base_model) if base_model else saved_query.dimensions
     )
+    validated_filters = list(saved_query.filters)
+    inherited_explore_filters = list(explore.filters) if explore is not None else []
+    from sidemantic.core.parameter import ParameterSet
+
+    parameter_set = ParameterSet(graph.parameters, saved_query.parameters)
+    try:
+        validated_filters = [parameter_set.interpolate(expression) for expression in validated_filters]
+        inherited_explore_filters = [parameter_set.interpolate(expression) for expression in inherited_explore_filters]
+    except (KeyError, TypeError, ValueError) as error:
+        errors.append(f"Saved query '{saved_query.name}' has invalid parameter values: {error}")
+        validated_filters = []
+        inherited_explore_filters = []
     if not preserved_external_syntax:
         errors.extend(validate_query(metrics, dimensions, graph))
         errors.extend(
             _validate_consumption_expressions(
                 f"Saved query '{saved_query.name}'",
                 "filter",
-                saved_query.filters,
+                validated_filters,
                 base_model,
                 graph,
                 query_metrics=metrics,
@@ -277,10 +319,19 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
                 )
         if explore is not None:
             errors.extend(
+                _validate_consumption_base_model(
+                    f"Saved query '{saved_query.name}'",
+                    explore.model,
+                    metrics,
+                    dimensions,
+                    graph,
+                )
+            )
+            errors.extend(
                 _validate_consumption_expressions(
                     f"Saved query '{saved_query.name}' inherited Explore '{explore.name}'",
                     "filter",
-                    explore.filters,
+                    inherited_explore_filters,
                     base_model,
                     graph,
                     query_metrics=metrics,
@@ -310,7 +361,7 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
             if explore.allowed_filter_fields is not None:
                 allowed_filters = set(_qualified_consumption_metrics(explore.allowed_filter_fields, base_model, graph))
                 denied_filters = sorted(
-                    expression_field_references(saved_query.filters, base_model, graph_metrics=graph_metrics)
+                    expression_field_references(validated_filters, base_model, graph_metrics=graph_metrics)
                     - allowed_filters
                 )
                 if denied_filters:

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -80,7 +80,12 @@ def _validate_consumption_expressions(
     from sidemantic.core.consumption import expression_field_references
 
     try:
-        references = expression_field_references(expressions, base_model, graph_metrics=graph.metrics.keys())
+        references = expression_field_references(
+            expressions,
+            base_model,
+            graph_metrics=graph.metrics.keys(),
+            graph_models=graph.models.keys(),
+        )
     except Exception as error:
         return [f"{label} contains an invalid {field_kind} expression: {error}"]
     errors = [
@@ -120,7 +125,12 @@ def _validate_order_fields_selected(
     from sidemantic.core.consumption import expression_field_references
 
     try:
-        references = expression_field_references(expressions, base_model, graph_metrics=graph.metrics.keys())
+        references = expression_field_references(
+            expressions,
+            base_model,
+            graph_metrics=graph.metrics.keys(),
+            graph_models=graph.models.keys(),
+        )
     except Exception:
         return []
     selected = {*selected_metrics, *selected_dimensions}
@@ -369,7 +379,12 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
             if explore.allowed_filter_fields is not None:
                 allowed_filters = set(_qualified_consumption_metrics(explore.allowed_filter_fields, base_model, graph))
                 denied_filters = sorted(
-                    expression_field_references(validated_filters, base_model, graph_metrics=graph_metrics)
+                    expression_field_references(
+                        validated_filters,
+                        base_model,
+                        graph_metrics=graph_metrics,
+                        graph_models=graph.models.keys(),
+                    )
                     - allowed_filters
                 )
                 if denied_filters:
@@ -380,7 +395,12 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
             if explore.allowed_order_by is not None:
                 allowed_ordering = set(_qualified_consumption_metrics(explore.allowed_order_by, base_model, graph))
                 denied_ordering = sorted(
-                    expression_field_references(saved_query.order_by, base_model, graph_metrics=graph_metrics)
+                    expression_field_references(
+                        saved_query.order_by,
+                        base_model,
+                        graph_metrics=graph_metrics,
+                        graph_models=graph.models.keys(),
+                    )
                     - allowed_ordering
                 )
                 if denied_ordering:

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -73,6 +73,9 @@ def _validate_consumption_expressions(
     expressions: list[str],
     base_model: str,
     graph: "SemanticGraph",
+    *,
+    query_metrics: list[str] | None = None,
+    query_dimensions: list[str] | None = None,
 ) -> list[str]:
     from sidemantic.core.consumption import expression_field_references
 
@@ -80,11 +83,51 @@ def _validate_consumption_expressions(
         references = expression_field_references(expressions, base_model, graph_metrics=graph.metrics.keys())
     except Exception as error:
         return [f"{label} contains an invalid {field_kind} expression: {error}"]
-    return [
+    errors = [
         f"{label} {field_kind} field '{reference}' is not a metric or dimension"
         for reference in sorted(references)
         if not _is_metric_or_dimension(reference, graph)
     ]
+    if errors:
+        return errors
+
+    expression_metrics: list[str] = []
+    expression_dimensions: list[str] = []
+    for reference in sorted(references):
+        if not validate_query([reference], [], graph):
+            expression_metrics.append(reference)
+        else:
+            expression_dimensions.append(reference)
+    compatibility_errors = validate_query(
+        [*(query_metrics or []), *expression_metrics],
+        [*(query_dimensions or []), *expression_dimensions],
+        graph,
+    )
+    return [
+        f"{label} {field_kind} expression is incompatible with its selected query: {error}"
+        for error in compatibility_errors
+    ]
+
+
+def _validate_order_fields_selected(
+    label: str,
+    expressions: list[str],
+    selected_metrics: list[str],
+    selected_dimensions: list[str],
+    base_model: str,
+    graph: "SemanticGraph",
+) -> list[str]:
+    from sidemantic.core.consumption import expression_field_references
+
+    try:
+        references = expression_field_references(expressions, base_model, graph_metrics=graph.metrics.keys())
+    except Exception:
+        return []
+    selected = {*selected_metrics, *selected_dimensions}
+    outside = sorted(references - selected)
+    if not outside:
+        return []
+    return [f"{label} ordering field(s) must be selected by the query: {', '.join(outside)}"]
 
 
 def validate_explore(explore: "Explore", graph: "SemanticGraph") -> tuple[list[str], list[str]]:
@@ -95,10 +138,12 @@ def validate_explore(explore: "Explore", graph: "SemanticGraph") -> tuple[list[s
         return errors, warnings
     dimensions = [*(explore.allowed_dimensions or []), *explore.default_dimensions]
     metrics = [*(explore.allowed_metrics or []), *explore.default_metrics]
+    qualified_metrics = _qualified_consumption_metrics(metrics, explore.model, graph)
+    qualified_dimensions = _qualified_consumption_refs(dimensions, explore.model)
     errors.extend(
         validate_query(
-            _qualified_consumption_metrics(metrics, explore.model, graph),
-            _qualified_consumption_refs(dimensions, explore.model),
+            qualified_metrics,
+            qualified_dimensions,
             graph,
         )
     )
@@ -116,11 +161,29 @@ def validate_explore(explore: "Explore", graph: "SemanticGraph") -> tuple[list[s
             [*explore.filters, *explore.default_filters],
             explore.model,
             graph,
+            query_metrics=qualified_metrics,
+            query_dimensions=qualified_dimensions,
         )
     )
     errors.extend(
         _validate_consumption_expressions(
-            f"Explore '{explore.name}'", "ordering", explore.default_order_by, explore.model, graph
+            f"Explore '{explore.name}'",
+            "ordering",
+            explore.default_order_by,
+            explore.model,
+            graph,
+            query_metrics=qualified_metrics,
+            query_dimensions=qualified_dimensions,
+        )
+    )
+    errors.extend(
+        _validate_order_fields_selected(
+            f"Explore '{explore.name}' default",
+            explore.default_order_by,
+            _qualified_consumption_metrics(explore.default_metrics, explore.model, graph),
+            _qualified_consumption_refs(explore.default_dimensions, explore.model),
+            explore.model,
+            graph,
         )
     )
     if not metrics and not dimensions:
@@ -160,12 +223,34 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
         errors.extend(validate_query(metrics, dimensions, graph))
         errors.extend(
             _validate_consumption_expressions(
-                f"Saved query '{saved_query.name}'", "filter", saved_query.filters, base_model, graph
+                f"Saved query '{saved_query.name}'",
+                "filter",
+                saved_query.filters,
+                base_model,
+                graph,
+                query_metrics=metrics,
+                query_dimensions=dimensions,
             )
         )
         errors.extend(
             _validate_consumption_expressions(
-                f"Saved query '{saved_query.name}'", "ordering", saved_query.order_by, base_model, graph
+                f"Saved query '{saved_query.name}'",
+                "ordering",
+                saved_query.order_by,
+                base_model,
+                graph,
+                query_metrics=metrics,
+                query_dimensions=dimensions,
+            )
+        )
+        errors.extend(
+            _validate_order_fields_selected(
+                f"Saved query '{saved_query.name}'",
+                saved_query.order_by,
+                metrics,
+                dimensions,
+                base_model,
+                graph,
             )
         )
         for raw_segment in saved_query.segments:

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -67,6 +67,26 @@ def _is_metric_or_dimension(reference: str, graph: "SemanticGraph") -> bool:
     return not validate_query([reference], [], graph) or not validate_query([], [reference], graph)
 
 
+def _validate_consumption_expressions(
+    label: str,
+    field_kind: str,
+    expressions: list[str],
+    base_model: str,
+    graph: "SemanticGraph",
+) -> list[str]:
+    from sidemantic.core.consumption import expression_field_references
+
+    try:
+        references = expression_field_references(expressions, base_model, graph_metrics=graph.metrics.keys())
+    except Exception as error:
+        return [f"{label} contains an invalid {field_kind} expression: {error}"]
+    return [
+        f"{label} {field_kind} field '{reference}' is not a metric or dimension"
+        for reference in sorted(references)
+        if not _is_metric_or_dimension(reference, graph)
+    ]
+
+
 def validate_explore(explore: "Explore", graph: "SemanticGraph") -> tuple[list[str], list[str]]:
     """Validate a curated Explore/View contract against the physical graph."""
     errors, warnings = validate_governance(explore, f"Explore '{explore.name}'")
@@ -89,6 +109,20 @@ def validate_explore(explore: "Explore", graph: "SemanticGraph") -> tuple[list[s
         for reference in _qualified_consumption_metrics(references, explore.model, graph):
             if not _is_metric_or_dimension(reference, graph):
                 errors.append(f"Explore '{explore.name}' {field_kind} field '{reference}' is not a metric or dimension")
+    errors.extend(
+        _validate_consumption_expressions(
+            f"Explore '{explore.name}'",
+            "filter",
+            [*explore.filters, *explore.default_filters],
+            explore.model,
+            graph,
+        )
+    )
+    errors.extend(
+        _validate_consumption_expressions(
+            f"Explore '{explore.name}'", "ordering", explore.default_order_by, explore.model, graph
+        )
+    )
     if not metrics and not dimensions:
         warnings.append(f"Explore '{explore.name}' defines no allowed or default fields")
     if any(not value.strip() for value in [*explore.filters, *explore.default_filters, *explore.default_order_by]):
@@ -124,6 +158,16 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
     )
     if not preserved_external_syntax:
         errors.extend(validate_query(metrics, dimensions, graph))
+        errors.extend(
+            _validate_consumption_expressions(
+                f"Saved query '{saved_query.name}'", "filter", saved_query.filters, base_model, graph
+            )
+        )
+        errors.extend(
+            _validate_consumption_expressions(
+                f"Saved query '{saved_query.name}'", "ordering", saved_query.order_by, base_model, graph
+            )
+        )
         for raw_segment in saved_query.segments:
             segment_ref = raw_segment
             if "." not in segment_ref and base_model:

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -136,10 +136,11 @@ def _validate_consumption_base_model(
     metrics: list[str],
     dimensions: list[str],
     graph: "SemanticGraph",
+    filters: list[str] | None = None,
 ) -> list[str]:
     from sidemantic.sql.generator import SQLGenerator
 
-    selected_models = SQLGenerator(graph)._find_required_models(metrics, dimensions, [])
+    selected_models = SQLGenerator(graph)._find_required_models(metrics, dimensions, filters or [])
     errors: list[str] = []
     for model_name in selected_models:
         if model_name == base_model:
@@ -295,6 +296,7 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
                 graph,
             )
         )
+        valid_segments: list[str] = []
         for raw_segment in saved_query.segments:
             segment_ref = raw_segment
             if "." not in segment_ref and base_model:
@@ -317,7 +319,12 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
                     f"Saved query '{saved_query.name}' references segment '{segment_name}' which doesn't exist "
                     f"on model '{model_name}'"
                 )
+            else:
+                valid_segments.append(segment_ref)
         if explore is not None:
+            from sidemantic.sql.generator import SQLGenerator
+
+            segment_filters = SQLGenerator(graph)._resolve_segments(valid_segments)
             errors.extend(
                 _validate_consumption_base_model(
                     f"Saved query '{saved_query.name}'",
@@ -325,6 +332,7 @@ def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> t
                     metrics,
                     dimensions,
                     graph,
+                    filters=segment_filters,
                 )
             )
             errors.extend(

--- a/sidemantic/validation_runner.py
+++ b/sidemantic/validation_runner.py
@@ -4,7 +4,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from sidemantic import SemanticLayer, load_from_directory
-from sidemantic.validation import validate_metric, validate_model, validate_model_warnings
+from sidemantic.validation import (
+    validate_explore,
+    validate_governance,
+    validate_metric,
+    validate_model,
+    validate_model_warnings,
+    validate_saved_query,
+)
 
 
 @dataclass
@@ -36,6 +43,9 @@ def validate_directory(directory: str | Path) -> ValidationReport:
     for model_name, model in layer.graph.models.items():
         report.errors.extend(validate_model(model))
         report.warnings.extend(validate_model_warnings(model))
+        governance_errors, governance_warnings = validate_governance(model, f"Model '{model_name}'")
+        report.errors.extend(governance_errors)
+        report.warnings.extend(governance_warnings)
 
         if not model.dimensions:
             report.warnings.append(f"Model '{model_name}' has no dimensions")
@@ -44,6 +54,9 @@ def validate_directory(directory: str | Path) -> ValidationReport:
 
         for metric in model.metrics:
             report.errors.extend(validate_metric(metric, layer.graph))
+            governance_errors, governance_warnings = validate_governance(metric, f"Metric '{model_name}.{metric.name}'")
+            report.errors.extend(governance_errors)
+            report.warnings.extend(governance_warnings)
 
         for rel in model.relationships:
             if rel.name not in layer.graph.models:
@@ -66,6 +79,19 @@ def validate_directory(directory: str | Path) -> ValidationReport:
 
     for metric in layer.graph.metrics.values():
         report.errors.extend(validate_metric(metric, layer.graph))
+        governance_errors, governance_warnings = validate_governance(metric, f"Metric '{metric.name}'")
+        report.errors.extend(governance_errors)
+        report.warnings.extend(governance_warnings)
+
+    for explore in layer.graph.explores.values():
+        errors, warnings = validate_explore(explore, layer.graph)
+        report.errors.extend(errors)
+        report.warnings.extend(warnings)
+
+    for saved_query in layer.graph.saved_queries.values():
+        errors, warnings = validate_saved_query(saved_query, layer.graph)
+        report.errors.extend(errors)
+        report.warnings.extend(warnings)
 
     if len(layer.graph.models) > 1:
         orphaned = []
@@ -89,5 +115,7 @@ def validate_directory(directory: str | Path) -> ValidationReport:
     report.info.append(f"Total dimensions: {total_dims}")
     report.info.append(f"Total metrics: {total_metrics}")
     report.info.append(f"Total relationships: {total_rels}")
+    report.info.append(f"Total explores: {len(layer.graph.explores)}")
+    report.info.append(f"Total saved queries: {len(layer.graph.saved_queries)}")
 
     return report

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 # Test captured output against Sidemantic's default policy even when the host
 # runner requests colored logs. Individual color tests opt back in explicitly.
 os.environ.pop("FORCE_COLOR", None)
+os.environ["NO_COLOR"] = "1"
 
 from sidemantic import SemanticLayer
 

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -482,23 +482,29 @@ view: customers {
   dimension: id { primary_key: yes sql: ${TABLE}.id ;; }
   dimension: region { sql: ${TABLE}.region ;; }
 }
-explore: orders {
-  sql_always_where: ${TABLE}.id > 0 ;;
-  always_filter: { filters: [customers.region: "West"] }
-  join: customers {
+explore: sales {
+  from: orders
+  fields: [orders.count, buyer.region]
+  sql_always_where: ${sales.id} > 0 AND ${TABLE}.id > 0 ;;
+  always_filter: { filters: [buyer.region: "West"] }
+  join: buyer {
+    from: customers
     relationship: many_to_one
-    sql_on: ${orders.customer_id} = ${customers.id} ;;
+    sql_on: ${sales.customer_id} = ${buyer.id} ;;
   }
 }
 """.strip()
     )
 
     graph = LookMLAdapter().parse(source)
-    assert graph.explores["orders"].filters == ["orders.id > 0", "customers.region = 'West'"]
+    explore = graph.explores["sales"]
+    assert explore.filters == ["orders.id > 0 AND orders.id > 0", "customers.region = 'West'"]
+    assert explore.allowed_metrics == ["orders.count"]
+    assert explore.allowed_dimensions == ["customers.region"]
 
     layer = SemanticLayer(auto_register=False)
     layer.graph = graph
-    sql = layer.compile(explore="orders", metrics=["orders.count"])
+    sql = layer.compile(explore="sales", metrics=["orders.count"])
     assert "FROM customers" in sql
     assert "WHERE region = 'West'" in sql
     assert "WHERE id > 0" in sql

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -1,0 +1,292 @@
+"""Tests for curated consumption and semantic-governance contracts."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+from typer.testing import CliRunner
+
+from sidemantic import Deprecation, Dimension, Explore, Metric, Model, SavedQuery, SecurityError, SemanticLayer, View
+from sidemantic.adapters.hex import HexAdapter
+from sidemantic.adapters.lookml import LookMLAdapter
+from sidemantic.adapters.metricflow import MetricFlowAdapter
+from sidemantic.adapters.sidemantic import SidemanticAdapter
+from sidemantic.api_server import create_app
+from sidemantic.cli import app
+from sidemantic.schema import generate_yaml_schema
+from sidemantic.validation import validate_explore, validate_governance, validate_saved_query
+
+
+def _layer() -> SemanticLayer:
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            primary_key="order_id",
+            owner="analytics",
+            domain="commerce",
+            category="sales",
+            tags=["tier-1", "finance"],
+            status="active",
+            certification="certified",
+            dimensions=[
+                Dimension(name="status", type="categorical"),
+                Dimension(name="created_at", type="time", granularity="day"),
+            ],
+            metrics=[
+                Metric(name="revenue", agg="sum", sql="amount", owner="finance"),
+                Metric(name="order_count", agg="count"),
+            ],
+        )
+    )
+    layer.graph.add_explore(
+        Explore(
+            name="revenue_overview",
+            model="orders",
+            label="Revenue overview",
+            allowed_dimensions=["status", "created_at__month"],
+            allowed_metrics=["revenue", "order_count"],
+            allowed_filter_fields=["status"],
+            allowed_order_by=["revenue"],
+            default_dimensions=["status"],
+            default_metrics=["revenue"],
+            filters=["orders.status != 'deleted'"],
+            default_filters=["orders.status = 'paid'"],
+            default_order_by=["orders.revenue DESC"],
+            default_limit=25,
+            max_limit=100,
+            owner="analytics",
+            domain="commerce",
+            certification="verified",
+        )
+    )
+    layer.graph.add_saved_query(
+        SavedQuery(
+            name="paid_revenue",
+            explore="revenue_overview",
+            dimensions=["status"],
+            metrics=["revenue"],
+            filters=["orders.status = 'paid'"],
+            order_by=["orders.revenue DESC"],
+            limit=10,
+        )
+    )
+    return layer
+
+
+def test_view_is_public_alias_for_explore():
+    assert View is Explore
+
+
+def test_explore_defaults_compile_and_mandatory_filters_apply():
+    sql = _layer().compile(explore="revenue_overview")
+
+    assert "SUM(orders_cte.revenue_raw)" in sql
+    assert "status <> 'deleted'" in sql
+    assert "status = 'paid'" in sql
+    assert "ORDER BY" in sql
+    assert "LIMIT 25" in sql
+
+
+def test_explore_enforces_allowlists_and_max_limit():
+    layer = _layer()
+
+    with pytest.raises(ValueError, match="does not allow dimension"):
+        layer.compile(explore="revenue_overview", dimensions=["orders.order_id"])
+    with pytest.raises(ValueError, match="does not allow filter field"):
+        layer.compile(explore="revenue_overview", filters=["orders.created_at > '2026-01-01'"])
+    with pytest.raises(ValueError, match="does not allow ordering"):
+        layer.compile(explore="revenue_overview", order_by=["orders.status"])
+    with pytest.raises(ValueError, match="exceeds max_limit"):
+        layer.compile(explore="revenue_overview", limit=101)
+
+
+def test_saved_query_is_immutable_and_compiles_through_its_explore():
+    layer = _layer()
+
+    sql = layer.compile(saved_query="paid_revenue")
+    assert "LIMIT 10" in sql
+    assert "status <> 'deleted'" in sql
+    with pytest.raises(ValueError, match="immutable"):
+        layer.compile(saved_query="paid_revenue", metrics=["orders.order_count"])
+
+
+def test_native_yaml_roundtrip_preserves_contracts_and_governance(tmp_path: Path):
+    source = tmp_path / "models.yml"
+    output = tmp_path / "roundtrip.yml"
+    source.write_text(
+        """
+version: 1
+models:
+  - name: orders
+    table: orders
+    owner: analytics
+    domain: commerce
+    category: sales
+    tags: [tier-1]
+    status: deprecated
+    certification: certified
+    deprecation:
+      message: Use completed_orders
+      deprecated_at: 2026-01-01
+      sunset_at: 2026-12-31
+      replaced_by: completed_orders
+    visibility: internal
+    dimensions:
+      - name: status
+        type: categorical
+    metrics:
+      - name: revenue
+        agg: sum
+        sql: amount
+        owner: finance
+        freshness:
+          watermark: updated_at
+          ttl_seconds: 3600
+explores:
+  - name: revenue_overview
+    model: orders
+    allowed_dimensions: [status]
+    allowed_metrics: [revenue]
+    allowed_filter_fields: [status]
+    allowed_order_by: [revenue]
+    default_metrics: [revenue]
+    owner: analytics
+saved_queries:
+  - name: revenue_by_status
+    explore: revenue_overview
+    dimensions: [status]
+    metrics: [revenue]
+    limit: 20
+""".strip()
+    )
+
+    graph = SidemanticAdapter().parse(source)
+    assert graph.models["orders"].deprecation == Deprecation(
+        message="Use completed_orders",
+        deprecated_at="2026-01-01",
+        sunset_at="2026-12-31",
+        replaced_by="completed_orders",
+    )
+    assert graph.models["orders"].visibility == "internal"
+    assert graph.models["orders"].metrics[0].freshness.ttl_seconds == 3600
+    assert graph.explores["revenue_overview"].owner == "analytics"
+    assert graph.saved_queries["revenue_by_status"].limit == 20
+
+    SidemanticAdapter().export(graph, output)
+    exported = yaml.safe_load(output.read_text())
+    assert exported["models"][0]["owner"] == "analytics"
+    assert exported["models"][0]["deprecation"]["replaced_by"] == "completed_orders"
+    assert exported["explores"][0]["allowed_metrics"] == ["revenue"]
+    assert exported["explores"][0]["allowed_filter_fields"] == ["status"]
+    assert exported["saved_queries"][0]["name"] == "revenue_by_status"
+
+
+def test_validation_catalog_and_description_include_consumption_contracts():
+    layer = _layer()
+    errors, warnings = validate_explore(layer.graph.explores["revenue_overview"], layer.graph)
+    assert errors == []
+    assert warnings == []
+
+    catalog = layer.get_catalog_metadata()
+    assert catalog["explores"][0]["name"] == "revenue_overview"
+    assert catalog["saved_queries"][0]["name"] == "paid_revenue"
+    assert catalog["tables"][0]["owner"] == "analytics"
+
+    description = layer.describe_models()
+    assert description["models"][0]["governance"]["certification"] == "certified"
+    assert description["explores"][0]["name"] == "revenue_overview"
+
+    errors, _warnings = validate_governance(Metric(name="legacy", agg="count", status="deprecated"), "Metric 'legacy'")
+    assert errors == ["Metric 'legacy' is deprecated but has no deprecation lifecycle/message"]
+
+
+def test_visibility_enforcement_covers_models_metrics_and_explores():
+    layer = _layer()
+    layer.enforce_visibility = True
+    layer.graph.models["orders"].visibility = "internal"
+    with pytest.raises(SecurityError, match="not public"):
+        layer.compile(explore="revenue_overview")
+    layer.graph.models["orders"].visibility = "public"
+    layer.graph.models["orders"].metrics[0].visibility = "internal"
+    with pytest.raises(SecurityError, match="not public"):
+        layer.compile(explore="revenue_overview")
+
+
+def test_meta_api_exposes_consumption_contracts():
+    client = TestClient(create_app(_layer()))
+
+    assert client.get("/explores").json()[0]["name"] == "revenue_overview"
+    assert client.get("/saved-queries").json()[0]["name"] == "paid_revenue"
+    graph = client.get("/graph").json()
+    assert graph["explores"][0]["model"] == "orders"
+    compiled = client.post("/compile", json={"saved_query": "paid_revenue"})
+    assert compiled.status_code == 200, compiled.text
+    assert "LIMIT 10" in compiled.json()["sql"]
+
+
+def test_schema_and_cli_expose_contracts(tmp_path: Path):
+    schema = generate_yaml_schema()
+    assert "explores" in schema["properties"]
+    assert "saved_queries" in schema["properties"]
+
+    model_file = tmp_path / "models.yml"
+    model_file.write_text(
+        """
+models:
+  - name: orders
+    table: orders
+    dimensions:
+      - name: status
+    metrics:
+      - name: revenue
+        agg: sum
+        sql: amount
+explores:
+  - name: revenue_overview
+    model: orders
+    default_dimensions: [status]
+    default_metrics: [revenue]
+saved_queries:
+  - name: revenue_by_status
+    explore: revenue_overview
+    dimensions: [status]
+    metrics: [revenue]
+""".strip()
+    )
+    runner = CliRunner()
+
+    info = runner.invoke(app, ["info", str(tmp_path), "--json"])
+    assert info.exit_code == 0, info.output
+    assert '"revenue_overview"' in info.output
+    assert '"revenue_by_status"' in info.output
+
+    dry_run = runner.invoke(
+        app,
+        ["query", "--models", str(tmp_path), "--saved-query", "revenue_by_status", "--dry-run"],
+    )
+    assert dry_run.exit_code == 0, dry_run.output
+    assert "SUM" in dry_run.output
+
+
+def test_lossless_adapter_bridges_create_typed_contracts():
+    hex_graph = HexAdapter().parse(Path("tests/fixtures/hex/subscriptions_project.yml"))
+    assert hex_graph.explores["revenue_overview"].model == "subscriptions"
+    assert hex_graph.explores["revenue_overview"].allowed_metrics == [
+        "subscriptions.total_mrr",
+        "subscriptions.current_mrr",
+    ]
+
+    metricflow_graph = MetricFlowAdapter().parse(Path("tests/fixtures/metricflow/simple_manifest_saved_queries.yaml"))
+    assert metricflow_graph.saved_queries["p0_booking_with_order_by_and_limit"].limit == 10
+    assert "metricflow" in metricflow_graph.saved_queries["p0_booking"].metadata
+    errors, warnings = validate_saved_query(metricflow_graph.saved_queries["p0_booking"], metricflow_graph)
+    assert errors == []
+    assert any("not executable" in warning for warning in warnings)
+
+    lookml_graph = LookMLAdapter().parse(Path("tests/fixtures/lookml/edge_cases_explores.lkml"))
+    assert lookml_graph.explores["orders"].model == "fact_orders"
+    assert lookml_graph.explores["orders"].category == "Sales"
+    assert lookml_graph.explores["completed_orders"].filters == ["{model}.status = 'completed'"]

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -13,6 +13,7 @@ from sidemantic import (
     Explore,
     Metric,
     Model,
+    Parameter,
     Relationship,
     SavedQuery,
     SecurityError,
@@ -447,6 +448,17 @@ def test_validation_rejects_expression_models_without_a_join_path():
     errors, _warnings = validate_saved_query(saved_query, layer.graph)
     assert any("filter expression is incompatible" in error and "No join path found" in error for error in errors)
 
+    disconnected_selection = Explore(
+        name="disconnected_selection",
+        model="orders",
+        default_dimensions=["customers.region"],
+    )
+    errors, _warnings = validate_explore(disconnected_selection, layer.graph)
+    assert (
+        "Explore 'disconnected_selection' has no join path from base model 'orders' to selected model 'customers'"
+        in errors
+    )
+
 
 def test_validation_checks_saved_query_with_mandatory_explore_filters():
     layer = _layer()
@@ -477,6 +489,37 @@ def test_validation_checks_saved_query_with_mandatory_explore_filters():
         and "No join path found" in error
         for error in errors
     )
+
+    layer.graph.add_explore(Explore(name="unfiltered_orders", model="orders"))
+    disconnected_without_filter = SavedQuery(
+        name="disconnected_without_filter",
+        explore="unfiltered_orders",
+        metrics=["customers.customer_count"],
+    )
+    errors, _warnings = validate_saved_query(disconnected_without_filter, layer.graph)
+    assert (
+        "Saved query 'disconnected_without_filter' has no join path from base model 'orders' "
+        "to selected model 'customers'" in errors
+    )
+
+
+def test_validation_interpolates_saved_query_parameters():
+    layer = _layer()
+    with pytest.warns(DeprecationWarning):
+        layer.graph.add_parameter(Parameter(name="status", type="string"))
+    saved_query = SavedQuery(
+        name="parameterized_status",
+        explore="revenue_overview",
+        metrics=["revenue"],
+        filters=["orders.status = {{ status }}"],
+        parameters={"status": "paid"},
+    )
+
+    errors, _warnings = validate_saved_query(saved_query, layer.graph)
+
+    assert errors == []
+    layer.graph.add_saved_query(saved_query)
+    assert "status = 'paid'" in layer.compile(saved_query="parameterized_status")
 
 
 def test_validation_requires_order_fields_in_default_or_saved_selection():
@@ -556,6 +599,17 @@ def test_visibility_enforcement_rejects_segments_on_private_models():
 
     with pytest.raises(SecurityError, match="secret_orders.visible_segment.*not public"):
         layer.compile(metrics=["orders.revenue"], segments=["secret_orders.visible_segment"])
+
+    layer.graph.models["orders"].segments.extend(
+        [
+            Segment(name="public_orders", sql="{model}.status = 'paid'"),
+            Segment(name="private_orders", sql="{model}.status = 'internal'", public=False),
+        ]
+    )
+    orders_graph = next(
+        model for model in TestClient(create_app(layer)).get("/graph").json()["models"] if model["name"] == "orders"
+    )
+    assert orders_graph["segments"] == ["public_orders"]
 
 
 def test_meta_api_exposes_consumption_contracts():

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -409,6 +409,37 @@ def test_validation_rejects_expression_models_without_a_join_path():
     assert any("filter expression is incompatible" in error and "No join path found" in error for error in errors)
 
 
+def test_validation_checks_saved_query_with_mandatory_explore_filters():
+    layer = _layer()
+    layer.add_model(
+        Model(
+            name="customers",
+            table="customers",
+            metrics=[Metric(name="customer_count", agg="count")],
+        )
+    )
+    layer.graph.add_explore(
+        Explore(
+            name="mandatory_orders_filter",
+            model="orders",
+            filters=["status = 'paid'"],
+        )
+    )
+    saved_query = SavedQuery(
+        name="disconnected_from_mandatory_filter",
+        explore="mandatory_orders_filter",
+        metrics=["customers.customer_count"],
+    )
+
+    errors, _warnings = validate_saved_query(saved_query, layer.graph)
+
+    assert any(
+        "inherited Explore 'mandatory_orders_filter' filter expression is incompatible" in error
+        and "No join path found" in error
+        for error in errors
+    )
+
+
 def test_validation_requires_order_fields_in_default_or_saved_selection():
     layer = _layer()
     explore = Explore(

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -310,6 +310,27 @@ def test_visibility_enforcement_covers_models_metrics_and_explores():
         layer.compile(explore="revenue_overview")
 
 
+def test_visibility_enforcement_rejects_graph_metrics_sourced_from_private_models():
+    layer = _layer()
+    layer.add_model(
+        Model(
+            name="secret_orders",
+            table="secret_orders",
+            visibility="private",
+            dimensions=[Dimension(name="amount", type="numeric")],
+        )
+    )
+    layer.add_metric(Metric(name="secret_revenue", agg="sum", sql="secret_orders.amount"))
+    layer.enforce_visibility = True
+
+    with pytest.raises(SecurityError, match="secret_revenue.*not public"):
+        layer.compile(metrics=["secret_revenue"])
+
+    assert layer.describe_models()["metrics"] == []
+    assert layer.get_catalog_metadata()["semantic_metrics"] == []
+    assert "graph_metrics" not in TestClient(create_app(layer)).get("/graph").json()
+
+
 def test_meta_api_exposes_consumption_contracts():
     client = TestClient(create_app(_layer()))
 

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -135,6 +135,9 @@ def test_explore_filter_qualification_skips_subquery_columns():
     ]
     assert expression_field_references([expression], "orders") == {"orders.status"}
 
+    correlated = "EXISTS (SELECT 1 FROM allowed_statuses AS allowed WHERE allowed.status = orders.status)"
+    assert expression_field_references([correlated], "orders", graph_models={"orders"}) == {"orders.status"}
+
 
 def test_explore_queries_remain_anchored_to_the_base_model():
     layer = _layer()
@@ -170,10 +173,20 @@ def test_explore_enforces_allowlists_and_max_limit():
         layer.compile(explore="revenue_overview", dimensions=["orders.order_id"])
     with pytest.raises(ValueError, match="does not allow filter field"):
         layer.compile(explore="revenue_overview", filters=["orders.created_at > '2026-01-01'"])
+    with pytest.raises(ValueError, match="does not allow filter field"):
+        layer.compile(
+            explore="revenue_overview",
+            filters=["EXISTS (SELECT 1 WHERE orders.created_at > '2026-01-01')"],
+        )
     with pytest.raises(ValueError, match="does not allow ordering"):
         layer.compile(explore="revenue_overview", order_by=["orders.status"])
     with pytest.raises(ValueError, match="exceeds max_limit"):
         layer.compile(explore="revenue_overview", limit=101)
+
+    layer.graph.add_explore(Explore(name="choose_revenue", model="orders", allowed_metrics=["revenue"]))
+    with pytest.raises(ValueError, match="must select at least one metric or dimension"):
+        layer.compile(explore="choose_revenue")
+    assert "SUM" in layer.compile(explore="choose_revenue", metrics=["revenue"])
 
 
 def test_saved_query_is_immutable_and_compiles_through_its_explore():
@@ -569,9 +582,39 @@ def test_visibility_enforcement_covers_models_metrics_and_explores():
     with pytest.raises(ValueError, match="Saved query 'paid_revenue' is not public"):
         layer.compile(saved_query="paid_revenue")
     layer.graph.saved_queries["paid_revenue"].visibility = "public"
+    layer.graph.add_explore(
+        Explore(
+            name="fieldless_private_base",
+            model="orders",
+            allowed_dimensions=[],
+            allowed_metrics=[],
+        )
+    )
+    layer.add_model(
+        Model(
+            name="customers",
+            table="customers",
+            primary_key="customer_id",
+            dimensions=[Dimension(name="region", type="categorical")],
+        )
+    )
+    layer.graph.models["orders"].relationships.append(
+        Relationship(name="customers", type="many_to_one", foreign_key="customer_id")
+    )
+    layer.graph.add_explore(
+        Explore(
+            name="private_base_public_join",
+            model="orders",
+            allowed_dimensions=["customers.region"],
+        )
+    )
     layer.graph.models["orders"].visibility = "internal"
     with pytest.raises(SecurityError, match="not public"):
         layer.compile(explore="revenue_overview")
+    with pytest.raises(SecurityError, match="base model 'orders' is not public"):
+        layer.compile(explore="fieldless_private_base")
+    with pytest.raises(SecurityError, match="base model 'orders' is not public"):
+        layer.compile(explore="private_base_public_join", dimensions=["customers.region"])
     layer.graph.models["orders"].visibility = "public"
     layer.graph.models["orders"].metrics[0].visibility = "internal"
     with pytest.raises(SecurityError, match="not public"):

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -111,6 +111,10 @@ def test_saved_query_is_immutable_and_compiles_through_its_explore():
     assert "status <> 'deleted'" in sql
     with pytest.raises(ValueError, match="immutable"):
         layer.compile(saved_query="paid_revenue", metrics=["orders.order_count"])
+    with pytest.raises(ValueError, match="offset"):
+        layer.compile(saved_query="paid_revenue", offset=5)
+    with pytest.raises(ValueError, match="ungrouped"):
+        layer.compile(saved_query="paid_revenue", ungrouped=True)
 
 
 def test_native_yaml_roundtrip_preserves_contracts_and_governance(tmp_path: Path):
@@ -289,4 +293,10 @@ def test_lossless_adapter_bridges_create_typed_contracts():
     lookml_graph = LookMLAdapter().parse(Path("tests/fixtures/lookml/edge_cases_explores.lkml"))
     assert lookml_graph.explores["orders"].model == "fact_orders"
     assert lookml_graph.explores["orders"].category == "Sales"
-    assert lookml_graph.explores["completed_orders"].filters == ["{model}.status = 'completed'"]
+    assert lookml_graph.explores["completed_orders"].filters == ["fact_orders.status = 'completed'"]
+
+    lookml_layer = SemanticLayer(auto_register=False)
+    lookml_layer.graph = lookml_graph
+    sql = lookml_layer.compile(explore="completed_orders", dimensions=["fact_orders.status"])
+    assert "{'model': model}" not in sql
+    assert "status = 'completed'" in sql

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -27,6 +27,7 @@ from sidemantic.adapters.metricflow import MetricFlowAdapter
 from sidemantic.adapters.sidemantic import SidemanticAdapter
 from sidemantic.api_server import create_app
 from sidemantic.cli import app
+from sidemantic.core.consumption import expression_field_references, qualify_expression_fields
 from sidemantic.schema import generate_yaml_schema
 from sidemantic.validation import validate_explore, validate_governance, validate_saved_query
 
@@ -124,6 +125,42 @@ def test_explore_qualifies_relative_filter_and_order_expressions():
     assert "revenue DESC" in sql
 
 
+def test_explore_filter_qualification_skips_subquery_columns():
+    expression = "status IN (SELECT status FROM allowed_statuses)"
+
+    assert qualify_expression_fields([expression], "orders") == [
+        "orders.status IN (SELECT status FROM allowed_statuses)"
+    ]
+    assert expression_field_references([expression], "orders") == {"orders.status"}
+
+
+def test_explore_queries_remain_anchored_to_the_base_model():
+    layer = _layer()
+    layer.graph.models["orders"].relationships.append(
+        Relationship(name="customers", type="many_to_one", foreign_key="customer_id")
+    )
+    layer.add_model(
+        Model(
+            name="customers",
+            table="customers",
+            primary_key="customer_id",
+            dimensions=[Dimension(name="region", type="categorical")],
+        )
+    )
+    layer.graph.add_explore(
+        Explore(
+            name="orders_by_customer",
+            model="orders",
+            allowed_dimensions=["customers.region"],
+        )
+    )
+
+    sql = layer.compile(explore="orders_by_customer", dimensions=["customers.region"])
+
+    assert "FROM orders_cte" in sql
+    assert "JOIN customers_cte" in sql
+
+
 def test_explore_enforces_allowlists_and_max_limit():
     layer = _layer()
 
@@ -149,6 +186,8 @@ def test_saved_query_is_immutable_and_compiles_through_its_explore():
         layer.compile(saved_query="paid_revenue", offset=5)
     with pytest.raises(ValueError, match="ungrouped"):
         layer.compile(saved_query="paid_revenue", ungrouped=True)
+    with pytest.raises(ValueError, match="timezone"):
+        layer.compile(saved_query="paid_revenue", timezone="America/Los_Angeles")
     with pytest.raises(ValueError, match="explore"):
         layer.compile(saved_query="paid_revenue", explore="revenue_overview")
 
@@ -529,6 +568,12 @@ def test_meta_api_exposes_consumption_contracts():
     compiled = client.post("/compile", json={"saved_query": "paid_revenue"})
     assert compiled.status_code == 200, compiled.text
     assert "LIMIT 10" in compiled.json()["sql"]
+    for endpoint in ("/compile", "/query"):
+        timezone_override = client.post(
+            endpoint,
+            json={"saved_query": "paid_revenue", "timezone": "America/Los_Angeles"},
+        )
+        assert timezone_override.status_code == 422, timezone_override.text
 
     explicit_empty = client.post(
         "/compile",

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -207,9 +207,37 @@ def test_validation_catalog_and_description_include_consumption_contracts():
     assert errors == ["Metric 'legacy' is deprecated but has no deprecation lifecycle/message"]
 
 
+def test_validation_accepts_metric_filters_and_preflights_saved_query_explore_constraints():
+    layer = _layer()
+    layer.graph.models["orders"].metrics.append(Metric(name="cost", agg="sum", sql="cost"))
+    explore = layer.graph.explores["revenue_overview"]
+    explore.allowed_filter_fields = ["status", "revenue"]
+    errors, _warnings = validate_explore(explore, layer.graph)
+    assert errors == []
+
+    invalid = SavedQuery(
+        name="invalid_contract",
+        explore="revenue_overview",
+        metrics=["cost"],
+        dimensions=["created_at__month"],
+        filters=["orders.created_at > '2026-01-01'"],
+        order_by=["orders.status"],
+        limit=101,
+    )
+    errors, _warnings = validate_saved_query(invalid, layer.graph)
+    assert any("metric(s) not allowed" in error for error in errors)
+    assert any("filters on field(s) not allowed" in error for error in errors)
+    assert any("orders by field(s) not allowed" in error for error in errors)
+    assert any("exceeds Explore" in error for error in errors)
+
+
 def test_visibility_enforcement_covers_models_metrics_and_explores():
     layer = _layer()
     layer.enforce_visibility = True
+    layer.graph.saved_queries["paid_revenue"].visibility = "private"
+    with pytest.raises(ValueError, match="Saved query 'paid_revenue' is not public"):
+        layer.compile(saved_query="paid_revenue")
+    layer.graph.saved_queries["paid_revenue"].visibility = "public"
     layer.graph.models["orders"].visibility = "internal"
     with pytest.raises(SecurityError, match="not public"):
         layer.compile(explore="revenue_overview")

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -624,6 +624,8 @@ def test_visibility_enforcement_rejects_segments_on_private_models():
         model for model in TestClient(create_app(layer)).get("/graph").json()["models"] if model["name"] == "orders"
     )
     assert orders_graph["segments"] == ["public_orders"]
+    described_orders = next(model for model in layer.describe_models()["models"] if model["name"] == "orders")
+    assert described_orders["segments"] == ["public_orders"]
 
 
 def test_meta_api_exposes_consumption_contracts():
@@ -895,6 +897,25 @@ explore: sales {
     assert "WHERE region = 'West'" in sql
     assert "WHERE id > 0" in sql
     assert "orders_cte.customer_id = customers_cte.id" in sql
+
+
+def test_lookml_empty_fields_preserves_empty_contract_allowlists(tmp_path: Path):
+    source = tmp_path / "empty_fields.lkml"
+    source.write_text(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { sql: ${TABLE}.id ;; }
+  measure: count { type: count }
+}
+explore: orders { fields: [] }
+""".strip()
+    )
+
+    explore = LookMLAdapter().parse(source).explores["orders"]
+
+    assert explore.allowed_dimensions == []
+    assert explore.allowed_metrics == []
 
 
 def test_metricflow_metric_ordering_is_preserved_but_not_executable(tmp_path: Path):

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -267,6 +267,8 @@ def test_validation_preflights_saved_query_segments():
     )
     errors, _warnings = validate_saved_query(valid, layer.graph)
     assert errors == []
+    layer.graph.add_saved_query(valid)
+    assert "status = 'paid'" in layer.compile(saved_query="valid_segment")
 
     invalid = valid.model_copy(update={"name": "invalid_segment", "segments": ["orders.missing"]})
     errors, _warnings = validate_saved_query(invalid, layer.graph)
@@ -329,6 +331,22 @@ def test_visibility_enforcement_rejects_graph_metrics_sourced_from_private_model
     assert layer.describe_models()["metrics"] == []
     assert layer.get_catalog_metadata()["semantic_metrics"] == []
     assert "graph_metrics" not in TestClient(create_app(layer)).get("/graph").json()
+
+
+def test_visibility_enforcement_rejects_segments_on_private_models():
+    layer = _layer()
+    layer.add_model(
+        Model(
+            name="secret_orders",
+            table="secret_orders",
+            visibility="private",
+            segments=[Segment(name="visible_segment", sql="{model}.status = 'paid'")],
+        )
+    )
+    layer.enforce_visibility = True
+
+    with pytest.raises(SecurityError, match="secret_orders.visible_segment.*not public"):
+        layer.compile(metrics=["orders.revenue"], segments=["secret_orders.visible_segment"])
 
 
 def test_meta_api_exposes_consumption_contracts():

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -128,6 +128,12 @@ def test_saved_query_is_immutable_and_compiles_through_its_explore():
         layer.compile(saved_query="paid_revenue", offset=5)
     with pytest.raises(ValueError, match="ungrouped"):
         layer.compile(saved_query="paid_revenue", ungrouped=True)
+    with pytest.raises(ValueError, match="explore"):
+        layer.compile(saved_query="paid_revenue", explore="revenue_overview")
+
+    layer.graph.add_saved_query(SavedQuery(name="all_revenue", metrics=["orders.revenue"]))
+    with pytest.raises(ValueError, match="explore"):
+        layer.compile(saved_query="all_revenue", explore="revenue_overview")
 
 
 def test_native_yaml_roundtrip_preserves_contracts_and_governance(tmp_path: Path):
@@ -388,6 +394,8 @@ def test_schema_and_cli_expose_contracts(tmp_path: Path):
     schema = generate_yaml_schema()
     assert "explores" in schema["properties"]
     assert "saved_queries" in schema["properties"]
+    assert {"required": ["explores"]} in schema["anyOf"]
+    assert {"required": ["saved_queries"]} in schema["anyOf"]
 
     model_file = tmp_path / "models.yml"
     model_file.write_text(
@@ -484,6 +492,27 @@ def test_lossless_adapter_bridges_create_typed_contracts():
     sql = lookml_layer.compile(explore="completed_orders", dimensions=["fact_orders.status"])
     assert "{'model': model}" not in sql
     assert "status = 'completed'" in sql
+
+
+def test_hex_private_view_is_private_as_model_and_explore(tmp_path: Path):
+    source = tmp_path / "private_view.yml"
+    source.write_text(
+        """
+id: subscriptions
+type: model
+base_sql_table: analytics.subscriptions
+---
+id: private_revenue
+type: view
+base: subscriptions
+visibility: private
+contents: []
+""".strip()
+    )
+
+    graph = HexAdapter().parse(source)
+    assert graph.models["private_revenue"].visibility == "private"
+    assert graph.explores["private_revenue"].visibility == "private"
 
 
 def test_lookml_joined_always_filter_preserves_join_target(tmp_path: Path):

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -7,7 +7,19 @@ import yaml
 from fastapi.testclient import TestClient
 from typer.testing import CliRunner
 
-from sidemantic import Deprecation, Dimension, Explore, Metric, Model, SavedQuery, SecurityError, SemanticLayer, View
+from sidemantic import (
+    Deprecation,
+    Dimension,
+    Explore,
+    Metric,
+    Model,
+    Relationship,
+    SavedQuery,
+    SecurityError,
+    Segment,
+    SemanticLayer,
+    View,
+)
 from sidemantic.adapters.hex import HexAdapter
 from sidemantic.adapters.lookml import LookMLAdapter
 from sidemantic.adapters.metricflow import MetricFlowAdapter
@@ -146,6 +158,7 @@ models:
         agg: sum
         sql: amount
         owner: finance
+        visibility: internal
         freshness:
           watermark: updated_at
           ttl_seconds: 3600
@@ -183,6 +196,10 @@ saved_queries:
     exported = yaml.safe_load(output.read_text())
     assert exported["models"][0]["owner"] == "analytics"
     assert exported["models"][0]["deprecation"]["replaced_by"] == "completed_orders"
+    exported_metric = exported["models"][0]["metrics"][0]
+    assert exported_metric["owner"] == "finance"
+    assert exported_metric["visibility"] == "internal"
+    assert exported_metric["freshness"] == {"watermark": "updated_at", "ttl_seconds": 3600}
     assert exported["explores"][0]["allowed_metrics"] == ["revenue"]
     assert exported["explores"][0]["allowed_filter_fields"] == ["status"]
     assert exported["saved_queries"][0]["name"] == "revenue_by_status"
@@ -231,6 +248,26 @@ def test_validation_accepts_metric_filters_and_preflights_saved_query_explore_co
     assert any("exceeds Explore" in error for error in errors)
 
 
+def test_validation_preflights_saved_query_segments():
+    layer = _layer()
+    layer.graph.models["orders"].segments.append(Segment(name="paid", sql="{model}.status = 'paid'"))
+
+    valid = SavedQuery(
+        name="valid_segment",
+        explore="revenue_overview",
+        metrics=["revenue"],
+        segments=["paid"],
+    )
+    errors, _warnings = validate_saved_query(valid, layer.graph)
+    assert errors == []
+
+    invalid = valid.model_copy(update={"name": "invalid_segment", "segments": ["orders.missing"]})
+    errors, _warnings = validate_saved_query(invalid, layer.graph)
+    assert errors == [
+        "Saved query 'invalid_segment' references segment 'missing' which doesn't exist on model 'orders'"
+    ]
+
+
 def test_visibility_enforcement_covers_models_metrics_and_explores():
     layer = _layer()
     layer.enforce_visibility = True
@@ -272,6 +309,28 @@ def test_meta_api_exposes_consumption_contracts():
     assert "SUM(" not in explicit_sql
     assert "status = 'paid'" not in explicit_sql
     assert "status <> 'deleted'" in explicit_sql
+
+
+def test_meta_api_does_not_leak_private_relationship_targets():
+    layer = _layer()
+    layer.enforce_visibility = True
+    layer.graph.models["orders"].relationships.append(
+        Relationship(name="private_customers", type="many_to_one", foreign_key="customer_id")
+    )
+    layer.add_model(
+        Model(
+            name="private_customers",
+            table="private_customers",
+            primary_key="customer_id",
+            visibility="private",
+            dimensions=[Dimension(name="customer_id", type="numeric")],
+        )
+    )
+
+    graph = TestClient(create_app(layer)).get("/graph").json()
+    assert [model["name"] for model in graph["models"]] == ["orders"]
+    assert graph["models"][0]["relationships"] == []
+    assert graph["joinable_pairs"] == []
 
 
 def test_schema_and_cli_expose_contracts(tmp_path: Path):
@@ -343,6 +402,42 @@ def test_lossless_adapter_bridges_create_typed_contracts():
     sql = lookml_layer.compile(explore="completed_orders", dimensions=["fact_orders.status"])
     assert "{'model': model}" not in sql
     assert "status = 'completed'" in sql
+
+
+def test_lookml_joined_always_filter_preserves_join_target(tmp_path: Path):
+    source = tmp_path / "joined_filter.lkml"
+    source.write_text(
+        """
+view: orders {
+  sql_table_name: orders ;;
+  dimension: id { primary_key: yes sql: ${TABLE}.id ;; }
+  dimension: customer_id { sql: ${TABLE}.customer_id ;; }
+  measure: count { type: count }
+}
+view: customers {
+  sql_table_name: customers ;;
+  dimension: id { primary_key: yes sql: ${TABLE}.id ;; }
+  dimension: region { sql: ${TABLE}.region ;; }
+}
+explore: orders {
+  always_filter: { filters: [customers.region: "West"] }
+  join: customers {
+    relationship: many_to_one
+    sql_on: ${orders.customer_id} = ${customers.id} ;;
+  }
+}
+""".strip()
+    )
+
+    graph = LookMLAdapter().parse(source)
+    assert graph.explores["orders"].filters == ["customers.region = 'West'"]
+
+    layer = SemanticLayer(auto_register=False)
+    layer.graph = graph
+    sql = layer.compile(explore="orders", metrics=["orders.count"])
+    assert "FROM customers" in sql
+    assert "WHERE region = 'West'" in sql
+    assert "orders_cte.customer_id = customers_cte.id" in sql
 
 
 def test_metricflow_metric_ordering_is_preserved_but_not_executable(tmp_path: Path):

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -103,6 +103,27 @@ def test_explore_defaults_compile_and_mandatory_filters_apply():
     assert "LIMIT 25" in sql
 
 
+def test_explore_qualifies_relative_filter_and_order_expressions():
+    layer = _layer()
+    layer.graph.add_explore(
+        Explore(
+            name="relative_contract",
+            model="orders",
+            default_metrics=["revenue"],
+            filters=["status != 'deleted'"],
+            default_filters=["status = 'paid'"],
+            default_order_by=["revenue DESC"],
+        )
+    )
+
+    sql = layer.compile(explore="relative_contract")
+
+    assert "status <> 'deleted'" in sql
+    assert "status = 'paid'" in sql
+    assert "status AS status" in sql
+    assert "revenue DESC" in sql
+
+
 def test_explore_enforces_allowlists_and_max_limit():
     layer = _layer()
 
@@ -210,6 +231,70 @@ saved_queries:
     assert exported["explores"][0]["allowed_metrics"] == ["revenue"]
     assert exported["explores"][0]["allowed_filter_fields"] == ["status"]
     assert exported["saved_queries"][0]["name"] == "revenue_by_status"
+
+
+def test_native_sql_frontmatter_extracts_root_consumption_contracts(tmp_path: Path):
+    source = tmp_path / "orders.sql"
+    source.write_text(
+        """
+---
+version: 1
+name: orders
+table: orders
+dimensions:
+  - name: status
+explores:
+  - name: revenue_overview
+    model: orders
+    default_metrics: [revenue]
+views:
+  - name: order_statuses
+    model: orders
+    default_dimensions: [status]
+saved_queries:
+  - name: revenue_by_status
+    explore: revenue_overview
+    dimensions: [status]
+    metrics: [revenue]
+---
+
+METRIC (
+  name revenue,
+  agg sum,
+  sql amount
+);
+""".strip()
+    )
+
+    graph = SidemanticAdapter().parse(source)
+
+    assert set(graph.models) == {"orders"}
+    assert set(graph.explores) == {"revenue_overview", "order_statuses"}
+    assert graph.saved_queries["revenue_by_status"].explore == "revenue_overview"
+
+
+def test_native_sql_frontmatter_can_contain_only_consumption_contracts(tmp_path: Path):
+    source = tmp_path / "contracts.sql"
+    source.write_text(
+        """
+---
+version: 1
+explores:
+  - name: revenue_overview
+    model: orders
+saved_queries:
+  - name: revenue_by_status
+    explore: revenue_overview
+    metrics: [revenue]
+---
+""".strip()
+    )
+
+    graph = SidemanticAdapter().parse(source)
+
+    assert graph.models == {}
+    assert set(graph.explores) == {"revenue_overview"}
+    assert set(graph.saved_queries) == {"revenue_by_status"}
 
 
 def test_validation_catalog_and_description_include_consumption_contracts():

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -332,6 +332,12 @@ def test_meta_api_does_not_leak_private_relationship_targets():
     assert graph["models"][0]["relationships"] == []
     assert graph["joinable_pairs"] == []
 
+    catalog = layer.get_catalog_metadata()
+    assert all(item.get("referenced_table_name") != "private_customers" for item in catalog["key_column_usage"])
+
+    description = layer.describe_models()
+    assert not description["models"][0].get("relationships")
+
 
 def test_schema_and_cli_expose_contracts(tmp_path: Path):
     schema = generate_yaml_schema()
@@ -420,6 +426,7 @@ view: customers {
   dimension: region { sql: ${TABLE}.region ;; }
 }
 explore: orders {
+  sql_always_where: ${TABLE}.id > 0 ;;
   always_filter: { filters: [customers.region: "West"] }
   join: customers {
     relationship: many_to_one
@@ -430,13 +437,14 @@ explore: orders {
     )
 
     graph = LookMLAdapter().parse(source)
-    assert graph.explores["orders"].filters == ["customers.region = 'West'"]
+    assert graph.explores["orders"].filters == ["orders.id > 0", "customers.region = 'West'"]
 
     layer = SemanticLayer(auto_register=False)
     layer.graph = graph
     sql = layer.compile(explore="orders", metrics=["orders.count"])
     assert "FROM customers" in sql
     assert "WHERE region = 'West'" in sql
+    assert "WHERE id > 0" in sql
     assert "orders_cte.customer_id = customers_cte.id" in sql
 
 

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -381,6 +381,60 @@ def test_validation_preflights_consumption_filter_and_order_fields():
     assert "Saved query 'invalid_expressions' ordering field 'orders.unknown' is not a metric or dimension" in errors
 
 
+def test_validation_rejects_expression_models_without_a_join_path():
+    layer = _layer()
+    layer.add_model(
+        Model(
+            name="customers",
+            table="customers",
+            dimensions=[Dimension(name="region", type="categorical")],
+        )
+    )
+    explore = Explore(
+        name="disconnected_filter",
+        model="orders",
+        default_metrics=["revenue"],
+        filters=["customers.region = 'West'"],
+    )
+    errors, _warnings = validate_explore(explore, layer.graph)
+    assert any("filter expression is incompatible" in error and "No join path found" in error for error in errors)
+
+    saved_query = SavedQuery(
+        name="disconnected_saved_query",
+        explore="revenue_overview",
+        metrics=["revenue"],
+        filters=["customers.region = 'West'"],
+    )
+    errors, _warnings = validate_saved_query(saved_query, layer.graph)
+    assert any("filter expression is incompatible" in error and "No join path found" in error for error in errors)
+
+
+def test_validation_requires_order_fields_in_default_or_saved_selection():
+    layer = _layer()
+    explore = Explore(
+        name="unselected_default_order",
+        model="orders",
+        default_metrics=["revenue"],
+        default_order_by=["status"],
+    )
+    errors, _warnings = validate_explore(explore, layer.graph)
+    assert (
+        "Explore 'unselected_default_order' default ordering field(s) must be selected by the query: orders.status"
+        in errors
+    )
+
+    saved_query = SavedQuery(
+        name="unselected_saved_order",
+        explore="revenue_overview",
+        metrics=["revenue"],
+        order_by=["status"],
+    )
+    errors, _warnings = validate_saved_query(saved_query, layer.graph)
+    assert (
+        "Saved query 'unselected_saved_order' ordering field(s) must be selected by the query: orders.status" in errors
+    )
+
+
 def test_visibility_enforcement_covers_models_metrics_and_explores():
     layer = _layer()
     layer.enforce_visibility = True

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -19,6 +19,7 @@ from sidemantic import (
     Segment,
     SemanticLayer,
     View,
+    load_from_directory,
 )
 from sidemantic.adapters.hex import HexAdapter
 from sidemantic.adapters.lookml import LookMLAdapter
@@ -339,6 +340,31 @@ def test_meta_api_does_not_leak_private_relationship_targets():
     assert not description["models"][0].get("relationships")
 
 
+def test_visibility_enforcement_hides_contracts_that_expose_private_fields():
+    layer = _layer()
+    layer.enforce_visibility = True
+    layer.graph.models["orders"].metrics.append(
+        Metric(name="secret_margin", agg="sum", sql="margin", visibility="private")
+    )
+    layer.graph.add_explore(
+        Explore(
+            name="leaky_explore",
+            model="orders",
+            allowed_metrics=["secret_margin"],
+            default_metrics=["secret_margin"],
+            metadata={"source_fields": ["secret_margin"]},
+        )
+    )
+    layer.graph.add_saved_query(SavedQuery(name="leaky_query", explore="leaky_explore", metrics=["secret_margin"]))
+
+    client = TestClient(create_app(layer))
+    assert {value["name"] for value in client.get("/explores").json()} == {"revenue_overview"}
+    assert {value["name"] for value in client.get("/saved-queries").json()} == {"paid_revenue"}
+    assert {value["name"] for value in client.get("/graph").json()["explores"]} == {"revenue_overview"}
+    assert {value["name"] for value in layer.get_catalog_metadata()["explores"]} == {"revenue_overview"}
+    assert {value["name"] for value in layer.describe_models()["explores"]} == {"revenue_overview"}
+
+
 def test_schema_and_cli_expose_contracts(tmp_path: Path):
     schema = generate_yaml_schema()
     assert "explores" in schema["properties"]
@@ -381,6 +407,37 @@ saved_queries:
     )
     assert dry_run.exit_code == 0, dry_run.output
     assert "SUM" in dry_run.output
+
+
+def test_directory_loader_recognizes_contract_only_native_yaml(tmp_path: Path):
+    (tmp_path / "models.yml").write_text(
+        """
+models:
+  - name: orders
+    table: orders
+    dimensions: [{name: status}]
+    metrics: [{name: revenue, agg: sum, sql: amount}]
+""".strip()
+    )
+    (tmp_path / "contracts.yml").write_text(
+        """
+version: 1
+explores:
+  - name: revenue_overview
+    model: orders
+    default_metrics: [revenue]
+saved_queries:
+  - name: revenue_by_status
+    explore: revenue_overview
+    dimensions: [status]
+    metrics: [revenue]
+""".strip()
+    )
+
+    layer = SemanticLayer(auto_register=False)
+    load_from_directory(layer, tmp_path)
+    assert set(layer.graph.explores) == {"revenue_overview"}
+    assert set(layer.graph.saved_queries) == {"revenue_by_status"}
 
 
 def test_lossless_adapter_bridges_create_typed_contracts():

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -230,6 +230,21 @@ def test_meta_api_exposes_consumption_contracts():
     assert compiled.status_code == 200, compiled.text
     assert "LIMIT 10" in compiled.json()["sql"]
 
+    explicit_empty = client.post(
+        "/compile",
+        json={
+            "explore": "revenue_overview",
+            "dimensions": ["orders.status"],
+            "metrics": [],
+            "filters": [],
+        },
+    )
+    assert explicit_empty.status_code == 200, explicit_empty.text
+    explicit_sql = explicit_empty.json()["sql"]
+    assert "SUM(" not in explicit_sql
+    assert "status = 'paid'" not in explicit_sql
+    assert "status <> 'deleted'" in explicit_sql
+
 
 def test_schema_and_cli_expose_contracts(tmp_path: Path):
     schema = generate_yaml_schema()
@@ -300,3 +315,35 @@ def test_lossless_adapter_bridges_create_typed_contracts():
     sql = lookml_layer.compile(explore="completed_orders", dimensions=["fact_orders.status"])
     assert "{'model': model}" not in sql
     assert "status = 'completed'" in sql
+
+
+def test_metricflow_metric_ordering_is_preserved_but_not_executable(tmp_path: Path):
+    source = tmp_path / "metricflow.yml"
+    source.write_text(
+        """
+semantic_models:
+  - name: bookings
+    model: ref('bookings')
+    measures:
+      - name: booking_count
+        expr: "1"
+        agg: sum
+saved_queries:
+  - name: ordered_bookings
+    query_params:
+      metrics: [booking_count]
+      order_by:
+        - Metric('booking_count').descending(True)
+""".strip()
+    )
+
+    graph = MetricFlowAdapter().parse(source)
+    saved_query = graph.saved_queries["ordered_bookings"]
+    metadata = saved_query.metadata["metricflow"]
+    assert metadata["executable"] is False
+    assert "Metric()" in metadata["compatibility_message"]
+
+    layer = SemanticLayer(auto_register=False)
+    layer.graph = graph
+    with pytest.raises(ValueError, match="cannot execute"):
+        layer.compile(saved_query="ordered_bookings")

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -1,5 +1,6 @@
 """Tests for curated consumption and semantic-governance contracts."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -502,6 +503,19 @@ def test_validation_checks_saved_query_with_mandatory_explore_filters():
         "to selected model 'customers'" in errors
     )
 
+    layer.graph.models["customers"].segments.append(Segment(name="vip", sql="region = 'VIP'"))
+    disconnected_segment = SavedQuery(
+        name="disconnected_segment",
+        explore="unfiltered_orders",
+        metrics=["revenue"],
+        segments=["customers.vip"],
+    )
+    errors, _warnings = validate_saved_query(disconnected_segment, layer.graph)
+    assert (
+        "Saved query 'disconnected_segment' has no join path from base model 'orders' to selected model 'customers'"
+        in errors
+    )
+
 
 def test_validation_interpolates_saved_query_parameters():
     layer = _layer()
@@ -742,6 +756,22 @@ saved_queries:
     )
     assert dry_run.exit_code == 0, dry_run.output
     assert "SUM" in dry_run.output
+
+    json_dry_run = runner.invoke(
+        app,
+        [
+            "--format",
+            "json",
+            "query",
+            "--models",
+            str(tmp_path),
+            "--saved-query",
+            "revenue_by_status",
+            "--dry-run",
+        ],
+    )
+    assert json_dry_run.exit_code == 0, json_dry_run.output
+    assert "SUM" in json.loads(json_dry_run.output)["sql"]
 
 
 def test_directory_loader_recognizes_contract_only_native_yaml(tmp_path: Path):

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -575,6 +575,47 @@ def test_validation_requires_order_fields_in_default_or_saved_selection():
     )
 
 
+def test_explore_order_override_requires_selected_field():
+    layer = _layer()
+    layer.graph.add_explore(
+        Explore(
+            name="order_override",
+            model="orders",
+            allowed_metrics=["revenue"],
+            allowed_order_by=["status"],
+            default_metrics=["revenue"],
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Explore 'order_override' ordering field\\(s\\) must be selected by the query: orders.status",
+    ):
+        layer.compile(explore="order_override", order_by=["status"])
+
+
+def test_describe_models_scopes_saved_queries_to_requested_models():
+    layer = _layer()
+    layer.add_model(
+        Model(
+            name="customers",
+            table="customers",
+            dimensions=[Dimension(name="region", type="categorical")],
+            metrics=[Metric(name="customer_count", agg="count")],
+        )
+    )
+    layer.graph.add_explore(Explore(name="customer_overview", model="customers"))
+    layer.graph.add_saved_query(
+        SavedQuery(name="customers_by_region", explore="customer_overview", dimensions=["region"])
+    )
+
+    orders = layer.describe_models(["orders"])
+    customers = layer.describe_models(["customers"])
+
+    assert {saved["name"] for saved in orders["saved_queries"]} == {"paid_revenue"}
+    assert {saved["name"] for saved in customers["saved_queries"]} == {"customers_by_region"}
+
+
 def test_visibility_enforcement_covers_models_metrics_and_explores():
     layer = _layer()
     layer.enforce_visibility = True

--- a/tests/test_consumption_contracts.py
+++ b/tests/test_consumption_contracts.py
@@ -269,6 +269,25 @@ def test_validation_preflights_saved_query_segments():
     ]
 
 
+def test_validation_preflights_consumption_filter_and_order_fields():
+    layer = _layer()
+    explore = layer.graph.explores["revenue_overview"].model_copy(
+        update={"name": "invalid_defaults", "default_order_by": ["orders.missing DESC"]}
+    )
+    errors, _warnings = validate_explore(explore, layer.graph)
+    assert "Explore 'invalid_defaults' ordering field 'orders.missing' is not a metric or dimension" in errors
+
+    saved_query = SavedQuery(
+        name="invalid_expressions",
+        metrics=["orders.revenue"],
+        filters=["orders.missing > 0"],
+        order_by=["orders.unknown DESC"],
+    )
+    errors, _warnings = validate_saved_query(saved_query, layer.graph)
+    assert "Saved query 'invalid_expressions' filter field 'orders.missing' is not a metric or dimension" in errors
+    assert "Saved query 'invalid_expressions' ordering field 'orders.unknown' is not a metric or dimension" in errors
+
+
 def test_visibility_enforcement_covers_models_metrics_and_explores():
     layer = _layer()
     layer.enforce_visibility = True

--- a/tests/test_schema_generation.py
+++ b/tests/test_schema_generation.py
@@ -13,7 +13,9 @@ def test_generate_yaml_schema_structure():
     assert "models" in schema["properties"]
     assert "metrics" in schema["properties"]
     assert "parameters" in schema["properties"]
-    assert schema["required"] == ["models"]
+    assert {"required": ["models"]} in schema["anyOf"]
+    assert {"required": ["explores"]} in schema["anyOf"]
+    assert {"required": ["saved_queries"]} in schema["anyOf"]
 
     defs = schema["$defs"]
     assert "Dimension" in defs


### PR DESCRIPTION
Adds first-class Explore/View and SavedQuery contracts with CLI query enforcement, validation, serialization, and catalog/API discovery.

Adds shared governance metadata for models, metrics, and explores, plus lossless Hex, LookML, and MetricFlow mappings, documentation, examples, and coverage.