### PR TITLE
Make model keys explicit and validate warehouse contracts

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,6 +71,42 @@ sidemantic explain "SELECT orders.revenue FROM orders"
 JSON is the only content written to stdout in these modes. Diagnostics remain
 on stderr.
 
+## Model validation
+
+Offline structural validation remains the default and needs no warehouse access:
+
+```bash
+sidemantic validate ./models
+sidemantic validate ./models --json
+```
+
+It checks model structure, relationship targets, explicit join keys, composite-key
+arity, and cardinality declarations. Unknown model identity is allowed for isolated
+models, but a relationship that needs an unknown key fails with an actionable
+structural error instead of compiling an inferred `id` join.
+
+Add `--warehouse` to inspect the configured project connection, or provide a
+connection explicitly:
+
+```bash
+sidemantic validate ./models --warehouse
+sidemantic validate ./models --db warehouse.duckdb
+sidemantic validate ./models --connection postgres://localhost/analytics
+sidemantic validate ./models --warehouse --check-keys
+```
+
+Warehouse validation checks physical table and column existence, basic semantic
+type compatibility, join columns, and prepares representative compiled queries.
+`--no-check-queries` skips the representative query checks. `--check-keys` also
+queries primary, unique, and relationship-cardinality keys for nulls or duplicates;
+it is opt-in because it can scan warehouse data.
+
+Human output separates `Structural Errors`, `Warehouse Errors`, and `Connection
+Errors`. JSON reports the same categories as `structural_errors`,
+`warehouse_errors`, and `connection_errors`, with their union retained in `errors`
+for compatibility. Structural failures skip warehouse checks, and connection
+failures do not get mislabeled as invalid model definitions.
+
 ## Standard output formats
 
 Structured inspection, reporting, and query commands share one format option:

--- a/docs/compatibility/malloy.md
+++ b/docs/compatibility/malloy.md
@@ -304,7 +304,7 @@ Sidemantic can export its semantic model back to Malloy format.
 | Filtered measures | Supported (exported as `agg(x) { where: filter }`) |
 | Derived measures | Supported (expression exported as-is) |
 | Ratio metrics | Supported (exported as `numerator / denominator`) |
-| `primary_key:` | Supported (exported when not the default `id`) |
+| `primary_key:` | Supported (exported whenever explicitly declared) |
 | `join_one:` / `join_many:` with `with` clause | Supported |
 | `join_one:` / `join_many:` with `on` condition | Supported (full `on` condition exported from `metadata["on_condition"]` when available) |
 | `where:` (segments) | Supported (source-level where clauses exported) |

--- a/docs/compatibility/osi.md
+++ b/docs/compatibility/osi.md
@@ -35,7 +35,7 @@ Features are marked **supported**, **partial support**, or **unsupported**. Part
 | `custom_extensions` (dataset level) | Supported (stored in `Model.meta["custom_extensions"]`) |
 | Dataset without `name` | Supported (gracefully skipped) |
 | Multi-file directory parsing (recursive `.yml`/`.yaml` discovery) | Supported |
-| Default primary key when omitted | Supported (defaults to `"id"`) |
+| Omitted primary key | Supported (preserved as unknown / `None`) |
 
 ---
 
@@ -94,8 +94,8 @@ Not mapped: `type` (the OSI `type` hint on metrics, e.g. `type: count`, is ignor
 | Relationship `name` | Supported (stored in `Relationship.metadata["osi_name"]` and reused on export) |
 | Relationship `ai_context` | Supported (stored in `Relationship.metadata["ai_context"]`) |
 | Relationship `custom_extensions` | Supported (stored in `Relationship.metadata["custom_extensions"]`) |
-| Missing `from_columns` | Supported (defaults foreign key to `{to_model}_id`) |
-| Missing `to_columns` | Supported (defaults primary key to `id`) |
+| Missing `from_columns` | Preserved as an unknown foreign key; structural validation rejects joins that need it |
+| Missing `to_columns` | Uses the target model's declared key when available; otherwise remains unknown |
 | Relationship with missing `from` or `to` | Supported (gracefully skipped) |
 | Relationship to non-existent model | Supported (gracefully skipped if the `from` model is not in the graph) |
 | `left_dataset` / `right_dataset` / `cardinality` format | Unsupported |

--- a/docs/compatibility/yardstick.md
+++ b/docs/compatibility/yardstick.md
@@ -32,7 +32,7 @@ The adapter only processes `CREATE VIEW` statements that contain at least one `A
 | CTE-backed views (`WITH ... AS ... SELECT ...`) | Supported (CTEs included in `Model.sql`) |
 | `FROM` with table alias | Supported (base relation preserved) |
 | `SELECT *` (star projections) | Supported (star columns are silently skipped; only explicitly aliased columns become dimensions) |
-| Primary key inference | Supported (defaults to the first dimension's name; falls back to `"id"` if no dimensions) |
+| Primary key inference | Not performed; Yardstick has no explicit declaration, so identity remains unknown |
 
 The adapter stores the original view SQL in `Model.metadata["yardstick"]["view_sql"]` for reference. When a simple single-table source is detected, the table name is also stored in `metadata["yardstick"]["base_table"]`. For complex base relations, the reconstructed subquery SQL is stored in `metadata["yardstick"]["base_relation_sql"]`.
 
@@ -255,5 +255,5 @@ Unsupported. The Yardstick adapter is import-only. There is no export path back 
 | No dimension metadata | Yardstick SQL has no syntax for descriptions, labels, formats, or visibility on dimensions or measures |
 | No relationships/joins at model level | Joins are handled at query time via SEMANTIC queries, not stored as model-level Relationships |
 | No segments | Yardstick SQL has no concept of named filters at the model level |
-| Primary key is heuristic | First dimension is assumed to be the primary key; no explicit PK declaration syntax exists |
+| No primary-key declaration syntax | Imported model identity remains unknown; no dimension is assumed unique |
 | Type inference is heuristic | Dimension types are inferred from column names and expression structure, not from declared types |

--- a/docs/model-key-migration.md
+++ b/docs/model-key-migration.md
@@ -1,0 +1,94 @@
+# Explicit model keys and warehouse validation
+
+Sidemantic no longer assumes that an omitted model or relationship key is named
+`id`. The old fallback could make a structurally plausible model compile a join
+against a nonexistent or non-unique column. Omitted keys now remain unknown.
+
+## Compatibility and rollout
+
+This change preserves models that declare keys and preserves explicit key metadata
+imported from source formats. Keyless models also continue to work for single-model
+queries. The intentional compatibility break is limited to operations that relied
+on an invented key; those relationships now fail structural validation before SQL
+compilation.
+
+Use this staged rollout for an existing project:
+
+1. Run offline validation and inventory keyless models:
+
+   ```bash
+   sidemantic validate ./models --verbose
+   ```
+
+2. Add each model's real `primary_key`. For composite keys, use a list. If a model
+   has another model-wide unique key, declare it under `unique_keys`:
+
+   ```yaml
+   primary_key: [tenant_id, order_id]
+   unique_keys:
+     - [tenant_id, external_order_id]
+   ```
+
+3. Make relationship join columns explicit. `many_to_one` relationships need the
+   source `foreign_key`; they may use the target model's primary key or an explicit
+   relationship `primary_key`. `one_to_many` and `one_to_one` relationships need the
+   foreign key on the related model and a declared key on the local model.
+
+4. Validate metadata against the warehouse:
+
+   ```bash
+   sidemantic validate ./models --warehouse
+   ```
+
+5. In a controlled environment, verify key and cardinality data contracts:
+
+   ```bash
+   sidemantic validate ./models --warehouse --check-keys
+   ```
+
+`--check-keys` is opt-in because null and duplicate checks may scan warehouse
+tables. It verifies model primary/unique keys, relationship-scoped alternate keys,
+and one-to-one uniqueness assumptions.
+
+## Relationship examples
+
+Use the target model's declared primary key:
+
+```yaml
+models:
+  - name: orders
+    table: analytics.orders
+    primary_key: order_id
+    relationships:
+      - name: customers
+        type: many_to_one
+        foreign_key: customer_id
+
+  - name: customers
+    table: analytics.customers
+    primary_key: customer_id
+```
+
+Use a scoped alternate unique key:
+
+```yaml
+relationships:
+  - name: customers
+    type: many_to_one
+    foreign_key: customer_email
+    primary_key: email
+```
+
+The relationship-level `primary_key` is an explicit uniqueness assertion for that
+join. Prefer model `unique_keys` when multiple relationships or queries share the
+same alternate identity.
+
+There is no flag that restores inferred `id` joins. This is deliberate: retaining
+that fallback would continue to compile SQL whose correctness cannot be established.
+
+`sidemantic migrate generate` uses warehouse foreign-key constraints when available
+to emit `many_to_one` cardinality. When query SQL alone only proves an equality
+between two columns, migration emits an explicit direct `many_to_many` relationship;
+it does not infer uniqueness from `id` or `_id` naming. After generation, replace
+that conservative cardinality only when the warehouse contract establishes a
+unique one side.

--- a/docs/native-format.md
+++ b/docs/native-format.md
@@ -112,7 +112,7 @@ At least one of `table`, `sql`, or `source_uri` should be present unless the mod
 | `sql` | Conditional | SQL subquery used as the model source. |
 | `source_uri` | Conditional | Source URI for external data discovery or file-backed sources. Native loaders preserve it; execution is adapter/runtime-specific until a concrete backend maps URI sources. |
 | `extends` | No | Parent model name. Child fields override or extend parent fields. |
-| `primary_key` | No | Single primary key string or list of columns. Defaults to `id`. |
+| `primary_key` | No | Single primary key string or list of columns. Omitted means the model's entity key is unknown. |
 | `primary_key_columns` | No | Explicit list form for primary keys. |
 | `unique_keys` | No | List of unique key column lists. |
 | `description` | No | Human-readable description. |
@@ -401,11 +401,20 @@ relationships:
 | `related_foreign_key_columns` | For many-to-many | Explicit through-to-target key columns. |
 | `sql` | No | Custom join SQL using `{from}` and `{to}` runtime placeholders. |
 
-For CLI-authored native files, prefer explicit `foreign_key` and `primary_key`
-fields. Omitted keys are still supported for compatibility: `many_to_one`
-defaults the source key to `{name}_id`, while `one_to_many` and `one_to_one`
-default the related-side key to `id`; omitted `primary_key` resolves to the
-target model's declared primary key when building graph joins.
+Join columns are never inferred from names. Every non-cross relationship without
+custom `sql` must declare `foreign_key`. A `many_to_one` relationship may omit
+`primary_key` only when the target model declares its `primary_key`; a
+`one_to_many` or `one_to_one` relationship may omit it only when the source model
+declares its `primary_key`. Use relationship `primary_key` for a scoped alternate
+unique key, or model `unique_keys` when the uniqueness applies model-wide.
+
+Cardinality is a data contract: the key on the "one" side must be unique. Run
+warehouse validation with `--check-keys` to verify the declared contract against
+data. Structural validation rejects missing keys and mismatched composite-key
+arity before SQL compilation.
+
+See [Explicit model keys and warehouse validation](model-key-migration.md) for
+the compatibility and migration path from implicit keys.
 
 When `sql` is present, Python and Rust use it instead of the FK/PK-generated
 predicate. `{from}` is replaced with the source model's runtime alias and `{to}`

--- a/plugins/sidemantic/skills/modeler/SKILL.md
+++ b/plugins/sidemantic/skills/modeler/SKILL.md
@@ -184,7 +184,7 @@ Inspect tables, columns, data types, and foreign key relationships. Identify whi
 For each table, create a Model with:
 - `name`: a short, snake_case identifier
 - `table`: schema-qualified table name (e.g., `public.orders`)
-- `primary_key`: the table's primary key column (default: `id`)
+- `primary_key`: the table's actual primary key column; omit it only when identity is genuinely unknown
 
 Use `sql` instead of `table` for derived/virtual tables built from a SQL expression.
 
@@ -247,7 +247,7 @@ Connect models with relationships so Sidemantic can auto-generate JOINs.
 | `one_to_many` | Other model has FK to this | customer -> orders |
 | `many_to_many` | Through junction table | students <-> courses |
 
-Declare relationships on the model that owns the foreign key. For `many_to_one`, `foreign_key` defaults to `{related_model}_id`.
+Declare relationships on the model that owns the foreign key. Always set the actual `foreign_key`; Sidemantic does not infer one from the related model name.
 
 For `many_to_many`, specify `through` (junction model), `through_foreign_key`, and `related_foreign_key`.
 
@@ -256,6 +256,12 @@ For `many_to_many`, specify `through` (junction model), `through_foreign_key`, a
 ```bash
 # Validate definitions (checks for errors and warnings)
 sidemantic validate models/ --verbose
+
+# Validate physical tables, columns, joins, and representative queries
+sidemantic validate models/ --warehouse
+
+# Also verify declared key uniqueness/nullability against data
+sidemantic validate models/ --warehouse --check-keys
 
 # Quick summary of what's defined
 sidemantic info models/
@@ -422,7 +428,7 @@ Load these when you need deeper detail:
 5. **Using `type: string` or `type: number` for dimensions.** The valid types are `categorical`, `time`, `boolean`, `numeric`.
 6. **Confusing model-level vs graph-level metrics.** Model-level metrics use `agg`. Graph-level metrics (ratio, derived, etc.) go in the top-level `metrics:` section.
 7. **Missing required fields on complex metrics.** ratio needs `numerator` + `denominator`. derived needs `sql`. time_comparison needs `base_metric`. conversion needs `entity`, `base_event`, `conversion_event`.
-8. **Plural relationship names create wrong FK defaults.** Relationship named `customers` defaults FK to `customers_id`, not `customer_id`. Always set `foreign_key` explicitly.
+8. **Relationship keys are omitted.** Sidemantic does not guess `customer_id`, `customers_id`, or `id`. Always set the real `foreign_key` and declare the one-side key.
 9. **SQL expressions with YAML special characters.** Quote SQL containing `:`, `#`, `{`, or `>`.
 10. **Duplicate model or metric names.** Names must be unique across the entire semantic layer.
 11. **Creating Models before SemanticLayer.** With auto-registration (default), Models must be created after the SemanticLayer, or they won't register.

--- a/plugins/sidemantic/skills/modeler/references/validation.md
+++ b/plugins/sidemantic/skills/modeler/references/validation.md
@@ -7,7 +7,7 @@ Every validation rule, error message, and common pitfall in Sidemantic model def
 Verify before loading any model:
 
 1. Every model has `table` or `sql` (not neither)
-2. Every model has a `primary_key` (defaults to `"id"`)
+2. Every joinable entity has its real `primary_key`; keyless isolated models are allowed
 3. Every dimension has a valid `type`: `categorical`, `time`, `boolean`, `numeric`
 4. Every `time` dimension has `granularity` set
 5. Every simple metric has a valid `agg` or SQL containing an aggregation function
@@ -19,12 +19,15 @@ Verify before loading any model:
 
 ## Model Validation
 
-### primary_key is required
+### primary_key is explicit
 
-Default is `"id"`. Only fails if explicitly set to empty.
+An omitted `primary_key` means identity is unknown. That is valid for an isolated
+model, but joins and entity-sensitive operations must have enough explicit key
+metadata to be safe.
 
-**Error:** `Model 'orders' must have a primary_key defined`
-**Fix:** `primary_key: order_id`
+**Warning:** `Model 'orders' has no primary_key; identity-dependent joins require explicit keys`
+**Fix:** Add the real key, such as `primary_key: order_id`, or keep the model
+keyless and avoid relationships that rely on its identity.
 
 ### table or sql required
 
@@ -134,15 +137,22 @@ There is no `type: simple`. Simple aggregations omit `type` and use `agg`.
 
 Must be one of: `many_to_one`, `one_to_one`, `one_to_many`, `many_to_many`.
 
-### foreign_key defaults
+### relationship keys are explicit
 
-- `many_to_one`: defaults to `{name}_id` (e.g., relationship named `customers` defaults to `customers_id`)
-- `one_to_one` / `one_to_many`: defaults to `id`
-- `many_to_many`: specify `through`, `through_foreign_key`, `related_foreign_key`
+- `many_to_one`: declare the source `foreign_key`; the target key may come from
+  the target model's declared `primary_key`
+- `one_to_one` / `one_to_many`: declare the related model's `foreign_key`; the
+  local key may come from the source model's declared `primary_key`
+- alternate unique keys: declare relationship `primary_key` for a scoped contract,
+  or add the key to model `unique_keys`
+- `many_to_many`: specify `through`, `through_foreign_key`, and `related_foreign_key`
+
+Missing keys and composite-key arity mismatches are structural errors. They are
+not added to the join graph, preventing invalid SQL from being compiled.
 
 ### Related model must exist
 
-Relationships to missing models are silently skipped during adjacency building. Queries across unresolved relationships fail at query time:
+Relationships to missing models fail structural validation and are omitted from adjacency building:
 
 **Error:** `No join path found between orders and customers`
 **Fix:** Ensure both models are added and the relationship's `name` matches the target model's `name` exactly.
@@ -190,7 +200,8 @@ Model-level: both `metrics` and `measures` work. Graph-level (top-level): only `
 
 ### Type defaults
 
-Dimensions in YAML default to `type: categorical` when omitted. Primary key defaults to `"id"`.
+Dimensions in YAML default to `type: categorical` when omitted. Primary keys and
+relationship keys do not default to column names.
 
 ### Indentation
 
@@ -238,7 +249,7 @@ Bare `yes`, `no`, `true`, `false` are parsed as booleans. Quote them if used as 
 
 | Error | Fix |
 |-------|-----|
-| `must have a primary_key defined` | Set `primary_key: column_name` |
+| `has no primary_key` | Set the real `primary_key`, or leave the model keyless if no join needs identity |
 | `must have either 'table' or 'sql' defined` | Add `table` or `sql` |
 | `Model X already exists` | Use unique names |
 | `Measure X already exists` | Use unique metric names |

--- a/plugins/sidemantic/skills/modeler/references/yaml-schema.md
+++ b/plugins/sidemantic/skills/modeler/references/yaml-schema.md
@@ -95,7 +95,7 @@ Dictionary form:
 | `source_uri` | string | No | -- | Remote data source URI (DuckDB) |
 | `description` | string | No | -- | Human-readable description |
 | `extends` | string | No | -- | Parent model name for inheritance |
-| `primary_key` | string or list | No | `"id"` | Primary key column(s) |
+| `primary_key` | string or list | No | `null` | Primary key column(s); omitted means identity is unknown |
 | `unique_keys` | list[list[string]] | No | -- | Unique constraints (Pydantic only, not in YAML adapter) |
 | `default_time_dimension` | string | No | -- | Auto-included time dimension for queries |
 | `default_grain` | string | No | -- | Default granularity: `hour`, `day`, `week`, `month`, `quarter`, `year` |
@@ -287,7 +287,7 @@ Current model-level validation aligns with this set (`sum`, `count`, `count_dist
 | `name` | string | Yes | -- | Name of the related model |
 | `type` | string | Yes | -- | `many_to_one`, `one_to_one`, `one_to_many`, `many_to_many` |
 | `foreign_key` | string or list | No | `{name}_id` (many_to_one) | FK column(s) in this model |
-| `primary_key` | string or list | No | `"id"` | PK in related model |
+| `primary_key` | string or list | Conditional | target/source model key | Explicit unique key on the relationship's one side |
 | `through` | string | No | -- | Junction model for many_to_many |
 | `through_foreign_key` | string | No | -- | FK in junction pointing to this model |
 | `related_foreign_key` | string | No | -- | FK in junction pointing to related model |

--- a/sidemantic-rs/src/config/schema.rs
+++ b/sidemantic-rs/src/config/schema.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::core::{
     Aggregation, CohortInnerMetric, ComparisonCalculation, ComparisonType, Dimension,
@@ -50,8 +50,8 @@ pub struct ModelConfig {
     pub table: Option<String>,
     pub sql: Option<String>,
     pub source_uri: Option<String>,
-    #[serde(default)]
-    pub primary_key: Option<KeyConfig>,
+    #[serde(default, deserialize_with = "deserialize_present_option")]
+    pub primary_key: Option<Option<KeyConfig>>,
     #[serde(default)]
     pub primary_key_columns: Option<Vec<String>>,
     #[serde(default)]
@@ -309,6 +309,14 @@ fn default_active() -> bool {
     true
 }
 
+fn deserialize_present_option<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::<T>::deserialize(deserializer).map(Some)
+}
+
 fn default_index_type() -> String {
     "regular".to_string()
 }
@@ -517,7 +525,13 @@ fn inherit_omitted_primary_keys(models: &mut [ModelConfig]) {
             model
                 .primary_key_columns
                 .clone()
-                .or_else(|| model.primary_key.clone().map(KeyConfig::into_columns))
+                .or_else(|| {
+                    model
+                        .primary_key
+                        .clone()
+                        .flatten()
+                        .map(KeyConfig::into_columns)
+                })
                 .map(|columns| (model.name.clone(), columns))
         })
         .collect();
@@ -554,6 +568,7 @@ impl ModelConfig {
             Some(columns) => columns,
             None => self
                 .primary_key
+                .flatten()
                 .map(KeyConfig::into_columns)
                 .unwrap_or_default(),
         };
@@ -1302,6 +1317,31 @@ models:
             .unwrap();
 
         assert_eq!(child.primary_keys(), vec!["event_id".to_string()]);
+    }
+
+    #[test]
+    fn test_explicit_null_child_primary_key_clears_parent_key() {
+        let yaml = r#"
+models:
+  - name: events
+    table: events
+    primary_key: event_id
+  - name: event_rollup
+    table: event_rollup
+    extends: events
+    primary_key: null
+"#;
+
+        let models = serde_yaml::from_str::<SidemanticConfig>(yaml)
+            .unwrap()
+            .into_models()
+            .unwrap();
+        let child = models
+            .iter()
+            .find(|model| model.name == "event_rollup")
+            .unwrap();
+
+        assert!(child.primary_keys().is_empty());
     }
 
     #[test]

--- a/sidemantic-rs/src/config/schema.rs
+++ b/sidemantic-rs/src/config/schema.rs
@@ -2,6 +2,8 @@
 //!
 //! Supports both native Sidemantic format and Cube.js format.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::core::{
@@ -483,8 +485,9 @@ impl SidemanticConfig {
     }
 
     /// Convert to core models, top-level metrics, and top-level parameters.
-    pub fn into_parts(self) -> crate::error::Result<(Vec<Model>, Vec<Metric>, Vec<Parameter>)> {
+    pub fn into_parts(mut self) -> crate::error::Result<(Vec<Model>, Vec<Metric>, Vec<Parameter>)> {
         self.validate_contract()?;
+        inherit_omitted_primary_keys(&mut self.models);
         let models = self.models.into_iter().map(|m| m.into_model()).collect();
         let metrics = self.metrics.into_iter().map(|m| m.into_metric()).collect();
         let parameters = self
@@ -498,6 +501,41 @@ impl SidemanticConfig {
     /// Convert to list of core Model types
     pub fn into_models(self) -> crate::error::Result<Vec<Model>> {
         Ok(self.into_parts()?.0)
+    }
+}
+
+fn inherit_omitted_primary_keys(models: &mut [ModelConfig]) {
+    let mut effective_keys: HashMap<String, Vec<String>> = models
+        .iter()
+        .filter_map(|model| {
+            model
+                .primary_key_columns
+                .clone()
+                .or_else(|| model.primary_key.clone().map(KeyConfig::into_columns))
+                .map(|columns| (model.name.clone(), columns))
+        })
+        .collect();
+
+    for _ in 0..models.len() {
+        let updates: Vec<_> = models
+            .iter()
+            .enumerate()
+            .filter(|(_, model)| model.primary_key.is_none() && model.primary_key_columns.is_none())
+            .filter_map(|(index, model)| {
+                let parent = model.extends.as_ref()?;
+                effective_keys
+                    .get(parent)
+                    .cloned()
+                    .map(|columns| (index, model.name.clone(), columns))
+            })
+            .collect();
+        if updates.is_empty() {
+            break;
+        }
+        for (index, name, columns) in updates {
+            models[index].primary_key_columns = Some(columns.clone());
+            effective_keys.insert(name, columns);
+        }
     }
 }
 
@@ -1209,6 +1247,29 @@ models:
 
         assert_eq!(model.primary_key, "");
         assert!(model.primary_keys().is_empty());
+    }
+
+    #[test]
+    fn test_omitted_child_primary_key_inherits_parent_key() {
+        let yaml = r#"
+models:
+  - name: base_events
+    table: events
+    primary_key: event_id
+  - name: recent_events
+    extends: base_events
+"#;
+
+        let models = serde_yaml::from_str::<SidemanticConfig>(yaml)
+            .unwrap()
+            .into_models()
+            .unwrap();
+        let child = models
+            .iter()
+            .find(|model| model.name == "recent_events")
+            .unwrap();
+
+        assert_eq!(child.primary_keys(), vec!["event_id".to_string()]);
     }
 
     #[test]

--- a/sidemantic-rs/src/config/schema.rs
+++ b/sidemantic-rs/src/config/schema.rs
@@ -48,8 +48,8 @@ pub struct ModelConfig {
     pub table: Option<String>,
     pub sql: Option<String>,
     pub source_uri: Option<String>,
-    #[serde(default = "default_primary_key_config")]
-    pub primary_key: KeyConfig,
+    #[serde(default)]
+    pub primary_key: Option<KeyConfig>,
     #[serde(default)]
     pub primary_key_columns: Option<Vec<String>>,
     #[serde(default)]
@@ -84,10 +84,6 @@ pub struct ModelConfig {
 
 fn default_primary_key() -> String {
     "id".to_string()
-}
-
-fn default_primary_key_config() -> KeyConfig {
-    KeyConfig::Single(default_primary_key())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -512,14 +508,17 @@ impl SidemanticConfig {
 impl ModelConfig {
     /// Convert to core Model type
     pub fn into_model(self) -> Model {
-        let primary_key_columns = self
-            .primary_key_columns
-            .filter(|columns| !columns.is_empty())
-            .unwrap_or_else(|| self.primary_key.into_columns());
-        let primary_key = primary_key_columns
-            .first()
-            .cloned()
-            .unwrap_or_else(default_primary_key);
+        // An explicitly empty columns list is the cross-runtime representation of
+        // a known-keyless model. When both fields are omitted, retain the legacy
+        // native-format `id` default for backward compatibility.
+        let primary_key_columns = match self.primary_key_columns {
+            Some(columns) => columns,
+            None => self
+                .primary_key
+                .map(KeyConfig::into_columns)
+                .unwrap_or_else(|| vec![default_primary_key()]),
+        };
+        let primary_key = primary_key_columns.first().cloned().unwrap_or_default();
 
         Model {
             name: self.name,
@@ -1178,6 +1177,44 @@ fn parse_comparison_calculation(s: &str) -> Option<ComparisonCalculation> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_explicit_empty_primary_key_columns_preserve_keyless_model() {
+        let yaml = r#"
+models:
+  - name: events
+    table: events
+    primary_key: null
+    primary_key_columns: []
+"#;
+
+        let mut models = serde_yaml::from_str::<SidemanticConfig>(yaml)
+            .unwrap()
+            .into_models()
+            .unwrap();
+        let model = models.remove(0);
+
+        assert_eq!(model.primary_key, "");
+        assert!(model.primary_keys().is_empty());
+    }
+
+    #[test]
+    fn test_omitted_primary_key_retains_legacy_id_default() {
+        let yaml = r#"
+models:
+  - name: events
+    table: events
+"#;
+
+        let mut models = serde_yaml::from_str::<SidemanticConfig>(yaml)
+            .unwrap()
+            .into_models()
+            .unwrap();
+        let model = models.remove(0);
+
+        assert_eq!(model.primary_key, "id");
+        assert_eq!(model.primary_keys(), vec!["id".to_string()]);
+    }
 
     #[test]
     fn test_parse_native_yaml() {

--- a/sidemantic-rs/src/config/schema.rs
+++ b/sidemantic-rs/src/config/schema.rs
@@ -215,6 +215,8 @@ pub struct RelationshipConfig {
     pub name: String,
     #[serde(default, rename = "type")]
     pub rel_type: Option<String>,
+    #[serde(default = "default_active")]
+    pub active: bool,
     pub foreign_key: Option<KeyConfig>,
     #[serde(default)]
     pub foreign_key_columns: Option<Vec<String>>,
@@ -300,6 +302,10 @@ pub struct IndexConfig {
 }
 
 fn default_public() -> bool {
+    true
+}
+
+fn default_active() -> bool {
     true
 }
 
@@ -571,6 +577,7 @@ impl ModelConfig {
             relationships: self
                 .relationships
                 .into_iter()
+                .filter(|relationship| relationship.active)
                 .map(|r| r.into_relationship())
                 .collect(),
             segments: self
@@ -1247,6 +1254,31 @@ models:
 
         assert_eq!(model.primary_key, "");
         assert!(model.primary_keys().is_empty());
+    }
+
+    #[test]
+    fn test_inactive_relationship_is_accepted_and_omitted_from_graph_model() {
+        let yaml = r#"
+models:
+  - name: orders
+    table: orders
+    primary_key: order_id
+    relationships:
+      - name: customers
+        type: many_to_one
+        foreign_key: customer_id
+        active: false
+  - name: customers
+    table: customers
+    primary_key: customer_id
+"#;
+
+        let models = serde_yaml::from_str::<SidemanticConfig>(yaml)
+            .unwrap()
+            .into_models()
+            .unwrap();
+
+        assert!(models[0].relationships.is_empty());
     }
 
     #[test]

--- a/sidemantic-rs/src/config/schema.rs
+++ b/sidemantic-rs/src/config/schema.rs
@@ -82,10 +82,6 @@ pub struct ModelConfig {
     pub sql_segments: Option<String>,
 }
 
-fn default_primary_key() -> String {
-    "id".to_string()
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum KeyConfig {
@@ -508,15 +504,14 @@ impl SidemanticConfig {
 impl ModelConfig {
     /// Convert to core Model type
     pub fn into_model(self) -> Model {
-        // An explicitly empty columns list is the cross-runtime representation of
-        // a known-keyless model. When both fields are omitted, retain the legacy
-        // native-format `id` default for backward compatibility.
+        // Missing or explicitly empty key fields both represent a model whose
+        // primary key is unknown. Never manufacture an `id` column here.
         let primary_key_columns = match self.primary_key_columns {
             Some(columns) => columns,
             None => self
                 .primary_key
                 .map(KeyConfig::into_columns)
-                .unwrap_or_else(|| vec![default_primary_key()]),
+                .unwrap_or_default(),
         };
         let primary_key = primary_key_columns.first().cloned().unwrap_or_default();
 
@@ -1199,7 +1194,7 @@ models:
     }
 
     #[test]
-    fn test_omitted_primary_key_retains_legacy_id_default() {
+    fn test_omitted_primary_key_preserves_keyless_model() {
         let yaml = r#"
 models:
   - name: events
@@ -1212,8 +1207,8 @@ models:
             .unwrap();
         let model = models.remove(0);
 
-        assert_eq!(model.primary_key, "id");
-        assert_eq!(model.primary_keys(), vec!["id".to_string()]);
+        assert_eq!(model.primary_key, "");
+        assert!(model.primary_keys().is_empty());
     }
 
     #[test]

--- a/sidemantic-rs/src/core/graph.rs
+++ b/sidemantic-rs/src/core/graph.rs
@@ -517,14 +517,7 @@ impl SemanticGraph {
                             continue;
                         }
 
-                        let source_pk = {
-                            let keys = model.primary_keys();
-                            if keys.is_empty() {
-                                vec!["id".to_string()]
-                            } else {
-                                keys
-                            }
-                        };
+                        let source_pk = model.primary_keys();
                         let target_pk =
                             if rel.primary_key.is_some() || rel.primary_key_columns.is_some() {
                                 rel.primary_key_columns()
@@ -532,13 +525,8 @@ impl SemanticGraph {
                                 self.models
                                     .get(&rel.name)
                                     .map(|target_model| target_model.primary_keys())
-                                    .unwrap_or_else(|| vec!["id".to_string()])
+                                    .unwrap_or_default()
                             };
-                        let target_pk = if target_pk.is_empty() {
-                            vec!["id".to_string()]
-                        } else {
-                            target_pk
-                        };
 
                         // source -> through (one_to_many)
                         self.adjacency.entry(model.name.clone()).or_default().push((
@@ -590,7 +578,7 @@ impl SemanticGraph {
                     self.models
                         .get(&rel.name)
                         .map(|target_model| target_model.primary_keys())
-                        .unwrap_or_else(|| vec!["id".to_string()])
+                        .unwrap_or_default()
                 };
 
                 let (from_keys, to_keys) = match rel.r#type {
@@ -650,7 +638,7 @@ impl SemanticGraph {
                     self.models
                         .get(&rel.name)
                         .map(|target_model| target_model.primary_keys())
-                        .unwrap_or_else(|| vec!["id".to_string()])
+                        .unwrap_or_default()
                 };
 
                 let (reverse_from_keys, reverse_to_keys) = match rel.r#type {

--- a/sidemantic-rs/src/core/graph.rs
+++ b/sidemantic-rs/src/core/graph.rs
@@ -527,6 +527,13 @@ impl SemanticGraph {
                                     .map(|target_model| target_model.primary_keys())
                                     .unwrap_or_default()
                             };
+                        if source_pk.is_empty()
+                            || target_pk.is_empty()
+                            || source_pk.len() != source_fks.len()
+                            || target_pk.len() != target_fks.len()
+                        {
+                            continue;
+                        }
 
                         // source -> through (one_to_many)
                         self.adjacency.entry(model.name.clone()).or_default().push((
@@ -590,6 +597,14 @@ impl SemanticGraph {
                     }
                 };
 
+                if rel.sql.is_none()
+                    && (from_keys.is_empty()
+                        || to_keys.is_empty()
+                        || from_keys.len() != to_keys.len())
+                {
+                    continue;
+                }
+
                 self.adjacency.entry(model.name.clone()).or_default().push((
                     rel.name.clone(),
                     from_keys.clone(),
@@ -649,6 +664,14 @@ impl SemanticGraph {
                         (fk_keys.clone(), pk_keys.clone())
                     }
                 };
+
+                if rel.sql.is_none()
+                    && (reverse_from_keys.is_empty()
+                        || reverse_to_keys.is_empty()
+                        || reverse_from_keys.len() != reverse_to_keys.len())
+                {
+                    continue;
+                }
 
                 self.adjacency.entry(rel.name.clone()).or_default().push((
                     model.name.clone(),
@@ -980,6 +1003,22 @@ mod tests {
         assert_eq!(path.steps.len(), 1);
         assert_eq!(path.steps[0].from_keys, vec!["customers_id".to_string()]);
         assert_eq!(path.steps[0].to_keys, vec!["customer_uid".to_string()]);
+    }
+
+    #[test]
+    fn test_keyless_target_does_not_create_incomplete_join_edge() {
+        let mut graph = SemanticGraph::new();
+
+        let orders = Model::new("orders", "order_id")
+            .with_table("orders")
+            .with_relationship(Relationship::many_to_one("customers"));
+        let customers = Model::new("customers", "").with_table("customers");
+
+        graph.add_model(orders).unwrap();
+        graph.add_model(customers).unwrap();
+
+        assert!(graph.find_join_path("orders", "customers").is_err());
+        assert!(graph.find_join_path("customers", "orders").is_err());
     }
 
     #[test]

--- a/sidemantic-rs/src/core/graph.rs
+++ b/sidemantic-rs/src/core/graph.rs
@@ -578,9 +578,9 @@ impl SemanticGraph {
                     }
                 }
 
-                let fk_keys = rel.foreign_key_columns();
+                let fk_keys = rel.declared_foreign_key_columns();
                 let pk_keys = if rel.primary_key.is_some() || rel.primary_key_columns.is_some() {
-                    rel.primary_key_columns()
+                    rel.declared_primary_key_columns()
                 } else {
                     self.models
                         .get(&rel.name)
@@ -646,9 +646,9 @@ impl SemanticGraph {
                         .replace("__TEMP__", "{to}")
                 });
 
-                let fk_keys = rel.foreign_key_columns();
+                let fk_keys = rel.declared_foreign_key_columns();
                 let pk_keys = if rel.primary_key.is_some() || rel.primary_key_columns.is_some() {
-                    rel.primary_key_columns()
+                    rel.declared_primary_key_columns()
                 } else {
                     self.models
                         .get(&rel.name)
@@ -792,7 +792,9 @@ mod tests {
             .with_dimension(Dimension::categorical("status"))
             .with_dimension(Dimension::time("order_date"))
             .with_metric(Metric::sum("revenue", "amount"))
-            .with_relationship(Relationship::many_to_one("customers"));
+            .with_relationship(
+                Relationship::many_to_one("customers").with_keys("customers_id", "id"),
+            );
 
         let customers = Model::new("customers", "id")
             .with_table("customers")
@@ -970,7 +972,7 @@ mod tests {
     }
 
     #[test]
-    fn test_one_to_many_omitted_key_defaults_to_id() {
+    fn test_one_to_many_omitted_key_does_not_create_join_edge() {
         let mut graph = SemanticGraph::new();
 
         let customers = Model::new("customers", "id")
@@ -981,14 +983,12 @@ mod tests {
         graph.add_model(customers).unwrap();
         graph.add_model(orders).unwrap();
 
-        let path = graph.find_join_path("customers", "orders").unwrap();
-        assert_eq!(path.steps.len(), 1);
-        assert_eq!(path.steps[0].from_keys, vec!["id".to_string()]);
-        assert_eq!(path.steps[0].to_keys, vec!["id".to_string()]);
+        assert!(graph.find_join_path("customers", "orders").is_err());
+        assert!(graph.find_join_path("orders", "customers").is_err());
     }
 
     #[test]
-    fn test_many_to_one_omitted_keys_use_name_id_and_target_primary_key() {
+    fn test_many_to_one_omitted_key_does_not_create_join_edge() {
         let mut graph = SemanticGraph::new();
 
         let orders = Model::new("orders", "order_id")
@@ -999,10 +999,8 @@ mod tests {
         graph.add_model(orders).unwrap();
         graph.add_model(customers).unwrap();
 
-        let path = graph.find_join_path("orders", "customers").unwrap();
-        assert_eq!(path.steps.len(), 1);
-        assert_eq!(path.steps[0].from_keys, vec!["customers_id".to_string()]);
-        assert_eq!(path.steps[0].to_keys, vec!["customer_uid".to_string()]);
+        assert!(graph.find_join_path("orders", "customers").is_err());
+        assert!(graph.find_join_path("customers", "orders").is_err());
     }
 
     #[test]
@@ -1022,7 +1020,7 @@ mod tests {
     }
 
     #[test]
-    fn test_one_to_one_omitted_key_defaults_to_id() {
+    fn test_one_to_one_omitted_key_does_not_create_join_edge() {
         let mut graph = SemanticGraph::new();
 
         let mut relationship = Relationship::new("profiles");
@@ -1036,10 +1034,8 @@ mod tests {
         graph.add_model(users).unwrap();
         graph.add_model(profiles).unwrap();
 
-        let path = graph.find_join_path("users", "profiles").unwrap();
-        assert_eq!(path.steps.len(), 1);
-        assert_eq!(path.steps[0].from_keys, vec!["id".to_string()]);
-        assert_eq!(path.steps[0].to_keys, vec!["id".to_string()]);
+        assert!(graph.find_join_path("users", "profiles").is_err());
+        assert!(graph.find_join_path("profiles", "users").is_err());
     }
 
     #[test]

--- a/sidemantic-rs/src/core/inheritance.rs
+++ b/sidemantic-rs/src/core/inheritance.rs
@@ -22,17 +22,10 @@ pub fn merge_model(child: &Model, parent: &Model) -> Model {
         .clone()
         .or_else(|| parent.source_uri.clone());
     let extends = child.extends.clone();
-    let child_primary_key_columns = if child.primary_key_columns.is_empty() {
-        vec![child.primary_key.clone()]
-    } else {
-        child.primary_key_columns.clone()
-    };
-    let parent_primary_key_columns = if parent.primary_key_columns.is_empty() {
-        vec![parent.primary_key.clone()]
-    } else {
-        parent.primary_key_columns.clone()
-    };
-    let child_overrides_primary_key = child_primary_key_columns.len() > 1
+    let child_primary_key_columns = child.primary_keys();
+    let parent_primary_key_columns = parent.primary_keys();
+    let child_overrides_primary_key = child_primary_key_columns.is_empty()
+        || child_primary_key_columns.len() > 1
         || child_primary_key_columns
             .first()
             .map(|value| value.as_str())
@@ -42,10 +35,7 @@ pub fn merge_model(child: &Model, parent: &Model) -> Model {
     } else {
         parent_primary_key_columns
     };
-    let primary_key = primary_key_columns
-        .first()
-        .cloned()
-        .unwrap_or_else(|| "id".to_string());
+    let primary_key = primary_key_columns.first().cloned().unwrap_or_default();
     let unique_keys = child
         .unique_keys
         .clone()

--- a/sidemantic-rs/src/core/model.rs
+++ b/sidemantic-rs/src/core/model.rs
@@ -742,12 +742,30 @@ impl Relationship {
             })
     }
 
+    /// Returns only explicitly declared foreign-key columns, without compatibility defaults.
+    pub fn declared_foreign_key_columns(&self) -> Vec<String> {
+        self.foreign_key_columns
+            .clone()
+            .filter(|columns| !columns.is_empty())
+            .or_else(|| self.foreign_key.clone().map(|key| vec![key]))
+            .unwrap_or_default()
+    }
+
     pub fn primary_key_columns(&self) -> Vec<String> {
         self.primary_key_columns
             .clone()
             .filter(|columns| !columns.is_empty())
             .or_else(|| self.primary_key.clone().map(|key| vec![key]))
             .unwrap_or_else(|| vec!["id".to_string()])
+    }
+
+    /// Returns only explicitly declared relationship-side primary-key columns.
+    pub fn declared_primary_key_columns(&self) -> Vec<String> {
+        self.primary_key_columns
+            .clone()
+            .filter(|columns| !columns.is_empty())
+            .or_else(|| self.primary_key.clone().map(|key| vec![key]))
+            .unwrap_or_default()
     }
 
     /// Returns the custom SQL condition if set

--- a/sidemantic-rs/src/core/model.rs
+++ b/sidemantic-rs/src/core/model.rs
@@ -977,6 +977,8 @@ impl Model {
     pub fn with_primary_key_columns(mut self, primary_key_columns: Vec<String>) -> Self {
         if let Some(primary_key) = primary_key_columns.first() {
             self.primary_key = primary_key.clone();
+        } else {
+            self.primary_key.clear();
         }
         self.primary_key_columns = primary_key_columns;
         self
@@ -1024,7 +1026,11 @@ impl Model {
 
     pub fn primary_keys(&self) -> Vec<String> {
         if self.primary_key_columns.is_empty() {
-            vec![self.primary_key.clone()]
+            if self.primary_key.is_empty() {
+                Vec::new()
+            } else {
+                vec![self.primary_key.clone()]
+            }
         } else {
             self.primary_key_columns.clone()
         }

--- a/sidemantic-rs/src/runtime.rs
+++ b/sidemantic-rs/src/runtime.rs
@@ -540,7 +540,7 @@ fn graph_model_primary_keys(model: &GraphPathModelPayload) -> Vec<String> {
     } else if let Some(primary_key) = model.primary_key.as_ref() {
         graph_path_key_to_columns(primary_key)
     } else {
-        vec!["id".to_string()]
+        Vec::new()
     }
 }
 
@@ -5663,10 +5663,7 @@ fn semantic_graph_from_graph_path_payload(
 
     for model_payload in &payload.models {
         let primary_key_columns = graph_model_primary_keys(model_payload);
-        let primary_key = primary_key_columns
-            .first()
-            .cloned()
-            .unwrap_or_else(|| "id".to_string());
+        let primary_key = primary_key_columns.first().cloned().unwrap_or_default();
 
         let mut model = Model::new(model_payload.name.clone(), primary_key)
             .with_primary_key_columns(primary_key_columns)

--- a/sidemantic/adapters/atscale_sml.py
+++ b/sidemantic/adapters/atscale_sml.py
@@ -453,15 +453,11 @@ class AtScaleSMLAdapter(BaseAdapter):
             metrics=[],
         )
 
-    def _infer_primary_key(self, columns: list[dict[str, Any]]) -> str:
-        for column in columns:
-            name = column.get("name")
-            if not name:
-                continue
-            lowered = name.lower()
-            if lowered == "id" or lowered.endswith("_id") or lowered.endswith("key"):
-                return name
-        return "id"
+    def _infer_primary_key(self, columns: list[dict[str, Any]]) -> str | None:
+        # AtScale dataset columns do not declare relational uniqueness. Dimension-level
+        # ``key_columns`` are used when building explicit relationships, but guessing a model
+        # primary key from an ``id``-shaped column would overstate the source contract.
+        return None
 
     def _collect_dimension_attrs(
         self,
@@ -822,7 +818,7 @@ class AtScaleSMLAdapter(BaseAdapter):
                         metrics=[],
                     )
                 else:
-                    model = Model(name=model_name, table=None, primary_key="id")
+                    model = Model(name=model_name, table=None, primary_key=None)
                 graph.add_model(model)
 
             for attr in attrs:
@@ -867,7 +863,7 @@ class AtScaleSMLAdapter(BaseAdapter):
                         metrics=[],
                     )
                 else:
-                    model = Model(name=model_name, table=None, primary_key="id")
+                    model = Model(name=model_name, table=None, primary_key=None)
                 graph.add_model(model)
 
             for info in metrics:
@@ -1013,7 +1009,7 @@ class AtScaleSMLAdapter(BaseAdapter):
 
             model = graph.models.get(source_model_name)
             if not model:
-                model = Model(name=source_model_name, table=None, primary_key="id")
+                model = Model(name=source_model_name, table=None, primary_key=None)
                 graph.add_model(model)
 
             if not any(existing.name == rel.name for existing in model.relationships):
@@ -1052,7 +1048,7 @@ class AtScaleSMLAdapter(BaseAdapter):
                             )
                         )
                     else:
-                        graph.add_model(Model(name=source_model_name, table=None, primary_key="id"))
+                        graph.add_model(Model(name=source_model_name, table=None, primary_key=None))
 
                 model = graph.models[source_model_name]
                 if not any(existing.name == rel.name for existing in model.relationships):
@@ -1388,11 +1384,11 @@ class AtScaleSMLAdapter(BaseAdapter):
             "expression": metric.sql or metric.name,
         }
 
-    def _resolve_relationship_level(self, related_model: Model | None, rel: Relationship, join_column: str) -> str:
+    def _resolve_relationship_level(self, related_model: Model | None, rel: Relationship) -> str | None:
         if not related_model:
-            return rel.primary_key or "id"
+            return rel.primary_key
 
-        candidates = [rel.primary_key, related_model.primary_key, join_column]
+        candidates = [rel.primary_key, related_model.primary_key]
         for candidate in candidates:
             if not candidate:
                 continue
@@ -1402,10 +1398,7 @@ class AtScaleSMLAdapter(BaseAdapter):
                 if dimension.sql == candidate:
                     return dimension.name
 
-        if related_model.dimensions:
-            return related_model.dimensions[0].name
-
-        return rel.primary_key or related_model.primary_key or "id"
+        return None
 
     def _export_model(self, model: Model, models: dict[str, Model]) -> dict[str, Any]:
         model_def: dict[str, Any] = {
@@ -1417,9 +1410,17 @@ class AtScaleSMLAdapter(BaseAdapter):
         if model.relationships:
             relationships = []
             for rel in model.relationships:
-                join_column = rel.foreign_key or f"{rel.name}_id"
+                join_column = rel.foreign_key
+                if not isinstance(join_column, str):
+                    raise ValueError(
+                        f"Cannot export relationship '{model.name}.{rel.name}' to AtScale without a single foreign_key"
+                    )
                 related_model = models.get(rel.name)
-                related_level = self._resolve_relationship_level(related_model, rel, join_column)
+                related_level = self._resolve_relationship_level(related_model, rel)
+                if related_level is None:
+                    raise ValueError(
+                        f"Cannot export relationship '{model.name}.{rel.name}' to AtScale without a target key"
+                    )
 
                 relationships.append(
                     {

--- a/sidemantic/adapters/bsl.py
+++ b/sidemantic/adapters/bsl.py
@@ -122,7 +122,7 @@ class BSLAdapter(BaseAdapter):
         description = model_def.get("description")
         database = model_def.get("database")
 
-        # Primary key: explicit field > is_entity dimension > default "id"
+        # Primary key: explicit field > explicitly marked entity dimension.
         primary_key = model_def.get("primary_key")
 
         dimensions = []
@@ -135,9 +135,6 @@ class BSLAdapter(BaseAdapter):
                     primary_key = dim_name
                 for derived_dim in self._parse_derived_dimensions(dim_name, dim_def, dim):
                     dimensions.append(derived_dim)
-
-        if not primary_key:
-            primary_key = "id"
 
         # Model-level time dimension and grain
         default_time_dimension = None
@@ -587,7 +584,7 @@ class BSLAdapter(BaseAdapter):
         if model.metadata and "bsl_database" in model.metadata:
             model_def["database"] = model.metadata["bsl_database"]
 
-        if model.primary_key and model.primary_key != "id":
+        if model.primary_key:
             model_def["primary_key"] = model.primary_key
 
         if model.default_time_dimension:

--- a/sidemantic/adapters/cube.py
+++ b/sidemantic/adapters/cube.py
@@ -533,14 +533,14 @@ class CubeAdapter(BaseAdapter):
         if native_sql:
             return Relationship(name=join_name, type=rel_type, sql=native_sql)
 
-        # Unparseable (references another cube, or no recognizable members): fall back
-        # to Cube's naming convention, but warn instead of silently faking a join.
+        # Preserve the relationship shape, but leave its key unknown. Structural validation will
+        # require the user to supply the real key instead of compiling a guessed join.
         warnings.warn(
             f"Could not parse Cube join '{self_name}' -> '{join_name}' from SQL {join_sql!r}; "
-            f"falling back to foreign key '{join_name}_id'.",
+            "leaving the foreign key unknown.",
             stacklevel=2,
         )
-        return Relationship(name=join_name, type=rel_type, foreign_key=f"{join_name}_id")
+        return Relationship(name=join_name, type=rel_type)
 
     @staticmethod
     def _native_join_sql_to_cube(native_sql: str, join_name: str) -> str:

--- a/sidemantic/adapters/gooddata.py
+++ b/sidemantic/adapters/gooddata.py
@@ -164,7 +164,7 @@ class GoodDataAdapter(BaseAdapter):
             table = None
 
         grain_ids = self._parse_grain_ids(dataset_def)
-        primary_key = grain_ids[0] if grain_ids else "id"
+        primary_key = grain_ids[0] if grain_ids else None
 
         attributes = self._as_list(dataset_def.get("attributes"))
         facts = self._as_list(dataset_def.get("facts"))
@@ -531,7 +531,7 @@ class GoodDataAdapter(BaseAdapter):
         label_map = self._build_legacy_label_map(dataset_def.get("labels"))
 
         dimensions = []
-        primary_key = "id"
+        primary_key = None
 
         anchor_def = dataset_def.get("anchor")
         if isinstance(anchor_def, dict):

--- a/sidemantic/adapters/graphene.py
+++ b/sidemantic/adapters/graphene.py
@@ -372,7 +372,7 @@ class GrapheneAdapter(BaseAdapter):
         for model_name, model in graph.models.items():
             if model_name in explicit_primary_keys:
                 continue
-            if model.primary_key != "id":
+            if model.primary_key is not None:
                 continue
             model.primary_key = _choose_primary_key(model.dimensions, candidates.get(model_name))
 
@@ -1483,19 +1483,14 @@ def _graphene_metadata(metadata: dict[str, Any], extra: dict[str, Any] | None = 
     return {"graphene": payload} if payload else None
 
 
-def _choose_primary_key(dimensions: list[Dimension], candidates: list[str] | None) -> str:
+def _choose_primary_key(dimensions: list[Dimension], candidates: list[str] | None) -> str | None:
     dimension_names = {dimension.name for dimension in dimensions}
     if candidates:
         for candidate in candidates:
             if candidate in dimension_names:
                 return candidate
         return candidates[0]
-    if "id" in dimension_names:
-        return "id"
-    for dimension in dimensions:
-        if dimension.name.endswith("_id"):
-            return dimension.name
-    return dimensions[0].name if dimensions else "id"
+    return None
 
 
 def _model_name_from_ref(ref: str) -> str:

--- a/sidemantic/adapters/hex.py
+++ b/sidemantic/adapters/hex.py
@@ -105,7 +105,7 @@ class HexAdapter(BaseAdapter):
 
         # Parse dimensions and find primary key
         dimensions = []
-        primary_key = "id"  # default
+        primary_key = None
 
         for dim_def in model_def.get("dimensions") or []:
             dim = self._parse_dimension(dim_def)

--- a/sidemantic/adapters/holistics.py
+++ b/sidemantic/adapters/holistics.py
@@ -1159,7 +1159,7 @@ def _parse_model_block(block: AmlBlock, constants: dict[str, AmlValue], context:
         table=table_name if model_type == "table" else None,
         sql=query_expr if model_type == "query" else None,
         description=description,
-        primary_key=primary_key or "id",
+        primary_key=primary_key,
         dimensions=dimensions,
         metrics=metrics,
     )
@@ -1538,7 +1538,7 @@ def _parse_dataset_block(
     return Model(
         name=block.name,
         description=description or label,
-        primary_key="id",
+        primary_key=None,
         dimensions=dimensions,
         metrics=metrics,
     )

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -2640,7 +2640,7 @@ class LookMLAdapter(BaseAdapter):
 
         # Parse dimensions with resolved SQL
         dimensions = []
-        primary_key = "id"  # default
+        primary_key = None
 
         for dim_def in dimension_defs:
             dim = self._parse_dimension(dim_def, resolved_dimension_sql)
@@ -2980,7 +2980,7 @@ class LookMLAdapter(BaseAdapter):
         # Build kwargs conditionally so that unset scalars don't appear in
         # model_fields_set. This matters for refinements: merge_model treats
         # every field in model_fields_set as an explicit child override, so
-        # passing table=None or primary_key="id" would erase the base view's
+        # passing table=None or an unknown primary key would erase the base view's
         # real values.
         model_kwargs: dict = {
             "name": name,
@@ -2997,7 +2997,7 @@ class LookMLAdapter(BaseAdapter):
             model_kwargs["description"] = desc
         if extends is not None:
             model_kwargs["extends"] = extends
-        if primary_key != "id":
+        if primary_key is not None:
             model_kwargs["primary_key"] = primary_key
         if model_meta:
             model_kwargs["meta"] = model_meta

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -282,7 +282,7 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         self.current_model_name: str | None = None
         self.current_table: str | None = None
         self.current_sql: str | None = None
-        self.current_primary_key: str = "id"
+        self.current_primary_key: str | None = None
         self.current_description: str | None = None
         self.current_extends: str | None = None
         self.current_connection: str | None = None
@@ -296,7 +296,7 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         self.current_model_name = None
         self.current_table = None
         self.current_sql = None
-        self.current_primary_key = "id"
+        self.current_primary_key = None
         self.current_description = None
         self.current_extends = None
         self.current_connection = None
@@ -1925,7 +1925,7 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         self.current_model_name = join_name
         self.current_table = None
         self.current_sql = None
-        self.current_primary_key = "id"
+        self.current_primary_key = None
         self.current_description = None
         self.current_extends = None
         self.current_connection = None
@@ -2276,7 +2276,7 @@ class MalloyAdapter(BaseAdapter):
             lines.append(f"source: {model.name} extend {{")
 
         # Primary key
-        if model.primary_key and model.primary_key != "id":
+        if model.primary_key:
             lines.append(f"  primary_key: {model.primary_key}")
 
         # Segments (source-level where clauses) - Tier 4.1

--- a/sidemantic/adapters/metricflow.py
+++ b/sidemantic/adapters/metricflow.py
@@ -131,8 +131,9 @@ class MetricFlowAdapter(BaseAdapter):
                 metric = self._parse_metric(metric_def)
                 if not metric:
                     continue
+                owning_model = None
                 if metric_def.get("type", "simple") == "simple" and metric.agg is not None:
-                    primary_key_ref = f"{model.name}.{model.primary_key}"
+                    primary_key_ref = f"{model.name}.{model.primary_key}" if model.primary_key else None
                     if metric.sql is not None:
                         qualified = self._qualify_measure_sql(metric.sql, model.name)
                         # A constant count measure (``agg: count`` with ``expr: 1``
@@ -142,14 +143,21 @@ class MetricFlowAdapter(BaseAdapter):
                         # model via its primary key, the same as a bare ``count``.
                         # COUNT over a non-null primary key is equivalent to COUNT(*).
                         if metric.agg == "count" and not self._has_qualified_column(qualified, model.name):
-                            metric.sql = primary_key_ref
+                            if primary_key_ref:
+                                metric.sql = primary_key_ref
+                            else:
+                                metric.sql = None
+                                owning_model = model.name
                         else:
                             metric.sql = qualified
                     elif metric.agg == "count":
                         # Bare ``count`` with no ``expr``: anchor it to the model
                         # via its primary key so the planner can resolve the model.
                         # COUNT over a non-null primary key is equivalent to COUNT(*).
-                        metric.sql = primary_key_ref
+                        if primary_key_ref:
+                            metric.sql = primary_key_ref
+                        else:
+                            owning_model = model.name
                     else:
                         # Any other expr-less aggregation (sum/avg/min/max/...): in
                         # MetricFlow an expr-less measure aggregates the column named
@@ -158,7 +166,7 @@ class MetricFlowAdapter(BaseAdapter):
                         # key here would silently aggregate the wrong column (e.g.
                         # ``SUM(orders.order_id)`` instead of ``SUM(orders.amount)``).
                         metric.sql = f"{model.name}.{metric.name}"
-                self._add_metric(graph, metric)
+                self._add_metric(graph, metric, model_name=owning_model)
 
         # Legacy spec: top-level ``semantic_models:``.
         for model_def in data.get("semantic_models") or []:
@@ -222,11 +230,11 @@ class MetricFlowAdapter(BaseAdapter):
         return False
 
     @staticmethod
-    def _add_metric(graph: SemanticGraph, metric: Metric) -> None:
+    def _add_metric(graph: SemanticGraph, metric: Metric, model_name: str | None = None) -> None:
         """Add a metric to the graph, ignoring duplicate names across files."""
         if metric.name in graph.metrics:
             return
-        graph.add_metric(metric)
+        graph.add_metric(metric, model_name=model_name)
 
     def _parse_saved_queries(self, saved_queries) -> None:
         """Parse top-level ``saved_queries`` into ``self.saved_queries``.

--- a/sidemantic/adapters/metricflow.py
+++ b/sidemantic/adapters/metricflow.py
@@ -303,7 +303,7 @@ class MetricFlowAdapter(BaseAdapter):
         model_sql = model_def.get("sql")
 
         # Parse entities to extract primary key and relationships
-        primary_key = "id"  # default
+        primary_key = None
         relationships = []
         # Map entity name -> backing SQL column, so semi-additive window_groupings that name an
         # entity (e.g. `user`, backed by `user_id`) resolve to the real column the generator can
@@ -418,7 +418,7 @@ class MetricFlowAdapter(BaseAdapter):
         # The underlying table is the dbt model itself.
         table = model_def.get("name")
 
-        primary_key = "id"
+        primary_key = None
         relationships = []
         dimensions = []
 
@@ -963,23 +963,28 @@ class MetricFlowAdapter(BaseAdapter):
         # Export entities (convert from relationships and primary_key)
         result["entities"] = []
 
-        # Add primary entity
-        result["entities"].append(
-            {
-                "name": model.name,  # Use model name as entity name
-                "type": "primary",
-                "expr": model.primary_key,
-            }
-        )
+        # Add a primary entity only when the source model actually declares one.
+        if model.primary_key is not None:
+            result["entities"].append(
+                {
+                    "name": model.name,
+                    "type": "primary",
+                    "expr": model.primary_key,
+                }
+            )
 
         # Add foreign entities from relationships
         for rel in model.relationships:
             if rel.type == "many_to_one":
+                if not rel.foreign_key:
+                    raise ValueError(
+                        f"Cannot export relationship '{model.name}.{rel.name}' to MetricFlow without foreign_key"
+                    )
                 result["entities"].append(
                     {
                         "name": rel.name,
                         "type": "foreign",
-                        "expr": rel.foreign_key or f"{rel.name}_id",
+                        "expr": rel.foreign_key,
                     }
                 )
 

--- a/sidemantic/adapters/omni.py
+++ b/sidemantic/adapters/omni.py
@@ -218,7 +218,7 @@ class OmniAdapter(BaseAdapter):
 
         # Parse dimensions
         dimensions = []
-        primary_key = "id"  # default
+        primary_key = None
 
         for dim_name, dim_def in (view.get("dimensions") or {}).items():
             if dim_def is None:
@@ -956,12 +956,17 @@ class OmniAdapter(BaseAdapter):
                 # depends on cardinality (see Relationship): for many_to_one the
                 # from_view holds the FK; for one_to_many / one_to_one the to_view
                 # (related model) holds the FK and the from_view contributes its key.
+                related_model = models.get(rel.name)
                 if rel.type in ("one_to_many", "one_to_one"):
-                    from_key = rel.primary_key or "id"
-                    to_key = rel.foreign_key or f"{model.name}_id"
+                    from_key = rel.primary_key or model.primary_key
+                    to_key = rel.foreign_key
                 else:
-                    from_key = rel.foreign_key or f"{rel.name}_id"
-                    to_key = rel.primary_key or "id"
+                    from_key = rel.foreign_key
+                    to_key = rel.primary_key or (related_model.primary_key if related_model else None)
+                if not from_key or not to_key:
+                    raise ValueError(
+                        f"Cannot export relationship '{model.name}.{rel.name}' without explicit/resolvable join keys"
+                    )
                 rel_def["on_sql"] = f"${{{model.name}.{from_key}}} = ${{{rel.name}.{to_key}}}"
 
                 relationships.append(rel_def)

--- a/sidemantic/adapters/osi.py
+++ b/sidemantic/adapters/osi.py
@@ -294,7 +294,7 @@ class OSIAdapter(BaseAdapter):
         # Primary key - preserve full list for multi-column keys
         primary_key_list = dataset_def.get("primary_key") or []
         if len(primary_key_list) == 0:
-            primary_key: str | list[str] = "id"
+            primary_key: str | list[str] | None = None
         elif len(primary_key_list) == 1:
             primary_key = primary_key_list[0]
         else:
@@ -490,14 +490,14 @@ class OSIAdapter(BaseAdapter):
 
         # Normalize to appropriate type (str for single, list for multi)
         if len(from_columns) == 0:
-            foreign_key: str | list[str] = f"{to_model}_id"
+            foreign_key: str | list[str] | None = None
         elif len(from_columns) == 1:
             foreign_key = from_columns[0]
         else:
             foreign_key = from_columns
 
         if len(to_columns) == 0:
-            primary_key: str | list[str] = "id"
+            primary_key: str | list[str] | None = None
         elif len(to_columns) == 1:
             primary_key = to_columns[0]
         else:
@@ -803,7 +803,7 @@ class OSIAdapter(BaseAdapter):
         # Use the related model's actual primary key when rel.primary_key is unset
         if rel.primary_key is None:
             related_model = models.get(rel.name)
-            to_columns = related_model.primary_key_columns if related_model else ["id"]
+            to_columns = related_model.primary_key_columns if related_model else []
         else:
             to_columns = rel.primary_key_columns
 

--- a/sidemantic/adapters/sidemantic.py
+++ b/sidemantic/adapters/sidemantic.py
@@ -775,7 +775,7 @@ class SidemanticAdapter(BaseAdapter):
                 model_kwargs["security"] = SecurityPolicy(**security_kwargs)
 
         if "primary_key_columns" in model_def:
-            model_kwargs["primary_key"] = model_def.get("primary_key_columns")
+            model_kwargs["primary_key"] = model_def.get("primary_key_columns") or None
         elif "primary_key" in model_def:
             model_kwargs["primary_key"] = model_def.get("primary_key")
 
@@ -964,6 +964,11 @@ class SidemanticAdapter(BaseAdapter):
         # Export primary key
         if model.primary_key is not None:
             result["primary_key"] = model.primary_key
+        else:
+            # Native Rust loaders retain the legacy `id` default for an omitted
+            # key. The empty columns marker distinguishes an explicitly keyless
+            # model without breaking older hand-authored definitions.
+            result["primary_key_columns"] = []
 
         # Export dimensions
         if model.dimensions:

--- a/sidemantic/adapters/sidemantic.py
+++ b/sidemantic/adapters/sidemantic.py
@@ -965,9 +965,8 @@ class SidemanticAdapter(BaseAdapter):
         if model.primary_key is not None:
             result["primary_key"] = model.primary_key
         else:
-            # Native Rust loaders retain the legacy `id` default for an omitted
-            # key. The empty columns marker distinguishes an explicitly keyless
-            # model without breaking older hand-authored definitions.
+            # Keep an explicit marker for compatibility with older Rust loaders
+            # that treated an omitted native key as `id`.
             result["primary_key_columns"] = []
 
         # Export dimensions

--- a/sidemantic/adapters/sidemantic.py
+++ b/sidemantic/adapters/sidemantic.py
@@ -160,6 +160,7 @@ RELATIONSHIP_FIELDS = {
     "related_foreign_key_columns",
     "sql",
     "metadata",
+    "active",
 }
 SEGMENT_FIELDS = {
     "name",
@@ -961,7 +962,7 @@ class SidemanticAdapter(BaseAdapter):
             ]
 
         # Export primary key
-        if model.primary_key != "id":  # Only export if non-default
+        if model.primary_key is not None:
             result["primary_key"] = model.primary_key
 
         # Export dimensions

--- a/sidemantic/adapters/snowflake.py
+++ b/sidemantic/adapters/snowflake.py
@@ -297,7 +297,7 @@ class SnowflakeAdapter(BaseAdapter):
         # Parse primary key
         primary_key_def = table_def.get("primary_key", {})
         primary_key_columns = primary_key_def.get("columns") or []
-        primary_key = primary_key_columns[0] if primary_key_columns else "id"
+        primary_key = primary_key_columns[0] if primary_key_columns else None
 
         # Parse dimensions (categorical attributes)
         dimensions = []

--- a/sidemantic/adapters/superset.py
+++ b/sidemantic/adapters/superset.py
@@ -91,17 +91,13 @@ class SupersetAdapter(BaseAdapter):
 
         # Parse columns
         dimensions = []
-        primary_key = "id"  # default
+        primary_key = None
         main_dttm_col = dataset.get("main_dttm_col")
 
         for col_def in dataset.get("columns") or []:
             dim = self._parse_column(col_def, main_dttm_col)
             if dim:
                 dimensions.append(dim)
-
-                # Check if this is the primary key
-                if col_def.get("column_name") == "id":
-                    primary_key = dim.name
 
         # Parse metrics
         metrics = []

--- a/sidemantic/adapters/tableau.py
+++ b/sidemantic/adapters/tableau.py
@@ -1118,16 +1118,9 @@ class TableauAdapter(BaseAdapter):
         # Parse groups as segments
         segments = self._parse_groups_as_segments(ds_elem)
 
-        # Determine primary key
-        primary_key = self._infer_primary_key(dimensions, metrics, metadata_lookup, collection_info)
-        if collection_info and sql:
-            sql = self._inject_collection_primary_key_sql(
-                sql,
-                primary_key,
-                collection_info,
-                metadata_lookup,
-            )
-            primary_key = "__tableau_pk"
+        # Tableau fields and collection columns do not declare uniqueness. Keep identity unknown
+        # instead of manufacturing a key from an id-shaped or first projected field.
+        primary_key = None
 
         # Surface Tableau Semantics-layer attributes (semantic-layer / is-legacy)
         # from the object-graph as model metadata so downstream consumers can
@@ -1645,77 +1638,6 @@ class TableauAdapter(BaseAdapter):
         table_name, column_name = field_sources.get(normalized, (expected_table, normalized))
         alias = alias_by_table.get(table_name, alias_by_table[expected_table])
         return f"{alias}.{_quote_sql_identifier(column_name)}"
-
-    def _infer_primary_key(
-        self,
-        dimensions: list[Dimension],
-        metrics: list[Metric],
-        metadata_lookup: dict[str, dict],
-        collection_info: _CollectionInfo | None,
-    ) -> str:
-        """Infer a primary key from actual imported fields instead of hard-coding id."""
-        fields: list[tuple[str, str | None]] = []
-        field_sources = self._build_collection_field_sources(metadata_lookup)
-        for dimension in dimensions:
-            fields.append((dimension.name, field_sources.get(dimension.name, (None, None))[0]))
-        for metric in metrics:
-            fields.append((metric.name, field_sources.get(metric.name, (None, None))[0]))
-
-        def rank(field_name: str) -> tuple[int, int]:
-            lowered = field_name.lower()
-            if lowered == "id":
-                return (0, 0)
-            if lowered in {"row id", "rowid"}:
-                return (1, 0)
-            if lowered.endswith("_id") or lowered.endswith(" id"):
-                return (2, 0)
-            if lowered.endswith("_key") or lowered.endswith(" key") or lowered.endswith("key"):
-                return (3, 0)
-            return (99, 0)
-
-        preferred_table = collection_info.base_table_name if collection_info else None
-        preferred_fields = [
-            field_name
-            for field_name, table_name in fields
-            if preferred_table is not None and table_name == preferred_table
-        ]
-        scored_preferred = [field_name for field_name in preferred_fields if rank(field_name)[0] < 99]
-        if scored_preferred:
-            return min(scored_preferred, key=rank)
-
-        scored_fields = [field_name for field_name, _ in fields if rank(field_name)[0] < 99]
-        if scored_fields:
-            return min(scored_fields, key=rank)
-
-        if preferred_fields:
-            return preferred_fields[0]
-        if fields:
-            return fields[0][0]
-        return "id"
-
-    def _inject_collection_primary_key_sql(
-        self,
-        sql: str,
-        primary_key: str,
-        collection_info: _CollectionInfo,
-        metadata_lookup: dict[str, dict],
-    ) -> str:
-        """Inject a stable projected PK alias into collection SQL."""
-        field_sources = self._build_collection_field_sources(metadata_lookup)
-        base_table = collection_info.base_table_name
-        if not base_table:
-            return sql
-
-        source_table, source_column = field_sources.get(primary_key, (base_table, primary_key))
-        alias_by_table = {table_name: f"j{i}" for i, (table_name, _) in enumerate(collection_info.tables)}
-        pk_expr = (
-            f"{alias_by_table.get(source_table, alias_by_table[base_table])}.{_quote_sql_identifier(source_column)}"
-        )
-        return sql.replace(
-            "SELECT\n",
-            f"SELECT\n  {pk_expr} AS {_quote_sql_identifier('__tableau_pk')},\n",
-            1,
-        )
 
     # --- Phase 2: Multi-table joins ---
 

--- a/sidemantic/adapters/thoughtspot.py
+++ b/sidemantic/adapters/thoughtspot.py
@@ -601,9 +601,7 @@ class ThoughtSpotAdapter(BaseAdapter):
                 default_grain = dim.granularity
                 break
 
-        primary_key = "id"
-        if any(d.name.lower() == "id" for d in dimensions):
-            primary_key = next(d.name for d in dimensions if d.name.lower() == "id")
+        primary_key = None
 
         relationships = self._parse_table_relationships(table_def.get("joins_with") or [])
 
@@ -736,9 +734,7 @@ class ThoughtSpotAdapter(BaseAdapter):
                 default_grain = dim.granularity
                 break
 
-        primary_key = "id"
-        if any(d.name.lower() == "id" for d in dimensions):
-            primary_key = next(d.name for d in dimensions if d.name.lower() == "id")
+        primary_key = None
 
         model = Model(
             name=name,
@@ -949,12 +945,9 @@ class ThoughtSpotAdapter(BaseAdapter):
                 )
                 dimensions.append(dim)
 
-        # The SQL generator always selects `model.primary_key` from derived models
-        # as a bare column, so it must name a column that exists on the base
-        # table. Prefer a dimension named `id`; otherwise infer the key from a
-        # base-table column so a model whose key is not literally `id` (e.g.
-        # `order_key`) does not project a non-existent `id` column.
-        primary_key = self._infer_model_primary_key(dimensions, metrics, base_table)
+        # TML model columns do not declare uniqueness. Keeping identity unknown avoids selecting a
+        # fabricated ``id`` from derived SQL and avoids overstating an id-shaped field as unique.
+        primary_key = None
 
         # A joined model is exported as derived SQL (FROM (<sql>) AS t); rewrite
         # its `SELECT *` into explicit aliased columns and update the dimension/
@@ -1026,46 +1019,6 @@ class ThoughtSpotAdapter(BaseAdapter):
         setattr(model, "_source_tml_type", "model")
 
         return model
-
-    def _infer_model_primary_key(
-        self,
-        dimensions: list[Dimension],
-        metrics: list[Metric],
-        base_table: str | None,
-    ) -> str:
-        """Infer a queryable primary key column for a TML Model.
-
-        Prefer a field named ``id`` but resolve it to its backing physical column
-        (a column named ``id`` may map to a differently named DB column, e.g.
-        ``column_id: orders::order_key``). Only accept it when its SQL is
-        unqualified or belongs to the base table; a joined-table ``id`` (e.g.
-        ``customers::id``) is not the base model's key. Otherwise, if the base
-        table is known, keep ``id`` when a base-table column actually resolves to
-        ``id``; failing that, use the first base-table column so the key
-        references a real column. ThoughtSpot often exports numeric key columns as
-        measures, so dimensions are scanned first but metrics are considered too.
-        Fall back to ``id`` only when no better candidate exists.
-        """
-        fields: list[Dimension | Metric] = [*dimensions, *metrics]
-        for field in fields:
-            if field.name.lower() == "id":
-                table, column = _split_sql_identifier(field.sql)
-                if table is None or base_table is None or table == base_table:
-                    return column or field.name
-                break
-
-        if base_table:
-            base_columns: list[str] = []
-            for field in fields:
-                table, column = _split_sql_identifier(field.sql)
-                if column and (table is None or table == base_table):
-                    base_columns.append(column)
-            if "id" in base_columns:
-                return "id"
-            if base_columns:
-                return base_columns[0]
-
-        return "id"
 
     def _parse_model_relationships(
         self,
@@ -1290,6 +1243,10 @@ class ThoughtSpotAdapter(BaseAdapter):
             rel_type = "one_to_one" if join_def.get("is_one_to_one") else "many_to_one"
             if join_type in {"RIGHT_OUTER", "FULL_OUTER", "OUTER"}:
                 rel_type = "many_to_many"
+            elif rel_type == "one_to_one":
+                # Sidemantic's one_to_one key direction stores the local unique key in
+                # primary_key and the related-side key in foreign_key.
+                foreign_key, primary_key = primary_key, foreign_key
 
             relationships.append(
                 Relationship(
@@ -1327,6 +1284,8 @@ class ThoughtSpotAdapter(BaseAdapter):
                 rel_type = "one_to_one"
             if join_type in {"RIGHT_OUTER", "FULL_OUTER", "OUTER"}:
                 rel_type = "many_to_many"
+            elif rel_type == "one_to_one":
+                foreign_key, primary_key = primary_key, foreign_key
 
             relationships.append(
                 Relationship(
@@ -1500,12 +1459,17 @@ class ThoughtSpotAdapter(BaseAdapter):
                 left_table = rel.name
                 left_key = rel.sql_expr
                 right_table = base_table
-                right_key = model.primary_key
+                right_key = rel.related_key or model.primary_key
             else:
                 left_table = base_table
                 left_key = rel.sql_expr
                 right_table = rel.name
                 right_key = rel.related_key
+            if not left_key or not right_key:
+                raise ValueError(
+                    f"Cannot export relationship '{model.name}.{rel.name}' to ThoughtSpot without explicit "
+                    "foreign and primary keys"
+                )
             on_expr = f"[{left_table}::{left_key}] = [{right_table}::{right_key}]"
             joins.append(
                 {

--- a/sidemantic/adapters/yardstick.py
+++ b/sidemantic/adapters/yardstick.py
@@ -210,10 +210,8 @@ class YardstickAdapter(BaseAdapter):
         if source_sql:
             yardstick_metadata["base_relation_sql"] = source_sql
 
-        primary_key = dimensions[0].name if dimensions else "id"
         model_kwargs: dict[str, object] = {
             "name": view_name,
-            "primary_key": primary_key,
             "dimensions": dimensions,
             "metrics": metrics,
             "metadata": {"yardstick": yardstick_metadata},

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -1971,6 +1971,23 @@ def validate(
     engine: str = typer.Option(None, "--engine", help="Runtime engine: python, rust, or auto"),
     fallback: bool | None = typer.Option(None, "--fallback/--no-fallback", help="Allow Rust engine fallback to Python"),
     json_output: bool = typer.Option(False, "--json", help="Emit the validation report as JSON"),
+    warehouse: bool = typer.Option(
+        False,
+        "--warehouse",
+        help="Validate tables, columns, types, joins, and representative queries against a warehouse",
+    ),
+    connection: str = typer.Option(None, "--connection", help="Warehouse connection string"),
+    db: Path = typer.Option(None, "--db", help="Path to a DuckDB database file"),
+    check_keys: bool = typer.Option(
+        False,
+        "--check-keys",
+        help="Query declared primary/unique keys for NULLs and duplicates (requires warehouse validation)",
+    ),
+    check_queries: bool = typer.Option(
+        True,
+        "--check-queries/--no-check-queries",
+        help="Compile and prepare representative semantic queries during warehouse validation",
+    ),
 ):
     """
     Validate semantic layer definitions.
@@ -1980,11 +1997,21 @@ def validate(
     Examples:
       sidemantic validate
       sidemantic validate ./models --verbose
+      sidemantic validate ./models --warehouse --db data/warehouse.duckdb
+      sidemantic validate ./models --warehouse --connection postgres://localhost/analytics --check-keys
     """
     output_format = resolve_output_format(json_output=json_output)
     structured = json_output or cli_state().requested_format is not None or cli_state().plain
     verbose = verbose or cli_state().verbose
     directory = _models_path(directory)
+
+    warehouse = warehouse or connection is not None or db is not None
+    if check_keys and not warehouse:
+        raise typer.BadParameter("--check-keys requires --warehouse, --connection, or --db")
+
+    resolved_connection = None
+    if warehouse:
+        resolved_connection = _resolve_connection(connection=connection, database=db, models=directory, required=True)
 
     engine, fallback = _resolve_engine_options(engine, fallback)
     _configure_engine_environment(engine, fallback)
@@ -2030,7 +2057,16 @@ def validate(
     try:
         from sidemantic.validation_runner import validate_directory
 
-        report = validate_directory(directory)
+        if resolved_connection is None:
+            report = validate_directory(directory)
+        else:
+            report = validate_directory(
+                directory,
+                connection=resolved_connection.connection,
+                init_sql=resolved_connection.init_sql,
+                check_keys=check_keys,
+                check_queries=check_queries,
+            )
     except Exception as e:
         if cli_state().debug:
             raise
@@ -2039,6 +2075,9 @@ def validate(
             "path": str(directory),
             "engine": engine or "python",
             "errors": [str(e)],
+            "structural_errors": [str(e)],
+            "warehouse_errors": [],
+            "connection_errors": [],
             "warnings": [],
             "info": [],
         }
@@ -2054,30 +2093,54 @@ def validate(
         raise typer.Exit(1)
 
     if structured:
+        warehouse_errors = list(getattr(report, "warehouse_errors", []))
+        connection_errors = list(getattr(report, "connection_errors", []))
+        all_errors = list(getattr(report, "all_errors", [*report.errors, *warehouse_errors, *connection_errors]))
+        passed = bool(getattr(report, "passed", not all_errors))
         payload = {
-            "valid": not report.errors,
+            "valid": passed,
             "path": str(directory),
             "engine": engine or "python",
             "rust_models": rust_models,
-            "errors": list(report.errors),
+            "errors": all_errors,
+            "structural_errors": list(report.errors),
+            "warehouse_errors": warehouse_errors,
+            "connection_errors": connection_errors,
             "warnings": list(report.warnings),
             "info": list(report.info),
         }
         records = [
-            *({"level": "error", "message": str(message)} for message in report.errors),
+            *({"level": "error", "category": "structural", "message": str(message)} for message in report.errors),
+            *({"level": "error", "category": "warehouse", "message": str(message)} for message in warehouse_errors),
+            *({"level": "error", "category": "connection", "message": str(message)} for message in connection_errors),
             *({"level": "warning", "message": str(message)} for message in report.warnings),
             *({"level": "info", "message": str(message)} for message in report.info),
         ]
         emit_records(records, columns=("level", "message"), output_format=output_format, json_value=payload)
-        if report.errors:
+        if not passed:
             raise typer.Exit(1)
         return
 
     lines = [f"Validation Results: {directory}"]
 
     if report.errors:
-        lines.append("Errors:")
+        lines.append("Structural Errors:")
         for error in report.errors:
+            lines.append(f"  - {error}")
+
+    warehouse_errors = list(getattr(report, "warehouse_errors", []))
+    connection_errors = list(getattr(report, "connection_errors", []))
+    all_errors = list(getattr(report, "all_errors", [*report.errors, *warehouse_errors, *connection_errors]))
+    passed = bool(getattr(report, "passed", not all_errors))
+
+    if warehouse_errors:
+        lines.append("Warehouse Errors:")
+        for error in warehouse_errors:
+            lines.append(f"  - {error}")
+
+    if connection_errors:
+        lines.append("Connection Errors:")
+        for error in connection_errors:
             lines.append(f"  - {error}")
 
     if report.warnings:
@@ -2085,14 +2148,14 @@ def validate(
         for warning in report.warnings:
             lines.append(f"  - {warning}")
 
-    if verbose or not (report.errors or report.warnings):
+    if verbose or not (all_errors or report.warnings):
         lines.append("Info:")
         for item in report.info:
             lines.append(f"  - {item}")
 
     _emit_long_report("\n".join(lines))
 
-    if report.errors:
+    if not passed:
         typer.echo("Validation Failed", err=True)
         raise typer.Exit(1)
 

--- a/sidemantic/core/migrator.py
+++ b/sidemantic/core/migrator.py
@@ -668,7 +668,9 @@ class Migrator:
     def _extract_relationships(self, parsed: exp.Expression, analysis: QueryAnalysis) -> None:
         """Extract relationships from JOIN ON conditions and WHERE clause equality conditions.
 
-        Uses information_schema data if available, falls back to pattern matching.
+        Uses information_schema constraints for cardinality when available. Without a constraint,
+        preserves the observed columns as a direct many-to-many relationship instead of guessing
+        which side is unique from names such as ``id`` or ``*_id``.
         """
 
         # Helper function to extract relationship from an equality condition
@@ -688,104 +690,23 @@ class Migrator:
             if left_table == right_table:
                 return
 
-            # Try information_schema first
-            fk_table = None
-            fk_column = None
-            pk_table = None
-            pk_column = None
-
-            # Check if left side is a known FK
             if (left_table, left.name) in self.foreign_keys:
                 pk_table, pk_column = self.foreign_keys[(left_table, left.name)]
-                fk_table = left_table
-                fk_column = left.name
-            # Check if right side is a known FK
+                analysis.relationships.append((left_table, pk_table, "many_to_one", left.name, pk_column))
             elif (right_table, right.name) in self.foreign_keys:
                 pk_table, pk_column = self.foreign_keys[(right_table, right.name)]
-                fk_table = right_table
-                fk_column = right.name
-
-            # Fall back to pattern matching if information_schema didn't help
-            if not fk_table:
-                # Determine which side has the foreign key by checking column names
-                # Foreign keys typically end with _id (e.g., customer_id, product_id)
-                left_is_fk = left.name.endswith("_id")
-                right_is_fk = right.name.endswith("_id")
-
-                if left_is_fk and not right_is_fk:
-                    # Left has the FK, right has the PK
-                    fk_table = left_table
-                    fk_column = left.name
-                    pk_table = right_table
-                    pk_column = right.name
-                elif right_is_fk and not left_is_fk:
-                    # Right has the FK, left has the PK
-                    fk_table = right_table
-                    fk_column = right.name
-                    pk_table = left_table
-                    pk_column = left.name
-                else:
-                    # Can't determine - use left as FK
-                    fk_table = left_table
-                    fk_column = left.name
-                    pk_table = right_table
-                    pk_column = right.name
-
-            # Infer primary key column if not from information_schema
-            if pk_column and not self.foreign_keys:
-                # If it ends with _id, the actual PK is probably "id"
-                pk_column = "id" if pk_column.endswith("_id") else pk_column
-
-            # Generate relationships for both directions
-            # FK table has many_to_one relationship to PK table
-            analysis.relationships.append((fk_table, pk_table, "many_to_one", fk_column, pk_column))
-
-            # PK table has one_to_many relationship to FK table
-            # For one_to_many, we don't store FK (it's on the other side)
-            analysis.relationships.append((pk_table, fk_table, "one_to_many", None, None))
+                analysis.relationships.append((right_table, pk_table, "many_to_one", right.name, pk_column))
+            else:
+                analysis.relationships.append((left_table, right_table, "many_to_many", left.name, right.name))
 
         # Extract from JOIN ON conditions
         for join in parsed.find_all(exp.Join):
             if not isinstance(join.this, exp.Table):
                 continue
 
-            to_table = join.this.name
-
             # Parse ON condition
             on_clause = join.args.get("on")
             if on_clause and isinstance(on_clause, exp.EQ):
-                # For ambiguous cases, pass context about which table is being joined TO
-                left = on_clause.left
-                right = on_clause.right
-
-                if isinstance(left, exp.Column) and isinstance(right, exp.Column):
-                    left_table = analysis.table_aliases.get(left.table, left.table) if left.table else ""
-                    right_table = analysis.table_aliases.get(right.table, right.table) if right.table else ""
-
-                    # If both columns end with _id, use join direction to determine FK
-                    if left.name.endswith("_id") and right.name.endswith("_id"):
-                        # The table being joined TO (to_table) usually has the FK
-                        if right_table == to_table:
-                            # Right table is being joined, so it has the FK
-                            fk_table = right_table
-                            fk_column = right.name
-                            pk_table = left_table
-                            pk_column = "id" if right.name.endswith("_id") else right.name
-
-                            analysis.relationships.append((fk_table, pk_table, "many_to_one", fk_column, pk_column))
-                            analysis.relationships.append((pk_table, fk_table, "one_to_many", None, None))
-                            continue
-                        elif left_table == to_table:
-                            # Left table is being joined, so it has the FK
-                            fk_table = left_table
-                            fk_column = left.name
-                            pk_table = right_table
-                            pk_column = "id" if left.name.endswith("_id") else left.name
-
-                            analysis.relationships.append((fk_table, pk_table, "many_to_one", fk_column, pk_column))
-                            analysis.relationships.append((pk_table, fk_table, "one_to_many", None, None))
-                            continue
-
                 extract_relationship_from_eq(on_clause)
 
         # Extract from WHERE clause (for implicit joins like FROM t1, t2 WHERE t1.id = t2.fk)
@@ -1555,12 +1476,12 @@ class Migrator:
                         "type": rel_type,
                     }
 
-                    # Add foreign_key for many_to_one relationships
-                    if rel_type == "many_to_one" and fk_col:
+                    # Preserve the observed source join column for constrained and direct joins.
+                    if rel_type in {"many_to_one", "many_to_many"} and fk_col:
                         rel_def["foreign_key"] = fk_col
 
-                    # Optionally add primary_key if it's not the default "id"
-                    if pk_col and pk_col != "id":
+                    # Relationship target keys are always explicit; there is no implicit ``id``.
+                    if pk_col:
                         rel_def["primary_key"] = pk_col
 
                     relationships.append(rel_def)

--- a/sidemantic/core/model.py
+++ b/sidemantic/core/model.py
@@ -35,10 +35,10 @@ class Model(BaseModel):
     # Relationships
     relationships: list[Relationship] = Field(default_factory=list, description="Relationships to other models")
 
-    # Primary key - single column or list for composite keys. None means "no known primary key"
-    # (e.g. a fact or disconnected table imported from a format that does not declare one); such a
-    # model contributes no key column to joins rather than a fabricated default.
-    primary_key: str | list[str] | None = Field(default="id", description="Primary key column(s)")
+    # Primary key - single column or list for composite keys. None means "no known primary key".
+    # Keys are never inferred here: callers and adapters must preserve the source model's actual
+    # declaration rather than manufacturing an ``id`` column that may not exist.
+    primary_key: str | list[str] | None = Field(default=None, description="Primary key column(s), if known")
 
     # Unique key constraints
     unique_keys: list[list[str]] | None = Field(None, description="Unique key constraints (each is a list of columns)")

--- a/sidemantic/core/relationship.py
+++ b/sidemantic/core/relationship.py
@@ -21,7 +21,7 @@ class Relationship(BaseModel):
         description="Type of relationship"
     )
     foreign_key: str | list[str] | None = Field(
-        default=None, description="Foreign key column(s) (defaults to {name}_id for many_to_one)"
+        default=None, description="Foreign key column(s); required for keyed relationships unless sql is provided"
     )
     primary_key: str | list[str] | None = Field(
         default=None,
@@ -47,27 +47,22 @@ class Relationship(BaseModel):
     metadata: dict[str, Any] | None = Field(None, description="Adapter-specific metadata payload")
 
     @property
-    def sql_expr(self) -> str:
-        """Get SQL expression for the foreign key (first column for composite keys)."""
+    def sql_expr(self) -> str | None:
+        """Get the first explicitly declared foreign-key column, if any."""
         if self.foreign_key:
             if isinstance(self.foreign_key, list):
-                return self.foreign_key[0] if self.foreign_key else f"{self.name}_id"
+                return self.foreign_key[0] if self.foreign_key else None
             return self.foreign_key
-
-        # Default: {name}_id for many_to_one
-        if self.type == "many_to_one":
-            return f"{self.name}_id"
-        else:
-            return "id"
+        return None
 
     @property
-    def related_key(self) -> str:
-        """Get the key in the related model (first column for composite keys)."""
+    def related_key(self) -> str | None:
+        """Get the first explicitly declared related key, if any."""
         if self.primary_key:
             if isinstance(self.primary_key, list):
-                return self.primary_key[0] if self.primary_key else "id"
+                return self.primary_key[0] if self.primary_key else None
             return self.primary_key
-        return "id"
+        return None
 
     @property
     def foreign_key_columns(self) -> list[str]:
@@ -75,10 +70,7 @@ class Relationship(BaseModel):
         if self.type == "cross":
             return []
         if self.foreign_key is None:
-            # Default: {name}_id for many_to_one
-            if self.type == "many_to_one":
-                return [f"{self.name}_id"]
-            return ["id"]
+            return []
         if isinstance(self.foreign_key, str):
             return [self.foreign_key]
         return self.foreign_key
@@ -89,7 +81,7 @@ class Relationship(BaseModel):
         if self.type == "cross":
             return []
         if self.primary_key is None:
-            return ["id"]
+            return []
         if isinstance(self.primary_key, str):
             return [self.primary_key]
         return self.primary_key

--- a/sidemantic/core/semantic_graph.py
+++ b/sidemantic/core/semantic_graph.py
@@ -261,6 +261,12 @@ class SemanticGraph:
             relationship_type: str,
             custom_condition: str | None = None,
         ) -> None:
+            # Invalid/unknown key pairs are not graph edges. Structural validation reports the
+            # actionable cause; omitting the edge prevents compilation from producing ``JOIN ON``
+            # predicates with fabricated or empty columns when validation is bypassed.
+            if relationship_type != "cross" and custom_condition is None:
+                if not from_keys or not to_keys or len(from_keys) != len(to_keys):
+                    return
             if from_model not in self._adjacency:
                 self._adjacency[from_model] = []
             self._adjacency[from_model].append((to_model, from_keys, to_keys, relationship_type, custom_condition))

--- a/sidemantic/core/semantic_graph.py
+++ b/sidemantic/core/semantic_graph.py
@@ -68,6 +68,7 @@ class SemanticGraph:
     def __init__(self):
         self.models: dict[str, Model] = {}
         self.metrics: dict[str, Metric] = {}
+        self.metric_owners: dict[str, str] = {}
         self.table_calculations: dict[str, TableCalculation] = {}
         self.parameters: dict[str, Parameter] = {}
         self.import_warnings: list[dict[str, object]] = []
@@ -103,16 +104,21 @@ class SemanticGraph:
 
         self._mark_dirty()
 
-    def add_metric(self, measure: Metric) -> None:
+    def add_metric(self, measure: Metric, model_name: str | None = None) -> None:
         """Add a measure to the graph.
 
         Args:
             measure: Metric to add
+            model_name: Optional owning model for a graph-addressable model metric
         """
         if measure.name in self.metrics:
             raise ValueError(f"Measure {measure.name} already exists")
+        if model_name is not None and model_name not in self.models:
+            raise ValueError(f"Model {model_name} not found for measure {measure.name}")
 
         self.metrics[measure.name] = measure
+        if model_name is not None:
+            self.metric_owners[measure.name] = model_name
         self._mark_dirty()
 
     def add_table_calculation(self, calc: TableCalculation) -> None:

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -1451,16 +1451,23 @@ class SemanticLayer:
             pk_columns = set(model.primary_key_columns)
             for candidate in candidates:
                 preagg = next((p for p in model.pre_aggregations if p.name == candidate.name), None)
-                if candidate.selected and (preagg is None or not pk_columns.issubset(set(preagg.dimensions or []))):
+                if candidate.selected and (
+                    not pk_columns or preagg is None or not pk_columns.issubset(set(preagg.dimensions or []))
+                ):
                     candidate.selected = False
             if not any(c.selected for c in candidates):
+                reason = (
+                    "ungrouped query, model has no declared primary key for unique rows"
+                    if not pk_columns
+                    else "ungrouped query, no rollup carries the primary key for unique rows"
+                )
                 return QueryPlan(
                     sql=sql,
                     model=model_name,
                     metrics=bare_metrics,
                     dimensions=bare_dims,
                     used_preaggregation=False,
-                    routing_reason="ungrouped query, no rollup carries the primary key for unique rows",
+                    routing_reason=reason,
                     candidates=candidates,
                 )
 

--- a/sidemantic/core/sql_definitions.py
+++ b/sidemantic/core/sql_definitions.py
@@ -270,7 +270,7 @@ def _parse_table_block_model_def(model_def: exp.Expression) -> Model:
     model_name = model_def.args["model_name"].name
     table = model_def.args.get("table")
     source_sql = model_def.args.get("source_sql")
-    primary_key: str | list[str] = "id"
+    primary_key: str | list[str] | None = None
     default_time_dimension: str | None = None
     default_grain: str | None = None
     relationships: list[Relationship] = []

--- a/sidemantic/mcp_server.py
+++ b/sidemantic/mcp_server.py
@@ -129,7 +129,7 @@ def _format_join_condition(model_name: str, rel, models: dict[str, Any]) -> str 
         return None
 
     if rel.type == "many_to_one":
-        fk = rel.foreign_key or f"{related_name}_id"
+        fk = rel.foreign_key
         pk = rel.primary_key or related_model.primary_key
         return _format_join_key_pairs(model_name, _key_columns(fk), related_name, _key_columns(pk))
 
@@ -174,6 +174,8 @@ def _format_join_condition(model_name: str, rel, models: dict[str, Any]) -> str 
 
 
 def _key_columns(value: Any) -> list[str]:
+    if value is None:
+        return []
     if isinstance(value, list):
         return [str(column) for column in value]
     return [str(value)]

--- a/sidemantic/mcp_server.py
+++ b/sidemantic/mcp_server.py
@@ -695,6 +695,7 @@ def get_semantic_graph() -> dict[str, Any]:
         model_info: dict[str, Any] = {
             "name": model_name,
             "table": model.table,
+            "primary_key": model.primary_key,
             "dimensions": [d.name for d in model.dimensions],
             "metrics": [m.name for m in model.metrics],
             "relationships": [{"name": r.name, "type": r.type} for r in model.relationships],
@@ -703,8 +704,6 @@ def get_semantic_graph() -> dict[str, Any]:
             model_info["description"] = model.description
         if model.segments:
             model_info["segments"] = [s.name for s in model.segments]
-        if model.primary_key:
-            model_info["primary_key"] = model.primary_key
         if model.default_time_dimension:
             model_info["default_time_dimension"] = model.default_time_dimension
         models.append(model_info)

--- a/sidemantic/rust_bridge.py
+++ b/sidemantic/rust_bridge.py
@@ -441,14 +441,14 @@ def models_to_rust_yaml(
     models_by_name = {m.name: m for m in models}
 
     for model in models:
-        primary_key_columns = model.primary_key if isinstance(model.primary_key, list) else [model.primary_key]
+        primary_key_columns = model.primary_key_columns
         model_data = {
             "name": model.name,
             "extends": model.extends if include_extends else None,
             "table": model.table,
             "sql": model.sql,
             "source_uri": model.source_uri,
-            "primary_key": primary_key_columns[0] if primary_key_columns else "id",
+            "primary_key": primary_key_columns[0] if primary_key_columns else None,
             "primary_key_columns": primary_key_columns,
             "unique_keys": model.unique_keys,
             "description": model.description,
@@ -1602,15 +1602,13 @@ def _normalize_filter_sql(filter_sql: str) -> str:
 
 def _serialize_relationship(relationship, source_model, target_model) -> dict | None:
     foreign_keys = _as_list(relationship.foreign_key)
-    if not foreign_keys:
-        foreign_keys = [f"{relationship.name}_id"] if relationship.type == "many_to_one" else ["id"]
 
     if relationship.primary_key is not None:
         primary_keys = _as_list(relationship.primary_key)
     elif target_model:
         primary_keys = target_model.primary_key_columns
     else:
-        primary_keys = ["id"]
+        primary_keys = []
 
     sql = None
     if len(foreign_keys) > 1 and len(foreign_keys) == len(primary_keys):

--- a/sidemantic/rust_bridge.py
+++ b/sidemantic/rust_bridge.py
@@ -267,6 +267,8 @@ def _graph_from_loaded_payload(payload: dict) -> SemanticGraph:
     for model_data in payload.get("models") or []:
         normalized_model = dict(model_data)
         _restore_composite_keys(normalized_model)
+        if normalized_model.get("primary_key_columns") == [] and not normalized_model.get("primary_key"):
+            normalized_model["primary_key"] = None
         original_metric_names = set(original_model_metrics.get(normalized_model.get("name"), []))
         normalized_metrics = []
         for metric_data in normalized_model.get("metrics") or []:

--- a/sidemantic/rust_bridge.py
+++ b/sidemantic/rust_bridge.py
@@ -1616,7 +1616,14 @@ def _serialize_relationship(relationship, source_model, target_model) -> dict | 
 
     sql = None
     if len(foreign_keys) > 1 and len(foreign_keys) == len(primary_keys):
-        sql = " AND ".join(f"{{from}}.{fk} = {{to}}.{pk}" for fk, pk in zip(foreign_keys, primary_keys, strict=False))
+        if relationship.type in {"one_to_many", "one_to_one"}:
+            sql = " AND ".join(
+                f"{{from}}.{pk} = {{to}}.{fk}" for fk, pk in zip(foreign_keys, primary_keys, strict=False)
+            )
+        else:
+            sql = " AND ".join(
+                f"{{from}}.{fk} = {{to}}.{pk}" for fk, pk in zip(foreign_keys, primary_keys, strict=False)
+            )
     if getattr(relationship, "sql", None):
         sql = relationship.sql
 

--- a/sidemantic/rust_bridge.py
+++ b/sidemantic/rust_bridge.py
@@ -1607,7 +1607,9 @@ def _serialize_relationship(relationship, source_model, target_model) -> dict | 
 
     if relationship.primary_key is not None:
         primary_keys = _as_list(relationship.primary_key)
-    elif target_model:
+    elif relationship.type in {"one_to_many", "one_to_one"}:
+        primary_keys = source_model.primary_key_columns
+    elif target_model and (relationship.type == "many_to_one" or relationship.through):
         primary_keys = target_model.primary_key_columns
     else:
         primary_keys = []

--- a/sidemantic/rust_bridge.py
+++ b/sidemantic/rust_bridge.py
@@ -140,6 +140,9 @@ def _assign_top_level_metrics_for_rust(graph: SemanticGraph) -> tuple[dict[str, 
 
         cache[metric.name] = None
         owners = model_metric_owners(metric.name)
+        explicit_owner = graph.metric_owners.get(metric.name)
+        if explicit_owner:
+            owners.add(explicit_owner)
 
         try:
             dependencies = metric.get_dependencies(graph)
@@ -1615,7 +1618,11 @@ def _serialize_relationship(relationship, source_model, target_model) -> dict | 
         primary_keys = []
 
     sql = None
-    if len(foreign_keys) > 1 and len(foreign_keys) == len(primary_keys):
+    if (
+        foreign_keys
+        and len(foreign_keys) == len(primary_keys)
+        and (len(foreign_keys) > 1 or relationship.type == "one_to_one")
+    ):
         if relationship.type in {"one_to_many", "one_to_one"}:
             sql = " AND ".join(
                 f"{{from}}.{pk} = {{to}}.{fk}" for fk, pk in zip(foreign_keys, primary_keys, strict=False)

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -1512,6 +1512,9 @@ class SQLGenerator:
                 return
 
             # It's a graph-level metric, need to resolve its dependencies.
+            owning_model = self.graph.metric_owners.get(metric_ref)
+            if owning_model:
+                add_model(owning_model)
             if metric.type == "ratio":
                 if metric.numerator:
                     collect_models_from_metric(metric.numerator)

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -6210,7 +6210,8 @@ LEFT JOIN {preagg_table} AS {rollup_alias}
             # dimensions; otherwise the stored rows are aggregated and must not
             # be served ungrouped. Fall through to raw tables.
             preagg_dims = set(preagg.dimensions or [])
-            if not set(model.primary_key_columns).issubset(preagg_dims):
+            primary_key_columns = set(model.primary_key_columns)
+            if not primary_key_columns or not primary_key_columns.issubset(preagg_dims):
                 return None
 
         # Generate SQL against pre-aggregation table

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -1772,7 +1772,7 @@ class SQLGenerator:
             """Recursively extract filter columns from a metric and its dependencies."""
             # Extract from the metric's own filters
             if metric.filters:
-                filter_model_name = None
+                filter_model_name = self.graph.metric_owners.get(metric.name)
                 deps = metric.get_dependencies(self.graph)
                 for dep in deps:
                     try:
@@ -3536,6 +3536,9 @@ class SQLGenerator:
         """
         if model_context and model_context in self.graph.models:
             return model_context
+        owning_model = self.graph.metric_owners.get(metric.name)
+        if owning_model:
+            return owning_model
         if metric.sql:
             try:
                 parsed = _parse_fragment(metric.sql, self.dialect)

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -70,6 +70,15 @@ def validate_model(model: "Model") -> list[str]:
     if model.primary_key is not None and not model.primary_key:
         errors.append(f"Model '{model.name}' must have a primary_key defined")
 
+    key_definitions = [(f"unique_keys[{index}]", columns) for index, columns in enumerate(model.unique_keys or [])]
+    if model.primary_key is not None:
+        key_definitions.insert(0, ("primary_key", model.primary_key_columns))
+    for key_name, key_columns in key_definitions:
+        if not key_columns:
+            errors.append(f"Model '{model.name}' {key_name} must contain at least one column")
+        elif len(key_columns) != len(set(key_columns)):
+            errors.append(f"Model '{model.name}' {key_name} contains duplicate columns")
+
     # Check for a physical, SQL, DAX, or externally sourced model definition.
     # Hex ``view`` resources are presentation layers over a base model and are
     # intentionally table-less, so they are exempt from this requirement.
@@ -218,6 +227,12 @@ def validate_model_warnings(model: "Model") -> list[str]:
     """
     warnings: list[str] = []
 
+    if model.primary_key is None:
+        warnings.append(
+            f"Model '{model.name}' has no primary_key declaration. This is valid for keyless models, "
+            "but the model cannot be used where a unique row identity or fan-out-safe aggregation is required."
+        )
+
     for preagg in model.pre_aggregations:
         prefix = f"Pre-aggregation '{model.name}.{preagg.name}'"
 
@@ -243,6 +258,146 @@ def validate_model_warnings(model: "Model") -> list[str]:
             )
 
     return warnings
+
+
+def _declared_unique_key(model: "Model", columns: list[str]) -> bool:
+    """Return whether columns are declared as a primary or alternate unique key."""
+    if not columns:
+        return False
+    candidate = tuple(columns)
+    declared = {tuple(model.primary_key_columns)} if model.primary_key_columns else set()
+    declared.update(tuple(key) for key in model.unique_keys or [] if key)
+    return candidate in declared
+
+
+def validate_relationships(graph: "SemanticGraph") -> list[str]:
+    """Validate relationship keys and the uniqueness implied by each cardinality.
+
+    This runs after all models have loaded because related-model keys cannot be resolved safely
+    while models are registered one at a time. Custom SQL relationships are exempt from column-key
+    requirements, but still require their target model and explicit cardinality.
+    """
+    errors: list[str] = []
+
+    def add_error(source_name: str, relationship, message: str) -> None:
+        errors.append(f"Relationship '{source_name}.{relationship.name}' ({relationship.type}): {message}")
+
+    def check_lengths(source_name: str, relationship, left: list[str], right: list[str]) -> None:
+        if left and right and len(left) != len(right):
+            add_error(
+                source_name,
+                relationship,
+                f"join key arity differs ({len(left)} source column(s), {len(right)} target column(s))",
+            )
+
+    for source_name, source in graph.models.items():
+        for relationship in source.relationships:
+            target = graph.models.get(relationship.name)
+            if target is None:
+                add_error(source_name, relationship, "target model does not exist")
+                continue
+
+            if relationship.type == "cross":
+                if any(
+                    (
+                        relationship.foreign_key,
+                        relationship.primary_key,
+                        relationship.through,
+                        relationship.through_foreign_key,
+                        relationship.related_foreign_key,
+                    )
+                ):
+                    add_error(source_name, relationship, "cross relationships must not declare join keys")
+                continue
+
+            if relationship.sql:
+                continue
+
+            if relationship.type == "many_to_one":
+                source_keys = relationship.foreign_key_columns
+                target_keys = relationship.primary_key_columns or target.primary_key_columns
+                if not source_keys:
+                    add_error(source_name, relationship, "foreign_key is required; no column name is inferred")
+                if not target_keys:
+                    add_error(
+                        source_name,
+                        relationship,
+                        f"target model '{target.name}' has no primary_key; declare relationship.primary_key "
+                        "for an alternate unique key or declare the model key",
+                    )
+                elif relationship.primary_key is None and not _declared_unique_key(target, target_keys):
+                    add_error(
+                        source_name,
+                        relationship,
+                        f"target columns {target_keys!r} are not declared as the primary_key or in unique_keys "
+                        f"on model '{target.name}'",
+                    )
+                check_lengths(source_name, relationship, source_keys, target_keys)
+                continue
+
+            if relationship.type in {"one_to_many", "one_to_one"}:
+                source_keys = relationship.primary_key_columns or source.primary_key_columns
+                target_keys = relationship.foreign_key_columns
+                if not source_keys:
+                    add_error(
+                        source_name,
+                        relationship,
+                        "the source model has no primary_key; declare relationship.primary_key for an alternate "
+                        "unique key or declare the model key",
+                    )
+                elif relationship.primary_key is None and not _declared_unique_key(source, source_keys):
+                    add_error(
+                        source_name,
+                        relationship,
+                        f"source columns {source_keys!r} are not declared as the primary_key or in unique_keys",
+                    )
+                if not target_keys:
+                    add_error(source_name, relationship, "foreign_key is required; no column name is inferred")
+                check_lengths(source_name, relationship, source_keys, target_keys)
+                continue
+
+            if relationship.type == "many_to_many":
+                if not relationship.through:
+                    # Some source formats represent a direct many-to-many predicate without a bridge.
+                    # Preserve it only when both sides are explicit; no conventional keys are invented.
+                    source_keys = relationship.foreign_key_columns
+                    target_keys = relationship.primary_key_columns
+                    if not source_keys or not target_keys:
+                        add_error(
+                            source_name,
+                            relationship,
+                            "through is required unless explicit foreign_key and primary_key columns describe "
+                            "a direct relationship",
+                        )
+                    check_lengths(source_name, relationship, source_keys, target_keys)
+                    continue
+
+                junction = graph.models.get(relationship.through)
+                if junction is None:
+                    add_error(source_name, relationship, f"junction model '{relationship.through}' does not exist")
+                    continue
+
+                source_keys = source.primary_key_columns
+                target_keys = relationship.primary_key_columns or target.primary_key_columns
+                junction_source_keys, junction_target_keys = relationship.junction_key_columns()
+                if not source_keys:
+                    add_error(source_name, relationship, "source model has no primary_key")
+                if not target_keys:
+                    add_error(source_name, relationship, f"target model '{target.name}' has no primary_key")
+                elif not _declared_unique_key(target, target_keys):
+                    add_error(
+                        source_name,
+                        relationship,
+                        f"target columns {target_keys!r} are not declared unique on model '{target.name}'",
+                    )
+                if not junction_source_keys:
+                    add_error(source_name, relationship, "through_foreign_key is required")
+                if not junction_target_keys:
+                    add_error(source_name, relationship, "related_foreign_key is required")
+                check_lengths(source_name, relationship, source_keys, junction_source_keys)
+                check_lengths(source_name, relationship, junction_target_keys, target_keys)
+
+    return errors
 
 
 def validate_metric(measure: "Metric", graph: "SemanticGraph") -> list[str]:
@@ -502,15 +657,26 @@ def validate_query(metrics: list[str], dimensions: list[str], graph: "SemanticGr
     # Only check models that exist in the graph (errors for missing models already reported above)
     valid_model_names = [m for m in model_names if m in graph.models]
     model_list = list(valid_model_names)
+    relationship_errors = []
+    if len(model_list) > 1:
+        selected = set(model_list)
+        for relationship_error in validate_relationships(graph):
+            relationship_ref = relationship_error.split("'", 2)[1]
+            source_name, _, target_name = relationship_ref.partition(".")
+            if source_name in selected or target_name in selected:
+                relationship_errors.append(relationship_error)
+        errors.extend(relationship_errors)
+
     for i, model_a in enumerate(model_list):
         for model_b in model_list[i + 1 :]:
             try:
                 graph.find_relationship_path(model_a, model_b)
             except (ValueError, KeyError):
                 # Catch both ValueError (no path) and KeyError (model doesn't exist)
-                errors.append(
-                    f"No join path found between models '{model_a}' and '{model_b}'. "
-                    f"Add relationships to enable joining these models."
-                )
+                if not relationship_errors:
+                    errors.append(
+                        f"No join path found between models '{model_a}' and '{model_b}'. "
+                        f"Add relationships to enable joining these models."
+                    )
 
     return errors

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -292,6 +292,8 @@ def validate_relationships(graph: "SemanticGraph") -> list[str]:
 
     for source_name, source in graph.models.items():
         for relationship in source.relationships:
+            if not relationship.active:
+                continue
             target = graph.models.get(relationship.name)
             if target is None:
                 add_error(source_name, relationship, "target model does not exist")
@@ -663,7 +665,7 @@ def validate_query(metrics: list[str], dimensions: list[str], graph: "SemanticGr
         for relationship_error in validate_relationships(graph):
             relationship_ref = relationship_error.split("'", 2)[1]
             source_name, _, target_name = relationship_ref.partition(".")
-            if source_name in selected or target_name in selected:
+            if source_name in selected and target_name in selected:
                 relationship_errors.append(relationship_error)
         errors.extend(relationship_errors)
 

--- a/sidemantic/validation_runner.py
+++ b/sidemantic/validation_runner.py
@@ -257,6 +257,15 @@ def _required_columns(model: "Model", graph: "SemanticGraph") -> dict[str, str |
         if column:
             columns[column] = "numeric" if metric.agg in numeric_aggs else None
 
+    for segment in model.segments:
+        try:
+            parsed = sqlglot.parse_one(segment.sql.replace("{model}", model.name))
+        except Exception:
+            continue
+        for column in parsed.find_all(exp.Column):
+            if not column.table or column.table == model.name:
+                columns[column.name] = None
+
     return columns
 
 

--- a/sidemantic/validation_runner.py
+++ b/sidemantic/validation_runner.py
@@ -293,6 +293,9 @@ def _check_key_columns(
     require_non_null: bool = True,
     require_unique: bool = True,
 ) -> None:
+    if not columns:
+        return
+
     adapter = layer.adapter
     dialect = layer.dialect
     source = _model_source_sql(model, dialect)

--- a/sidemantic/validation_runner.py
+++ b/sidemantic/validation_runner.py
@@ -222,6 +222,8 @@ def _required_columns(model: "Model", graph: "SemanticGraph") -> dict[str, str |
         for column in key:
             columns[column] = None
     for relationship in model.relationships:
+        if not relationship.active:
+            continue
         for column in relationship.foreign_key_columns:
             columns[column] = None
         if relationship.type in {"one_to_many", "one_to_one"}:
@@ -231,6 +233,8 @@ def _required_columns(model: "Model", graph: "SemanticGraph") -> dict[str, str |
     # Include keys declared by relationships on other models but physically owned by this model.
     for source in graph.models.values():
         for relationship in source.relationships:
+            if not relationship.active:
+                continue
             if relationship.name == model.name:
                 if relationship.type == "many_to_one" and relationship.primary_key is not None:
                     for column in relationship.primary_key_columns:

--- a/sidemantic/validation_runner.py
+++ b/sidemantic/validation_runner.py
@@ -517,8 +517,14 @@ def _validate_warehouse(
                     )
                     continue
                 try:
-                    inspection_name = table_ref.qualified_name if table_ref.catalog else table_ref.name
-                    inspection_schema = None if table_ref.catalog else table_ref.schema
+                    if table_ref.catalog and layer.dialect == "bigquery":
+                        # BigQueryAdapter addresses tables as dataset + table; the
+                        # project is already selected by the connection/client.
+                        inspection_name = table_ref.name
+                        inspection_schema = table_ref.schema
+                    else:
+                        inspection_name = table_ref.qualified_name if table_ref.catalog else table_ref.name
+                        inspection_schema = None if table_ref.catalog else table_ref.schema
                     warehouse_columns = layer.adapter.get_columns(inspection_name, schema=inspection_schema)
                 except Exception as exc:
                     report.warehouse_errors.append(

--- a/sidemantic/validation_runner.py
+++ b/sidemantic/validation_runner.py
@@ -185,10 +185,15 @@ def _warehouse_table_exists(
 
 
 def _warehouse_column_type(actual: dict[str, str], column: str, dialect: str) -> str | None:
+    actual_name = _warehouse_column_name(actual, column, dialect)
+    return actual.get(actual_name) if actual_name is not None else None
+
+
+def _warehouse_column_name(actual: dict[str, str], column: str, dialect: str) -> str | None:
     if column in actual:
-        return actual[column]
-    if dialect == "snowflake":
-        return actual.get(column.upper())
+        return column
+    if dialect == "snowflake" and column.upper() in actual:
+        return column.upper()
     return None
 
 
@@ -292,6 +297,7 @@ def _check_key_columns(
     columns: list[str],
     require_non_null: bool = True,
     require_unique: bool = True,
+    actual_columns: dict[str, str] | None = None,
 ) -> None:
     if not columns:
         return
@@ -299,7 +305,7 @@ def _check_key_columns(
     adapter = layer.adapter
     dialect = layer.dialect
     source = _model_source_sql(model, dialect)
-    quoted = [_quote_identifier(column, dialect) for column in columns]
+    quoted = [_quote_identifier((actual_columns or {}).get(column, column), dialect) for column in columns]
 
     if require_non_null:
         null_predicate = " OR ".join(f"{column} IS NULL" for column in quoted)
@@ -327,7 +333,12 @@ def _check_key_columns(
             report.warehouse_errors.append(f"Model '{model.name}' {label} uniqueness check failed: {exc}")
 
 
-def _check_declared_keys(layer, model: "Model", report: ValidationReport) -> None:
+def _check_declared_keys(
+    layer,
+    model: "Model",
+    report: ValidationReport,
+    actual_columns: dict[str, str] | None = None,
+) -> None:
     if model.primary_key_columns:
         _check_key_columns(
             layer,
@@ -335,13 +346,26 @@ def _check_declared_keys(layer, model: "Model", report: ValidationReport) -> Non
             report,
             label="primary_key",
             columns=model.primary_key_columns,
+            actual_columns=actual_columns,
         )
     for columns in model.unique_keys or []:
         if columns:
-            _check_key_columns(layer, model, report, label="unique_key", columns=columns)
+            _check_key_columns(
+                layer,
+                model,
+                report,
+                label="unique_key",
+                columns=columns,
+                actual_columns=actual_columns,
+            )
 
 
-def _check_relationship_cardinality(layer, graph: "SemanticGraph", report: ValidationReport) -> None:
+def _check_relationship_cardinality(
+    layer,
+    graph: "SemanticGraph",
+    report: ValidationReport,
+    warehouse_column_names: dict[str, dict[str, str]],
+) -> None:
     """Check data assumptions introduced by relationship-scoped keys/cardinality."""
     for source in graph.models.values():
         for relationship in source.relationships:
@@ -359,6 +383,7 @@ def _check_relationship_cardinality(layer, graph: "SemanticGraph", report: Valid
                     report,
                     label=f"relationship '{source.name}.{target.name}' primary_key",
                     columns=relationship.primary_key_columns,
+                    actual_columns=warehouse_column_names.get(key_model.name),
                 )
 
             # one_to_one additionally asserts that the target-side foreign key has at most one
@@ -371,6 +396,7 @@ def _check_relationship_cardinality(layer, graph: "SemanticGraph", report: Valid
                     label=f"relationship '{source.name}.{target.name}' foreign_key",
                     columns=relationship.foreign_key_columns,
                     require_non_null=False,
+                    actual_columns=warehouse_column_names.get(target.name),
                 )
 
 
@@ -496,6 +522,7 @@ def _validate_warehouse(
         for table in available_tables
     }
     warehouse_types: dict[str, dict[str, str]] = {}
+    warehouse_column_names: dict[str, dict[str, str]] = {}
 
     if not report.connection_errors:
         for model in layer.graph.models.values():
@@ -539,14 +566,17 @@ def _validate_warehouse(
                     str(column.get("column_name")): str(column.get("data_type") or "") for column in warehouse_columns
                 }
                 warehouse_types[model.name] = {}
+                warehouse_column_names[model.name] = {}
                 for column, expected_type in _required_columns(model, layer.graph).items():
-                    actual_type = _warehouse_column_type(actual, column, layer.dialect)
-                    if actual_type is None:
+                    actual_name = _warehouse_column_name(actual, column, layer.dialect)
+                    if actual_name is None:
                         report.warehouse_errors.append(
                             f"Model '{model.name}' references missing column '{column}' in table '{model.table}'"
                         )
                         continue
+                    actual_type = actual[actual_name]
                     warehouse_types[model.name][column] = actual_type
+                    warehouse_column_names[model.name][column] = actual_name
                     if expected_type in {"numeric", "time", "boolean"}:
                         actual_family = _warehouse_type_family(actual_type)
                         if actual_family is not None and actual_family != expected_type:
@@ -556,10 +586,10 @@ def _validate_warehouse(
                             )
 
             if check_keys and (model.table or model.sql):
-                _check_declared_keys(layer, model, report)
+                _check_declared_keys(layer, model, report, warehouse_column_names.get(model.name))
 
         if check_keys:
-            _check_relationship_cardinality(layer, layer.graph, report)
+            _check_relationship_cardinality(layer, layer.graph, report, warehouse_column_names)
 
         _check_join_key_types(layer.graph, warehouse_types, report)
 

--- a/sidemantic/validation_runner.py
+++ b/sidemantic/validation_runner.py
@@ -485,6 +485,8 @@ def _representative_query_specs(graph: "SemanticGraph") -> list[tuple[str, list[
 
     for source in graph.models.values():
         for relationship in source.relationships:
+            if not relationship.active:
+                continue
             target = graph.models.get(relationship.name)
             if target is None or relationship.type == "cross":
                 continue

--- a/sidemantic/validation_runner.py
+++ b/sidemantic/validation_runner.py
@@ -131,12 +131,65 @@ def validate_directory(
     return report
 
 
-def _split_table_reference(table: str, dialect: str) -> tuple[str, str | None] | None:
+@dataclass(frozen=True)
+class _TableReference:
+    name: str
+    schema: str | None = None
+    catalog: str | None = None
+    name_quoted: bool = False
+    schema_quoted: bool = False
+
+    @property
+    def qualified_name(self) -> str:
+        return ".".join(part for part in (self.catalog, self.schema, self.name) if part)
+
+
+def _split_table_reference(table: str, dialect: str) -> _TableReference | None:
     try:
         parsed = sqlglot.parse_one(table, into=exp.Table, dialect=dialect)
     except Exception:
         return None
-    return parsed.name, parsed.db or None
+    name_identifier = parsed.this
+    schema_identifier = parsed.args.get("db")
+    return _TableReference(
+        name=parsed.name,
+        schema=parsed.db or None,
+        catalog=parsed.catalog or None,
+        name_quoted=bool(getattr(name_identifier, "args", {}).get("quoted")),
+        schema_quoted=bool(getattr(schema_identifier, "args", {}).get("quoted")),
+    )
+
+
+def _warehouse_identifier_matches(expected: str, actual: str, dialect: str, *, quoted: bool = False) -> bool:
+    if dialect == "snowflake" and not quoted:
+        expected = expected.upper()
+    return expected == actual
+
+
+def _warehouse_table_exists(
+    table_ref: _TableReference,
+    available: set[tuple[str, str]],
+    dialect: str,
+) -> bool:
+    for known_schema, known_name in available:
+        if not _warehouse_identifier_matches(table_ref.name, known_name, dialect, quoted=table_ref.name_quoted):
+            continue
+        if table_ref.schema is None or _warehouse_identifier_matches(
+            table_ref.schema,
+            known_schema,
+            dialect,
+            quoted=table_ref.schema_quoted,
+        ):
+            return True
+    return False
+
+
+def _warehouse_column_type(actual: dict[str, str], column: str, dialect: str) -> str | None:
+    if column in actual:
+        return actual[column]
+    if dialect == "snowflake":
+        return actual.get(column.upper())
+    return None
 
 
 def _single_column(expression: str | None, fallback: str | None = None) -> str | None:
@@ -450,18 +503,23 @@ def _validate_warehouse(
                         f"Model '{model.name}' table '{model.table}' is not a simple warehouse table reference"
                     )
                     continue
-                table_name, schema = table_ref
+                # get_tables() is scoped to the adapter's current catalog on several
+                # warehouses. For a catalog-qualified model, let get_columns() inspect
+                # the fully qualified source instead of rejecting it against incomplete
+                # current-catalog metadata.
                 if (
-                    table_names
-                    and (schema or "", table_name) not in table_names
-                    and not any(known_name == table_name for _, known_name in table_names)
+                    table_ref.catalog is None
+                    and table_names
+                    and not _warehouse_table_exists(table_ref, table_names, layer.dialect)
                 ):
                     report.warehouse_errors.append(
                         f"Model '{model.name}' table '{model.table}' does not exist in the warehouse"
                     )
                     continue
                 try:
-                    warehouse_columns = layer.adapter.get_columns(table_name, schema=schema)
+                    inspection_name = table_ref.qualified_name if table_ref.catalog else table_ref.name
+                    inspection_schema = None if table_ref.catalog else table_ref.schema
+                    warehouse_columns = layer.adapter.get_columns(inspection_name, schema=inspection_schema)
                 except Exception as exc:
                     report.warehouse_errors.append(
                         f"Model '{model.name}' table '{model.table}' could not be inspected: {exc}"
@@ -471,19 +529,21 @@ def _validate_warehouse(
                 actual = {
                     str(column.get("column_name")): str(column.get("data_type") or "") for column in warehouse_columns
                 }
-                warehouse_types[model.name] = actual
+                warehouse_types[model.name] = {}
                 for column, expected_type in _required_columns(model, layer.graph).items():
-                    if column not in actual:
+                    actual_type = _warehouse_column_type(actual, column, layer.dialect)
+                    if actual_type is None:
                         report.warehouse_errors.append(
                             f"Model '{model.name}' references missing column '{column}' in table '{model.table}'"
                         )
                         continue
+                    warehouse_types[model.name][column] = actual_type
                     if expected_type in {"numeric", "time", "boolean"}:
-                        actual_family = _warehouse_type_family(actual[column])
+                        actual_family = _warehouse_type_family(actual_type)
                         if actual_family is not None and actual_family != expected_type:
                             report.warehouse_errors.append(
                                 f"Model '{model.name}' column '{column}' is declared {expected_type} but warehouse "
-                                f"type is {actual[column]}"
+                                f"type is {actual_type}"
                             )
 
             if check_keys and (model.table or model.sql):

--- a/sidemantic/validation_runner.py
+++ b/sidemantic/validation_runner.py
@@ -2,25 +2,52 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+import sqlglot
+from sqlglot import exp
 
 from sidemantic import SemanticLayer, load_from_directory
-from sidemantic.validation import validate_metric, validate_model, validate_model_warnings
+from sidemantic.validation import validate_metric, validate_model, validate_model_warnings, validate_relationships
+
+if TYPE_CHECKING:
+    from sidemantic.core.model import Model
+    from sidemantic.core.semantic_graph import SemanticGraph
 
 
 @dataclass
 class ValidationReport:
     directory: Path
+    # ``errors`` remains the structural/offline error list for API compatibility.
     errors: list[str] = field(default_factory=list)
+    warehouse_errors: list[str] = field(default_factory=list)
+    connection_errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     info: list[str] = field(default_factory=list)
 
     @property
     def passed(self) -> bool:
-        return not self.errors
+        return not self.all_errors
+
+    @property
+    def all_errors(self) -> list[str]:
+        return [*self.errors, *self.warehouse_errors, *self.connection_errors]
 
 
-def validate_directory(directory: str | Path) -> ValidationReport:
-    """Load and validate semantic layer definitions from a directory."""
+def validate_directory(
+    directory: str | Path,
+    *,
+    connection: str | None = None,
+    init_sql: list[str] | None = None,
+    check_keys: bool = False,
+    check_queries: bool = True,
+) -> ValidationReport:
+    """Load and validate semantic definitions, optionally against a warehouse.
+
+    Structural validation is always completed first and does not require a connection. When a
+    connection is supplied, warehouse errors and connection failures are collected separately so
+    callers can distinguish an invalid model from an unavailable warehouse.
+    """
     directory = Path(directory)
     report = ValidationReport(directory=directory)
 
@@ -45,10 +72,6 @@ def validate_directory(directory: str | Path) -> ValidationReport:
         for metric in model.metrics:
             report.errors.extend(validate_metric(metric, layer.graph))
 
-        for rel in model.relationships:
-            if rel.name not in layer.graph.models:
-                report.errors.append(f"Model '{model_name}' has relationship to '{rel.name}' which doesn't exist")
-
         # Hex ``view`` resources reference a base model by name and carry their
         # own ``contents``. Both are required by the Hex spec, but views are
         # exempt from the physical-source check in ``validate_model``, so a
@@ -66,6 +89,8 @@ def validate_directory(directory: str | Path) -> ValidationReport:
 
     for metric in layer.graph.metrics.values():
         report.errors.extend(validate_metric(metric, layer.graph))
+
+    report.errors.extend(validate_relationships(layer.graph))
 
     if len(layer.graph.models) > 1:
         orphaned = []
@@ -90,4 +115,401 @@ def validate_directory(directory: str | Path) -> ValidationReport:
     report.info.append(f"Total metrics: {total_metrics}")
     report.info.append(f"Total relationships: {total_rels}")
 
+    if connection is not None:
+        if report.errors:
+            report.info.append("Warehouse validation skipped because structural validation failed")
+        else:
+            _validate_warehouse(
+                directory,
+                connection,
+                report,
+                init_sql=init_sql,
+                check_keys=check_keys,
+                check_queries=check_queries,
+            )
+
     return report
+
+
+def _split_table_reference(table: str, dialect: str) -> tuple[str, str | None] | None:
+    try:
+        parsed = sqlglot.parse_one(table, into=exp.Table, dialect=dialect)
+    except Exception:
+        return None
+    return parsed.name, parsed.db or None
+
+
+def _single_column(expression: str | None, fallback: str | None = None) -> str | None:
+    """Return a physical column for a simple column expression, not a computed expression."""
+    candidate = expression or fallback
+    if not candidate:
+        return None
+    candidate = candidate.replace("{model}.", "")
+    try:
+        parsed = sqlglot.parse_one(candidate)
+    except Exception:
+        return None
+    if isinstance(parsed, exp.Column):
+        return parsed.name
+    return None
+
+
+def _required_columns(model: "Model", graph: "SemanticGraph") -> dict[str, str | None]:
+    """Collect physical source columns and any basic semantic type expectation."""
+    columns: dict[str, str | None] = {}
+
+    for column in model.primary_key_columns:
+        columns[column] = None
+    for key in model.unique_keys or []:
+        for column in key:
+            columns[column] = None
+    for relationship in model.relationships:
+        for column in relationship.foreign_key_columns:
+            columns[column] = None
+        if relationship.type in {"one_to_many", "one_to_one"}:
+            for column in relationship.primary_key_columns:
+                columns[column] = None
+
+    # Include keys declared by relationships on other models but physically owned by this model.
+    for source in graph.models.values():
+        for relationship in source.relationships:
+            if relationship.name == model.name:
+                if relationship.type == "many_to_one" and relationship.primary_key is not None:
+                    for column in relationship.primary_key_columns:
+                        columns[column] = None
+                elif relationship.type in {"one_to_many", "one_to_one"}:
+                    for column in relationship.foreign_key_columns:
+                        columns[column] = None
+                elif relationship.type == "many_to_many" and relationship.primary_key is not None:
+                    for column in relationship.primary_key_columns:
+                        columns[column] = None
+            if relationship.through == model.name:
+                junction_source, junction_target = relationship.junction_key_columns()
+                for column in junction_source + junction_target:
+                    columns[column] = None
+
+    for dimension in model.dimensions:
+        column = _single_column(dimension.sql, dimension.name)
+        if column:
+            columns[column] = dimension.type
+
+    numeric_aggs = {"sum", "avg", "median", "stddev", "stddev_pop", "variance", "variance_pop"}
+    for metric in model.metrics:
+        column = _single_column(metric.sql)
+        if column:
+            columns[column] = "numeric" if metric.agg in numeric_aggs else None
+
+    return columns
+
+
+def _warehouse_type_family(data_type: str) -> str | None:
+    normalized = data_type.upper()
+    if any(token in normalized for token in ("BOOL",)):
+        return "boolean"
+    if any(token in normalized for token in ("DATE", "TIME")):
+        return "time"
+    if any(
+        token in normalized for token in ("INT", "DECIMAL", "NUMERIC", "NUMBER", "REAL", "DOUBLE", "FLOAT", "HUGEINT")
+    ):
+        return "numeric"
+    if any(token in normalized for token in ("CHAR", "TEXT", "STRING")):
+        return "categorical"
+    return None
+
+
+def _quote_identifier(identifier: str, dialect: str) -> str:
+    return exp.to_identifier(identifier, quoted=True).sql(dialect=dialect)
+
+
+def _model_source_sql(model: "Model", dialect: str) -> str:
+    if model.sql:
+        return f"({model.sql}) AS {_quote_identifier('_sidemantic_source', dialect)}"
+    if not model.table:
+        raise ValueError("model has no SQL-queryable table or sql source")
+    parsed = sqlglot.parse_one(model.table, into=exp.Table, dialect=dialect)
+    return parsed.sql(dialect=dialect)
+
+
+def _check_key_columns(
+    layer,
+    model: "Model",
+    report: ValidationReport,
+    *,
+    label: str,
+    columns: list[str],
+    require_non_null: bool = True,
+    require_unique: bool = True,
+) -> None:
+    adapter = layer.adapter
+    dialect = layer.dialect
+    source = _model_source_sql(model, dialect)
+    quoted = [_quote_identifier(column, dialect) for column in columns]
+
+    if require_non_null:
+        null_predicate = " OR ".join(f"{column} IS NULL" for column in quoted)
+        null_sql = f"SELECT 1 FROM {source} WHERE {null_predicate} LIMIT 1"
+        try:
+            if adapter.fetchone(adapter.execute(null_sql)) is not None:
+                report.warehouse_errors.append(f"Model '{model.name}' {label} {columns!r} contains NULL values")
+        except Exception as exc:
+            report.warehouse_errors.append(f"Model '{model.name}' {label} nullability check failed: {exc}")
+            return
+
+    if require_unique:
+        group_columns = ", ".join(quoted)
+        where_clause = ""
+        if not require_non_null:
+            non_null_predicate = " AND ".join(f"{column} IS NOT NULL" for column in quoted)
+            where_clause = f" WHERE {non_null_predicate}"
+        duplicate_sql = (
+            f"SELECT {group_columns} FROM {source}{where_clause} GROUP BY {group_columns} HAVING COUNT(*) > 1 LIMIT 1"
+        )
+        try:
+            if adapter.fetchone(adapter.execute(duplicate_sql)) is not None:
+                report.warehouse_errors.append(f"Model '{model.name}' {label} {columns!r} is not unique")
+        except Exception as exc:
+            report.warehouse_errors.append(f"Model '{model.name}' {label} uniqueness check failed: {exc}")
+
+
+def _check_declared_keys(layer, model: "Model", report: ValidationReport) -> None:
+    if model.primary_key_columns:
+        _check_key_columns(
+            layer,
+            model,
+            report,
+            label="primary_key",
+            columns=model.primary_key_columns,
+        )
+    for columns in model.unique_keys or []:
+        if columns:
+            _check_key_columns(layer, model, report, label="unique_key", columns=columns)
+
+
+def _check_relationship_cardinality(layer, graph: "SemanticGraph", report: ValidationReport) -> None:
+    """Check data assumptions introduced by relationship-scoped keys/cardinality."""
+    for source in graph.models.values():
+        for relationship in source.relationships:
+            target = graph.models.get(relationship.name)
+            if target is None or relationship.type in {"cross", "many_to_many"}:
+                continue
+
+            # An explicit relationship primary_key is a scoped uniqueness declaration. Its side
+            # follows the relationship direction: target for many_to_one, source otherwise.
+            if relationship.primary_key is not None:
+                key_model = target if relationship.type == "many_to_one" else source
+                _check_key_columns(
+                    layer,
+                    key_model,
+                    report,
+                    label=f"relationship '{source.name}.{target.name}' primary_key",
+                    columns=relationship.primary_key_columns,
+                )
+
+            # one_to_one additionally asserts that the target-side foreign key has at most one
+            # row per source key. Nullable foreign keys are valid, but non-NULL values must be unique.
+            if relationship.type == "one_to_one":
+                _check_key_columns(
+                    layer,
+                    target,
+                    report,
+                    label=f"relationship '{source.name}.{target.name}' foreign_key",
+                    columns=relationship.foreign_key_columns,
+                    require_non_null=False,
+                )
+
+
+def _check_join_key_types(
+    graph: "SemanticGraph",
+    warehouse_types: dict[str, dict[str, str]],
+    report: ValidationReport,
+) -> None:
+    def compare(label: str, left_model: str, left: list[str], right_model: str, right: list[str]) -> None:
+        for left_column, right_column in zip(left, right, strict=False):
+            left_type = warehouse_types.get(left_model, {}).get(left_column)
+            right_type = warehouse_types.get(right_model, {}).get(right_column)
+            if not left_type or not right_type:
+                continue
+            left_family = _warehouse_type_family(left_type)
+            right_family = _warehouse_type_family(right_type)
+            if left_family and right_family and left_family != right_family:
+                report.warehouse_errors.append(
+                    f"{label} joins incompatible warehouse types: "
+                    f"{left_model}.{left_column} is {left_type}, "
+                    f"{right_model}.{right_column} is {right_type}"
+                )
+
+    for source in graph.models.values():
+        for relationship in source.relationships:
+            target = graph.models.get(relationship.name)
+            if target is None or relationship.type == "cross" or relationship.sql:
+                continue
+            label = f"Relationship '{source.name}.{target.name}'"
+            if relationship.type == "many_to_one":
+                compare(
+                    label,
+                    source.name,
+                    relationship.foreign_key_columns,
+                    target.name,
+                    relationship.primary_key_columns or target.primary_key_columns,
+                )
+            elif relationship.type in {"one_to_many", "one_to_one"}:
+                compare(
+                    label,
+                    source.name,
+                    relationship.primary_key_columns or source.primary_key_columns,
+                    target.name,
+                    relationship.foreign_key_columns,
+                )
+            elif relationship.through and relationship.through in graph.models:
+                junction_source, junction_target = relationship.junction_key_columns()
+                compare(label, source.name, source.primary_key_columns, relationship.through, junction_source)
+                compare(
+                    label,
+                    relationship.through,
+                    junction_target,
+                    target.name,
+                    relationship.primary_key_columns or target.primary_key_columns,
+                )
+            else:
+                compare(
+                    label,
+                    source.name,
+                    relationship.foreign_key_columns,
+                    target.name,
+                    relationship.primary_key_columns,
+                )
+
+
+def _representative_query_specs(graph: "SemanticGraph") -> list[tuple[str, list[str], list[str]]]:
+    specs: list[tuple[str, list[str], list[str]]] = []
+    for model in graph.models.values():
+        metrics = [f"{model.name}.{model.metrics[0].name}"] if model.metrics else []
+        dimensions = [f"{model.name}.{model.dimensions[0].name}"] if model.dimensions else []
+        if metrics or dimensions:
+            specs.append((f"model '{model.name}'", metrics, dimensions))
+
+    for source in graph.models.values():
+        for relationship in source.relationships:
+            target = graph.models.get(relationship.name)
+            if target is None or relationship.type == "cross":
+                continue
+            metrics = [f"{source.name}.{source.metrics[0].name}"] if source.metrics else []
+            dimensions = [f"{target.name}.{target.dimensions[0].name}"] if target.dimensions else []
+            if not metrics and target.metrics:
+                metrics = [f"{target.name}.{target.metrics[0].name}"]
+            if not dimensions and source.dimensions:
+                dimensions = [f"{source.name}.{source.dimensions[0].name}"]
+            if metrics and dimensions:
+                specs.append((f"relationship '{source.name}.{target.name}'", metrics, dimensions))
+    return specs
+
+
+def _validate_warehouse(
+    directory: Path,
+    connection: str,
+    report: ValidationReport,
+    *,
+    init_sql: list[str] | None,
+    check_keys: bool,
+    check_queries: bool,
+) -> None:
+    try:
+        layer = SemanticLayer(connection=connection, init_sql=init_sql, auto_register=False)
+    except Exception as exc:
+        report.connection_errors.append(f"Could not connect to warehouse: {exc}")
+        return
+
+    try:
+        load_from_directory(layer, str(directory))
+    except Exception as exc:
+        report.connection_errors.append(f"Could not load models with the warehouse connection: {exc}")
+        try:
+            layer.adapter.close()
+        except Exception:
+            pass
+        return
+
+    try:
+        available_tables = layer.adapter.get_tables()
+    except Exception as exc:
+        report.connection_errors.append(f"Could not inspect warehouse tables: {exc}")
+        available_tables = []
+
+    table_names = {
+        (str(table.get("schema") or table.get("table_schema") or ""), str(table.get("table_name") or ""))
+        for table in available_tables
+    }
+    warehouse_types: dict[str, dict[str, str]] = {}
+
+    if not report.connection_errors:
+        for model in layer.graph.models.values():
+            if model.table:
+                table_ref = _split_table_reference(model.table, layer.dialect)
+                if table_ref is None:
+                    report.warehouse_errors.append(
+                        f"Model '{model.name}' table '{model.table}' is not a simple warehouse table reference"
+                    )
+                    continue
+                table_name, schema = table_ref
+                if (
+                    table_names
+                    and (schema or "", table_name) not in table_names
+                    and not any(known_name == table_name for _, known_name in table_names)
+                ):
+                    report.warehouse_errors.append(
+                        f"Model '{model.name}' table '{model.table}' does not exist in the warehouse"
+                    )
+                    continue
+                try:
+                    warehouse_columns = layer.adapter.get_columns(table_name, schema=schema)
+                except Exception as exc:
+                    report.warehouse_errors.append(
+                        f"Model '{model.name}' table '{model.table}' could not be inspected: {exc}"
+                    )
+                    continue
+
+                actual = {
+                    str(column.get("column_name")): str(column.get("data_type") or "") for column in warehouse_columns
+                }
+                warehouse_types[model.name] = actual
+                for column, expected_type in _required_columns(model, layer.graph).items():
+                    if column not in actual:
+                        report.warehouse_errors.append(
+                            f"Model '{model.name}' references missing column '{column}' in table '{model.table}'"
+                        )
+                        continue
+                    if expected_type in {"numeric", "time", "boolean"}:
+                        actual_family = _warehouse_type_family(actual[column])
+                        if actual_family is not None and actual_family != expected_type:
+                            report.warehouse_errors.append(
+                                f"Model '{model.name}' column '{column}' is declared {expected_type} but warehouse "
+                                f"type is {actual[column]}"
+                            )
+
+            if check_keys and (model.table or model.sql):
+                _check_declared_keys(layer, model, report)
+
+        if check_keys:
+            _check_relationship_cardinality(layer, layer.graph, report)
+
+        _check_join_key_types(layer.graph, warehouse_types, report)
+
+        if check_queries:
+            for label, metrics, dimensions in _representative_query_specs(layer.graph):
+                try:
+                    compiled = layer.compile(metrics=metrics, dimensions=dimensions).rstrip().rstrip(";")
+                    # Keep the wrapper's closing parenthesis on a new line. Compiled SQL ends with
+                    # an instrumentation comment, and placing ``)`` on that same line comments it out.
+                    layer.adapter.execute(f"SELECT * FROM (\n{compiled}\n) AS _sidemantic_validation LIMIT 0")
+                except Exception as exc:
+                    report.warehouse_errors.append(f"Representative query for {label} failed: {exc}")
+
+        report.info.append(
+            "Warehouse validation: table/column/type/join/query checks"
+            + (" plus declared key data checks" if check_keys else " (declared key data checks not requested)")
+        )
+
+    try:
+        layer.adapter.close()
+    except Exception:
+        pass

--- a/tests/adapters/atscale_sml/test_export.py
+++ b/tests/adapters/atscale_sml/test_export.py
@@ -34,7 +34,7 @@ class TestAtScaleSMLExport:
         customers = Model(
             name="customers",
             table="public.customers",
-            primary_key="id",
+            primary_key="customer_id",
             dimensions=[
                 Dimension(name="id", type="numeric", sql="id"),
                 Dimension(name="name", type="categorical", sql="name"),
@@ -302,7 +302,7 @@ class TestAtScaleSMLExport:
         customers = Model(
             name="customers",
             table="public.customers",
-            primary_key="id",
+            primary_key="customer_id",
             dimensions=[Dimension(name="customer_id", type="numeric", sql="customer_id")],
         )
 

--- a/tests/adapters/cube/test_joins.py
+++ b/tests/adapters/cube/test_joins.py
@@ -114,7 +114,7 @@ cubes:
     assert rel.sql == "{from}.id = {to}.id"
 
 
-def test_unparseable_join_warns_and_falls_back():
+def test_unparseable_join_warns_and_keeps_key_unknown():
     adapter = CubeAdapter()
     yaml_text = """
 cubes:
@@ -136,7 +136,7 @@ cubes:
     finally:
         path.unlink()
     rel = graph.get_model("x").relationships[0]
-    assert rel.foreign_key == "y_id"
+    assert rel.foreign_key is None
     assert rel.sql is None
 
 

--- a/tests/adapters/graphene/test_parsing.py
+++ b/tests/adapters/graphene/test_parsing.py
@@ -300,7 +300,7 @@ extend regional_orders (
     load_from_directory(layer, tmp_path)
 
     model = layer.graph.models["regional_orders"]
-    assert model.primary_key == "region"
+    assert model.primary_key is None
     total_revenue = model.get_dimension("total_revenue")
     assert total_revenue is not None
     assert total_revenue.sql == "total_revenue"

--- a/tests/adapters/holistics/test_parsing.py
+++ b/tests/adapters/holistics/test_parsing.py
@@ -1137,8 +1137,8 @@ Model extra_child {
 # =============================================================================
 
 
-def test_holistics_primary_key_default_and_definition_name():
-    """Default primary_key is id; definition matching name is omitted."""
+def test_holistics_unknown_primary_key_and_definition_name():
+    """An undeclared primary key stays unknown; a definition matching its name is omitted."""
     aml_content = """
 Model test_model {
   table_name: 'test_table'
@@ -1158,7 +1158,7 @@ Model test_model {
         graph = adapter.parse(temp_path)
 
         model = graph.models["test_model"]
-        assert model.primary_key == "id"
+        assert model.primary_key is None
         assert model.description == "Test model"
 
         name_dim = model.get_dimension("name")

--- a/tests/adapters/metricflow/test_fixtures.py
+++ b/tests/adapters/metricflow/test_fixtures.py
@@ -164,9 +164,9 @@ class TestBookingsSource:
             assert r.type == "many_to_one"
 
     def test_primary_entity_shorthand_not_handled(self, graph):
-        """primary_entity shorthand (outside entities list) defaults pk to 'id'."""
+        """Unsupported primary_entity shorthand does not invent an id key."""
         model = graph.models["bookings_source"]
-        assert model.primary_key == "id"
+        assert model.primary_key is None
 
     def test_default_time_dimension(self, graph):
         """defaults.agg_time_dimension is captured."""
@@ -370,9 +370,9 @@ class TestSCDTypeII:
         assert model.primary_key == "company_id"
 
     def test_primary_entity_shorthand_not_handled(self, graph):
-        """primary_entity shorthand on listings/primary_accounts defaults pk to 'id'."""
-        assert graph.models["listings"].primary_key == "id"
-        assert graph.models["primary_accounts"].primary_key == "id"
+        """Unsupported primary_entity shorthand does not invent id keys."""
+        assert graph.models["listings"].primary_key is None
+        assert graph.models["primary_accounts"].primary_key is None
 
     def test_categorical_dimensions(self, graph):
         """Categorical dimensions on SCD models parse correctly."""

--- a/tests/adapters/metricflow/test_parsing.py
+++ b/tests/adapters/metricflow/test_parsing.py
@@ -1034,6 +1034,52 @@ def test_metricflow_inline_constant_count_anchored_to_model():
         path.unlink(missing_ok=True)
 
 
+def test_metricflow_inline_counts_support_keyless_models():
+    """Keyless inline row counts retain model context without a fabricated key."""
+    import tempfile
+    import textwrap
+
+    yml = textwrap.dedent("""
+        models:
+          - name: events
+            semantic_model:
+              enabled: true
+              name: events
+            metrics:
+              - name: row_count
+                type: simple
+                agg: count
+                expr: 1
+              - name: star_count
+                type: simple
+                agg: count
+                expr: '*'
+              - name: bare_count
+                type: simple
+                agg: count
+    """)
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
+        f.write(yml)
+        path = Path(f.name)
+
+    try:
+        graph = MetricFlowAdapter().parse(path)
+        assert graph.get_model("events").primary_key is None
+
+        generator = SQLGenerator(graph)
+        for metric_name in ("row_count", "star_count", "bare_count"):
+            metric = graph.get_metric(metric_name)
+            assert metric.sql is None
+            assert graph.metric_owners[metric_name] == "events"
+
+            sql = generator.generate(metrics=[metric_name])
+            assert "events" in sql.lower()
+            assert "count(*)" in sql.lower()
+            assert ".none" not in sql.lower()
+    finally:
+        path.unlink(missing_ok=True)
+
+
 def test_metricflow_inline_exprless_non_count_uses_metric_column():
     """An expr-less non-count inline measure aggregates its own column, not the PK.
 

--- a/tests/adapters/metricflow/test_parsing.py
+++ b/tests/adapters/metricflow/test_parsing.py
@@ -1057,6 +1057,7 @@ def test_metricflow_inline_counts_support_keyless_models():
               - name: bare_count
                 type: simple
                 agg: count
+                filter: status = 'active'
     """)
     with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as f:
         f.write(yml)
@@ -1074,7 +1075,11 @@ def test_metricflow_inline_counts_support_keyless_models():
 
             sql = generator.generate(metrics=[metric_name])
             assert "events" in sql.lower()
-            assert "count(*)" in sql.lower()
+            if metric_name == "bare_count":
+                assert "status as status" in sql.lower()
+                assert "events_cte.status = 'active'" in sql.lower()
+            else:
+                assert "count(*)" in sql.lower()
             assert ".none" not in sql.lower()
     finally:
         path.unlink(missing_ok=True)

--- a/tests/adapters/sidemantic_adapter/test_parsing.py
+++ b/tests/adapters/sidemantic_adapter/test_parsing.py
@@ -7,6 +7,8 @@ import pytest
 import yaml
 
 from sidemantic.adapters.sidemantic import SidemanticAdapter
+from sidemantic.core.model import Model
+from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.core.semantic_layer import SemanticLayer
 
 
@@ -1012,6 +1014,19 @@ def test_export_native_yaml():
 
     finally:
         temp_path.unlink(missing_ok=True)
+
+
+def test_export_native_yaml_marks_keyless_models_explicitly(tmp_path):
+    adapter = SidemanticAdapter()
+    graph = SemanticGraph()
+    graph.add_model(Model(name="events", table="events"))
+    export_path = tmp_path / "keyless.yml"
+
+    adapter.export(graph, export_path)
+
+    exported = yaml.safe_load(export_path.read_text())
+    assert exported["models"][0]["primary_key_columns"] == []
+    assert adapter.parse(export_path).models["events"].primary_key is None
 
 
 def test_semantic_layer_from_yaml():

--- a/tests/adapters/snowflake/test_parsing.py
+++ b/tests/adapters/snowflake/test_parsing.py
@@ -213,7 +213,7 @@ tables:
         assert "test_table" in graph.models
         model = graph.models["test_table"]
         assert model.table == "test"
-        assert model.primary_key == "id"  # Default
+        assert model.primary_key is None
 
     def test_parse_table_without_base_table(self, adapter, tmp_path):
         """Test parsing a table without base_table."""

--- a/tests/adapters/tableau/test_real_world.py
+++ b/tests/adapters/tableau/test_real_world.py
@@ -278,16 +278,16 @@ def test_sf_trial_collection_builds_join_sql(adapter):
     assert "LEFT JOIN" in model.sql
 
 
-def test_sf_trial_primary_key_projected(adapter):
-    """thoughtspot_sf_trial.tds: inferred PK comes from projected collection SQL."""
+def test_sf_trial_primary_key_remains_unknown(adapter):
+    """thoughtspot_sf_trial.tds: collection fields do not establish uniqueness."""
     _skip_if_missing()
     graph = adapter.parse(REAL_WORLD / "thoughtspot_sf_trial.tds")
     model = graph.models.get("SF Trial")
     assert model is not None
 
-    assert model.primary_key == "__tableau_pk"
+    assert model.primary_key is None
     assert model.sql is not None
-    assert '"__tableau_pk"' in model.sql
+    assert '"__tableau_pk"' not in model.sql
 
 
 def test_sf_trial_all_labeled(adapter):
@@ -332,7 +332,7 @@ def test_sf_trial_joined_metric_uses_collection_sql(adapter):
         skip_default_time_dimensions=True,
     )
     assert "id AS id" not in sql
-    assert "__tableau_pk AS __tableau_pk" in sql
+    assert "__tableau_pk" not in sql
     assert '"LINEITEM"' in sql
 
 

--- a/tests/adapters/test_added_fixture_coverage.py
+++ b/tests/adapters/test_added_fixture_coverage.py
@@ -550,10 +550,9 @@ def _pick_execution_query(graph):
         execution_model_name, requires_model_override = _execution_model_name(model.name)
         base_requires_sql_override = bool(model.sql)
 
-        primary_keys = model.primary_key if isinstance(model.primary_key, list) else [model.primary_key]
-        if any(not isinstance(pk, str) or not pk.strip() for pk in primary_keys):
-            continue
-        base_column_types = {pk: "INTEGER" for pk in primary_keys}
+        # Isolated model queries do not require an entity key. Unknown identity is represented by
+        # an empty list rather than inventing an ``id`` column for execution fixtures.
+        base_column_types = {pk: "INTEGER" for pk in model.primary_key_columns}
 
         def pick_metric_candidate():
             for metric in model.metrics:

--- a/tests/adapters/thoughtspot/test_parsing.py
+++ b/tests/adapters/thoughtspot/test_parsing.py
@@ -23,7 +23,7 @@ def test_import_real_thoughtspot_examples():
 
     orders = graph.models["orders"]
     assert orders.table == "analytics.public.orders"
-    assert orders.primary_key == "id"
+    assert orders.primary_key is None
 
     order_date = orders.get_dimension("order_date")
     assert order_date is not None
@@ -1223,14 +1223,14 @@ def test_thoughtspot_one_to_one_join_keys_match_direction():
     assert rows == [("PACIFIC", 125.0)]
 
 
-def test_thoughtspot_non_id_primary_key_is_queryable():
-    """A joined model whose key is not literally `id` stays queryable.
+def test_thoughtspot_unknown_primary_key_is_queryable():
+    """A joined model without declared uniqueness stays queryable.
 
     Regression: `primary_key` defaulted to `id`, and the derived projection
     injected `orders.id AS id`. The SQL generator always selects the primary key
     from derived models, so even a basic aggregate failed with
-    `Table "orders" does not have a column named "id"`. The key must be inferred
-    from a real base-table column (here `order_key`).
+    `Table "orders" does not have a column named "id"`. Leaving identity unknown
+    avoids projecting any invented key.
     """
     import duckdb
 
@@ -1238,10 +1238,9 @@ def test_thoughtspot_non_id_primary_key_is_queryable():
     graph = adapter.parse("tests/fixtures/thoughtspot/model_non_id_key.model.tml")
     model = graph.models["orders_model"]
 
-    # The primary key is inferred from a real base-table column, not the default.
-    assert model.primary_key == "order_key"
+    assert model.primary_key is None
     assert model.sql is not None
-    assert "orders.order_key AS order_key" in model.sql
+    assert "orders.order_key AS orders__order_key" in model.sql
     assert "orders.id AS id" not in model.sql
 
     layer = SemanticLayer()
@@ -1381,10 +1380,9 @@ def test_thoughtspot_renamed_id_key_uses_backing_column():
     graph = adapter.parse("tests/fixtures/thoughtspot/model_renamed_id_key.model.tml")
     model = graph.models["orders_model"]
 
-    # The primary key resolves to the backing physical column, not the name `id`.
-    assert model.primary_key == "order_key"
+    assert model.primary_key is None
     assert model.sql is not None
-    assert "orders.order_key AS order_key" in model.sql
+    assert "orders.order_key AS orders__order_key" in model.sql
     assert "orders.id AS id" not in model.sql
 
     layer = SemanticLayer()
@@ -1415,10 +1413,9 @@ def test_thoughtspot_joined_id_dimension_is_not_used_as_primary_key():
     graph = adapter.parse("tests/fixtures/thoughtspot/model_joined_id_key.model.tml")
     model = graph.models["orders_model"]
 
-    # The joined-table id is skipped; the base-table column is used as the key.
-    assert model.primary_key == "order_key"
+    assert model.primary_key is None
     assert model.sql is not None
-    assert "orders.order_key AS order_key" in model.sql
+    assert "orders.order_key AS orders__order_key" in model.sql
     assert "orders.id AS id" not in model.sql
 
     layer = SemanticLayer()
@@ -1551,8 +1548,8 @@ def test_thoughtspot_join_target_by_id_resolves_to_alias():
     assert rows == [("US", 125.0)]
 
 
-def test_thoughtspot_measure_key_column_is_inferred_as_primary_key():
-    """A base-table key exported as a measure is still inferred as the primary key.
+def test_thoughtspot_measure_key_does_not_imply_uniqueness():
+    """A key-shaped base-table measure does not establish entity uniqueness.
 
     Regression: `_infer_model_primary_key` only scanned dimensions, but
     ThoughtSpot often exports key columns as measures. With `order_key` as a
@@ -1566,8 +1563,7 @@ def test_thoughtspot_measure_key_column_is_inferred_as_primary_key():
     graph = adapter.parse("tests/fixtures/thoughtspot/model_measure_key.model.tml")
     model = graph.models["orders_model"]
 
-    # The measure-backed base-table column is used as the key.
-    assert model.primary_key == "order_key"
+    assert model.primary_key is None
     assert model.sql is not None
     assert "orders.id AS id" not in model.sql
 

--- a/tests/adapters/thoughtspot/test_roundtrip.py
+++ b/tests/adapters/thoughtspot/test_roundtrip.py
@@ -71,6 +71,7 @@ def test_thoughtspot_export_one_to_many_join_direction(tmp_path: Path):
     model = Model(
         name="customers",
         table="customers",
+        primary_key="id",
         relationships=[Relationship(name="orders", type="one_to_many", foreign_key="customer_id")],
     )
     graph = SemanticGraph()

--- a/tests/adapters/yardstick/test_parsing.py
+++ b/tests/adapters/yardstick/test_parsing.py
@@ -30,7 +30,7 @@ FROM sales;
 
     assert model.table == "sales"
     assert [dim.name for dim in model.dimensions] == ["year", "region"]
-    assert model.primary_key == "year"
+    assert model.primary_key is None
 
     revenue = model.get_metric("revenue")
     assert revenue is not None

--- a/tests/core/test_pure_rust_python_test_parity.py
+++ b/tests/core/test_pure_rust_python_test_parity.py
@@ -228,6 +228,9 @@ EXPECTED_GAPS = {
     "tests.optimizations.test_pre_aggregations::test_ungrouped_rollup_without_pk_falls_to_raw": (
         "Rust adapter does not yet support Python pre-aggregation routing (ungrouped drill-to-detail)"
     ),
+    "tests.optimizations.test_pre_aggregations::test_ungrouped_keyless_model_falls_to_raw": (
+        "Rust adapter does not yet support Python pre-aggregation routing (ungrouped drill-to-detail)"
+    ),
     "tests.optimizations.test_pre_aggregations::test_lambda_preaggregation_unions_batch_rollup_with_fresh_source": (
         "Rust adapter does not yet support Python pre-aggregation routing (lambda union)"
     ),

--- a/tests/core/test_rust_bridge_yaml_serialization.py
+++ b/tests/core/test_rust_bridge_yaml_serialization.py
@@ -142,6 +142,22 @@ def test_rust_payload_restores_explicit_keyless_model_as_none():
     assert graph.get_model("events").primary_key is None
 
 
+def test_models_to_rust_yaml_uses_source_key_for_reverse_relationship():
+    users = Model(
+        name="users",
+        table="users",
+        primary_key="user_id",
+        relationships=[Relationship(name="profiles", type="one_to_many", foreign_key="user_id")],
+    )
+    profiles = Model(name="profiles", table="profiles", primary_key="profile_id")
+
+    payload = yaml.safe_load(models_to_rust_yaml([users, profiles]))
+    relationship = payload["models"][0]["relationships"][0]
+
+    assert relationship["primary_key"] == "user_id"
+    assert relationship["primary_key_columns"] == ["user_id"]
+
+
 def test_graph_to_rust_yaml_assigns_complex_metrics_by_entity_dimension():
     graph = SemanticGraph()
     graph.add_model(

--- a/tests/core/test_rust_bridge_yaml_serialization.py
+++ b/tests/core/test_rust_bridge_yaml_serialization.py
@@ -179,6 +179,35 @@ def test_models_to_rust_yaml_orients_composite_reverse_relationship_sql():
     assert relationship["sql"] == ("{from}.account_id = {to}.owner_account_id AND {from}.tenant_id = {to}.tenant_id")
 
 
+def test_models_to_rust_yaml_orients_single_column_one_to_one_sql():
+    users = Model(
+        name="users",
+        table="users",
+        primary_key="id",
+        relationships=[Relationship(name="profiles", type="one_to_one", foreign_key="user_id")],
+    )
+    profiles = Model(name="profiles", table="profiles", primary_key="profile_id")
+
+    payload = yaml.safe_load(models_to_rust_yaml([users, profiles]))
+    relationship = payload["models"][0]["relationships"][0]
+
+    assert relationship["sql"] == "{from}.id = {to}.user_id"
+
+
+def test_graph_to_rust_yaml_preserves_explicit_keyless_metric_owner():
+    graph = SemanticGraph()
+    graph.add_model(Model(name="events", table="events"))
+    graph.add_model(Model(name="orders", table="orders", primary_key="order_id"))
+    metric = Metric(name="event_count", agg="count")
+    graph.add_metric(metric, model_name="events")
+
+    payload = yaml.safe_load(graph_to_rust_yaml(graph))
+    models = {model["name"]: model for model in payload["models"]}
+
+    assert [item["name"] for item in models["events"]["metrics"]] == ["event_count"]
+    assert payload.get("metrics") in (None, [])
+
+
 def test_graph_to_rust_yaml_assigns_complex_metrics_by_entity_dimension():
     graph = SemanticGraph()
     graph.add_model(

--- a/tests/core/test_rust_bridge_yaml_serialization.py
+++ b/tests/core/test_rust_bridge_yaml_serialization.py
@@ -8,7 +8,7 @@ from sidemantic.core.model import Model
 from sidemantic.core.pre_aggregation import Index, PreAggregation, RefreshKey
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_graph import SemanticGraph
-from sidemantic.rust_bridge import graph_to_rust_yaml, models_to_rust_yaml
+from sidemantic.rust_bridge import _graph_from_loaded_payload, graph_to_rust_yaml, models_to_rust_yaml
 
 
 def test_models_to_rust_yaml_preserves_extended_core_metadata():
@@ -116,6 +116,30 @@ def test_models_to_rust_yaml_does_not_invent_table_for_source_uri_model():
 
     assert model_payload["source_uri"] == "s3://warehouse/events.parquet"
     assert model_payload["table"] is None
+
+
+def test_models_to_rust_yaml_preserves_explicit_keyless_model():
+    payload = yaml.safe_load(models_to_rust_yaml([Model(name="events", table="events")]))
+
+    assert payload["models"][0]["primary_key"] is None
+    assert payload["models"][0]["primary_key_columns"] == []
+
+
+def test_rust_payload_restores_explicit_keyless_model_as_none():
+    graph = _graph_from_loaded_payload(
+        {
+            "models": [
+                {
+                    "name": "events",
+                    "table": "events",
+                    "primary_key": "",
+                    "primary_key_columns": [],
+                }
+            ]
+        }
+    )
+
+    assert graph.get_model("events").primary_key is None
 
 
 def test_graph_to_rust_yaml_assigns_complex_metrics_by_entity_dimension():

--- a/tests/core/test_rust_bridge_yaml_serialization.py
+++ b/tests/core/test_rust_bridge_yaml_serialization.py
@@ -158,6 +158,27 @@ def test_models_to_rust_yaml_uses_source_key_for_reverse_relationship():
     assert relationship["primary_key_columns"] == ["user_id"]
 
 
+def test_models_to_rust_yaml_orients_composite_reverse_relationship_sql():
+    accounts = Model(
+        name="accounts",
+        table="accounts",
+        primary_key=["account_id", "tenant_id"],
+        relationships=[
+            Relationship(
+                name="profiles",
+                type="one_to_many",
+                foreign_key=["owner_account_id", "tenant_id"],
+            )
+        ],
+    )
+    profiles = Model(name="profiles", table="profiles", primary_key="profile_id")
+
+    payload = yaml.safe_load(models_to_rust_yaml([accounts, profiles]))
+    relationship = payload["models"][0]["relationships"][0]
+
+    assert relationship["sql"] == ("{from}.account_id = {to}.owner_account_id AND {from}.tenant_id = {to}.tenant_id")
+
+
 def test_graph_to_rust_yaml_assigns_complex_metrics_by_entity_dimension():
     graph = SemanticGraph()
     graph.add_model(

--- a/tests/joins/test_composite_key_joins.py
+++ b/tests/joins/test_composite_key_joins.py
@@ -470,9 +470,9 @@ def test_relationship_foreign_key_columns_multi():
 
 
 def test_relationship_foreign_key_columns_default():
-    """Test foreign_key_columns defaults to {name}_id for many_to_one."""
+    """Unknown relationship foreign keys remain explicit."""
     rel = Relationship(name="customers", type="many_to_one")
-    assert rel.foreign_key_columns == ["customers_id"]
+    assert rel.foreign_key_columns == []
 
 
 def test_relationship_primary_key_columns_single():
@@ -492,9 +492,9 @@ def test_relationship_primary_key_columns_multi():
 
 
 def test_relationship_primary_key_columns_default():
-    """Test primary_key_columns defaults to [id]."""
+    """Unknown relationship primary keys remain explicit."""
     rel = Relationship(name="customers", type="many_to_one")
-    assert rel.primary_key_columns == ["id"]
+    assert rel.primary_key_columns == []
 
 
 if __name__ == "__main__":

--- a/tests/native-fixtures/relationship_default_keys/README.md
+++ b/tests/native-fixtures/relationship_default_keys/README.md
@@ -1,7 +1,7 @@
-# Relationship Default Keys
+# Relationship Key Resolution
 
-Verifies relationship default-key compatibility between Python and Rust:
+Verifies explicit relationship-key compatibility between Python and Rust:
 
-- omitted `one_to_many` and `one_to_one` keys use `id`
-- omitted `many_to_one` foreign keys use `{name}_id`
-- omitted relationship `primary_key` resolves to the target model's declared primary key
+- `one_to_many` and `one_to_one` relationships declare their foreign-key columns
+- `many_to_one` relationships declare their foreign-key columns instead of relying on naming conventions
+- an omitted relationship `primary_key` safely resolves to the related model's declared primary key

--- a/tests/native-fixtures/relationship_default_keys/models/models.yml
+++ b/tests/native-fixtures/relationship_default_keys/models/models.yml
@@ -13,8 +13,10 @@ models:
     relationships:
       - name: orders
         type: one_to_many
+        foreign_key: id
       - name: profiles
         type: one_to_one
+        foreign_key: id
 
   - name: orders
     table: orders
@@ -42,6 +44,7 @@ models:
     relationships:
       - name: accounts
         type: many_to_one
+        foreign_key: accounts_id
 
   - name: accounts
     table: accounts

--- a/tests/optimizations/test_pre_aggregations.py
+++ b/tests/optimizations/test_pre_aggregations.py
@@ -2362,6 +2362,40 @@ def test_ungrouped_rollup_without_pk_falls_to_raw(layer):
     assert plan.used_preaggregation is False
 
 
+def test_ungrouped_keyless_model_falls_to_raw(layer):
+    """An empty key set is not evidence that an aggregate rollup preserves detail rows."""
+    layer.use_preaggregations = True
+    layer.conn.execute("CREATE TABLE orders (status VARCHAR, amount DECIMAL(10, 2))")
+    layer.conn.execute("CREATE TABLE orders_preagg_by_status (status VARCHAR, revenue_raw DECIMAL(10, 2))")
+    model = Model(
+        name="orders",
+        table="orders",
+        dimensions=[Dimension(name="status", type="categorical", sql="status")],
+        metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        pre_aggregations=[PreAggregation(name="by_status", measures=["revenue"], dimensions=["status"])],
+    )
+    layer.add_model(model)
+
+    sql = layer.compile(
+        metrics=["orders.revenue"],
+        dimensions=["orders.status"],
+        ungrouped=True,
+    )
+
+    assert "orders_preagg_by_status" not in sql
+    assert "orders_cte" in sql
+    assert "used_preagg=true" not in sql
+
+    plan = layer.explain(
+        metrics=["orders.revenue"],
+        dimensions=["orders.status"],
+        ungrouped=True,
+        use_preaggregations=True,
+    )
+    assert plan.used_preaggregation is False
+    assert plan.routing_reason == "ungrouped query, model has no declared primary key for unique rows"
+
+
 def test_ungrouped_composite_pk_partial_rollup_falls_to_raw(layer):
     """A rollup carrying only part of a composite primary key cannot guarantee unique rows."""
     layer.use_preaggregations = True

--- a/tests/queries/test_basic.py
+++ b/tests/queries/test_basic.py
@@ -6,6 +6,7 @@ import sqlglot
 from sqlglot import exp
 
 from sidemantic import Dimension, Metric, Model, Relationship, Segment, SemanticLayer
+from sidemantic.validation import QueryValidationError
 from tests.utils import df_rows
 
 
@@ -766,15 +767,8 @@ def test_count_distinct_with_actual_data(layer):
     assert counts["Los Angeles"] == 3
 
 
-def test_direct_many_to_many_without_target_key_joins_on_model_pk():
-    """Regression: a direct (no-bridge) many_to_many that records only a foreign_key (the related
-    side's column) and no target primary_key must join the local side on the model's primary key.
-
-    Treating foreign_key as the local column too would emit a join on a column the source CTE does
-    not have. (A TMDL many-to-many records both endpoints via primary_key and is handled separately.)
-    """
-    import re
-
+def test_direct_many_to_many_without_target_key_fails_validation():
+    """A direct many-to-many must declare both endpoints instead of compiling a guessed join."""
     layer = SemanticLayer()
     layer.add_model(
         Model(
@@ -795,10 +789,8 @@ def test_direct_many_to_many_without_target_key_joins_on_model_pk():
         )
     )
 
-    sql = layer.compile(metrics=["a.cnt"], dimensions=["b.label"])
-    # Local side joins on A's primary key; it never references a raw a_id column (A has none).
-    assert re.search(r"a_cte\.id\b", sql)
-    assert "a_cte.a_id" not in sql
+    with pytest.raises(QueryValidationError, match="explicit foreign_key and primary_key columns"):
+        layer.compile(metrics=["a.cnt"], dimensions=["b.label"])
 
 
 if __name__ == "__main__":

--- a/tests/queries/test_yardstick_measures_replay.py
+++ b/tests/queries/test_yardstick_measures_replay.py
@@ -692,7 +692,7 @@ def _assert_definition_blocks_match(path: Path) -> None:
             context = f"{context} ({view_name})"
 
         assert model.name == view_name, context
-        assert model.primary_key == (expected_dimensions[0].name if expected_dimensions else "id"), context
+        assert model.primary_key is None, context
         assert model.table == (expected_source_table or (view_name if expected_source_sql is None else None)), context
         assert model.sql == expected_source_sql, context
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -519,7 +519,7 @@ models:
     result = runner.invoke(app, ["validate", str(tmp_path), "--engine", "python"])
 
     assert result.exit_code == 1
-    assert "relationship to 'customers' which doesn't exist" in result.output
+    assert "Relationship 'orders.customers' (many_to_one): target model does not exist" in result.output
     assert "Validation Failed" in result.output
 
 
@@ -558,6 +558,48 @@ def test_validate_engine_rust_uses_rust_loader(monkeypatch, tmp_path):
     assert "canonical Python validation ran" in result.stdout
     assert "Validation Passed" in result.stdout
     assert "orders" in result.stdout
+
+
+def test_validate_warehouse_json_reports_separate_categories(tmp_path):
+    _write_min_model(tmp_path)
+    database = tmp_path / "warehouse.duckdb"
+    _write_orders_db(database)
+
+    result = runner.invoke(
+        app,
+        ["validate", str(tmp_path), "--warehouse", "--db", str(database), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["valid"] is True
+    assert payload["structural_errors"] == []
+    assert payload["warehouse_errors"] == []
+    assert payload["connection_errors"] == []
+
+
+def test_validate_warehouse_cli_labels_warehouse_errors(tmp_path):
+    _write_min_model(tmp_path)
+    database = tmp_path / "warehouse.duckdb"
+    connection = duckdb.connect(str(database))
+    connection.execute("CREATE TABLE orders (id INTEGER)")
+    connection.close()
+
+    result = runner.invoke(app, ["validate", str(tmp_path), "--warehouse", "--db", str(database)])
+
+    assert result.exit_code == 1
+    assert "Warehouse Errors:" in result.output
+    assert "missing column 'status'" in result.output
+    assert "Structural Errors:" not in result.output
+
+
+def test_validate_check_keys_requires_warehouse(tmp_path):
+    _write_min_model(tmp_path)
+
+    result = runner.invoke(app, ["validate", str(tmp_path), "--check-keys"])
+
+    assert result.exit_code == 2
+    assert "--check-keys requires" in result.output
 
 
 def test_lsp_command_calls_main(monkeypatch):

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import duckdb
 import pytest
+from click.utils import strip_ansi
 from typer.testing import CliRunner
 
 import sidemantic.cli as cli_module
@@ -599,7 +600,7 @@ def test_validate_check_keys_requires_warehouse(tmp_path):
     result = runner.invoke(app, ["validate", str(tmp_path), "--check-keys"])
 
     assert result.exit_code == 2
-    assert "--check-keys requires" in result.output
+    assert "--check-keys requires" in strip_ansi(result.output)
 
 
 def test_lsp_command_calls_main(monkeypatch):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -513,7 +513,7 @@ def test_get_semantic_graph(demo_layer):
     assert "metrics" in model
     assert "segments" in model
     assert "completed_orders" in model["segments"]
-    assert model["primary_key"] == "id"
+    assert model["primary_key"] is None
 
 
 def test_get_models_enriched(demo_layer):
@@ -522,7 +522,7 @@ def test_get_models_enriched(demo_layer):
     model = result["models"][0]
 
     # Check new fields
-    assert model["primary_key"] == "id"
+    assert model["primary_key"] is None
     assert model["description"] == "All customer orders"
 
     # Check segments are included

--- a/tests/test_migrator_edge_cases.py
+++ b/tests/test_migrator_edge_cases.py
@@ -277,8 +277,15 @@ def test_generate_models_implicit_join():
     assert "orders" in models
 
     # Should extract relationship from WHERE clause
-    orders = models["orders"]
-    assert "relationships" in orders
+    customers = models["customers"]
+    assert customers["relationships"] == [
+        {
+            "name": "orders",
+            "type": "many_to_many",
+            "foreign_key": "id",
+            "primary_key": "customer_id",
+        }
+    ]
 
 
 def test_generate_models_self_join():

--- a/tests/test_migrator_generation.py
+++ b/tests/test_migrator_generation.py
@@ -749,24 +749,8 @@ def test_extract_relationships_from_joins():
     report = analyzer.analyze_queries(queries)
     analysis = report.query_analyses[0]
 
-    # Should extract relationships
-    assert len(analysis.relationships) == 2
-
-    # Check relationships
-    rels_by_table = {}
-    for from_model, to_model, rel_type, fk_col, pk_col in analysis.relationships:
-        rels_by_table[from_model] = (to_model, rel_type, fk_col, pk_col)
-
-    # orders has many_to_one to customers
-    assert "orders" in rels_by_table
-    assert rels_by_table["orders"][0] == "customers"  # to_model
-    assert rels_by_table["orders"][1] == "many_to_one"  # rel_type
-    assert rels_by_table["orders"][2] == "customer_id"  # fk_col
-
-    # customers has one_to_many to orders
-    assert "customers" in rels_by_table
-    assert rels_by_table["customers"][0] == "orders"  # to_model
-    assert rels_by_table["customers"][1] == "one_to_many"  # rel_type
+    # The equality establishes join columns, but not uniqueness/cardinality.
+    assert analysis.relationships == [("customers", "orders", "many_to_many", "customer_id", "customer_id")]
 
 
 def test_generate_models_with_relationships():
@@ -791,16 +775,13 @@ def test_generate_models_with_relationships():
     assert "relationships" in customers
     cust_rels = {r["name"]: r for r in customers["relationships"]}
     assert "orders" in cust_rels
-    assert cust_rels["orders"]["type"] == "one_to_many"
-    assert "foreign_key" not in cust_rels["orders"]  # FK is on orders side
-
-    # Check orders model
-    orders = models["orders"]
-    assert "relationships" in orders
-    orders_rels = {r["name"]: r for r in orders["relationships"]}
-    assert "customers" in orders_rels
-    assert orders_rels["customers"]["type"] == "many_to_one"
-    assert orders_rels["customers"]["foreign_key"] == "customer_id"
+    assert cust_rels["orders"] == {
+        "name": "orders",
+        "type": "many_to_many",
+        "foreign_key": "id",
+        "primary_key": "customer_id",
+    }
+    assert "relationships" not in models["orders"]
 
 
 def test_generate_models_with_multiple_joins():
@@ -821,18 +802,20 @@ def test_generate_models_with_multiple_joins():
     report = analyzer.analyze_queries(queries)
     models = analyzer.generate_models(report)
 
-    # orders should have relationships to both customers and products
+    # Each observed equality is preserved in its SQL orientation without guessing cardinality.
+    customers = models["customers"]
+    customers_rels = {r["name"]: r for r in customers["relationships"]}
+    assert customers_rels["orders"]["type"] == "many_to_many"
+    assert customers_rels["orders"]["foreign_key"] == "id"
+    assert customers_rels["orders"]["primary_key"] == "customer_id"
+
     orders = models["orders"]
     assert "relationships" in orders
     orders_rels = {r["name"]: r for r in orders["relationships"]}
-
-    assert "customers" in orders_rels
-    assert orders_rels["customers"]["type"] == "many_to_one"
-    assert orders_rels["customers"]["foreign_key"] == "customer_id"
-
     assert "products" in orders_rels
-    assert orders_rels["products"]["type"] == "many_to_one"
+    assert orders_rels["products"]["type"] == "many_to_many"
     assert orders_rels["products"]["foreign_key"] == "product_id"
+    assert orders_rels["products"]["primary_key"] == "id"
 
 
 def test_rewrite_query_with_derived_metrics():
@@ -912,7 +895,7 @@ def test_information_schema_relationship_detection():
     analysis = report.query_analyses[0]
 
     # Should extract relationships using information_schema
-    assert len(analysis.relationships) == 2
+    assert len(analysis.relationships) == 1
 
     # Verify correct FK/PK detection
     rels_by_table = {}

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -1,8 +1,11 @@
 """Test relationship property methods and edge cases."""
 
+import pytest
+
 from sidemantic.core.model import Model
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_graph import SemanticGraph
+from sidemantic.validation import validate_relationships
 
 
 def test_relationship_sql_expr_with_explicit_foreign_key():
@@ -11,22 +14,19 @@ def test_relationship_sql_expr_with_explicit_foreign_key():
     assert rel.sql_expr == "cust_id"
 
 
-def test_relationship_sql_expr_default_many_to_one():
-    """Test sql_expr property defaults to {name}_id for many_to_one."""
+def test_relationship_sql_expr_does_not_invent_many_to_one_key():
     rel = Relationship(name="customers", type="many_to_one")
-    assert rel.sql_expr == "customers_id"
+    assert rel.sql_expr is None
 
 
-def test_relationship_sql_expr_default_one_to_many():
-    """Test sql_expr property defaults to 'id' for one_to_many."""
+def test_relationship_sql_expr_does_not_invent_one_to_many_key():
     rel = Relationship(name="orders", type="one_to_many")
-    assert rel.sql_expr == "id"
+    assert rel.sql_expr is None
 
 
-def test_relationship_sql_expr_default_one_to_one():
-    """Test sql_expr property defaults to 'id' for one_to_one."""
+def test_relationship_sql_expr_does_not_invent_one_to_one_key():
     rel = Relationship(name="profile", type="one_to_one")
-    assert rel.sql_expr == "id"
+    assert rel.sql_expr is None
 
 
 def test_relationship_related_key_with_explicit_primary_key():
@@ -35,10 +35,9 @@ def test_relationship_related_key_with_explicit_primary_key():
     assert rel.related_key == "customer_uid"
 
 
-def test_relationship_related_key_default():
-    """Test related_key property defaults to 'id'."""
+def test_relationship_related_key_is_unknown_when_omitted():
     rel = Relationship(name="customers", type="many_to_one")
-    assert rel.related_key == "id"
+    assert rel.related_key is None
 
 
 def test_relationship_many_to_many():
@@ -68,21 +67,21 @@ def test_relationship_all_fields():
     assert rel.related_key == "organization_id"
 
 
-def test_relationship_default_column_lists_match_native_contract():
+def test_relationship_omitted_column_lists_remain_unknown():
     many_to_one = Relationship(name="customers", type="many_to_one")
-    assert many_to_one.foreign_key_columns == ["customers_id"]
-    assert many_to_one.primary_key_columns == ["id"]
+    assert many_to_one.foreign_key_columns == []
+    assert many_to_one.primary_key_columns == []
 
     one_to_many = Relationship(name="orders", type="one_to_many")
-    assert one_to_many.foreign_key_columns == ["id"]
-    assert one_to_many.primary_key_columns == ["id"]
+    assert one_to_many.foreign_key_columns == []
+    assert one_to_many.primary_key_columns == []
 
     one_to_one = Relationship(name="profile", type="one_to_one")
-    assert one_to_one.foreign_key_columns == ["id"]
-    assert one_to_one.primary_key_columns == ["id"]
+    assert one_to_one.foreign_key_columns == []
+    assert one_to_one.primary_key_columns == []
 
 
-def test_graph_many_to_one_omitted_keys_use_name_id_and_target_primary_key():
+def test_graph_many_to_one_omitted_foreign_key_is_not_joinable():
     graph = SemanticGraph()
     graph.add_model(
         Model(
@@ -94,14 +93,12 @@ def test_graph_many_to_one_omitted_keys_use_name_id_and_target_primary_key():
     )
     graph.add_model(Model(name="customers", table="customers", primary_key="customer_uid"))
 
-    path = graph.find_relationship_path("orders", "customers")
-
-    assert [(step.from_columns, step.to_columns, step.relationship) for step in path] == [
-        (["customers_id"], ["customer_uid"], "many_to_one")
-    ]
+    with pytest.raises(ValueError, match="No join path"):
+        graph.find_relationship_path("orders", "customers")
+    assert "foreign_key is required" in "\n".join(validate_relationships(graph))
 
 
-def test_graph_one_to_many_omitted_keys_default_to_id_columns():
+def test_graph_one_to_many_omitted_foreign_key_is_not_joinable():
     graph = SemanticGraph()
     graph.add_model(
         Model(
@@ -113,14 +110,12 @@ def test_graph_one_to_many_omitted_keys_default_to_id_columns():
     )
     graph.add_model(Model(name="orders", table="orders", primary_key="id"))
 
-    path = graph.find_relationship_path("customers", "orders")
-
-    assert [(step.from_columns, step.to_columns, step.relationship) for step in path] == [
-        (["id"], ["id"], "one_to_many")
-    ]
+    with pytest.raises(ValueError, match="No join path"):
+        graph.find_relationship_path("customers", "orders")
+    assert "foreign_key is required" in "\n".join(validate_relationships(graph))
 
 
-def test_graph_one_to_one_omitted_keys_default_to_id_columns():
+def test_graph_one_to_one_requires_explicit_unique_target_key():
     graph = SemanticGraph()
     graph.add_model(
         Model(
@@ -132,11 +127,10 @@ def test_graph_one_to_one_omitted_keys_default_to_id_columns():
     )
     graph.add_model(Model(name="profiles", table="profiles", primary_key="id"))
 
-    path = graph.find_relationship_path("users", "profiles")
-
-    assert [(step.from_columns, step.to_columns, step.relationship) for step in path] == [
-        (["id"], ["id"], "one_to_one")
-    ]
+    with pytest.raises(ValueError, match="No join path"):
+        graph.find_relationship_path("users", "profiles")
+    errors = "\n".join(validate_relationships(graph))
+    assert "foreign_key is required" in errors
 
 
 def test_graph_explicit_foreign_key_omitted_primary_key_uses_target_primary_key():
@@ -162,3 +156,40 @@ def test_graph_explicit_foreign_key_omitted_primary_key_uses_target_primary_key(
     assert [(step.from_columns, step.to_columns, step.relationship) for step in path] == [
         (["vendor_ref"], ["vendor_uid"], "many_to_one")
     ]
+
+
+def test_many_to_one_explicit_alternate_target_key_is_relationship_scoped_key_declaration():
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            primary_key="order_id",
+            relationships=[
+                Relationship(
+                    name="customers",
+                    type="many_to_one",
+                    foreign_key="customer_external_id",
+                    primary_key="external_id",
+                )
+            ],
+        )
+    )
+    graph.add_model(Model(name="customers", table="customers", primary_key="customer_id"))
+
+    assert validate_relationships(graph) == []
+
+
+def test_one_to_one_cardinality_declares_target_foreign_key_unique():
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="users",
+            table="users",
+            primary_key="user_id",
+            relationships=[Relationship(name="profiles", type="one_to_one", foreign_key="user_id")],
+        )
+    )
+    graph.add_model(Model(name="profiles", table="profiles", primary_key="profile_id"))
+
+    assert validate_relationships(graph) == []

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -758,6 +758,59 @@ models:
     assert inspected == [("analytics.public.orders", None)]
 
 
+def test_snowflake_key_checks_use_inspected_column_casing(monkeypatch, tmp_path):
+    (tmp_path / "models.yml").write_text(
+        """
+models:
+  - name: orders
+    table: public.orders
+    primary_key: order_id
+"""
+    )
+
+    executed = []
+
+    class FakeSnowflakeAdapter:
+        def get_tables(self):
+            return [{"schema": "PUBLIC", "table_name": "ORDERS"}]
+
+        def get_columns(self, table_name, schema=None):
+            return [{"column_name": "ORDER_ID", "data_type": "NUMBER"}]
+
+        def execute(self, sql):
+            executed.append(sql)
+            return sql
+
+        def fetchone(self, result):
+            return None
+
+        def close(self):
+            pass
+
+    from sidemantic.validation_runner import SemanticLayer as RealSemanticLayer
+
+    def semantic_layer(*args, **kwargs):
+        layer = RealSemanticLayer(auto_register=False)
+        if kwargs.get("connection") is not None:
+            layer.adapter = FakeSnowflakeAdapter()
+            layer.dialect = "snowflake"
+        return layer
+
+    monkeypatch.setattr("sidemantic.validation_runner.SemanticLayer", semantic_layer)
+
+    report = validate_directory(
+        tmp_path,
+        connection="snowflake://unused",
+        check_keys=True,
+        check_queries=False,
+    )
+
+    assert report.passed, report.all_errors
+    assert executed
+    assert all('"ORDER_ID"' in sql for sql in executed)
+    assert all('"order_id"' not in sql for sql in executed)
+
+
 def test_warehouse_validation_splits_catalog_qualified_bigquery_table(monkeypatch, tmp_path):
     (tmp_path / "models.yml").write_text(
         """

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -9,6 +9,7 @@ from sidemantic.validation import (
     ModelValidationError,
     QueryValidationError,
     validate_model_warnings,
+    validate_relationships,
 )
 from sidemantic.validation_runner import validate_directory
 
@@ -26,6 +27,22 @@ def test_model_without_primary_key_remains_explicitly_keyless(layer):
     layer.add_model(model)
     assert model.primary_key is None
     assert model.primary_key_columns == []
+
+
+def test_inactive_relationships_are_ignored_by_structural_validation():
+    from sidemantic.core.semantic_graph import SemanticGraph
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            primary_key="order_id",
+            relationships=[Relationship(name="removed_model", type="many_to_one", active=False)],
+        )
+    )
+
+    assert validate_relationships(graph) == []
 
 
 def test_model_validation_no_table(layer):
@@ -225,6 +242,39 @@ def test_query_validation_no_join_path(layer):
     assert "No join path found between models" in str(exc_info.value)
     assert "'orders'" in str(exc_info.value)
     assert "'products'" in str(exc_info.value)
+
+
+def test_query_validation_ignores_unrelated_broken_relationship(layer):
+    layer.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            primary_key="order_id",
+            relationships=[
+                Relationship(
+                    name="products",
+                    type="many_to_one",
+                    foreign_key="product_id",
+                    primary_key="product_id",
+                ),
+                Relationship(name="customers", type="many_to_one"),
+            ],
+            metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        )
+    )
+    layer.add_model(
+        Model(
+            name="products",
+            table="products",
+            primary_key="product_id",
+            dimensions=[Dimension(name="category", type="categorical")],
+        )
+    )
+    layer.add_model(Model(name="customers", table="customers", primary_key="customer_id"))
+
+    sql = layer.compile(metrics=["orders.revenue"], dimensions=["products.category"])
+
+    assert "products_cte" in sql
 
 
 def test_query_validation_invalid_granularity(layer):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -634,6 +634,38 @@ models:
     assert report.passed, report.all_errors
 
 
+def test_warehouse_key_checks_skip_custom_one_to_one_without_structured_keys(tmp_path):
+    import duckdb
+
+    (tmp_path / "models.yml").write_text(
+        """
+models:
+  - name: customers
+    table: customers
+    relationships:
+      - name: profiles
+        type: one_to_one
+        sql: "{from}.customer_id = {to}.customer_id"
+  - name: profiles
+    table: profiles
+"""
+    )
+    database = tmp_path / "warehouse.duckdb"
+    connection = duckdb.connect(str(database))
+    connection.execute("CREATE TABLE customers (customer_id INTEGER)")
+    connection.execute("CREATE TABLE profiles (customer_id INTEGER)")
+    connection.close()
+
+    report = validate_directory(
+        tmp_path,
+        connection=f"duckdb:///{database}",
+        check_keys=True,
+        check_queries=False,
+    )
+
+    assert report.passed, report.all_errors
+
+
 def test_warehouse_connection_failure_is_separate_from_structural_errors(monkeypatch, tmp_path):
     (tmp_path / "models.yml").write_text(
         """

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -504,6 +504,33 @@ def test_warehouse_validation_reports_missing_columns_and_type_mismatches(tmp_pa
     assert "column 'amount' is declared numeric" in errors
 
 
+def test_warehouse_validation_checks_columns_used_only_by_segments(tmp_path):
+    import duckdb
+
+    (tmp_path / "models.yml").write_text(
+        """
+models:
+  - name: orders
+    table: orders
+    segments:
+      - name: paid
+        sql: "{model}.status = 'paid'"
+"""
+    )
+    database = tmp_path / "warehouse.duckdb"
+    connection = duckdb.connect(str(database))
+    connection.execute("CREATE TABLE orders (order_id INTEGER)")
+    connection.close()
+
+    report = validate_directory(
+        tmp_path,
+        connection=f"duckdb:///{database}",
+        check_queries=False,
+    )
+
+    assert "Model 'orders' references missing column 'status'" in "\n".join(report.warehouse_errors)
+
+
 def test_warehouse_validation_reports_incompatible_join_key_types(tmp_path):
     import duckdb
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -581,7 +581,7 @@ models:
     assert "Model 'orders' references missing column 'status'" in "\n".join(report.warehouse_errors)
 
 
-def test_warehouse_validation_ignores_inactive_relationship_columns(tmp_path):
+def test_warehouse_validation_ignores_inactive_relationships(tmp_path):
     import duckdb
 
     (tmp_path / "models.yml").write_text(
@@ -590,22 +590,34 @@ models:
   - name: orders
     table: orders
     primary_key: order_id
+    metrics:
+      - name: revenue
+        agg: sum
+        sql: amount
     relationships:
       - name: removed_customers
         type: many_to_one
         foreign_key: old_customer_id
         active: false
+  - name: removed_customers
+    table: removed_customers
+    primary_key: customer_id
+    dimensions:
+      - name: region
+        type: categorical
 """
     )
     database = tmp_path / "warehouse.duckdb"
     connection = duckdb.connect(str(database))
-    connection.execute("CREATE TABLE orders (order_id INTEGER PRIMARY KEY)")
+    connection.execute(
+        "CREATE TABLE orders (order_id INTEGER PRIMARY KEY, amount DECIMAL(12, 2)); "
+        "CREATE TABLE removed_customers (customer_id INTEGER PRIMARY KEY, region VARCHAR)"
+    )
     connection.close()
 
     report = validate_directory(
         tmp_path,
         connection=f"duckdb:///{database}",
-        check_queries=False,
     )
 
     assert report.passed, report.all_errors

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -726,5 +726,49 @@ models:
     assert inspected == [("analytics.public.orders", None)]
 
 
+def test_warehouse_validation_splits_catalog_qualified_bigquery_table(monkeypatch, tmp_path):
+    (tmp_path / "models.yml").write_text(
+        """
+models:
+  - name: orders
+    table: analytics.sales.orders
+    primary_key: order_id
+"""
+    )
+
+    inspected = []
+
+    class FakeBigQueryAdapter:
+        def get_tables(self):
+            return []
+
+        def get_columns(self, table_name, schema=None):
+            inspected.append((table_name, schema))
+            return [{"column_name": "order_id", "data_type": "INT64"}]
+
+        def close(self):
+            pass
+
+    from sidemantic.validation_runner import SemanticLayer as RealSemanticLayer
+
+    def semantic_layer(*args, **kwargs):
+        layer = RealSemanticLayer(auto_register=False)
+        if kwargs.get("connection") is not None:
+            layer.adapter = FakeBigQueryAdapter()
+            layer.dialect = "bigquery"
+        return layer
+
+    monkeypatch.setattr("sidemantic.validation_runner.SemanticLayer", semantic_layer)
+
+    report = validate_directory(
+        tmp_path,
+        connection="bigquery://analytics",
+        check_queries=False,
+    )
+
+    assert report.passed, report.all_errors
+    assert inspected == [("orders", "sales")]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -13,9 +13,8 @@ from sidemantic.validation import (
 from sidemantic.validation_runner import validate_directory
 
 
-def test_model_has_default_primary_key(layer):
-    """Test that models have a default primary key."""
-    # Model without explicit primary_key should default to "id"
+def test_model_without_primary_key_remains_explicitly_keyless(layer):
+    """Models must not manufacture an ``id`` key when none was declared."""
     model = Model(
         name="orders",
         table="orders",
@@ -25,7 +24,8 @@ def test_model_has_default_primary_key(layer):
     )
 
     layer.add_model(model)
-    assert model.primary_key == "id"
+    assert model.primary_key is None
+    assert model.primary_key_columns == []
 
 
 def test_model_validation_no_table(layer):
@@ -425,6 +425,238 @@ models:
     joined = "\n".join(report.warnings)
     assert "type 'lambda' is parsed but not executed" in joined
     assert "partition_granularity" not in joined  # now functional via build_partitions(), no longer warned
+
+
+def _write_warehouse_validation_model(tmp_path, *, foreign_key: str = "customer_id"):
+    (tmp_path / "models.yml").write_text(
+        f"""
+models:
+  - name: orders
+    table: orders
+    primary_key: order_id
+    dimensions:
+      - name: created_at
+        type: time
+        granularity: day
+      - name: status
+        type: categorical
+    metrics:
+      - name: revenue
+        agg: sum
+        sql: amount
+    relationships:
+      - name: customers
+        type: many_to_one
+        foreign_key: {foreign_key}
+  - name: customers
+    table: customers
+    primary_key: customer_id
+    dimensions:
+      - name: region
+        type: categorical
+"""
+    )
+
+
+def test_warehouse_validation_checks_schema_types_joins_and_queries(tmp_path):
+    import duckdb
+
+    _write_warehouse_validation_model(tmp_path)
+    database = tmp_path / "warehouse.duckdb"
+    connection = duckdb.connect(str(database))
+    connection.execute(
+        "CREATE TABLE customers (customer_id INTEGER PRIMARY KEY, region VARCHAR); "
+        "CREATE TABLE orders (order_id INTEGER PRIMARY KEY, customer_id INTEGER, created_at TIMESTAMP, "
+        "status VARCHAR, amount DECIMAL(12, 2))"
+    )
+    connection.close()
+
+    report = validate_directory(tmp_path, connection=f"duckdb:///{database}")
+
+    assert report.passed, report.all_errors
+    assert report.connection_errors == []
+    assert report.warehouse_errors == []
+    assert any("Warehouse validation:" in item for item in report.info)
+
+
+def test_warehouse_validation_reports_missing_columns_and_type_mismatches(tmp_path):
+    import duckdb
+
+    _write_warehouse_validation_model(tmp_path, foreign_key="missing_customer_id")
+    database = tmp_path / "warehouse.duckdb"
+    connection = duckdb.connect(str(database))
+    connection.execute(
+        "CREATE TABLE customers (customer_id INTEGER, region VARCHAR); "
+        "CREATE TABLE orders (order_id INTEGER, created_at VARCHAR, status VARCHAR, amount VARCHAR)"
+    )
+    connection.close()
+
+    report = validate_directory(
+        tmp_path,
+        connection=f"duckdb:///{database}",
+        check_queries=False,
+    )
+
+    errors = "\n".join(report.warehouse_errors)
+    assert report.errors == []
+    assert "missing column 'missing_customer_id'" in errors
+    assert "column 'created_at' is declared time" in errors
+    assert "column 'amount' is declared numeric" in errors
+
+
+def test_warehouse_validation_reports_incompatible_join_key_types(tmp_path):
+    import duckdb
+
+    _write_warehouse_validation_model(tmp_path)
+    database = tmp_path / "warehouse.duckdb"
+    connection = duckdb.connect(str(database))
+    connection.execute(
+        "CREATE TABLE customers (customer_id VARCHAR, region VARCHAR); "
+        "CREATE TABLE orders (order_id INTEGER, customer_id INTEGER, created_at TIMESTAMP, "
+        "status VARCHAR, amount DECIMAL(12, 2))"
+    )
+    connection.close()
+
+    report = validate_directory(tmp_path, connection=f"duckdb:///{database}", check_queries=False)
+
+    errors = "\n".join(report.warehouse_errors)
+    assert "Relationship 'orders.customers' joins incompatible warehouse types" in errors
+    assert "orders.customer_id is INTEGER" in errors
+    assert "customers.customer_id is VARCHAR" in errors
+
+
+def test_warehouse_key_checks_find_null_and_duplicate_primary_keys(tmp_path):
+    import duckdb
+
+    (tmp_path / "models.yml").write_text(
+        """
+models:
+  - name: events
+    table: events
+    primary_key: event_id
+    dimensions:
+      - name: category
+        type: categorical
+"""
+    )
+    database = tmp_path / "warehouse.duckdb"
+    connection = duckdb.connect(str(database))
+    connection.execute("CREATE TABLE events (event_id INTEGER, category VARCHAR)")
+    connection.execute("INSERT INTO events VALUES (1, 'a'), (1, 'b'), (NULL, 'c')")
+    connection.close()
+
+    report = validate_directory(
+        tmp_path,
+        connection=f"duckdb:///{database}",
+        check_keys=True,
+        check_queries=False,
+    )
+
+    errors = "\n".join(report.warehouse_errors)
+    assert "contains NULL values" in errors
+    assert "is not unique" in errors
+
+
+def test_warehouse_key_checks_verify_one_to_one_cardinality(tmp_path):
+    import duckdb
+
+    (tmp_path / "models.yml").write_text(
+        """
+models:
+  - name: customers
+    table: customers
+    primary_key: customer_id
+    dimensions:
+      - name: name
+        type: categorical
+    relationships:
+      - name: profiles
+        type: one_to_one
+        foreign_key: customer_id
+  - name: profiles
+    table: profiles
+    primary_key: profile_id
+    dimensions:
+      - name: plan
+        type: categorical
+"""
+    )
+    database = tmp_path / "warehouse.duckdb"
+    connection = duckdb.connect(str(database))
+    connection.execute("CREATE TABLE customers (customer_id INTEGER, name VARCHAR)")
+    connection.execute("CREATE TABLE profiles (profile_id INTEGER, customer_id INTEGER, plan VARCHAR)")
+    connection.execute("INSERT INTO profiles VALUES (1, 7, 'free'), (2, 7, 'paid')")
+    connection.close()
+
+    report = validate_directory(
+        tmp_path,
+        connection=f"duckdb:///{database}",
+        check_keys=True,
+        check_queries=False,
+    )
+
+    errors = "\n".join(report.warehouse_errors)
+    assert "relationship 'customers.profiles' foreign_key ['customer_id'] is not unique" in errors
+
+
+def test_warehouse_key_checks_allow_multiple_null_one_to_one_foreign_keys(tmp_path):
+    import duckdb
+
+    (tmp_path / "models.yml").write_text(
+        """
+models:
+  - name: customers
+    table: customers
+    primary_key: customer_id
+    relationships:
+      - name: profiles
+        type: one_to_one
+        foreign_key: customer_id
+  - name: profiles
+    table: profiles
+    primary_key: profile_id
+"""
+    )
+    database = tmp_path / "warehouse.duckdb"
+    connection = duckdb.connect(str(database))
+    connection.execute("CREATE TABLE customers (customer_id INTEGER)")
+    connection.execute("CREATE TABLE profiles (profile_id INTEGER, customer_id INTEGER)")
+    connection.execute("INSERT INTO profiles VALUES (1, NULL), (2, NULL), (3, 7)")
+    connection.close()
+
+    report = validate_directory(
+        tmp_path,
+        connection=f"duckdb:///{database}",
+        check_keys=True,
+        check_queries=False,
+    )
+
+    assert report.passed, report.all_errors
+
+
+def test_warehouse_connection_failure_is_separate_from_structural_errors(monkeypatch, tmp_path):
+    (tmp_path / "models.yml").write_text(
+        """
+models:
+  - name: events
+    table: events
+"""
+    )
+
+    from sidemantic.validation_runner import SemanticLayer as RealSemanticLayer
+
+    def fail_to_connect(*args, **kwargs):
+        if kwargs.get("connection") is not None:
+            raise RuntimeError("warehouse unavailable")
+        return RealSemanticLayer(*args, **kwargs)
+
+    monkeypatch.setattr("sidemantic.validation_runner.SemanticLayer", fail_to_connect)
+
+    report = validate_directory(tmp_path, connection="duckdb:///unreachable.duckdb")
+
+    assert report.errors == []
+    assert report.warehouse_errors == []
+    assert report.connection_errors == ["Could not connect to warehouse: warehouse unavailable"]
 
 
 if __name__ == "__main__":

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -659,5 +659,72 @@ models:
     assert report.connection_errors == ["Could not connect to warehouse: warehouse unavailable"]
 
 
+def test_snowflake_warehouse_identifiers_match_unquoted_metadata_case():
+    from sidemantic.validation_runner import _split_table_reference, _warehouse_column_type, _warehouse_table_exists
+
+    table_ref = _split_table_reference("public.orders", "snowflake")
+
+    assert table_ref is not None
+    assert _warehouse_table_exists(table_ref, {("PUBLIC", "ORDERS")}, "snowflake")
+    assert _warehouse_column_type({"ORDER_ID": "NUMBER"}, "order_id", "snowflake") == "NUMBER"
+
+
+def test_warehouse_table_reference_preserves_catalog_for_inspection():
+    from sidemantic.validation_runner import _split_table_reference
+
+    table_ref = _split_table_reference("analytics.public.orders", "snowflake")
+
+    assert table_ref is not None
+    assert table_ref.catalog == "analytics"
+    assert table_ref.schema == "public"
+    assert table_ref.name == "orders"
+    assert table_ref.qualified_name == "analytics.public.orders"
+
+
+def test_warehouse_validation_inspects_catalog_qualified_snowflake_table(monkeypatch, tmp_path):
+    (tmp_path / "models.yml").write_text(
+        """
+models:
+  - name: orders
+    table: analytics.public.orders
+    primary_key: order_id
+"""
+    )
+
+    inspected = []
+
+    class FakeSnowflakeAdapter:
+        def get_tables(self):
+            # Catalog-less metadata describes only the connection's current database.
+            return [{"schema": "PUBLIC", "table_name": "CURRENT_DATABASE_TABLE"}]
+
+        def get_columns(self, table_name, schema=None):
+            inspected.append((table_name, schema))
+            return [{"column_name": "ORDER_ID", "data_type": "NUMBER"}]
+
+        def close(self):
+            pass
+
+    from sidemantic.validation_runner import SemanticLayer as RealSemanticLayer
+
+    def semantic_layer(*args, **kwargs):
+        layer = RealSemanticLayer(auto_register=False)
+        if kwargs.get("connection") is not None:
+            layer.adapter = FakeSnowflakeAdapter()
+            layer.dialect = "snowflake"
+        return layer
+
+    monkeypatch.setattr("sidemantic.validation_runner.SemanticLayer", semantic_layer)
+
+    report = validate_directory(
+        tmp_path,
+        connection="snowflake://unused",
+        check_queries=False,
+    )
+
+    assert report.passed, report.all_errors
+    assert inspected == [("analytics.public.orders", None)]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -581,6 +581,36 @@ models:
     assert "Model 'orders' references missing column 'status'" in "\n".join(report.warehouse_errors)
 
 
+def test_warehouse_validation_ignores_inactive_relationship_columns(tmp_path):
+    import duckdb
+
+    (tmp_path / "models.yml").write_text(
+        """
+models:
+  - name: orders
+    table: orders
+    primary_key: order_id
+    relationships:
+      - name: removed_customers
+        type: many_to_one
+        foreign_key: old_customer_id
+        active: false
+"""
+    )
+    database = tmp_path / "warehouse.duckdb"
+    connection = duckdb.connect(str(database))
+    connection.execute("CREATE TABLE orders (order_id INTEGER PRIMARY KEY)")
+    connection.close()
+
+    report = validate_directory(
+        tmp_path,
+        connection=f"duckdb:///{database}",
+        check_queries=False,
+    )
+
+    assert report.passed, report.all_errors
+
+
 def test_warehouse_validation_reports_incompatible_join_key_types(tmp_path):
     import duckdb
 


### PR DESCRIPTION
Stops inventing model and relationship keys when source metadata does not declare them, and makes invalid joins fail with actionable structural diagnostics. Adds optional warehouse-backed CLI validation for schema, types, key/cardinality assumptions, join keys, and representative queries, with separate structural, warehouse, and connection error categories. Includes adapter compatibility updates and a documented staged migration path for existing keyless models.