### PR TITLE
Harden query serving execution and observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,11 @@ curl -s http://localhost:4400/sql \
   -d '{"query":"SELECT status, total_amount FROM orders ORDER BY status"}'
 ```
 
+File-backed DuckDB serving is read-only by default. The API also applies
+conservative row, response-size, execution-time, concurrency, and queue limits.
+See [query serving operations](docs/query-serving.md) for configuration,
+cancellation behavior, response IDs, and process-local telemetry hooks.
+
 ## Agent Plugin
 
 Sidemantic ships a [plugin bundle](plugins/sidemantic/) with Claude Code and Codex metadata for two skills:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,6 +191,15 @@ supported for deployment systems that inject configuration securely. Prefer
 credential files when the project configuration is shared or checked into
 source control.
 
+File-backed DuckDB query and serving commands default to read-only. Use
+`--read-write` only when a query/serving process intentionally needs writes;
+`preagg refresh` is the explicit writable materialization workflow. HTTP query
+limits can be set with `--max-rows`, `--max-response-bytes`,
+`--execution-timeout-seconds`, `--max-concurrent-queries`,
+`--max-queued-queries`, and `--queue-timeout-seconds`, or under `api_server` in
+project configuration. See [query serving operations](query-serving.md) for the
+full defaults, PostgreSQL wire settings, cancellation semantics, and telemetry.
+
 The old `--password` and `--auth-token` command-line options remain accepted for
 compatibility but are hidden and deprecated because command arguments may be
 visible to other processes. Their values are registered for output redaction,

--- a/docs/query-serving.md
+++ b/docs/query-serving.md
@@ -1,0 +1,127 @@
+# Query serving operations
+
+Sidemantic's HTTP and PostgreSQL-compatible servers apply conservative,
+process-local limits. They are safeguards for a library server, not a
+multi-tenant persistence, scheduling, alerting, or dashboard system.
+
+## Safe defaults
+
+The HTTP API defaults are:
+
+| Setting | Default | HTTP CLI flag |
+| --- | ---: | --- |
+| Maximum result rows | 10,000 | `--max-rows` |
+| Maximum JSON or Arrow response | 16 MiB | `--max-response-bytes` |
+| Execution deadline | 30 seconds | `--execution-timeout-seconds` |
+| Concurrent queries | 4 | `--max-concurrent-queries` |
+| Queued queries | 16 | `--max-queued-queries` |
+| Maximum queue wait | 5 seconds | `--queue-timeout-seconds` |
+| Retained local query events | 1,000 | `--query-history-size` |
+
+The PostgreSQL wire server uses the same defaults. Configure them in
+`pg_server`; HTTP settings live in `api_server`:
+
+```yaml
+connection:
+  type: duckdb
+  path: data/warehouse.duckdb
+
+api_server:
+  max_rows: 10000
+  max_response_bytes: 16777216
+  execution_timeout_seconds: 30
+  max_concurrent_queries: 4
+  max_queued_queries: 16
+  queue_timeout_seconds: 5
+  query_history_size: 1000
+
+pg_server:
+  max_rows: 10000
+  max_response_bytes: 16777216
+  execution_timeout_seconds: 30
+  max_concurrent_queries: 4
+  max_queued_queries: 16
+  queue_timeout_seconds: 5
+```
+
+HTTP query responses include `X-Sidemantic-Query-ID`,
+`X-Sidemantic-Request-ID`, `X-Sidemantic-Row-Count`, and
+`X-Sidemantic-Response-Bytes`. An incoming `X-Request-ID` becomes the local
+request ID; otherwise Sidemantic generates one.
+
+The server applies an outer `LIMIT` and stops consuming Arrow batches once a
+limit is crossed. JSON and Arrow serialization are both checked against the
+exact response-byte ceiling before a response is sent. The result cache only
+sees already bounded tables.
+
+HTTP policy failures are stable:
+
+- `413`: serialized response is too large
+- `422`: result exceeds the row ceiling
+- `429`: the bounded queue is full
+- `503`: queue wait exceeded its deadline
+- `504`: query execution exceeded its deadline
+
+## Timeouts, cancellation, and disconnects
+
+The execution deadline is local. Sidemantic also requests a warehouse-side
+statement timeout for PostgreSQL, Snowflake, and ClickHouse. Other adapters
+record a clear diagnostic that no portable statement-timeout setting exists.
+
+On an HTTP disconnect, deadline, PostgreSQL client disconnect, or result-limit
+overflow, Sidemantic requests cancellation on the exact execution handle. The
+base adapter recognizes common driver methods such as `cancel_safe()`,
+`cancel()`, `interrupt()`, and `adbc_cancel()`. Cancellation is best effort:
+some drivers or deployments do not expose it, and their warehouse work may
+continue. The query event records whether cancellation was supported and the
+diagnostic returned by the adapter.
+
+An uncancellable timed-out worker retains its concurrency slot until it really
+finishes. This prevents timed-out warehouse work from silently exceeding the
+configured concurrency ceiling.
+
+## DuckDB read-only serving
+
+File-backed DuckDB connections used by `sidemantic query`, `sidemantic server
+api`, `sidemantic server postgres`, and `sidemantic dashboard serve` default to
+read-only. Each query uses an independently opened connection, allowing
+concurrent readers and avoiding a needless writer-mode lock across processes.
+In-memory DuckDB stays writable and serialized because it cannot be reopened
+read-only onto the same data.
+
+Set the mode explicitly in project configuration when needed:
+
+```yaml
+connection:
+  type: duckdb
+  path: data/warehouse.duckdb
+  read_only: false
+```
+
+Or opt into writer mode for a serving/query command with `--read-write`.
+`sidemantic preagg refresh` remains an explicit write workflow and always opens
+DuckDB writable. DuckDB does not allow an in-place writer alongside existing
+read-only processes using a different access mode; stop readers during refresh
+or publish refreshed data through an operational file-swap workflow.
+
+Use read-only warehouse credentials for remote databases. DuckDB read-only mode
+does not add permissions to PostgreSQL, BigQuery, Snowflake, or other systems.
+
+## Process-local query telemetry
+
+Every `SemanticLayer` owns a lightweight `query_telemetry` hook. HTTP, PostgreSQL
+wire, and direct `SemanticLayer.query()` / `.sql()` executions record a local
+query ID, duration, row/byte counts when available, cache and pre-aggregation
+use, timeout/cancellation/error state, and sanitized SQL metadata.
+
+```python
+layer.query_telemetry.add_listener(lambda event: logger.info("query", extra=event.to_dict()))
+
+for event in layer.query_telemetry.history(limit=20):
+    print(event.query_id, event.duration_ms, event.row_count, event.error)
+```
+
+SQL literals and comments are removed before retention. If SQL cannot be parsed,
+only its SHA-256 fingerprint is retained. Listener failures are logged and never
+change query success. History is bounded and process-local; export events through
+the listener if an operator needs external observability.

--- a/examples/pre_aggregations/README.md
+++ b/examples/pre_aggregations/README.md
@@ -115,6 +115,11 @@ uvx sidemantic preagg refresh
 uvx sidemantic preagg refresh --db data/warehouse.db
 ```
 
+Refresh is an explicit write workflow. Normal file-backed DuckDB query and
+serving commands open read-only by default; stop those readers before an
+in-place refresh, or publish a refreshed file using an operational swap. See
+the [query serving operations guide](../../docs/query-serving.md#duckdb-read-only-serving).
+
 This creates tables like:
 - `preagg.orders_preagg_daily_status` - Daily metrics by status
 - `preagg.orders_preagg_daily_region` - Daily metrics by region

--- a/sidemantic/__init__.py
+++ b/sidemantic/__init__.py
@@ -12,6 +12,7 @@ from sidemantic.core.parameter import Parameter
 from sidemantic.core.pre_aggregation import PreAggregation, RefreshKey, RefreshResult
 from sidemantic.core.preagg_recommender import PreAggRecommendation, PreAggregationRecommender, QueryPattern
 from sidemantic.core.query_plan import PreaggCandidate, PreaggCheck, QueryPlan
+from sidemantic.core.query_telemetry import QueryEvent, QueryTelemetry
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.security import SecurityPolicy
 from sidemantic.core.segment import Segment
@@ -35,6 +36,8 @@ __all__ = [
     "PreaggCheck",
     "QueryPattern",
     "QueryPlan",
+    "QueryEvent",
+    "QueryTelemetry",
     "RefreshKey",
     "RefreshResult",
     "Relationship",

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -35,6 +35,7 @@ from sidemantic.server.query_execution import (
     QueryResponseTooLargeError,
     QueryRowLimitExceededError,
     execute_bounded,
+    limit_query_sql,
 )
 from sidemantic.sql.query_rewriter import QueryRewriter
 
@@ -498,7 +499,7 @@ def create_app(
         )
         # Preserve the layer's default/max-limit policy for omitted limits, then
         # apply the server ceiling outside the compiled semantic query.
-        sql = _limit_query_sql(sql, limits.max_rows)
+        sql = limit_query_sql(sql, limits.max_rows, current_layer.dialect)
         return await _execute_http_query(
             app,
             request,
@@ -529,7 +530,7 @@ def create_app(
         deny_free_sql_if_secured()
         query = _normalize_sql_query(payload.query)
         rewritten_sql = QueryRewriter(current_layer.graph, dialect=current_layer.dialect).rewrite(query)
-        limited_sql = _limit_query_sql(rewritten_sql, app.state.query_limits.max_rows)
+        limited_sql = limit_query_sql(rewritten_sql, app.state.query_limits.max_rows, current_layer.dialect)
         return await _execute_http_query(
             app,
             request,
@@ -555,7 +556,7 @@ def create_app(
         deny_free_sql_if_secured()
         query = _normalize_sql_query(payload.query)
         _require_select_statement(query)
-        limited_sql = _limit_query_sql(query, app.state.query_limits.max_rows)
+        limited_sql = limit_query_sql(query, app.state.query_limits.max_rows, current_layer.dialect)
         return await _execute_http_query(
             app,
             request,
@@ -847,13 +848,6 @@ def _consume_background_task(task: asyncio.Task) -> None:
         task.exception()
     except (asyncio.CancelledError, Exception):
         pass
-
-
-def _limit_query_sql(sql: str, max_rows: int) -> str:
-    """Apply an outer ``LIMIT max_rows + 1`` so overflow is detectable."""
-    # The rewriter's instrumentation is a trailing ``--`` comment, so the
-    # closing parenthesis must begin on a fresh line rather than be commented.
-    return f"SELECT * FROM ({sql}\n) AS _sidemantic_bounded LIMIT {max_rows + 1}"
 
 
 def _normalize_sql_query(query: str) -> str:

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -739,6 +739,20 @@ async def _execute_http_query(
             headers={"X-Sidemantic-Query-ID": query_id, "X-Sidemantic-Request-ID": request_id},
         )
 
+    try:
+        disconnected = await request.is_disconnected()
+    except BaseException:  # noqa: BLE001 - release the slot on task cancellation too
+        admission.release()
+        raise
+    if disconnected:
+        admission.release()
+        record(error="ClientDisconnected", metadata={"queue_duration_ms": queue_ms})
+        raise HTTPException(
+            status_code=499,
+            detail="Client disconnected while waiting for an execution slot; no warehouse query was started",
+            headers={"X-Sidemantic-Query-ID": query_id, "X-Sidemantic-Request-ID": request_id},
+        )
+
     control = QueryExecutionControl()
 
     def worker() -> tuple[Any, bool]:

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
+import time
+import uuid
 from pathlib import Path
 from typing import Any, Literal
 
@@ -21,11 +24,17 @@ from sidemantic import SemanticLayer, __version__
 from sidemantic.loaders import load_from_directory
 from sidemantic.server.common import (
     ARROW_STREAM_MEDIA_TYPE,
-    record_batch_reader_to_table,
-    result_to_record_batch_reader,
     table_to_arrow_bytes,
     table_to_json_rows,
     validate_filter_expression,
+)
+from sidemantic.server.query_execution import (
+    QueryAdmission,
+    QueryExecutionControl,
+    QueryLimits,
+    QueryResponseTooLargeError,
+    QueryRowLimitExceededError,
+    execute_bounded,
 )
 from sidemantic.sql.query_rewriter import QueryRewriter
 
@@ -116,6 +125,13 @@ def start_api_server(
     serve_ui: bool = True,
     result_cache_mb: int = 0,
     result_cache_ttl: float = 60.0,
+    max_rows: int = 10_000,
+    max_response_bytes: int = 16 * 1024 * 1024,
+    execution_timeout_seconds: float = 30.0,
+    max_concurrent_queries: int = 4,
+    max_queued_queries: int = 16,
+    queue_timeout_seconds: float = 5.0,
+    query_history_size: int = 1000,
     require_user_attrs: bool = False,
     enforce_visibility: bool = False,
     user_header: str = "X-Sidemantic-User",
@@ -135,6 +151,13 @@ def start_api_server(
         serve_ui=serve_ui,
         result_cache_mb=result_cache_mb,
         result_cache_ttl=result_cache_ttl,
+        max_rows=max_rows,
+        max_response_bytes=max_response_bytes,
+        execution_timeout_seconds=execution_timeout_seconds,
+        max_concurrent_queries=max_concurrent_queries,
+        max_queued_queries=max_queued_queries,
+        queue_timeout_seconds=queue_timeout_seconds,
+        query_history_size=query_history_size,
         require_user_attrs=require_user_attrs,
         enforce_visibility=enforce_visibility,
         user_header=user_header,
@@ -156,6 +179,13 @@ def create_app(
     serve_ui: bool = False,
     result_cache_mb: int = 0,
     result_cache_ttl: float = 60.0,
+    max_rows: int = 10_000,
+    max_response_bytes: int = 16 * 1024 * 1024,
+    execution_timeout_seconds: float = 30.0,
+    max_concurrent_queries: int = 4,
+    max_queued_queries: int = 16,
+    queue_timeout_seconds: float = 5.0,
+    query_history_size: int = 1000,
     require_user_attrs: bool = False,
     enforce_visibility: bool = False,
     user_header: str = "X-Sidemantic-User",
@@ -194,6 +224,16 @@ def create_app(
     app.state.lock = threading.RLock()
     app.state.auth_token = auth_token
     app.state.dashboard = dashboard.to_dict() if hasattr(dashboard, "to_dict") else dashboard
+    app.state.query_limits = QueryLimits(
+        max_rows=max_rows,
+        max_response_bytes=max_response_bytes,
+        execution_timeout_seconds=execution_timeout_seconds,
+        max_concurrent_queries=max_concurrent_queries,
+        max_queued_queries=max_queued_queries,
+        queue_timeout_seconds=queue_timeout_seconds,
+    )
+    app.state.query_admission = QueryAdmission(max_concurrent_queries, max_queued_queries)
+    layer.query_telemetry.resize(query_history_size)
 
     if result_cache_mb and result_cache_mb > 0:
         from sidemantic.core.result_cache import ResultCache
@@ -426,7 +466,7 @@ def create_app(
         return {"sql": sql}
 
     @app.post("/query", dependencies=[Depends(require_auth)])
-    def run_query(
+    async def run_query(
         payload: StructuredQueryRequest,
         request: Request,
         format: Literal["json", "arrow"] | None = Query(default=None),
@@ -435,6 +475,9 @@ def create_app(
         # cursor so concurrent reads do not serialize on one connection. Execution
         # flows through _query_table so the opt-in result cache can serve repeats.
         current_layer = app.state.layer
+        limits = app.state.query_limits
+        if payload.limit is not None and payload.limit > limits.max_rows:
+            raise ValueError(f"limit must be <= the server maximum of {limits.max_rows}")
         user_attributes = resolve_user_attributes(request)
         filters = payload.resolved_filters()
         for filter_str in filters:
@@ -445,7 +488,7 @@ def create_app(
             filters=filters,
             segments=payload.segments or None,
             order_by=payload.order_by or None,
-            limit=payload.limit,
+            limit=payload.limit if payload.limit is not None else limits.max_rows + 1,
             offset=payload.offset,
             ungrouped=payload.ungrouped,
             parameters=payload.parameters,
@@ -453,8 +496,14 @@ def create_app(
             user_attributes=user_attributes,
             timezone=payload.timezone,
         )
-        table = _query_table(app, current_layer, sql, user_attributes=user_attributes)
-        return _build_query_response(request, current_layer, table, sql=sql, format_override=format)
+        return await _execute_http_query(
+            app,
+            request,
+            current_layer,
+            sql,
+            format_override=format,
+            user_attributes=user_attributes,
+        )
 
     @app.post("/sql/compile", dependencies=[Depends(require_auth)])
     def compile_sql(payload: SQLRequest) -> dict[str, str]:
@@ -465,7 +514,7 @@ def create_app(
         return {"sql": rewritten_sql}
 
     @app.post("/sql", dependencies=[Depends(require_auth)])
-    def run_sql(
+    async def run_sql(
         payload: SQLRequest,
         request: Request,
         format: Literal["json", "arrow"] | None = Query(default=None),
@@ -477,18 +526,20 @@ def create_app(
         deny_free_sql_if_secured()
         query = _normalize_sql_query(payload.query)
         rewritten_sql = QueryRewriter(current_layer.graph, dialect=current_layer.dialect).rewrite(query)
-        table = _query_table(app, current_layer, rewritten_sql, user_attributes=user_attributes)
-        return _build_query_response(
+        limited_sql = _limit_query_sql(rewritten_sql, app.state.query_limits.max_rows)
+        return await _execute_http_query(
+            app,
             request,
             current_layer,
-            table,
-            sql=rewritten_sql,
+            limited_sql,
             original_sql=query,
             format_override=format,
+            response_sql=rewritten_sql,
+            user_attributes=user_attributes,
         )
 
     @app.post("/raw", dependencies=[Depends(require_auth)])
-    def run_raw_sql(
+    async def run_raw_sql(
         payload: SQLRequest,
         request: Request,
         format: Literal["json", "arrow"] | None = Query(default=None),
@@ -501,13 +552,15 @@ def create_app(
         deny_free_sql_if_secured()
         query = _normalize_sql_query(payload.query)
         _require_select_statement(query)
-        table = _query_table(app, current_layer, query, user_attributes=user_attributes)
-        return _build_query_response(
+        limited_sql = _limit_query_sql(query, app.state.query_limits.max_rows)
+        return await _execute_http_query(
+            app,
             request,
             current_layer,
-            table,
-            sql=query,
+            limited_sql,
             format_override=format,
+            response_sql=query,
+            user_attributes=user_attributes,
         )
 
     if serve_ui:
@@ -538,36 +591,33 @@ def create_app(
     return app
 
 
-def _execute_to_table(layer: SemanticLayer, sql: str) -> Any:
-    """Execute SQL on the layer's adapter and materialize a PyArrow table.
-
-    Caching operates on fully-materialized tables (rather than single-use
-    RecordBatchReaders) so a cached result can be served to many requests.
-
-    Executes on a fresh per-request cursor rather than the shared connection so
-    concurrent reads run in parallel; the result cache's singleflight then dedups
-    identical concurrent queries into a single underlying execute.
-    """
-    result = layer.adapter.cursor().execute(sql)
-    reader = result_to_record_batch_reader(result, layer.adapter)
-    return record_batch_reader_to_table(reader)
+def _execute_to_table(
+    layer: SemanticLayer,
+    sql: str,
+    limits: QueryLimits,
+    control: QueryExecutionControl,
+) -> Any:
+    """Execute SQL and consume at most the configured bounded Arrow result."""
+    return execute_bounded(layer, sql, limits=limits, control=control).table
 
 
-def _query_table(app: FastAPI, layer: SemanticLayer, sql: str, user_attributes: dict | None = None) -> Any:
-    """Return the Arrow table for ``sql``, served from the result cache if enabled.
-
-    The cache is opt-in (``result_cache_mb`` > 0). The key covers the compiled
-    SQL, dialect + connection fingerprint, layer generation, and the caller's
-    security-scoped ``user_attributes`` so cached results never leak across
-    users. Singleflight in ResultCache ensures a duplicate in-flight query runs
-    the underlying execute exactly once.
-    """
+def _query_table(
+    app: FastAPI,
+    layer: SemanticLayer,
+    sql: str,
+    control: QueryExecutionControl,
+    user_attributes: dict | None = None,
+) -> tuple[Any, bool]:
+    """Return a bounded Arrow table and whether it was already cached."""
     cache = getattr(app.state, "result_cache", None)
     if cache is None:
-        return _execute_to_table(layer, sql)
+        return _execute_to_table(layer, sql, app.state.query_limits, control), False
 
     key = layer.build_result_key(sql, user_attributes=user_attributes)
-    return cache.get_or_compute(key, lambda: _execute_to_table(layer, sql))
+    return cache.get_or_compute_with_status(
+        key,
+        lambda: _execute_to_table(layer, sql, app.state.query_limits, control),
+    )
 
 
 def _build_query_response(
@@ -576,20 +626,28 @@ def _build_query_response(
     table: Any,
     sql: str,
     format_override: Literal["json", "arrow"] | None,
+    max_response_bytes: int,
+    query_id: str,
+    request_id: str,
     original_sql: str | None = None,
-):
+) -> tuple[Response, int]:
+    """Serialize a bounded table and enforce the exact transport byte ceiling."""
     response_format = _resolve_response_format(request, format_override)
+    headers = {
+        "X-Sidemantic-Query-ID": query_id,
+        "X-Sidemantic-Request-ID": request_id,
+        "X-Sidemantic-Row-Count": str(table.num_rows),
+        "X-Sidemantic-Dialect": layer.dialect,
+    }
 
     if response_format == ARROW_FORMAT:
         body = table_to_arrow_bytes(table)
-        return Response(
-            content=body,
-            media_type=ARROW_STREAM_MEDIA_TYPE,
-            headers={
-                "X-Sidemantic-Row-Count": str(table.num_rows),
-                "X-Sidemantic-Dialect": layer.dialect,
-            },
-        )
+        if len(body) > max_response_bytes:
+            raise QueryResponseTooLargeError(
+                f"Arrow response exceeds the configured maximum of {max_response_bytes} bytes"
+            )
+        headers["X-Sidemantic-Response-Bytes"] = str(len(body))
+        return Response(content=body, media_type=ARROW_STREAM_MEDIA_TYPE, headers=headers), len(body)
 
     payload: dict[str, Any] = {
         "sql": sql,
@@ -598,7 +656,195 @@ def _build_query_response(
     }
     if original_sql is not None:
         payload["original_sql"] = original_sql
-    return JSONResponse(payload)
+    body = json.dumps(payload, ensure_ascii=False, allow_nan=False, separators=(",", ":")).encode("utf-8")
+    if len(body) > max_response_bytes:
+        raise QueryResponseTooLargeError(f"JSON response exceeds the configured maximum of {max_response_bytes} bytes")
+    headers["X-Sidemantic-Response-Bytes"] = str(len(body))
+    return Response(content=body, media_type="application/json", headers=headers), len(body)
+
+
+async def _execute_http_query(
+    app: FastAPI,
+    request: Request,
+    layer: SemanticLayer,
+    sql: str,
+    *,
+    format_override: Literal["json", "arrow"] | None,
+    user_attributes: dict | None,
+    response_sql: str | None = None,
+    original_sql: str | None = None,
+) -> Response:
+    """Run one HTTP query under admission, deadline, cancellation, and telemetry."""
+    from sidemantic.core.query_telemetry import QueryEvent, sanitize_sql
+
+    limits: QueryLimits = app.state.query_limits
+    query_id = uuid.uuid4().hex
+    request_id = (request.headers.get("X-Request-ID") or uuid.uuid4().hex)[:128]
+    started = time.monotonic()
+    sanitized_sql, fingerprint = sanitize_sql(sql, layer.dialect)
+    used_preaggregation = "used_preagg=true" in sql
+
+    def record(
+        *,
+        row_count: int | None = None,
+        response_bytes: int | None = None,
+        cache_hit: bool = False,
+        cancelled: bool = False,
+        timed_out: bool = False,
+        error: str | None = None,
+        cancellation_diagnostic: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        layer.query_telemetry.record(
+            QueryEvent(
+                query_id=query_id,
+                request_id=request_id,
+                duration_ms=(time.monotonic() - started) * 1000,
+                dialect=layer.dialect,
+                row_count=row_count,
+                response_bytes=response_bytes,
+                cache_hit=cache_hit,
+                used_preaggregation=used_preaggregation,
+                cancelled=cancelled,
+                timed_out=timed_out,
+                error=error,
+                sql=sanitized_sql,
+                sql_fingerprint=fingerprint,
+                plan_metadata={"source": "http", **(metadata or {})},
+                cancellation_diagnostic=cancellation_diagnostic,
+            )
+        )
+
+    admission = app.state.query_admission
+    queue_started = time.monotonic()
+    admission_status = await asyncio.to_thread(admission.acquire, limits.queue_timeout_seconds)
+    queue_ms = (time.monotonic() - queue_started) * 1000
+    if admission_status == "full":
+        record(error="QueryQueueFull", metadata={"queue_duration_ms": queue_ms})
+        raise HTTPException(
+            status_code=429,
+            detail=f"Query queue is full (maximum {limits.max_queued_queries} waiting)",
+            headers={"X-Sidemantic-Query-ID": query_id, "X-Sidemantic-Request-ID": request_id},
+        )
+    if admission_status == "timeout":
+        record(error="QueryQueueTimeout", metadata={"queue_duration_ms": queue_ms})
+        raise HTTPException(
+            status_code=503,
+            detail=f"Query waited more than {limits.queue_timeout_seconds:g}s for an execution slot",
+            headers={"X-Sidemantic-Query-ID": query_id, "X-Sidemantic-Request-ID": request_id},
+        )
+
+    control = QueryExecutionControl()
+
+    def worker() -> tuple[Any, bool]:
+        try:
+            return _query_table(app, layer, sql, control, user_attributes=user_attributes)
+        finally:
+            # A timed-out uncancellable driver keeps its slot until the worker
+            # actually stops, preventing hidden concurrency-limit overruns.
+            admission.release()
+
+    task = asyncio.create_task(asyncio.to_thread(worker))
+    deadline = time.monotonic() + limits.execution_timeout_seconds
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                outcome = await asyncio.to_thread(control.cancel)
+                task.add_done_callback(_consume_background_task)
+                record(
+                    cancelled=outcome.cancelled,
+                    timed_out=True,
+                    error="QueryExecutionTimeout",
+                    cancellation_diagnostic=outcome.diagnostic,
+                    metadata={"queue_duration_ms": queue_ms, "timeout": control.timeout_diagnostic},
+                )
+                raise HTTPException(
+                    status_code=504,
+                    detail=(
+                        f"Query exceeded the {limits.execution_timeout_seconds:g}s execution deadline. "
+                        f"{outcome.diagnostic}"
+                    ),
+                    headers={"X-Sidemantic-Query-ID": query_id, "X-Sidemantic-Request-ID": request_id},
+                )
+            try:
+                table, cache_hit = await asyncio.wait_for(asyncio.shield(task), timeout=min(0.1, remaining))
+                break
+            except TimeoutError:
+                if await request.is_disconnected():
+                    outcome = await asyncio.to_thread(control.cancel)
+                    task.add_done_callback(_consume_background_task)
+                    record(
+                        cancelled=outcome.cancelled,
+                        error="ClientDisconnected",
+                        cancellation_diagnostic=outcome.diagnostic,
+                        metadata={"queue_duration_ms": queue_ms, "timeout": control.timeout_diagnostic},
+                    )
+                    raise HTTPException(
+                        status_code=499,
+                        detail=f"Client disconnected. {outcome.diagnostic}",
+                        headers={"X-Sidemantic-Query-ID": query_id, "X-Sidemantic-Request-ID": request_id},
+                    )
+
+        response, response_bytes = _build_query_response(
+            request,
+            layer,
+            table,
+            sql=response_sql or sql,
+            format_override=format_override,
+            max_response_bytes=limits.max_response_bytes,
+            query_id=query_id,
+            request_id=request_id,
+            original_sql=original_sql,
+        )
+        record(
+            row_count=table.num_rows,
+            response_bytes=response_bytes,
+            cache_hit=cache_hit,
+            metadata={
+                "queue_duration_ms": queue_ms,
+                "timeout": control.timeout_diagnostic,
+                "response_format": _resolve_response_format(request, format_override),
+            },
+        )
+        return response
+    except (QueryRowLimitExceededError, QueryResponseTooLargeError) as exc:
+        outcome = control.cancellation_outcome
+        record(
+            cancelled=bool(outcome and outcome.cancelled),
+            error=type(exc).__name__,
+            cancellation_diagnostic=outcome.diagnostic if outcome else None,
+            metadata={"queue_duration_ms": queue_ms, "timeout": control.timeout_diagnostic},
+        )
+        status_code = 413 if isinstance(exc, QueryResponseTooLargeError) else 422
+        raise HTTPException(
+            status_code=status_code,
+            detail=str(exc),
+            headers={"X-Sidemantic-Query-ID": query_id, "X-Sidemantic-Request-ID": request_id},
+        ) from exc
+    except HTTPException:
+        raise
+    except Exception as exc:
+        record(
+            error=type(exc).__name__,
+            metadata={"queue_duration_ms": queue_ms, "timeout": control.timeout_diagnostic},
+        )
+        raise
+
+
+def _consume_background_task(task: asyncio.Task) -> None:
+    """Retrieve a detached timed-out worker's eventual exception."""
+    try:
+        task.exception()
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+def _limit_query_sql(sql: str, max_rows: int) -> str:
+    """Apply an outer ``LIMIT max_rows + 1`` so overflow is detectable."""
+    # The rewriter's instrumentation is a trailing ``--`` comment, so the
+    # closing parenthesis must begin on a fresh line rather than be commented.
+    return f"SELECT * FROM ({sql}\n) AS _sidemantic_bounded LIMIT {max_rows + 1}"
 
 
 def _normalize_sql_query(query: str) -> str:

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -771,6 +771,12 @@ async def _execute_http_query(
                 table, cache_hit = await asyncio.wait_for(asyncio.shield(task), timeout=min(0.1, remaining))
                 break
             except TimeoutError:
+                # ``wait_for`` and the worker can both raise the built-in
+                # TimeoutError. A completed worker must propagate its own
+                # exception instead of being mistaken for a polling tick.
+                if task.done():
+                    table, cache_hit = task.result()
+                    break
                 if await request.is_disconnected():
                     outcome = await asyncio.to_thread(control.cancel)
                     task.add_done_callback(_consume_background_task)

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -488,7 +488,7 @@ def create_app(
             filters=filters,
             segments=payload.segments or None,
             order_by=payload.order_by or None,
-            limit=payload.limit if payload.limit is not None else limits.max_rows + 1,
+            limit=payload.limit,
             offset=payload.offset,
             ungrouped=payload.ungrouped,
             parameters=payload.parameters,
@@ -496,6 +496,9 @@ def create_app(
             user_attributes=user_attributes,
             timezone=payload.timezone,
         )
+        # Preserve the layer's default/max-limit policy for omitted limits, then
+        # apply the server ceiling outside the compiled semantic query.
+        sql = _limit_query_sql(sql, limits.max_rows)
         return await _execute_http_query(
             app,
             request,

--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -621,6 +621,7 @@ def _query_table(
     return cache.get_or_compute_with_status(
         key,
         lambda: _execute_to_table(layer, sql, app.state.query_limits, control),
+        cancelled=lambda: control.cancel_requested,
     )
 
 

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -285,13 +285,22 @@ def _load_graph_layer(
     *,
     engine: str | None = None,
     fallback: bool | None = None,
+    dialect: str | None = None,
+    use_preaggregations: bool = False,
 ) -> SemanticLayer:
     """Load project models without opening the configured database."""
 
     models = _models_path(models)
     engine, resolved_fallback = _resolve_engine_options(engine, fallback)
     _configure_engine_environment(engine, resolved_fallback)
-    layer = SemanticLayer(engine=engine, fallback=resolved_fallback)
+    layer = SemanticLayer(
+        dialect=dialect,
+        engine=engine,
+        fallback=resolved_fallback,
+        preagg_database=_loaded_config.preagg_database if _loaded_config else None,
+        preagg_schema=_loaded_config.preagg_schema if _loaded_config else None,
+        use_preaggregations=use_preaggregations,
+    )
     if models.is_file():
         from sidemantic.loaders import load_from_file
 
@@ -301,6 +310,67 @@ def _load_graph_layer(
     if not layer.graph.models:
         raise ValueError("No models found")
     return layer
+
+
+def _compile_only_dialect(models: Path | None, connection: str | None, db: Path | None) -> str:
+    """Resolve a CLI compilation dialect without opening its database."""
+    if connection is not None and db is not None:
+        raise typer.BadParameter("--connection and --db are mutually exclusive")
+    if db is not None:
+        return "duckdb"
+
+    resolved = _resolve_connection(connection=connection, models=models)
+    connection_str = resolved.connection if resolved else "duckdb:///:memory:"
+    if connection_str.startswith(("duckdb://", "motherduck://")):
+        return "duckdb"
+    if connection_str.startswith(("postgres://", "postgresql://")):
+        return "postgres"
+    for scheme, dialect in (
+        ("bigquery://", "bigquery"),
+        ("snowflake://", "snowflake"),
+        ("clickhouse://", "clickhouse"),
+        ("databricks://", "databricks"),
+        ("spark://", "spark"),
+    ):
+        if connection_str.startswith(scheme):
+            return dialect
+    if connection_str.startswith("adbc://"):
+        from urllib.parse import urlsplit
+
+        driver = urlsplit(connection_str).netloc.removeprefix("adbc_driver_")
+        return {
+            "bigquery": "bigquery",
+            "duckdb": "duckdb",
+            "mysql": "mysql",
+            "postgresql": "postgres",
+            "redshift": "redshift",
+            "snowflake": "snowflake",
+            "sqlite": "sqlite",
+            "sqlserver": "tsql",
+            "trino": "trino",
+        }.get(driver, driver)
+    raise ValueError(f"Unsupported connection URL for compilation: {connection_str}")
+
+
+def _load_compile_layer(
+    models: Path | None,
+    *,
+    connection: str | None,
+    db: Path | None,
+    engine: str | None,
+    fallback: bool | None,
+    use_preaggregations: bool,
+) -> SemanticLayer:
+    """Load models and dialect for compilation without opening a warehouse."""
+    models = _models_path(models)
+    dialect = _compile_only_dialect(models, connection, db)
+    return _load_graph_layer(
+        models,
+        engine=engine,
+        fallback=fallback,
+        dialect=dialect,
+        use_preaggregations=use_preaggregations,
+    )
 
 
 @app.callback()
@@ -1040,7 +1110,7 @@ def rewrite(
     """
     try:
         sql = read_sql_input(sql)
-        layer = _load_query_layer(
+        layer = _load_compile_layer(
             models,
             connection=connection,
             db=db,
@@ -1054,7 +1124,7 @@ def rewrite(
         typer.echo(
             QueryRewriter(
                 layer.graph,
-                dialect=layer.adapter.dialect,
+                dialect=layer.dialect,
                 use_preaggregations=layer.use_preaggregations,
             ).rewrite(sql)
         )
@@ -1256,23 +1326,21 @@ def query(
     try:
         output_format = resolve_output_format(default="csv")
         sql = read_sql_input(sql)
-        layer = _load_query_layer(
-            models,
-            connection=connection,
-            db=db,
-            use_preaggregations=use_preaggregations,
-            engine=engine,
-            fallback=fallback,
-            read_only=read_only,
-        )
-
         # Dry run: show generated SQL without executing
         if dry_run:
+            layer = _load_compile_layer(
+                models,
+                connection=connection,
+                db=db,
+                use_preaggregations=use_preaggregations,
+                engine=engine,
+                fallback=fallback,
+            )
             from sidemantic.sql.query_rewriter import QueryRewriter
 
             rewriter = QueryRewriter(
                 layer.graph,
-                dialect=layer.adapter.dialect,
+                dialect=layer.dialect,
                 use_preaggregations=layer.use_preaggregations,
             )
             rewritten_sql = rewriter.rewrite(sql)
@@ -1288,6 +1356,15 @@ def query(
             return
 
         # Execute query
+        layer = _load_query_layer(
+            models,
+            connection=connection,
+            db=db,
+            use_preaggregations=use_preaggregations,
+            engine=engine,
+            fallback=fallback,
+            read_only=read_only,
+        )
         result = layer.sql(sql)
 
         # Get results

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -166,6 +166,22 @@ def _resolve_connection(**kwargs):
         raise typer.BadParameter(str(exc)) from exc
 
 
+def _with_duckdb_access_mode(connection: str | None, read_only: bool | None = None) -> str | None:
+    """Apply the safe CLI DuckDB access mode without overriding explicit config."""
+    if connection is None or not connection.startswith("duckdb://") or connection.startswith("duckdb://md:"):
+        return connection
+    from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+    parsed = urlsplit(connection)
+    if parsed.path in {"", "/", "/:memory:", ":memory:"}:
+        return connection
+    params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    if read_only is None and "read_only" in params:
+        return connection
+    params["read_only"] = "true" if read_only is not False else "false"
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, urlencode(params), parsed.fragment))
+
+
 def _normalize_engine(engine: str | None) -> str | None:
     if engine is None:
         return None
@@ -220,6 +236,7 @@ def _load_query_layer(
     use_preaggregations: bool = False,
     engine: str | None = None,
     fallback: bool | None = None,
+    read_only: bool | None = None,
 ) -> SemanticLayer:
     """Load a semantic layer for CLI query/explain commands."""
     engine, resolved_fallback = _resolve_engine_options(engine, fallback)
@@ -228,6 +245,7 @@ def _load_query_layer(
     models = _models_path(models)
     resolved_connection = _resolve_connection(connection=connection, database=db, models=models)
     connection_str = resolved_connection.connection if resolved_connection else None
+    connection_str = _with_duckdb_access_mode(connection_str, read_only)
     init_sql = resolved_connection.init_sql if resolved_connection else None
 
     preagg_db = _loaded_config.preagg_database if _loaded_config else None
@@ -1212,6 +1230,11 @@ def query(
     use_preaggregations: bool = typer.Option(
         False, "--use-preaggregations", help="Enable automatic pre-aggregation routing"
     ),
+    read_only: bool | None = typer.Option(
+        None,
+        "--read-only/--read-write",
+        help="DuckDB access mode (file databases default to read-only for queries)",
+    ),
 ):
     """
     Execute a SQL query and output results as CSV.
@@ -1235,6 +1258,7 @@ def query(
             use_preaggregations=use_preaggregations,
             engine=engine,
             fallback=fallback,
+            read_only=read_only,
         )
 
         # Dry run: show generated SQL without executing
@@ -1363,6 +1387,11 @@ def dashboard_serve(
     use_preaggregations: bool = typer.Option(
         False, "--use-preaggregations", help="Enable automatic pre-aggregation routing"
     ),
+    read_only: bool | None = typer.Option(
+        None,
+        "--read-only/--read-write",
+        help="DuckDB access mode (file databases default to read-only while serving)",
+    ),
     output_dir: Path = typer.Option(None, "--output-dir", hidden=True),
     warm_interaction_preaggregations: bool = typer.Option(False, "--warm-interaction-preaggregations", hidden=True),
 ):
@@ -1390,6 +1419,7 @@ def dashboard_serve(
                 connection=connection,
                 db=db,
                 use_preaggregations=use_preaggregations,
+                read_only=read_only,
             )
             document = DashboardDocument.from_file(spec)
             errors = document.validate(layer, execute_sql=True)
@@ -1425,6 +1455,13 @@ def dashboard_serve(
             max_request_body_bytes=api_config.max_request_body_bytes if api_config else 1024 * 1024,
             result_cache_mb=api_config.result_cache_mb if api_config else 0,
             result_cache_ttl=api_config.result_cache_ttl if api_config else 60.0,
+            max_rows=api_config.max_rows if api_config else 10_000,
+            max_response_bytes=api_config.max_response_bytes if api_config else 16 * 1024 * 1024,
+            execution_timeout_seconds=api_config.execution_timeout_seconds if api_config else 30.0,
+            max_concurrent_queries=api_config.max_concurrent_queries if api_config else 4,
+            max_queued_queries=api_config.max_queued_queries if api_config else 16,
+            queue_timeout_seconds=api_config.queue_timeout_seconds if api_config else 5.0,
+            query_history_size=api_config.query_history_size if api_config else 1000,
         )
     except typer.Exit:
         raise
@@ -1600,6 +1637,11 @@ def serve(
         "--user-attrs-file",
         help="Path to a JSON file mapping usernames -> user-attribute dicts for row/access security",
     ),
+    read_only: bool | None = typer.Option(
+        None,
+        "--read-only/--read-write",
+        help="DuckDB access mode (file databases default to read-only while serving)",
+    ),
 ):
     """
     Start a PostgreSQL-compatible server for the semantic layer.
@@ -1650,6 +1692,7 @@ def serve(
     # Build connection string from args or config
     resolved_connection = _resolve_connection(connection=connection, database=db, models=directory)
     connection_str = resolved_connection.connection if resolved_connection else None
+    connection_str = _with_duckdb_access_mode(connection_str, read_only)
 
     # Resolve host, port, username, password from args or config
     host_resolved = host or (_loaded_config.pg_server.host if _loaded_config else "127.0.0.1")
@@ -1742,6 +1785,12 @@ def serve(
         username=username_resolved,
         password=password_resolved,
         user_attrs_map=user_attrs_map,
+        max_rows=_loaded_config.pg_server.max_rows if _loaded_config else 10_000,
+        max_response_bytes=_loaded_config.pg_server.max_response_bytes if _loaded_config else 16 * 1024 * 1024,
+        execution_timeout_seconds=(_loaded_config.pg_server.execution_timeout_seconds if _loaded_config else 30.0),
+        max_concurrent_queries=_loaded_config.pg_server.max_concurrent_queries if _loaded_config else 4,
+        max_queued_queries=_loaded_config.pg_server.max_queued_queries if _loaded_config else 16,
+        queue_timeout_seconds=_loaded_config.pg_server.queue_timeout_seconds if _loaded_config else 5.0,
     )
 
 
@@ -1773,6 +1822,30 @@ def api_serve(
     ),
     result_cache_ttl: float = typer.Option(
         None, "--result-cache-ttl", help="Result cache entry TTL in seconds (default 60)"
+    ),
+    max_rows: int = typer.Option(None, "--max-rows", help="Maximum rows returned per query (default 10000)"),
+    max_response_bytes: int = typer.Option(
+        None, "--max-response-bytes", help="Maximum JSON or Arrow response bytes (default 16777216)"
+    ),
+    execution_timeout_seconds: float = typer.Option(
+        None, "--execution-timeout-seconds", help="Query execution deadline (default 30)"
+    ),
+    max_concurrent_queries: int = typer.Option(
+        None, "--max-concurrent-queries", help="Maximum simultaneously executing queries (default 4)"
+    ),
+    max_queued_queries: int = typer.Option(
+        None, "--max-queued-queries", help="Maximum queries waiting for execution (default 16)"
+    ),
+    queue_timeout_seconds: float = typer.Option(
+        None, "--queue-timeout-seconds", help="Maximum queue wait in seconds (default 5)"
+    ),
+    query_history_size: int = typer.Option(
+        None, "--query-history-size", help="Sanitized process-local query events retained (default 1000)"
+    ),
+    read_only: bool | None = typer.Option(
+        None,
+        "--read-only/--read-write",
+        help="DuckDB access mode (file databases default to read-only while serving)",
     ),
     require_user_attrs: bool = typer.Option(
         False,
@@ -1828,6 +1901,7 @@ def api_serve(
 
     resolved_connection = _resolve_connection(connection=connection, database=db, models=directory)
     connection_str = resolved_connection.connection if resolved_connection else None
+    connection_str = _with_duckdb_access_mode(connection_str, read_only)
     init_sql = resolved_connection.init_sql if resolved_connection else None
 
     host_resolved = host or (_loaded_config.api_server.host if _loaded_config else "127.0.0.1")
@@ -1863,6 +1937,36 @@ def api_serve(
         result_cache_ttl
         if result_cache_ttl is not None
         else (_loaded_config.api_server.result_cache_ttl if _loaded_config else 60.0)
+    )
+    api_config = _loaded_config.api_server if _loaded_config else None
+    max_rows_resolved = max_rows if max_rows is not None else (api_config.max_rows if api_config else 10_000)
+    max_response_bytes_resolved = (
+        max_response_bytes
+        if max_response_bytes is not None
+        else (api_config.max_response_bytes if api_config else 16 * 1024 * 1024)
+    )
+    execution_timeout_resolved = (
+        execution_timeout_seconds
+        if execution_timeout_seconds is not None
+        else (api_config.execution_timeout_seconds if api_config else 30.0)
+    )
+    max_concurrent_resolved = (
+        max_concurrent_queries
+        if max_concurrent_queries is not None
+        else (api_config.max_concurrent_queries if api_config else 4)
+    )
+    max_queued_resolved = (
+        max_queued_queries if max_queued_queries is not None else (api_config.max_queued_queries if api_config else 16)
+    )
+    queue_timeout_resolved = (
+        queue_timeout_seconds
+        if queue_timeout_seconds is not None
+        else (api_config.queue_timeout_seconds if api_config else 5.0)
+    )
+    query_history_size_resolved = (
+        query_history_size
+        if query_history_size is not None
+        else (api_config.query_history_size if api_config else 1000)
     )
 
     preagg_db = _loaded_config.preagg_database if _loaded_config else None
@@ -1934,6 +2038,13 @@ def api_serve(
         serve_ui=serve_ui,
         result_cache_mb=result_cache_mb_resolved,
         result_cache_ttl=result_cache_ttl_resolved,
+        max_rows=max_rows_resolved,
+        max_response_bytes=max_response_bytes_resolved,
+        execution_timeout_seconds=execution_timeout_resolved,
+        max_concurrent_queries=max_concurrent_resolved,
+        max_queued_queries=max_queued_resolved,
+        queue_timeout_seconds=queue_timeout_resolved,
+        query_history_size=query_history_size_resolved,
         require_user_attrs=require_user_attrs,
         enforce_visibility=enforce_visibility,
         user_header=user_header,
@@ -2472,10 +2583,16 @@ def refresh(
 
         # Connect to database
         if connection_str.startswith("duckdb://"):
-            import duckdb
+            from sidemantic.db.duckdb import DuckDBAdapter
 
-            db_path = connection_str.replace("duckdb:///", "")
-            conn = duckdb.connect(db_path)
+            writable_connection = _with_duckdb_access_mode(connection_str, read_only=False)
+            assert writable_connection is not None
+            write_adapter = DuckDBAdapter.from_url(
+                writable_connection,
+                init_sql=resolved_connection.init_sql,
+            )
+            conn = write_adapter.raw_connection
+            emit_diagnostic("DuckDB pre-aggregation refresh opened explicit write mode")
 
             # Create schema if it doesn't exist (DuckDB only)
             if preagg_sch:

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -175,10 +175,11 @@ def _with_duckdb_access_mode(connection: str | None, read_only: bool | None = No
     parsed = urlsplit(connection)
     if parsed.path in {"", "/", "/:memory:", ":memory:"}:
         return connection
-    params = dict(parse_qsl(parsed.query, keep_blank_values=True))
-    if read_only is None and "read_only" in params:
+    params = parse_qsl(parsed.query, keep_blank_values=True)
+    if read_only is None and any(key == "read_only" for key, _ in params):
         return connection
-    params["read_only"] = "true" if read_only is not False else "false"
+    params = [(key, value) for key, value in params if key != "read_only"]
+    params.append(("read_only", "true" if read_only is not False else "false"))
     return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, urlencode(params), parsed.fragment))
 
 

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -170,7 +170,7 @@ def _with_duckdb_access_mode(connection: str | None, read_only: bool | None = No
     """Apply the safe CLI DuckDB access mode without overriding explicit config."""
     if connection is None or not connection.startswith("duckdb://") or connection.startswith("duckdb://md:"):
         return connection
-    from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+    from urllib.parse import parse_qsl, urlencode, urlsplit
 
     parsed = urlsplit(connection)
     if parsed.path in {"", "/", "/:memory:", ":memory:"}:
@@ -180,7 +180,11 @@ def _with_duckdb_access_mode(connection: str | None, read_only: bool | None = No
         return connection
     params = [(key, value) for key, value in params if key != "read_only"]
     params.append(("read_only", "true" if read_only is not False else "false"))
-    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, urlencode(params), parsed.fragment))
+    # urlunsplit collapses ``duckdb:///path`` to ``duckdb:/path`` when the
+    # authority is empty. Rebuild the scheme separator explicitly so documented
+    # three- and four-slash DuckDB URLs remain valid connection strings.
+    fragment = f"#{parsed.fragment}" if parsed.fragment else ""
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}?{urlencode(params)}{fragment}"
 
 
 def _normalize_engine(engine: str | None) -> str | None:

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -341,6 +341,7 @@ def _compile_only_dialect(models: Path | None, connection: str | None, db: Path 
         return {
             "bigquery": "bigquery",
             "duckdb": "duckdb",
+            "mssql": "tsql",
             "mysql": "mysql",
             "postgresql": "postgres",
             "redshift": "redshift",

--- a/sidemantic/config.py
+++ b/sidemantic/config.py
@@ -11,6 +11,10 @@ class DuckDBConnection(BaseModel):
 
     type: Literal["duckdb"] = "duckdb"
     path: str = Field(..., description="Path to DuckDB database file or :memory:")
+    read_only: bool | None = Field(
+        default=None,
+        description="Open DuckDB read-only; serving/query commands default file databases to true when omitted",
+    )
     init_sql: list[str] | None = Field(
         default=None,
         description="SQL statements to run after connecting (e.g., loading extensions, attaching catalogs)",
@@ -113,6 +117,12 @@ class PostgresServerConfig(BaseModel):
     username: str | None = Field(default=None, description="Username for authentication (optional)")
     password_file: str | None = Field(default=None, description="Credential file containing the password")
     password: str | None = Field(default=None, description="Inline password (prefer password_file in shared config)")
+    max_rows: int = Field(default=10_000, gt=0, description="Maximum rows returned by one query")
+    max_response_bytes: int = Field(default=16 * 1024 * 1024, gt=0, description="Maximum buffered result bytes")
+    execution_timeout_seconds: float = Field(default=30.0, gt=0, description="Query execution deadline")
+    max_concurrent_queries: int = Field(default=4, gt=0, description="Maximum simultaneously executing queries")
+    max_queued_queries: int = Field(default=16, ge=0, description="Maximum queries waiting for execution")
+    queue_timeout_seconds: float = Field(default=5.0, gt=0, description="Maximum query queue wait")
 
 
 class APIServerConfig(BaseModel):
@@ -126,6 +136,17 @@ class APIServerConfig(BaseModel):
     )
     cors_origins: list[str] = Field(default_factory=list, description="Allowed CORS origins")
     max_request_body_bytes: int = Field(default=1024 * 1024, description="Maximum request body size in bytes")
+    max_rows: int = Field(default=10_000, gt=0, description="Maximum rows returned by one query")
+    max_response_bytes: int = Field(
+        default=16 * 1024 * 1024, gt=0, description="Maximum serialized JSON or Arrow response size"
+    )
+    execution_timeout_seconds: float = Field(
+        default=30.0, gt=0, description="Query execution deadline and requested warehouse statement timeout"
+    )
+    max_concurrent_queries: int = Field(default=4, gt=0, description="Maximum simultaneously executing queries")
+    max_queued_queries: int = Field(default=16, ge=0, description="Maximum queries waiting for an execution slot")
+    queue_timeout_seconds: float = Field(default=5.0, gt=0, description="Maximum time a query may wait in the queue")
+    query_history_size: int = Field(default=1000, ge=0, description="Process-local sanitized query events retained")
     result_cache_mb: int = Field(default=0, description="Result cache size in megabytes (0 disables the result cache)")
     result_cache_ttl: float = Field(default=60.0, description="Result cache entry TTL in seconds")
 
@@ -235,7 +256,12 @@ class SidemanticConfig(BaseModel):
             db_p = Path(connection.path)
             if not db_p.is_absolute():
                 db_p = (base / db_p).resolve()
-            connection = DuckDBConnection(type="duckdb", path=str(db_p), init_sql=connection.init_sql)
+            connection = DuckDBConnection(
+                type="duckdb",
+                path=str(db_p),
+                read_only=connection.read_only,
+                init_sql=connection.init_sql,
+            )
 
         pg_server = self.pg_server.model_copy()
         if pg_server.password_file:
@@ -356,7 +382,10 @@ def build_connection_string(config: SidemanticConfig) -> str:
         return "duckdb:///:memory:"
 
     if isinstance(config.connection, DuckDBConnection):
-        return f"duckdb:///{config.connection.path}"
+        connection = f"duckdb:///{config.connection.path}"
+        if config.connection.read_only is not None:
+            connection += f"?read_only={'true' if config.connection.read_only else 'false'}"
+        return connection
     elif isinstance(config.connection, PostgreSQLConnection):
         password_part = f":{config.connection.password}" if config.connection.password else ""
         return (

--- a/sidemantic/core/query_telemetry.py
+++ b/sidemantic/core/query_telemetry.py
@@ -1,0 +1,122 @@
+"""Process-local query telemetry and bounded history hooks."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import threading
+from collections import deque
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class QueryEvent:
+    """A sanitized, process-local record of one query execution."""
+
+    query_id: str
+    request_id: str | None
+    duration_ms: float
+    dialect: str
+    row_count: int | None = None
+    response_bytes: int | None = None
+    cache_hit: bool = False
+    used_preaggregation: bool = False
+    cancelled: bool = False
+    timed_out: bool = False
+    error: str | None = None
+    sql: str | None = None
+    sql_fingerprint: str | None = None
+    plan_metadata: dict[str, Any] = field(default_factory=dict)
+    cancellation_diagnostic: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation."""
+        return asdict(self)
+
+
+class QueryTelemetry:
+    """Thread-safe bounded query history with failure-isolated listeners.
+
+    This intentionally remains an in-process library primitive. It does not
+    persist events, expose users, or implement a monitoring backend.
+    """
+
+    def __init__(self, history_size: int = 1000):
+        if history_size < 0:
+            raise ValueError("history_size must be >= 0")
+        self._history: deque[QueryEvent] = deque(maxlen=history_size or None)
+        self._history_enabled = history_size > 0
+        self._listeners: list[Callable[[QueryEvent], None]] = []
+        self._lock = threading.Lock()
+
+    def add_listener(self, listener: Callable[[QueryEvent], None]) -> Callable[[], None]:
+        """Register a listener and return a function that unregisters it."""
+        with self._lock:
+            self._listeners.append(listener)
+
+        def remove() -> None:
+            with self._lock:
+                if listener in self._listeners:
+                    self._listeners.remove(listener)
+
+        return remove
+
+    def record(self, event: QueryEvent) -> None:
+        """Record an event and notify listeners without affecting query success."""
+        with self._lock:
+            if self._history_enabled:
+                self._history.append(event)
+            listeners = tuple(self._listeners)
+        for listener in listeners:
+            try:
+                listener(event)
+            except Exception:
+                logging.getLogger(__name__).exception("Query telemetry listener failed")
+
+    def history(self, limit: int | None = None) -> list[QueryEvent]:
+        """Return newest-first history, optionally capped to ``limit`` events."""
+        if limit is not None and limit < 0:
+            raise ValueError("limit must be >= 0")
+        with self._lock:
+            events = list(reversed(self._history)) if self._history_enabled else []
+        return events if limit is None else events[:limit]
+
+    def clear(self) -> None:
+        """Clear retained history without removing listeners."""
+        with self._lock:
+            self._history.clear()
+
+    def resize(self, history_size: int) -> None:
+        """Change bounded retention while preserving listeners and newest events."""
+        if history_size < 0:
+            raise ValueError("history_size must be >= 0")
+        with self._lock:
+            existing = list(self._history)
+            self._history = deque(existing[-history_size:] if history_size else [], maxlen=history_size or None)
+            self._history_enabled = history_size > 0
+
+
+def sanitize_sql(sql: str, dialect: str | None = None) -> tuple[str | None, str]:
+    """Return literal-free SQL plus a fingerprint of the original statement.
+
+    Parsing failures deliberately return no SQL text: an unknown statement may
+    contain credentials or other secrets that a regex cannot safely identify.
+    """
+    fingerprint = hashlib.sha256(sql.encode("utf-8", errors="replace")).hexdigest()
+    try:
+        import sqlglot
+        from sqlglot import exp
+
+        parsed = sqlglot.parse_one(sql, read=dialect)
+
+        def redact(node):
+            if isinstance(node, exp.Literal):
+                return exp.Placeholder()
+            return node
+
+        sanitized = parsed.transform(redact).sql(dialect=dialect, comments=False)
+    except Exception:
+        return None, fingerprint
+    return sanitized, fingerprint

--- a/sidemantic/core/result_cache.py
+++ b/sidemantic/core/result_cache.py
@@ -87,6 +87,10 @@ class _InFlight:
         self.error: BaseException | None = None
 
 
+class ResultCacheWaitCancelledError(RuntimeError):
+    """Raised when a singleflight follower stops waiting for its leader."""
+
+
 class ResultCache:
     """LRU-by-bytes Arrow result cache with TTL and singleflight dedup.
 
@@ -126,7 +130,13 @@ class ResultCache:
         table, _cache_hit = self.get_or_compute_with_status(key, compute)
         return table
 
-    def get_or_compute_with_status(self, key: str, compute: Callable[[], pa.Table]) -> tuple[pa.Table, bool]:
+    def get_or_compute_with_status(
+        self,
+        key: str,
+        compute: Callable[[], pa.Table],
+        *,
+        cancelled: Callable[[], bool] | None = None,
+    ) -> tuple[pa.Table, bool]:
         """Return ``(table, cache_hit)`` while preserving singleflight behavior."""
         with self._lock:
             entry = self._get_live_entry_locked(key)
@@ -147,7 +157,11 @@ class ResultCache:
 
         if not leader:
             # Wait for the leader of this generation, then share its outcome.
-            inflight.event.wait()
+            while True:
+                if cancelled is not None and cancelled():
+                    raise ResultCacheWaitCancelledError("result cache wait was cancelled")
+                if inflight.event.wait(timeout=0.05):
+                    break
             if inflight.error is not None:
                 raise inflight.error
             return inflight.result, False

--- a/sidemantic/core/result_cache.py
+++ b/sidemantic/core/result_cache.py
@@ -123,11 +123,16 @@ class ResultCache:
 
     def get_or_compute(self, key: str, compute: Callable[[], pa.Table]) -> pa.Table:
         """Return the cached table for ``key`` or compute (once) and cache it."""
+        table, _cache_hit = self.get_or_compute_with_status(key, compute)
+        return table
+
+    def get_or_compute_with_status(self, key: str, compute: Callable[[], pa.Table]) -> tuple[pa.Table, bool]:
+        """Return ``(table, cache_hit)`` while preserving singleflight behavior."""
         with self._lock:
             entry = self._get_live_entry_locked(key)
             if entry is not None:
                 self._hits += 1
-                return entry.table
+                return entry.table, True
 
             # Miss. Either join an in-flight compute or become the leader.
             inflight = self._inflight.get(key)
@@ -145,7 +150,7 @@ class ResultCache:
             inflight.event.wait()
             if inflight.error is not None:
                 raise inflight.error
-            return inflight.result
+            return inflight.result, False
 
         # Leader path: run compute outside the lock so other keys are unblocked.
         try:
@@ -165,7 +170,7 @@ class ResultCache:
             if self._inflight.get(key) is inflight:
                 del self._inflight[key]
         inflight.event.set()
-        return table
+        return table, False
 
     def invalidate_all(self) -> None:
         """Drop every cached entry (does not disturb in-flight computations)."""

--- a/sidemantic/core/result_cache.py
+++ b/sidemantic/core/result_cache.py
@@ -88,7 +88,7 @@ class _InFlight:
 
 
 class ResultCacheWaitCancelledError(RuntimeError):
-    """Raised when a singleflight follower stops waiting for its leader."""
+    """Raised when a singleflight caller is cancelled before receiving a result."""
 
 
 class ResultCache:
@@ -169,6 +169,8 @@ class ResultCache:
         # Leader path: run compute outside the lock so other keys are unblocked.
         try:
             table = compute()
+            if cancelled is not None and cancelled():
+                raise ResultCacheWaitCancelledError("result cache computation was cancelled")
         except BaseException as exc:  # noqa: BLE001 - propagate to all waiters
             inflight.error = exc
             with self._lock:

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import time
+import uuid
 from collections.abc import Callable
 from pathlib import Path
 
@@ -76,6 +78,7 @@ class SemanticLayer:
         max_limit: int | None = None,
         allow_non_additive_unsafe: bool = False,
         enforce_visibility: bool = False,
+        query_history_size: int = 1000,
     ):
         """Initialize semantic layer.
 
@@ -122,6 +125,8 @@ class SemanticLayer:
             enforce_visibility: When True, requesting a dimension/metric whose ``public=False``
                 raises during compile, and catalog/introspection listings omit non-public
                 fields. Defaults to False so library users are unaffected.
+            query_history_size: Number of sanitized process-local query events to retain.
+                Set to 0 to disable retention while keeping listener hooks available.
         """
         from sidemantic.db.base import BaseDatabaseAdapter
 
@@ -146,6 +151,9 @@ class SemanticLayer:
         self.max_limit = max_limit
         self.allow_non_additive_unsafe = allow_non_additive_unsafe
         self.enforce_visibility = enforce_visibility
+        from sidemantic.core.query_telemetry import QueryTelemetry
+
+        self.query_telemetry = QueryTelemetry(history_size=query_history_size)
         self._strict_rust_sql_generator_entrypoint = is_strict_for("sql_generator_entrypoint")
         self._strict_rust_query_validation = is_strict_for("semantic_core_query_validation")
         if engine == "python":
@@ -738,6 +746,42 @@ class SemanticLayer:
         - if the routed rollup table does not exist, fall back to recompile_raw() (or
           raise in strict mode). Any other error surfaces unchanged.
         """
+        started = time.monotonic()
+        query_id = uuid.uuid4().hex
+        error: Exception | None = None
+        try:
+            return self._execute_with_preagg_fallback_uninstrumented(
+                primary_sql,
+                recompile_raw,
+                use_preaggs=use_preaggs,
+                strict=strict,
+                used_preagg=used_preagg,
+            )
+        except Exception as exc:
+            error = exc
+            raise
+        finally:
+            from sidemantic.core.query_telemetry import QueryEvent, sanitize_sql
+
+            sanitized_sql, fingerprint = sanitize_sql(primary_sql, self.dialect)
+            self.query_telemetry.record(
+                QueryEvent(
+                    query_id=query_id,
+                    request_id=None,
+                    duration_ms=(time.monotonic() - started) * 1000,
+                    dialect=self.dialect,
+                    used_preaggregation=used_preagg,
+                    error=type(error).__name__ if error is not None else None,
+                    sql=sanitized_sql,
+                    sql_fingerprint=fingerprint,
+                    plan_metadata={"source": "library"},
+                )
+            )
+
+    def _execute_with_preagg_fallback_uninstrumented(
+        self, primary_sql, recompile_raw, *, use_preaggs: bool, strict: bool, used_preagg: bool
+    ):
+        """Execute with pre-aggregation fallback without emitting telemetry."""
         if not use_preaggs:
             return self.adapter.execute(primary_sql)
 

--- a/sidemantic/db/base.py
+++ b/sidemantic/db/base.py
@@ -3,6 +3,7 @@
 import re
 import threading
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
@@ -140,6 +141,8 @@ class _SerializedCursor:
     enforce result limits batch-by-batch before materializing a complete Arrow table.
     """
 
+    defer_execution_registration = True
+
     def __init__(self, adapter: "BaseDatabaseAdapter", lock: threading.Lock):
         self._adapter = adapter
         self._lock = lock
@@ -156,9 +159,11 @@ class _SerializedCursor:
         return _MaterializedResult(table)
 
     @contextmanager
-    def execute_stream(self, sql: str):
+    def execute_stream(self, sql: str, *, on_acquired: Callable[[], None] | None = None):
         """Yield a reader while retaining exclusive access to the shared connection."""
         with self._lock:
+            if on_acquired is not None:
+                on_acquired()
             result = self._adapter.execute(sql)
             reader = self._adapter.fetch_record_batch(result)
             try:

--- a/sidemantic/db/base.py
+++ b/sidemantic/db/base.py
@@ -3,6 +3,7 @@
 import re
 import threading
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any
 
 # Pattern for valid SQL identifiers: starts with letter or underscore,
@@ -13,6 +14,15 @@ _IDENTIFIER_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9
 # Guards lazy creation of each adapter's shared-connection lock so two threads
 # calling cursor() concurrently cannot end up with two different locks.
 _SHARED_LOCK_INIT_GUARD = threading.Lock()
+
+
+@dataclass(frozen=True, slots=True)
+class CancellationOutcome:
+    """Best-effort database cancellation result."""
+
+    supported: bool
+    cancelled: bool
+    diagnostic: str
 
 
 def validate_identifier(value: str, name: str = "identifier") -> str:
@@ -144,6 +154,15 @@ class _SerializedCursor:
             table = reader.read_all()
         return _MaterializedResult(table)
 
+    def execute_control(self, sql: str) -> None:
+        """Execute a session control command without trying to fetch rows."""
+        with self._lock:
+            result = self._adapter.execute(sql)
+            result_cursor = getattr(result, "cursor", None)
+            close = getattr(result_cursor or result, "close", None)
+            if callable(close):
+                close()
+
     def fetch_record_batch(self, result: Any) -> Any:
         """Return a RecordBatchReader; results from ``execute`` are already materialized."""
         if isinstance(result, _MaterializedResult):
@@ -191,6 +210,64 @@ class BaseDatabaseAdapter(ABC):
                     # Store so all fallback cursors for this adapter share one lock.
                     self._shared_connection_lock = lock
         return _SerializedCursor(self, lock)
+
+    def configure_statement_timeout(self, cursor: Any, timeout_seconds: float) -> str | None:
+        """Apply a warehouse-side statement timeout when this dialect supports one.
+
+        Returns ``None`` when applied, otherwise a diagnostic explaining that
+        Sidemantic's local deadline/cancellation is the only available guard.
+        """
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        execute_control = getattr(cursor, "execute_control", cursor.execute)
+        if self.dialect == "postgres":
+            execute_control(f"SET statement_timeout = {max(1, int(timeout_seconds * 1000))}")
+            return None
+        if self.dialect == "snowflake":
+            import math
+
+            execute_control(f"ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = {max(1, math.ceil(timeout_seconds))}")
+            return None
+        if self.dialect == "clickhouse":
+            execute_control(f"SET max_execution_time = {timeout_seconds:g}")
+            return None
+        return (
+            f"{self.dialect} adapter does not expose a portable warehouse statement timeout; "
+            "the local execution deadline will request best-effort cancellation"
+        )
+
+    def cancel(self, handle: Any) -> CancellationOutcome:
+        """Best-effort cancellation for an executing cursor/connection."""
+        candidates = [handle, getattr(handle, "cursor", None)]
+        try:
+            candidates.append(self.raw_connection)
+        except Exception:
+            pass
+        for candidate in candidates:
+            if candidate is None:
+                continue
+            for method_name in ("cancel_safe", "cancel", "interrupt", "adbc_cancel"):
+                method = getattr(candidate, method_name, None)
+                if not callable(method):
+                    continue
+                try:
+                    method()
+                except Exception as exc:
+                    return CancellationOutcome(
+                        supported=True,
+                        cancelled=False,
+                        diagnostic=f"{self.dialect} cancellation request failed: {type(exc).__name__}: {exc}",
+                    )
+                return CancellationOutcome(
+                    supported=True,
+                    cancelled=True,
+                    diagnostic=f"{self.dialect} cancellation requested via {method_name}()",
+                )
+        return CancellationOutcome(
+            supported=False,
+            cancelled=False,
+            diagnostic=f"{self.dialect} adapter cannot cancel an in-flight query; warehouse work may continue",
+        )
 
     @abstractmethod
     def execute(self, sql: str) -> Any:

--- a/sidemantic/db/base.py
+++ b/sidemantic/db/base.py
@@ -3,6 +3,7 @@
 import re
 import threading
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
 
@@ -133,10 +134,10 @@ class _SerializedCursor:
 
     Adapters that do not expose an independent concurrent handle fall back to this
     wrapper. It preserves the pre-existing serialized single-connection behavior: the
-    query AND its full result materialization run under a per-adapter lock, so callers
-    that switch to ``adapter.cursor()`` for concurrency cannot interleave fetches on a
-    driver that does not support concurrent handles. The result is returned already
-    materialized so no connection access happens after the lock is released.
+    query and result consumption run under a per-adapter lock, so callers that switch
+    to ``adapter.cursor()`` for concurrency cannot interleave fetches on a driver that
+    does not support concurrent handles. Server query paths use ``execute_stream`` to
+    enforce result limits batch-by-batch before materializing a complete Arrow table.
     """
 
     def __init__(self, adapter: "BaseDatabaseAdapter", lock: threading.Lock):
@@ -153,6 +154,23 @@ class _SerializedCursor:
             reader = self._adapter.fetch_record_batch(result)
             table = reader.read_all()
         return _MaterializedResult(table)
+
+    @contextmanager
+    def execute_stream(self, sql: str):
+        """Yield a reader while retaining exclusive access to the shared connection."""
+        with self._lock:
+            result = self._adapter.execute(sql)
+            reader = self._adapter.fetch_record_batch(result)
+            try:
+                yield reader
+            finally:
+                reader_close = getattr(reader, "close", None)
+                if callable(reader_close):
+                    reader_close()
+                result_cursor = getattr(result, "cursor", None)
+                result_close = getattr(result_cursor or result, "close", None)
+                if callable(result_close):
+                    result_close()
 
     def execute_control(self, sql: str) -> None:
         """Execute a session control command without trying to fetch rows."""

--- a/sidemantic/db/duckdb.py
+++ b/sidemantic/db/duckdb.py
@@ -30,6 +30,12 @@ class DuckDBAdapter(BaseDatabaseAdapter):
             init_sql: SQL statements to run immediately after connecting
                 (e.g., loading extensions, attaching catalogs, creating secrets)
         """
+        if read_only and path == ":memory:":
+            raise ValueError("DuckDB :memory: databases cannot be opened read-only")
+        self.path = path
+        self.read_only = read_only
+        self.config = dict(config) if config else None
+        self.init_sql = list(init_sql) if init_sql else None
         if not read_only and config is None:
             self.conn = duckdb.connect(path)
         elif config is None:
@@ -42,16 +48,23 @@ class DuckDBAdapter(BaseDatabaseAdapter):
                 self.conn.execute(stmt)
 
     def cursor(self) -> Any:
-        """Return an independent DuckDB cursor for concurrent reads.
+        """Return an execution handle safe for the database kind.
 
-        In duckdb-python, ``conn.cursor()`` creates a new connection that shares
-        the same underlying database. This is the sanctioned pattern for
-        multithreaded reads: each thread gets its own handle, so concurrent
-        ``execute`` calls do not serialize on a single connection. The returned
-        cursor exposes ``execute`` returning a relation with ``fetch_record_batch``
-        and ``fetchone``, matching the result API used across the codebase.
+        File-backed databases get an independently opened connection so query
+        threads never share DuckDB cursor state. In-memory databases cannot be
+        reopened onto the same data, so they use the base class's serialized
+        cursor wrapper.
         """
-        return self.conn.cursor()
+        if self.path == ":memory:":
+            return super().cursor()
+        if self.config is None:
+            cursor = duckdb.connect(self.path, read_only=self.read_only)
+        else:
+            cursor = duckdb.connect(self.path, read_only=self.read_only, config=self.config)
+        if self.init_sql:
+            for stmt in self.init_sql:
+                cursor.execute(stmt)
+        return cursor
 
     def execute(self, sql: str) -> Any:
         """Execute SQL and return DuckDB relation."""
@@ -165,7 +178,10 @@ class DuckDBAdapter(BaseDatabaseAdapter):
                 continue
             value = values[-1]
             if key == "read_only":
-                read_only = bool(parse_value(value))
+                normalized = value.strip().lower()
+                if normalized not in {"true", "false", "1", "0"}:
+                    raise ValueError("DuckDB read_only must be true, false, 1, or 0")
+                read_only = normalized in {"true", "1"}
             else:
                 config[key] = parse_value(value)
 

--- a/sidemantic/man/sidemantic.1
+++ b/sidemantic/man/sidemantic.1
@@ -149,6 +149,9 @@ Allow Rust engine fallback to Python
 .TP
 \fB\-\-use\-preaggregations\fR
 Enable automatic pre\-aggregation routing
+.TP
+\fB\-\-read\-only, \-\-read\-write\fR
+DuckDB access mode (file databases default to read\-only for queries)
 .SH "SIDEMANTIC EXPLAIN"
 .SS SYNOPSIS
 .B
@@ -298,6 +301,9 @@ Port for dashboard server
 .TP
 \fB\-\-use\-preaggregations\fR
 Enable automatic pre\-aggregation routing
+.TP
+\fB\-\-read\-only, \-\-read\-write\fR
+DuckDB access mode (file databases default to read\-only while serving)
 .SH "SIDEMANTIC DASHBOARD TYPES"
 .SS SYNOPSIS
 .B
@@ -498,6 +504,9 @@ Read the authentication password from a file, or \- for stdin
 .TP
 \fB\-\-user\-attrs\-file PATH\fR
 Path to a JSON file mapping usernames \-> user\-attribute dicts for row/access security
+.TP
+\fB\-\-read\-only, \-\-read\-write\fR
+DuckDB access mode (file databases default to read\-only while serving)
 .SH "SIDEMANTIC SERVER API"
 .SS SYNOPSIS
 .B
@@ -540,6 +549,30 @@ Result cache size in MB (0 disables; default 0)
 .TP
 \fB\-\-result\-cache\-ttl FLOAT\fR
 Result cache entry TTL in seconds (default 60)
+.TP
+\fB\-\-max\-rows INTEGER\fR
+Maximum rows returned per query (default 10000)
+.TP
+\fB\-\-max\-response\-bytes INTEGER\fR
+Maximum JSON or Arrow response bytes (default 16777216)
+.TP
+\fB\-\-execution\-timeout\-seconds FLOAT\fR
+Query execution deadline (default 30)
+.TP
+\fB\-\-max\-concurrent\-queries INTEGER\fR
+Maximum simultaneously executing queries (default 4)
+.TP
+\fB\-\-max\-queued\-queries INTEGER\fR
+Maximum queries waiting for execution (default 16)
+.TP
+\fB\-\-queue\-timeout\-seconds FLOAT\fR
+Maximum queue wait in seconds (default 5)
+.TP
+\fB\-\-query\-history\-size INTEGER\fR
+Sanitized process\-local query events retained (default 1000)
+.TP
+\fB\-\-read\-only, \-\-read\-write\fR
+DuckDB access mode (file databases default to read\-only while serving)
 .TP
 \fB\-\-require\-user\-attrs\fR
 Require the user\-attributes header on data endpoints (reject with 400 if missing)

--- a/sidemantic/server/connection.py
+++ b/sidemantic/server/connection.py
@@ -1,6 +1,7 @@
 """PostgreSQL wire protocol connection handler for semantic layer."""
 
 import logging
+import queue
 import re
 import threading
 import time
@@ -121,19 +122,22 @@ class SemanticLayerConnection(riffq.BaseConnection):
             # information_schema, pg_catalog) are unaffected.
             user_attributes = self._user_attributes()
 
+            # PG clients commonly bracket read-only SELECTs in transactions. The
+            # server executes each query on its own database handle, so acknowledge
+            # these controls without opening a disposable warehouse transaction or
+            # trying to fetch rows from a command result.
+            if _is_transaction_control(sql):
+                import pyarrow as pa
+
+                reader = pa.table({"ok": pa.array([], type=pa.bool_())}).to_reader()
+                self.send_reader(reader, callback)
+                return
+
             # Each executor thread gets its own cursor so concurrent reads do not
             # serialize on a single shared connection. For DuckDB this is an
             # independent handle over the same database; other adapters fall back
             # to a lock-guarded wrapper preserving today's behavior.
             cursor = self.layer.adapter.cursor()
-
-            # Transaction control must remain pass-through. Wrapping BEGIN / COMMIT /
-            # ROLLBACK as a bounded SELECT produces invalid SQL for PG-wire clients.
-            if _is_transaction_control(sql):
-                result = cursor.execute(sql.strip().removesuffix(";"))
-                reader = result.fetch_record_batch()
-                self.send_reader(reader, callback)
-                return
 
             # Check for DML commands first (before multi-statement check)
             # These are often PostgreSQL session config and should just succeed
@@ -193,68 +197,88 @@ class SemanticLayerConnection(riffq.BaseConnection):
             started = time.monotonic()
             control = QueryExecutionControl()
             timed_out = threading.Event()
-            error: Exception | None = None
-            row_count: int | None = None
-            response_bytes: int | None = None
-
-            def cancel_at_deadline() -> None:
-                timed_out.set()
-                control.cancel()
-
-            timer = threading.Timer(query_limits.execution_timeout_seconds, cancel_at_deadline)
-            timer.daemon = True
             if not hasattr(self, "_active_controls_lock"):
                 self._active_controls_lock = threading.Lock()
                 self._active_controls = set()
             with self._active_controls_lock:
                 self._active_controls.add(control)
-            timer.start()
+            result_queue = queue.Queue(maxsize=1)
+            execution_cursor = cursor
+
+            def execute_in_worker() -> None:
+                bounded = None
+                error = None
+                row_count = None
+                response_bytes = None
+                try:
+                    bounded_sql = limit_query_sql(rendered_sql, query_limits.max_rows, self.layer.dialect)
+                    bounded = execute_bounded(
+                        self.layer,
+                        bounded_sql,
+                        limits=query_limits,
+                        control=control,
+                        cursor=execution_cursor,
+                    )
+                    row_count = bounded.row_count
+                    response_bytes = int(bounded.table.nbytes)
+                except Exception as exc:
+                    error = exc
+                finally:
+                    try:
+                        sanitized_sql, fingerprint = sanitize_sql(rendered_sql, self.layer.dialect)
+                        outcome = control.cancellation_outcome
+                        self.layer.query_telemetry.record(
+                            QueryEvent(
+                                query_id=query_id,
+                                request_id=str(getattr(self, "connection_id", "unknown")),
+                                duration_ms=(time.monotonic() - started) * 1000,
+                                dialect=self.layer.dialect,
+                                row_count=row_count,
+                                response_bytes=response_bytes,
+                                used_preaggregation="used_preagg=true" in rendered_sql,
+                                cancelled=bool(outcome and outcome.cancelled),
+                                timed_out=timed_out.is_set(),
+                                error=(
+                                    type(error).__name__
+                                    if error is not None
+                                    else "TimeoutError"
+                                    if timed_out.is_set()
+                                    else None
+                                ),
+                                sql=sanitized_sql,
+                                sql_fingerprint=fingerprint,
+                                plan_metadata={"source": "postgres_wire", "timeout": control.timeout_diagnostic},
+                                cancellation_diagnostic=outcome.diagnostic if outcome else None,
+                            )
+                        )
+                    except Exception:
+                        logging.exception("Error recording query telemetry")
+                    finally:
+                        close = getattr(execution_cursor, "close", None)
+                        if callable(close):
+                            close()
+                        with self._active_controls_lock:
+                            self._active_controls.discard(control)
+                        query_admission.release()
+                        result_queue.put((bounded, error))
+
+            worker = threading.Thread(target=execute_in_worker, daemon=True)
+            worker.start()
+            # The worker owns this cursor through execution and cleanup. Do not let
+            # the outer finally close it when a local deadline returns first.
+            cursor = None
             try:
-                bounded_sql = limit_query_sql(rendered_sql, query_limits.max_rows, self.layer.dialect)
-                bounded = execute_bounded(
-                    self.layer,
-                    bounded_sql,
-                    limits=query_limits,
-                    control=control,
-                    cursor=cursor,
-                )
-                row_count = bounded.row_count
-                response_bytes = int(bounded.table.nbytes)
-                if timed_out.is_set():
-                    outcome = control.cancellation_outcome
-                    diagnostic = outcome.diagnostic if outcome else "cancellation was unavailable"
-                    raise TimeoutError(
-                        f"Query exceeded the {query_limits.execution_timeout_seconds:g}s deadline. {diagnostic}"
-                    )
+                bounded, error = result_queue.get(timeout=query_limits.execution_timeout_seconds)
+            except queue.Empty:
+                timed_out.set()
+                outcome = control.cancel()
+                raise TimeoutError(
+                    f"Query exceeded the {query_limits.execution_timeout_seconds:g}s deadline. {outcome.diagnostic}"
+                ) from None
+            if error is not None:
+                raise error
+            if bounded is not None:
                 self.send_reader(bounded.table.to_reader(), callback)
-            except Exception as exc:
-                error = exc
-                raise
-            finally:
-                timer.cancel()
-                with self._active_controls_lock:
-                    self._active_controls.discard(control)
-                query_admission.release()
-                sanitized_sql, fingerprint = sanitize_sql(rendered_sql, self.layer.dialect)
-                outcome = control.cancellation_outcome
-                self.layer.query_telemetry.record(
-                    QueryEvent(
-                        query_id=query_id,
-                        request_id=str(getattr(self, "connection_id", "unknown")),
-                        duration_ms=(time.monotonic() - started) * 1000,
-                        dialect=self.layer.dialect,
-                        row_count=row_count,
-                        response_bytes=response_bytes,
-                        used_preaggregation="used_preagg=true" in rendered_sql,
-                        cancelled=bool(outcome and outcome.cancelled),
-                        timed_out=timed_out.is_set(),
-                        error=type(error).__name__ if error is not None else None,
-                        sql=sanitized_sql,
-                        sql_fingerprint=fingerprint,
-                        plan_metadata={"source": "postgres_wire", "timeout": control.timeout_diagnostic},
-                        cancellation_diagnostic=outcome.diagnostic if outcome else None,
-                    )
-                )
 
         except Exception:
             logging.exception("Error executing query")

--- a/sidemantic/server/connection.py
+++ b/sidemantic/server/connection.py
@@ -2,10 +2,14 @@
 
 import logging
 import re
+import threading
+import time
+import uuid
 
 import riffq
 
 from sidemantic.core.semantic_layer import SemanticLayer
+from sidemantic.server.query_execution import QueryAdmission, QueryExecutionControl, QueryLimits, execute_bounded
 from sidemantic.sql.query_rewriter import QueryRewriter
 
 
@@ -20,6 +24,8 @@ class SemanticLayerConnection(riffq.BaseConnection):
         username: str | None = None,
         password: str | None = None,
         user_attrs_map: dict[str, dict] | None = None,
+        query_limits: QueryLimits | None = None,
+        query_admission: QueryAdmission | None = None,
     ):
         super().__init__(connection_id, executor)
         self.layer = layer
@@ -32,6 +38,13 @@ class SemanticLayerConnection(riffq.BaseConnection):
         # connecting username is captured in handle_auth and looked up here.
         self.user_attrs_map = user_attrs_map or {}
         self.session_user: str | None = None
+        self.query_limits = query_limits or QueryLimits()
+        self.query_admission = query_admission or QueryAdmission(
+            self.query_limits.max_concurrent_queries,
+            self.query_limits.max_queued_queries,
+        )
+        self._active_controls: set[QueryExecutionControl] = set()
+        self._active_controls_lock = threading.Lock()
 
     def _user_attributes(self) -> dict | None:
         """Resolve security user attributes for the current session.
@@ -66,10 +79,20 @@ class SemanticLayerConnection(riffq.BaseConnection):
 
     def handle_disconnect(self, ip, port, callback=callable):
         """Handle disconnection."""
+        controls_lock = getattr(self, "_active_controls_lock", None)
+        if controls_lock is None:
+            controls = ()
+        else:
+            with controls_lock:
+                controls = tuple(self._active_controls)
+        for control in controls:
+            outcome = control.cancel()
+            logging.info("Cancelled disconnected PostgreSQL query: %s", outcome.diagnostic)
         callback(True)
 
     def _handle_query(self, sql, callback, **kwargs):
         """Handle a SQL query."""
+        cursor = None
         try:
             sql_lower = sql.lower().strip()
 
@@ -116,18 +139,113 @@ class SemanticLayerConnection(riffq.BaseConnection):
             # Use non-strict mode to pass through system queries (SHOW, SET, etc.)
             rendered_sql = rewriter.rewrite(sql, strict=False, user_attributes=user_attributes)
 
-            # Execute the query
-            result = cursor.execute(rendered_sql)
+            query_limits = getattr(self, "query_limits", None) or QueryLimits()
+            query_admission = getattr(self, "query_admission", None)
+            if query_admission is None:
+                query_admission = QueryAdmission(
+                    query_limits.max_concurrent_queries,
+                    query_limits.max_queued_queries,
+                )
+                self.query_admission = query_admission
+            admission_status = query_admission.acquire(query_limits.queue_timeout_seconds)
+            if admission_status == "full":
+                close = getattr(cursor, "close", None)
+                if callable(close):
+                    close()
+                raise RuntimeError(
+                    f"Sidemantic query queue is full (maximum {query_limits.max_queued_queries} waiting)"
+                )
+            if admission_status == "timeout":
+                close = getattr(cursor, "close", None)
+                if callable(close):
+                    close()
+                raise TimeoutError(
+                    f"Sidemantic query waited more than {query_limits.queue_timeout_seconds:g}s for an execution slot"
+                )
 
-            # Convert to Arrow record batch
-            reader = result.fetch_record_batch()
-            self.send_reader(reader, callback)
+            from sidemantic.core.query_telemetry import QueryEvent, sanitize_sql
+
+            query_id = uuid.uuid4().hex
+            started = time.monotonic()
+            control = QueryExecutionControl()
+            timed_out = threading.Event()
+            error: Exception | None = None
+            row_count: int | None = None
+            response_bytes: int | None = None
+
+            def cancel_at_deadline() -> None:
+                timed_out.set()
+                control.cancel()
+
+            timer = threading.Timer(query_limits.execution_timeout_seconds, cancel_at_deadline)
+            timer.daemon = True
+            if not hasattr(self, "_active_controls_lock"):
+                self._active_controls_lock = threading.Lock()
+                self._active_controls = set()
+            with self._active_controls_lock:
+                self._active_controls.add(control)
+            timer.start()
+            try:
+                bounded_sql = (
+                    f"SELECT * FROM ({rendered_sql}\n) AS _sidemantic_bounded LIMIT {query_limits.max_rows + 1}"
+                )
+                bounded = execute_bounded(
+                    self.layer,
+                    bounded_sql,
+                    limits=query_limits,
+                    control=control,
+                    cursor=cursor,
+                )
+                row_count = bounded.row_count
+                response_bytes = int(bounded.table.nbytes)
+                if timed_out.is_set():
+                    outcome = control.cancellation_outcome
+                    diagnostic = outcome.diagnostic if outcome else "cancellation was unavailable"
+                    raise TimeoutError(
+                        f"Query exceeded the {query_limits.execution_timeout_seconds:g}s deadline. {diagnostic}"
+                    )
+                self.send_reader(bounded.table.to_reader(), callback)
+            except Exception as exc:
+                error = exc
+                raise
+            finally:
+                timer.cancel()
+                with self._active_controls_lock:
+                    self._active_controls.discard(control)
+                query_admission.release()
+                sanitized_sql, fingerprint = sanitize_sql(rendered_sql, self.layer.dialect)
+                outcome = control.cancellation_outcome
+                self.layer.query_telemetry.record(
+                    QueryEvent(
+                        query_id=query_id,
+                        request_id=str(getattr(self, "connection_id", "unknown")),
+                        duration_ms=(time.monotonic() - started) * 1000,
+                        dialect=self.layer.dialect,
+                        row_count=row_count,
+                        response_bytes=response_bytes,
+                        used_preaggregation="used_preagg=true" in rendered_sql,
+                        cancelled=bool(outcome and outcome.cancelled),
+                        timed_out=timed_out.is_set(),
+                        error=type(error).__name__ if error is not None else None,
+                        sql=sanitized_sql,
+                        sql_fingerprint=fingerprint,
+                        plan_metadata={"source": "postgres_wire", "timeout": control.timeout_diagnostic},
+                        cancellation_diagnostic=outcome.diagnostic if outcome else None,
+                    )
+                )
 
         except Exception:
             logging.exception("Error executing query")
             # Raise to let riffq send a proper PG ErrorResponse to the client.
             # Returning errors as data rows confuses BI tools that expect PG protocol errors.
             raise
+        finally:
+            # File-backed DuckDB returns an independent connection per query.
+            # Close it for system-query and early-return paths too; the bounded
+            # execution path may already have closed it, which drivers tolerate.
+            close = getattr(cursor, "close", None)
+            if callable(close):
+                close()
 
     def _enforce_pg_access(self, rendered_sql: str, user_attributes: dict | None) -> None:
         """Enforce model access gates for the PG wire path.

--- a/sidemantic/server/connection.py
+++ b/sidemantic/server/connection.py
@@ -20,8 +20,19 @@ from sidemantic.server.query_execution import (
 from sidemantic.sql.query_rewriter import QueryRewriter
 
 _TRANSACTION_CONTROL = re.compile(
-    r"^\s*(?:begin(?:\s+(?:work|transaction))?|start\s+transaction|commit(?:\s+work)?|rollback(?:\s+work)?)\s*;?\s*$",
-    re.IGNORECASE,
+    r"""
+    ^\s*(?:
+        (?:begin(?:\s+(?:work|transaction))?|start\s+transaction)
+        (?:\s+(?:
+            isolation\s+level\s+(?:serializable|repeatable\s+read|read\s+committed|read\s+uncommitted)
+            |read\s+(?:write|only)
+            |(?:not\s+)?deferrable
+        ))*
+        |
+        (?:commit|end|rollback)(?:\s+(?:work|transaction))?(?:\s+and\s+(?:no\s+)?chain)?
+    )\s*;?\s*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
 )
 
 

--- a/sidemantic/server/connection.py
+++ b/sidemantic/server/connection.py
@@ -110,6 +110,10 @@ class SemanticLayerConnection(riffq.BaseConnection):
     def _handle_query(self, sql, callback, **kwargs):
         """Handle a SQL query."""
         cursor = None
+        control = None
+        query_admission = None
+        admission_acquired = False
+        worker_started = False
         try:
             sql_lower = sql.lower().strip()
 
@@ -185,33 +189,32 @@ class SemanticLayerConnection(riffq.BaseConnection):
                     query_limits.max_queued_queries,
                 )
                 self.query_admission = query_admission
-            admission_status = query_admission.acquire(query_limits.queue_timeout_seconds)
-            if admission_status == "full":
-                close = getattr(cursor, "close", None)
-                if callable(close):
-                    close()
-                raise RuntimeError(
-                    f"Sidemantic query queue is full (maximum {query_limits.max_queued_queries} waiting)"
-                )
-            if admission_status == "timeout":
-                close = getattr(cursor, "close", None)
-                if callable(close):
-                    close()
-                raise TimeoutError(
-                    f"Sidemantic query waited more than {query_limits.queue_timeout_seconds:g}s for an execution slot"
-                )
 
-            from sidemantic.core.query_telemetry import QueryEvent, sanitize_sql
-
-            query_id = uuid.uuid4().hex
-            started = time.monotonic()
             control = QueryExecutionControl()
-            timed_out = threading.Event()
             if not hasattr(self, "_active_controls_lock"):
                 self._active_controls_lock = threading.Lock()
                 self._active_controls = set()
             with self._active_controls_lock:
                 self._active_controls.add(control)
+
+            admission_status = query_admission.acquire(query_limits.queue_timeout_seconds)
+            if admission_status == "full":
+                raise RuntimeError(
+                    f"Sidemantic query queue is full (maximum {query_limits.max_queued_queries} waiting)"
+                )
+            if admission_status == "timeout":
+                raise TimeoutError(
+                    f"Sidemantic query waited more than {query_limits.queue_timeout_seconds:g}s for an execution slot"
+                )
+            admission_acquired = True
+            if control.cancel_requested:
+                raise ConnectionAbortedError("PostgreSQL client disconnected before query execution started")
+
+            from sidemantic.core.query_telemetry import QueryEvent, sanitize_sql
+
+            query_id = uuid.uuid4().hex
+            started = time.monotonic()
+            timed_out = threading.Event()
             result_queue = queue.Queue(maxsize=1)
             execution_cursor = cursor
 
@@ -279,6 +282,7 @@ class SemanticLayerConnection(riffq.BaseConnection):
 
             worker = threading.Thread(target=execute_in_worker, daemon=True)
             worker.start()
+            worker_started = True
             # The worker owns this cursor through execution and cleanup. Do not let
             # the outer finally close it when a local deadline returns first.
             cursor = None
@@ -301,6 +305,11 @@ class SemanticLayerConnection(riffq.BaseConnection):
             # Returning errors as data rows confuses BI tools that expect PG protocol errors.
             raise
         finally:
+            if control is not None and not worker_started:
+                with self._active_controls_lock:
+                    self._active_controls.discard(control)
+            if admission_acquired and not worker_started and query_admission is not None:
+                query_admission.release()
             # File-backed DuckDB returns an independent connection per query.
             # Close it for system-query and early-return paths too; the bounded
             # execution path may already have closed it, which drivers tolerate.

--- a/sidemantic/server/connection.py
+++ b/sidemantic/server/connection.py
@@ -220,8 +220,10 @@ class SemanticLayerConnection(riffq.BaseConnection):
                 error = None
                 row_count = None
                 response_bytes = None
+                execution_started = False
                 try:
                     bounded_sql = limit_query_sql(rendered_sql, query_limits.max_rows, self.layer.dialect)
+                    execution_started = True
                     bounded = execute_bounded(
                         self.layer,
                         bounded_sql,
@@ -264,9 +266,12 @@ class SemanticLayerConnection(riffq.BaseConnection):
                     except Exception:
                         logging.exception("Error recording query telemetry")
                     finally:
-                        close = getattr(execution_cursor, "close", None)
-                        if callable(close):
-                            close()
+                        # execute_bounded owns cursor cleanup once entered. Only
+                        # close here if SQL limiting failed before execution began.
+                        if not execution_started:
+                            close = getattr(execution_cursor, "close", None)
+                            if callable(close):
+                                close()
                         with self._active_controls_lock:
                             self._active_controls.discard(control)
                         query_admission.release()

--- a/sidemantic/server/connection.py
+++ b/sidemantic/server/connection.py
@@ -9,8 +9,24 @@ import uuid
 import riffq
 
 from sidemantic.core.semantic_layer import SemanticLayer
-from sidemantic.server.query_execution import QueryAdmission, QueryExecutionControl, QueryLimits, execute_bounded
+from sidemantic.server.query_execution import (
+    QueryAdmission,
+    QueryExecutionControl,
+    QueryLimits,
+    execute_bounded,
+    limit_query_sql,
+)
 from sidemantic.sql.query_rewriter import QueryRewriter
+
+_TRANSACTION_CONTROL = re.compile(
+    r"^\s*(?:begin(?:\s+(?:work|transaction))?|start\s+transaction|commit(?:\s+work)?|rollback(?:\s+work)?)\s*;?\s*$",
+    re.IGNORECASE,
+)
+
+
+def _is_transaction_control(sql: str) -> bool:
+    """Return whether SQL is one standalone transaction-control statement."""
+    return _TRANSACTION_CONTROL.fullmatch(sql) is not None
 
 
 class SemanticLayerConnection(riffq.BaseConnection):
@@ -111,6 +127,14 @@ class SemanticLayerConnection(riffq.BaseConnection):
             # to a lock-guarded wrapper preserving today's behavior.
             cursor = self.layer.adapter.cursor()
 
+            # Transaction control must remain pass-through. Wrapping BEGIN / COMMIT /
+            # ROLLBACK as a bounded SELECT produces invalid SQL for PG-wire clients.
+            if _is_transaction_control(sql):
+                result = cursor.execute(sql.strip().removesuffix(";"))
+                reader = result.fetch_record_batch()
+                self.send_reader(reader, callback)
+                return
+
             # Check for DML commands first (before multi-statement check)
             # These are often PostgreSQL session config and should just succeed
             if sql_lower.startswith(("set ", "update ", "insert ", "delete ")):
@@ -186,9 +210,7 @@ class SemanticLayerConnection(riffq.BaseConnection):
                 self._active_controls.add(control)
             timer.start()
             try:
-                bounded_sql = (
-                    f"SELECT * FROM ({rendered_sql}\n) AS _sidemantic_bounded LIMIT {query_limits.max_rows + 1}"
-                )
+                bounded_sql = limit_query_sql(rendered_sql, query_limits.max_rows, self.layer.dialect)
                 bounded = execute_bounded(
                     self.layer,
                     bounded_sql,

--- a/sidemantic/server/connection.py
+++ b/sidemantic/server/connection.py
@@ -147,6 +147,16 @@ class SemanticLayerConnection(riffq.BaseConnection):
                 self.send_reader(reader, callback)
                 return
 
+            # SHOW is a row-producing database command, but not a SELECT that can
+            # be wrapped in a derived table. Pass a single command through so
+            # startup probes and metadata clients receive the database result.
+            statement = sql.strip().removesuffix(";")
+            if statement.lower().startswith("show ") and ";" not in statement:
+                result = cursor.execute(statement)
+                reader = result.fetch_record_batch()
+                self.send_reader(reader, callback)
+                return
+
             # Try to handle PostgreSQL-specific system queries
             # Skip multi-statement queries to avoid response count mismatch
             if ";" not in sql:

--- a/sidemantic/server/query_execution.py
+++ b/sidemantic/server/query_execution.py
@@ -164,6 +164,19 @@ def limit_query_sql(sql: str, max_rows: int, dialect: str) -> str:
     from sqlglot import exp
 
     statement = sqlglot.parse_one(sql, read=dialect)
+    if dialect == "tsql" and isinstance(statement, exp.Select):
+        # SQL Server rejects ORDER BY inside a derived table unless the inner
+        # query also has TOP/OFFSET. Apply or tighten TOP/FETCH on the original
+        # SELECT so ordered queries remain legal and smaller user limits survive.
+        cap = max_rows + 1
+        existing_limit = statement.args.get("limit")
+        existing_count = None
+        if existing_limit is not None:
+            existing_count = existing_limit.args.get("expression") or existing_limit.args.get("count")
+        if isinstance(existing_count, exp.Literal) and existing_count.is_int:
+            if int(existing_count.this) <= cap:
+                return statement.sql(dialect=dialect)
+        return statement.limit(cap).sql(dialect=dialect)
     bounded = exp.select("*").from_(statement.subquery("_sidemantic_bounded")).limit(max_rows + 1)
     return bounded.sql(dialect=dialect)
 

--- a/sidemantic/server/query_execution.py
+++ b/sidemantic/server/query_execution.py
@@ -188,6 +188,34 @@ def limit_query_sql(sql: str, max_rows: int, dialect: str) -> str:
             if int(existing_count.this) <= cap:
                 return statement.sql(dialect=dialect)
         return statement.limit(cap).sql(dialect=dialect)
+    if dialect == "tsql" and isinstance(statement, (exp.Union, exp.Except, exp.Intersect)):
+        # SQLGlot implements limit() on set operations by nesting the complete
+        # expression. Hoist ORDER BY to the capped outer SELECT so SQL Server
+        # does not see an illegal ordered derived table.
+        cap = max_rows + 1
+        existing_limit = statement.args.get("limit")
+        existing_count = None
+        if existing_limit is not None:
+            existing_count = existing_limit.args.get("expression") or existing_limit.args.get("count")
+        if isinstance(existing_count, exp.Literal) and existing_count.is_int and int(existing_count.this) <= cap:
+            return statement.sql(dialect=dialect)
+        inner = statement.copy()
+        order = inner.args.get("order")
+        if order is not None:
+            inner.set("order", None)
+        else:
+            # SQLGlot represents a trailing TSQL ORDER BY on the rightmost
+            # SELECT rather than on the set-operation node.
+            rightmost = inner
+            while isinstance(rightmost, (exp.Union, exp.Except, exp.Intersect)):
+                rightmost = rightmost.expression
+            order = rightmost.args.get("order")
+            rightmost.set("order", None)
+        inner.set("limit", None)
+        bounded = exp.select("*").from_(inner.subquery("_sidemantic_bounded")).limit(cap)
+        if order is not None:
+            bounded.set("order", order.copy())
+        return bounded.sql(dialect=dialect)
     bounded = exp.select("*").from_(statement.subquery("_sidemantic_bounded")).limit(max_rows + 1)
     return bounded.sql(dialect=dialect)
 

--- a/sidemantic/server/query_execution.py
+++ b/sidemantic/server/query_execution.py
@@ -1,0 +1,199 @@
+"""Bounded, cancellable execution primitives for server query paths."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from sidemantic.db.base import CancellationOutcome
+from sidemantic.server.common import result_to_record_batch_reader
+
+
+class QueryExecutionError(RuntimeError):
+    """Base class for stable server execution-policy errors."""
+
+
+class QueryRowLimitExceededError(QueryExecutionError):
+    """Raised when a result contains more than the configured row ceiling."""
+
+
+class QueryResponseTooLargeError(QueryExecutionError):
+    """Raised when a result cannot fit within the response byte ceiling."""
+
+
+@dataclass(frozen=True, slots=True)
+class QueryLimits:
+    """Conservative per-process server query limits."""
+
+    max_rows: int = 10_000
+    max_response_bytes: int = 16 * 1024 * 1024
+    execution_timeout_seconds: float = 30.0
+    max_concurrent_queries: int = 4
+    max_queued_queries: int = 16
+    queue_timeout_seconds: float = 5.0
+
+    def __post_init__(self) -> None:
+        positive = {
+            "max_rows": self.max_rows,
+            "max_response_bytes": self.max_response_bytes,
+            "execution_timeout_seconds": self.execution_timeout_seconds,
+            "max_concurrent_queries": self.max_concurrent_queries,
+            "queue_timeout_seconds": self.queue_timeout_seconds,
+        }
+        for name, value in positive.items():
+            if value <= 0:
+                raise ValueError(f"{name} must be positive")
+        if self.max_queued_queries < 0:
+            raise ValueError("max_queued_queries must be >= 0")
+
+
+class QueryAdmission:
+    """Bounded execution slots plus a bounded waiter count."""
+
+    def __init__(self, max_concurrent: int, max_queued: int):
+        if max_concurrent <= 0 or max_queued < 0:
+            raise ValueError("invalid query admission limits")
+        self._semaphore = threading.BoundedSemaphore(max_concurrent)
+        self._max_queued = max_queued
+        self._lock = threading.Lock()
+        self._active = 0
+        self._queued = 0
+
+    def acquire(self, timeout: float) -> Literal["acquired", "full", "timeout"]:
+        if self._semaphore.acquire(blocking=False):
+            with self._lock:
+                self._active += 1
+            return "acquired"
+        with self._lock:
+            if self._queued >= self._max_queued:
+                return "full"
+            self._queued += 1
+        try:
+            acquired = self._semaphore.acquire(timeout=timeout)
+        finally:
+            with self._lock:
+                self._queued -= 1
+        if not acquired:
+            return "timeout"
+        with self._lock:
+            self._active += 1
+        return "acquired"
+
+    def release(self) -> None:
+        with self._lock:
+            self._active -= 1
+        self._semaphore.release()
+
+    def stats(self) -> dict[str, int]:
+        with self._lock:
+            return {"active": self._active, "queued": self._queued}
+
+
+class QueryExecutionControl:
+    """Thread-safe reference to the exact handle executing one query."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._adapter: Any | None = None
+        self._handle: Any | None = None
+        self._cancel_requested = False
+        self._cancel_outcome: CancellationOutcome | None = None
+        self.timeout_diagnostic: str | None = None
+
+    @property
+    def cancellation_outcome(self) -> CancellationOutcome | None:
+        with self._lock:
+            return self._cancel_outcome
+
+    def register(self, adapter: Any, handle: Any) -> None:
+        with self._lock:
+            self._adapter = adapter
+            self._handle = handle
+            cancel_requested = self._cancel_requested
+        if cancel_requested:
+            self.cancel()
+
+    def unregister(self, handle: Any) -> None:
+        with self._lock:
+            if self._handle is handle:
+                self._adapter = None
+                self._handle = None
+
+    def cancel(self) -> CancellationOutcome:
+        with self._lock:
+            self._cancel_requested = True
+            if self._cancel_outcome is not None and not self._cancel_outcome.diagnostic.startswith(
+                "query execution handle"
+            ):
+                return self._cancel_outcome
+            adapter = self._adapter
+            handle = self._handle
+        if adapter is None or handle is None:
+            outcome = CancellationOutcome(
+                supported=False,
+                cancelled=False,
+                diagnostic="query execution handle is not available yet; cancellation remains pending",
+            )
+        else:
+            outcome = adapter.cancel(handle)
+        with self._lock:
+            if self._cancel_outcome is None or self._cancel_outcome.diagnostic.startswith("query execution handle"):
+                self._cancel_outcome = outcome
+            return self._cancel_outcome
+
+
+@dataclass(frozen=True, slots=True)
+class BoundedQueryResult:
+    table: Any
+    row_count: int
+
+
+def execute_bounded(
+    layer: Any,
+    sql: str,
+    *,
+    limits: QueryLimits,
+    control: QueryExecutionControl,
+    cursor: Any | None = None,
+) -> BoundedQueryResult:
+    """Execute and consume Arrow batches without reading past ``max_rows + 1``."""
+    import pyarrow as pa
+
+    if cursor is None:
+        cursor = layer.adapter.cursor()
+    control.register(layer.adapter, cursor)
+    try:
+        control.timeout_diagnostic = layer.adapter.configure_statement_timeout(cursor, limits.execution_timeout_seconds)
+        result = cursor.execute(sql)
+        reader = result_to_record_batch_reader(result, layer.adapter)
+        batches = []
+        row_count = 0
+        buffered_bytes = 0
+        for batch in reader:
+            remaining = limits.max_rows + 1 - row_count
+            if remaining <= 0:
+                break
+            if batch.num_rows > remaining:
+                batch = batch.slice(0, remaining)
+            row_count += batch.num_rows
+            buffered_bytes += int(batch.nbytes)
+            if row_count > limits.max_rows:
+                control.cancel()
+                raise QueryRowLimitExceededError(
+                    f"Query result exceeds the configured maximum of {limits.max_rows} rows; "
+                    "add a narrower filter or LIMIT"
+                )
+            if buffered_bytes > limits.max_response_bytes:
+                control.cancel()
+                raise QueryResponseTooLargeError(
+                    f"Query result exceeds the configured maximum response size of {limits.max_response_bytes} bytes"
+                )
+            batches.append(batch)
+        table = pa.Table.from_batches(batches, schema=reader.schema)
+        return BoundedQueryResult(table=table, row_count=row_count)
+    finally:
+        control.unregister(cursor)
+        close = getattr(cursor, "close", None)
+        if callable(close):
+            close()

--- a/sidemantic/server/query_execution.py
+++ b/sidemantic/server/query_execution.py
@@ -200,21 +200,44 @@ def limit_query_sql(sql: str, max_rows: int, dialect: str) -> str:
         if isinstance(existing_count, exp.Literal) and existing_count.is_int and int(existing_count.this) <= cap:
             return statement.sql(dialect=dialect)
         inner = statement.copy()
+        rightmost = inner
+        while isinstance(rightmost, (exp.Union, exp.Except, exp.Intersect)):
+            rightmost = rightmost.expression
         order = inner.args.get("order")
         if order is not None:
             inner.set("order", None)
         else:
             # SQLGlot represents a trailing TSQL ORDER BY on the rightmost
             # SELECT rather than on the set-operation node.
-            rightmost = inner
-            while isinstance(rightmost, (exp.Union, exp.Except, exp.Intersect)):
-                rightmost = rightmost.expression
             order = rightmost.args.get("order")
             rightmost.set("order", None)
-        inner.set("limit", None)
+
+        offset = inner.args.get("offset")
+        if offset is not None:
+            inner.set("offset", None)
+        else:
+            offset = rightmost.args.get("offset")
+            rightmost.set("offset", None)
+
+        # A trailing TSQL FETCH is attached to the rightmost SELECT while its
+        # OFFSET is attached to the set node. Treat that pair as the limit for
+        # the complete set expression, not as a right-branch limit.
+        trailing_limit = inner.args.get("limit")
+        if trailing_limit is not None:
+            inner.set("limit", None)
+        elif offset is not None:
+            trailing_limit = rightmost.args.get("limit")
+            rightmost.set("limit", None)
+
         bounded = exp.select("*").from_(inner.subquery("_sidemantic_bounded")).limit(cap)
         if order is not None:
             bounded.set("order", order.copy())
+        if offset is not None:
+            bounded.set("offset", offset.copy())
+        if trailing_limit is not None:
+            trailing_count = trailing_limit.args.get("expression") or trailing_limit.args.get("count")
+            if isinstance(trailing_count, exp.Literal) and trailing_count.is_int and int(trailing_count.this) <= cap:
+                bounded.set("limit", trailing_limit.copy())
         return bounded.sql(dialect=dialect)
     bounded = exp.select("*").from_(statement.subquery("_sidemantic_bounded")).limit(max_rows + 1)
     return bounded.sql(dialect=dialect)

--- a/sidemantic/server/query_execution.py
+++ b/sidemantic/server/query_execution.py
@@ -170,6 +170,11 @@ def limit_query_sql(sql: str, max_rows: int, dialect: str) -> str:
     from sqlglot import exp
 
     statement = sqlglot.parse_one(sql, read=dialect)
+    if not isinstance(statement, exp.Query):
+        # Commands such as EXPLAIN, DESCRIBE, and PRAGMA may produce rows but
+        # cannot be embedded in a derived table. Their streamed results still
+        # pass through the row and byte checks in execute_bounded().
+        return statement.sql(dialect=dialect)
     if dialect == "tsql" and isinstance(statement, exp.Select):
         # SQL Server rejects ORDER BY inside a derived table unless the inner
         # query also has TOP/OFFSET. Apply or tighten TOP/FETCH on the original

--- a/sidemantic/server/query_execution.py
+++ b/sidemantic/server/query_execution.py
@@ -160,13 +160,7 @@ def execute_bounded(
     """Execute and consume Arrow batches without reading past ``max_rows + 1``."""
     import pyarrow as pa
 
-    if cursor is None:
-        cursor = layer.adapter.cursor()
-    control.register(layer.adapter, cursor)
-    try:
-        control.timeout_diagnostic = layer.adapter.configure_statement_timeout(cursor, limits.execution_timeout_seconds)
-        result = cursor.execute(sql)
-        reader = result_to_record_batch_reader(result, layer.adapter)
+    def consume(reader: Any) -> BoundedQueryResult:
         batches = []
         row_count = 0
         buffered_bytes = 0
@@ -192,6 +186,18 @@ def execute_bounded(
             batches.append(batch)
         table = pa.Table.from_batches(batches, schema=reader.schema)
         return BoundedQueryResult(table=table, row_count=row_count)
+
+    if cursor is None:
+        cursor = layer.adapter.cursor()
+    control.register(layer.adapter, cursor)
+    try:
+        control.timeout_diagnostic = layer.adapter.configure_statement_timeout(cursor, limits.execution_timeout_seconds)
+        execute_stream = getattr(cursor, "execute_stream", None)
+        if callable(execute_stream):
+            with execute_stream(sql) as reader:
+                return consume(reader)
+        result = cursor.execute(sql)
+        return consume(result_to_record_batch_reader(result, layer.adapter))
     finally:
         control.unregister(cursor)
         close = getattr(cursor, "close", None)

--- a/sidemantic/server/query_execution.py
+++ b/sidemantic/server/query_execution.py
@@ -106,6 +106,12 @@ class QueryExecutionControl:
         with self._lock:
             return self._cancel_outcome
 
+    @property
+    def cancel_requested(self) -> bool:
+        """Whether the caller has requested that execution stop."""
+        with self._lock:
+            return self._cancel_requested
+
     def register(self, adapter: Any, handle: Any) -> None:
         with self._lock:
             self._adapter = adapter

--- a/sidemantic/server/query_execution.py
+++ b/sidemantic/server/query_execution.py
@@ -158,6 +158,16 @@ class BoundedQueryResult:
     row_count: int
 
 
+def limit_query_sql(sql: str, max_rows: int, dialect: str) -> str:
+    """Apply a dialect-aware outer row limit with one overflow sentinel row."""
+    import sqlglot
+    from sqlglot import exp
+
+    statement = sqlglot.parse_one(sql, read=dialect)
+    bounded = exp.select("*").from_(statement.subquery("_sidemantic_bounded")).limit(max_rows + 1)
+    return bounded.sql(dialect=dialect)
+
+
 def execute_bounded(
     layer: Any,
     sql: str,

--- a/sidemantic/server/query_execution.py
+++ b/sidemantic/server/query_execution.py
@@ -114,6 +114,15 @@ class QueryExecutionControl:
         if cancel_requested:
             self.cancel()
 
+    def register_if_active(self, adapter: Any, handle: Any) -> bool:
+        """Register an acquired handle unless cancellation was already requested."""
+        with self._lock:
+            if self._cancel_requested:
+                return False
+            self._adapter = adapter
+            self._handle = handle
+            return True
+
     def unregister(self, handle: Any) -> None:
         with self._lock:
             if self._handle is handle:
@@ -189,12 +198,24 @@ def execute_bounded(
 
     if cursor is None:
         cursor = layer.adapter.cursor()
-    control.register(layer.adapter, cursor)
+    execute_stream = getattr(cursor, "execute_stream", None)
+    defer_registration = bool(getattr(cursor, "defer_execution_registration", False))
+    if not defer_registration:
+        control.register(layer.adapter, cursor)
     try:
         control.timeout_diagnostic = layer.adapter.configure_statement_timeout(cursor, limits.execution_timeout_seconds)
-        execute_stream = getattr(cursor, "execute_stream", None)
         if callable(execute_stream):
-            with execute_stream(sql) as reader:
+            stream_kwargs = {}
+            if defer_registration:
+
+                def register_after_lock_acquired() -> None:
+                    if not control.register_if_active(layer.adapter, cursor):
+                        raise QueryExecutionError(
+                            "Query execution was cancelled before acquiring the shared database connection"
+                        )
+
+                stream_kwargs["on_acquired"] = register_after_lock_acquired
+            with execute_stream(sql, **stream_kwargs) as reader:
                 return consume(reader)
         result = cursor.execute(sql)
         return consume(result_to_record_batch_reader(result, layer.adapter))

--- a/sidemantic/server/server.py
+++ b/sidemantic/server/server.py
@@ -5,6 +5,7 @@ import typer
 
 from sidemantic.core.semantic_layer import SemanticLayer
 from sidemantic.server.connection import SemanticLayerConnection
+from sidemantic.server.query_execution import QueryAdmission, QueryLimits
 
 
 def _sql_string_literal(value: str) -> str:
@@ -42,6 +43,12 @@ def start_server(
     username: str | None = None,
     password: str | None = None,
     user_attrs_map: dict[str, dict] | None = None,
+    max_rows: int = 10_000,
+    max_response_bytes: int = 16 * 1024 * 1024,
+    execution_timeout_seconds: float = 30.0,
+    max_concurrent_queries: int = 4,
+    max_queued_queries: int = 16,
+    queue_timeout_seconds: float = 5.0,
 ):
     """Start PostgreSQL-compatible server for the semantic layer.
 
@@ -67,10 +74,22 @@ def start_server(
             "connecting username cannot be spoofed to select another user's security attributes."
         )
 
+    query_limits = QueryLimits(
+        max_rows=max_rows,
+        max_response_bytes=max_response_bytes,
+        execution_timeout_seconds=execution_timeout_seconds,
+        max_concurrent_queries=max_concurrent_queries,
+        max_queued_queries=max_queued_queries,
+        queue_timeout_seconds=queue_timeout_seconds,
+    )
+    query_admission = QueryAdmission(max_concurrent_queries, max_queued_queries)
+
     # Create connection class with layer injected
     class BoundConnection(SemanticLayerConnection):
         def __init__(self, connection_id, executor):
             super().__init__(connection_id, executor, layer, username, password, user_attrs_map=user_attrs_map)
+            self.query_limits = query_limits
+            self.query_admission = query_admission
 
     # Start server
     server = riffq.RiffqServer(f"{host}:{port}", connection_cls=BoundConnection)

--- a/tests/core/test_query_telemetry.py
+++ b/tests/core/test_query_telemetry.py
@@ -1,0 +1,64 @@
+"""Tests for process-local sanitized query telemetry."""
+
+from sidemantic.core.query_telemetry import QueryEvent, QueryTelemetry, sanitize_sql
+
+
+def _event(query_id: str) -> QueryEvent:
+    return QueryEvent(query_id=query_id, request_id=None, duration_ms=1.0, dialect="duckdb")
+
+
+def test_history_is_bounded_and_newest_first():
+    telemetry = QueryTelemetry(history_size=2)
+    telemetry.record(_event("one"))
+    telemetry.record(_event("two"))
+    telemetry.record(_event("three"))
+
+    assert [event.query_id for event in telemetry.history()] == ["three", "two"]
+
+
+def test_listener_failure_does_not_block_other_listeners():
+    telemetry = QueryTelemetry(history_size=1)
+    received = []
+
+    def broken(_event):
+        raise RuntimeError("listener failed")
+
+    telemetry.add_listener(broken)
+    telemetry.add_listener(received.append)
+    telemetry.record(_event("query"))
+
+    assert [event.query_id for event in received] == ["query"]
+
+
+def test_resize_preserves_newest_events_and_listeners():
+    telemetry = QueryTelemetry(history_size=3)
+    received = []
+    telemetry.add_listener(received.append)
+    for query_id in ("one", "two", "three"):
+        telemetry.record(_event(query_id))
+
+    telemetry.resize(1)
+    telemetry.record(_event("four"))
+
+    assert [event.query_id for event in telemetry.history()] == ["four"]
+    assert received[-1].query_id == "four"
+
+
+def test_sql_sanitization_removes_literals_and_comments():
+    sanitized, fingerprint = sanitize_sql(
+        "SELECT * FROM orders WHERE token = 'top-secret' AND account_id = 42 -- private",
+        "duckdb",
+    )
+
+    assert sanitized is not None
+    assert "top-secret" not in sanitized
+    assert "42" not in sanitized
+    assert "private" not in sanitized
+    assert len(fingerprint) == 64
+
+
+def test_unparseable_sql_retains_only_fingerprint():
+    sanitized, fingerprint = sanitize_sql("SELECT 'secret' !!!", "duckdb")
+
+    assert sanitized is None
+    assert len(fingerprint) == 64

--- a/tests/core/test_result_cache.py
+++ b/tests/core/test_result_cache.py
@@ -194,6 +194,23 @@ def test_singleflight_follower_can_cancel_without_waiting_for_leader():
     leader.join(timeout=1.0)
 
 
+def test_singleflight_leader_does_not_cache_result_after_cancellation():
+    cache = ResultCache(max_bytes=10 * 1024 * 1024)
+    cancelled = threading.Event()
+
+    def compute():
+        cancelled.set()
+        return _table()
+
+    with pytest.raises(ResultCacheWaitCancelledError, match="computation was cancelled"):
+        cache.get_or_compute_with_status("k", compute, cancelled=cancelled.is_set)
+
+    assert cache.stats()["entries"] == 0
+    table, cache_hit = cache.get_or_compute_with_status("k", _table)
+    assert table.num_rows == 1
+    assert cache_hit is False
+
+
 def test_singleflight_compute_raises_propagates_without_deadlock():
     cache = ResultCache(max_bytes=10 * 1024 * 1024)
 

--- a/tests/core/test_result_cache.py
+++ b/tests/core/test_result_cache.py
@@ -5,13 +5,14 @@
 from __future__ import annotations
 
 import threading
+import time
 
 import pytest
 
 pa = pytest.importorskip("pyarrow")
 
 from sidemantic import Metric, Model, SemanticLayer
-from sidemantic.core.result_cache import ResultCache, build_result_key
+from sidemantic.core.result_cache import ResultCache, ResultCacheWaitCancelledError, build_result_key
 
 
 class _Clock:
@@ -151,6 +152,46 @@ def test_singleflight_runs_compute_once():
 
     assert calls["n"] == 1
     assert results["t1"] is results["t2"]
+
+
+def test_singleflight_follower_can_cancel_without_waiting_for_leader():
+    cache = ResultCache(max_bytes=10 * 1024 * 1024)
+    leader_entered = threading.Event()
+    release_leader = threading.Event()
+    cancel_waiter = threading.Event()
+
+    def compute():
+        leader_entered.set()
+        assert release_leader.wait(timeout=5.0)
+        return _table()
+
+    leader = threading.Thread(target=lambda: cache.get_or_compute("k", compute))
+    leader.start()
+    assert leader_entered.wait(timeout=1.0)
+
+    errors = []
+
+    def wait_for_leader():
+        try:
+            cache.get_or_compute_with_status("k", compute, cancelled=cancel_waiter.is_set)
+        except BaseException as exc:  # noqa: BLE001 - capture for assertion
+            errors.append(exc)
+
+    follower = threading.Thread(target=wait_for_leader)
+    follower.start()
+    deadline = time.monotonic() + 1.0
+    while cache.stats()["misses"] < 2 and time.monotonic() < deadline:
+        time.sleep(0.001)
+
+    cancel_waiter.set()
+    follower.join(timeout=1.0)
+
+    assert not follower.is_alive()
+    assert isinstance(errors[0], ResultCacheWaitCancelledError)
+    assert leader.is_alive()
+
+    release_leader.set()
+    leader.join(timeout=1.0)
 
 
 def test_singleflight_compute_raises_propagates_without_deadlock():

--- a/tests/db/test_duckdb_adapter.py
+++ b/tests/db/test_duckdb_adapter.py
@@ -65,6 +65,29 @@ def test_duckdb_adapter_from_url_read_only():
             adapter.execute("CREATE TABLE blocked (id INT)")
 
 
+def test_duckdb_read_only_rejects_memory_database():
+    with pytest.raises(ValueError, match="cannot be opened read-only"):
+        DuckDBAdapter(":memory:", read_only=True)
+
+
+def test_duckdb_read_only_url_rejects_invalid_boolean(tmp_path):
+    with pytest.raises(ValueError, match="read_only must be"):
+        DuckDBAdapter.from_url(f"duckdb:///{tmp_path / 'test.db'}?read_only=maybe")
+
+
+def test_file_backed_cursor_uses_independent_connection(tmp_path):
+    db_path = tmp_path / "test.duckdb"
+    adapter = DuckDBAdapter(str(db_path))
+    adapter.execute("CREATE TABLE values_table AS SELECT 42 AS value")
+
+    cursor = adapter.cursor()
+    try:
+        assert cursor is not adapter.raw_connection
+        assert cursor.execute("SELECT value FROM values_table").fetchone() == (42,)
+    finally:
+        cursor.close()
+
+
 def test_duckdb_adapter_get_tables():
     """Test getting table list."""
     adapter = DuckDBAdapter()

--- a/tests/db/test_duckdb_init_sql_config.py
+++ b/tests/db/test_duckdb_init_sql_config.py
@@ -94,3 +94,19 @@ def test_resolve_paths_preserves_init_sql(tmp_path):
     resolved = config.resolve_paths(tmp_path)
     assert isinstance(resolved.connection, DuckDBConnection)
     assert resolved.connection.init_sql == ["LOAD httpfs"]
+
+
+def test_duckdb_read_only_config_round_trip(tmp_path):
+    config = SidemanticConfig(connection=DuckDBConnection(path="data/warehouse.db", read_only=True))
+
+    resolved = config.resolve_paths(tmp_path)
+
+    assert isinstance(resolved.connection, DuckDBConnection)
+    assert resolved.connection.read_only is True
+    assert build_connection_string(resolved).endswith("?read_only=true")
+
+
+def test_duckdb_explicit_write_config_is_preserved():
+    config = SidemanticConfig(connection=DuckDBConnection(path="warehouse.db", read_only=False))
+
+    assert build_connection_string(config).endswith("?read_only=false")

--- a/tests/server/test_api_server.py
+++ b/tests/server/test_api_server.py
@@ -4,10 +4,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
 import time
 from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -680,6 +682,51 @@ def test_timed_out_cache_leader_result_is_not_inserted():
 
     assert app.state.query_admission.stats()["active"] == 0
     assert app.state.result_cache.stats()["entries"] == 0
+
+
+def test_disconnected_http_request_does_not_start_work_after_queue(monkeypatch):
+    from unittest.mock import AsyncMock, MagicMock
+
+    from fastapi import HTTPException
+
+    from sidemantic.api_server import _execute_http_query
+    from sidemantic.core.query_telemetry import QueryTelemetry
+    from sidemantic.server.query_execution import QueryAdmission, QueryLimits
+
+    admission = QueryAdmission(1, 0)
+    layer = MagicMock()
+    layer.dialect = "duckdb"
+    layer.query_telemetry = QueryTelemetry()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            query_limits=QueryLimits(),
+            query_admission=admission,
+        )
+    )
+    request = MagicMock()
+    request.headers = {}
+    request.is_disconnected = AsyncMock(return_value=True)
+    query_table = MagicMock()
+    monkeypatch.setattr("sidemantic.api_server._query_table", query_table)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            _execute_http_query(
+                app,
+                request,
+                layer,
+                "SELECT 1",
+                format_override=None,
+                user_attributes=None,
+            )
+        )
+
+    assert exc_info.value.status_code == 499
+    assert "no warehouse query was started" in exc_info.value.detail
+    assert admission.stats() == {"active": 0, "queued": 0}
+    query_table.assert_not_called()
+    event = layer.query_telemetry.history()[0]
+    assert event.error == "ClientDisconnected"
 
 
 def test_worker_timeout_error_is_not_swallowed_as_poll_timeout():

--- a/tests/server/test_api_server.py
+++ b/tests/server/test_api_server.py
@@ -323,6 +323,24 @@ def test_compile_and_query_json_endpoints(tmp_path):
     ]
 
 
+def test_structured_query_preserves_layer_default_limit(tmp_path):
+    client = _build_test_client(tmp_path)
+    client.app.state.layer.default_limit = 1
+
+    response = client.post(
+        "/query",
+        headers=_auth_headers(),
+        json={
+            "dimensions": ["orders.status"],
+            "metrics": ["orders.order_count"],
+            "order_by": ["orders.status"],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["row_count"] == 1
+
+
 def test_compile_accepts_timezone(tmp_path):
     # The optional timezone field on the structured-query request threads into
     # layer.compile so time-dimension truncation happens in the requested zone.

--- a/tests/server/test_api_server.py
+++ b/tests/server/test_api_server.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import threading
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -19,7 +20,7 @@ from fastapi.testclient import TestClient
 
 from sidemantic import DashboardDocument, Dimension, Metric, Model, SemanticLayer, load_from_directory
 from sidemantic.api_server import create_app
-from sidemantic.db.base import BaseDatabaseAdapter
+from sidemantic.db.base import BaseDatabaseAdapter, CancellationOutcome
 from sidemantic.server.common import ARROW_STREAM_MEDIA_TYPE
 
 
@@ -50,7 +51,11 @@ models:
 
 
 def _build_test_client(
-    tmp_path: Path, auth_token: str | None = "secret", max_body_bytes: int = 1024 * 1024, serve_ui: bool = False
+    tmp_path: Path,
+    auth_token: str | None = "secret",
+    max_body_bytes: int = 1024 * 1024,
+    serve_ui: bool = False,
+    **app_kwargs,
 ):
     models_dir = tmp_path / "models"
     _write_models(models_dir)
@@ -79,7 +84,13 @@ def _build_test_client(
 
     layer = SemanticLayer(connection=f"duckdb:///{db_path}", auto_register=False)
     load_from_directory(layer, str(models_dir))
-    app = create_app(layer, auth_token=auth_token, max_request_body_bytes=max_body_bytes, serve_ui=serve_ui)
+    app = create_app(
+        layer,
+        auth_token=auth_token,
+        max_request_body_bytes=max_body_bytes,
+        serve_ui=serve_ui,
+        **app_kwargs,
+    )
     return TestClient(app)
 
 
@@ -235,6 +246,9 @@ def test_result_cache_serves_repeated_query(tmp_path):
     assert stats["hits"] == 1
     assert stats["misses"] == 1
     assert stats["entries"] == 1
+    history = app.state.layer.query_telemetry.history(limit=2)
+    assert history[0].cache_hit is True
+    assert history[1].cache_hit is False
 
     # A different query is a distinct cache entry (another miss).
     other = client.post(
@@ -373,6 +387,58 @@ def test_query_arrow_respects_accept_header(tmp_path):
     assert table.to_pylist() == [{"order_count": 3}]
 
 
+@pytest.mark.parametrize("response_format", ["json", "arrow"])
+def test_query_row_limit_applies_to_json_and_arrow(tmp_path, response_format):
+    client = _build_test_client(tmp_path, max_rows=2)
+
+    response = client.post(
+        f"/raw?format={response_format}",
+        headers=_auth_headers(),
+        json={"query": "SELECT * FROM range(3)"},
+    )
+
+    assert response.status_code == 422
+    assert "maximum of 2 rows" in response.json()["detail"]
+    assert response.headers["X-Sidemantic-Query-ID"]
+
+
+@pytest.mark.parametrize("response_format", ["json", "arrow"])
+def test_query_response_byte_limit_applies_to_json_and_arrow(tmp_path, response_format):
+    client = _build_test_client(tmp_path, max_response_bytes=128)
+
+    response = client.post(
+        f"/raw?format={response_format}",
+        headers=_auth_headers(),
+        json={"query": "SELECT repeat('x', 1024) AS payload"},
+    )
+
+    assert response.status_code == 413
+    assert "maximum" in response.json()["detail"]
+
+
+def test_query_response_ids_and_sanitized_telemetry(tmp_path):
+    client = _build_test_client(tmp_path)
+
+    response = client.post(
+        "/raw",
+        headers={**_auth_headers(), "X-Request-ID": "caller-request"},
+        json={"query": "SELECT 'top-secret' AS value"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-Sidemantic-Request-ID"] == "caller-request"
+    query_id = response.headers["X-Sidemantic-Query-ID"]
+    assert len(query_id) == 32
+    event = client.app.state.layer.query_telemetry.history()[0]
+    assert event.query_id == query_id
+    assert event.request_id == "caller-request"
+    assert event.row_count == 1
+    assert event.response_bytes == int(response.headers["X-Sidemantic-Response-Bytes"])
+    assert event.error is None
+    assert event.sql is not None
+    assert "top-secret" not in event.sql
+
+
 def test_sql_compile_and_sql_query_endpoints(tmp_path):
     client = _build_test_client(tmp_path)
 
@@ -478,6 +544,59 @@ class _ArrowOnlyAdapter(BaseDatabaseAdapter):
     @property
     def raw_connection(self) -> Any:
         return None
+
+
+class _CancellableCursor:
+    def __init__(self, entered: threading.Event, cancelled: threading.Event):
+        self.entered = entered
+        self.cancelled = cancelled
+
+    def execute(self, _sql: str):
+        self.entered.set()
+        self.cancelled.wait(timeout=5)
+        if self.cancelled.is_set():
+            raise RuntimeError("cancelled")
+        return _ArrowOnlyResult()
+
+    def close(self):
+        return None
+
+
+class _CancellableAdapter(_ArrowOnlyAdapter):
+    def __init__(self):
+        self.entered = threading.Event()
+        self.cancelled = threading.Event()
+
+    def cursor(self):
+        return _CancellableCursor(self.entered, self.cancelled)
+
+    def cancel(self, _handle):
+        self.cancelled.set()
+        return CancellationOutcome(True, True, "duckdb cancellation requested via test handle")
+
+
+def test_execution_timeout_cancels_and_records_diagnostic():
+    adapter = _CancellableAdapter()
+    layer = SemanticLayer(connection=adapter, auto_register=False)
+    client = TestClient(
+        create_app(
+            layer,
+            execution_timeout_seconds=0.05,
+            max_concurrent_queries=1,
+            max_queued_queries=0,
+        )
+    )
+
+    response = client.post("/raw", json={"query": "SELECT 1"})
+
+    assert response.status_code == 504
+    assert adapter.entered.is_set()
+    assert adapter.cancelled.is_set()
+    assert "cancellation requested" in response.json()["detail"]
+    event = layer.query_telemetry.history()[0]
+    assert event.timed_out is True
+    assert event.cancelled is True
+    assert event.error == "QueryExecutionTimeout"
 
 
 def test_sql_with_semicolon_in_string_literal(tmp_path):

--- a/tests/server/test_api_server.py
+++ b/tests/server/test_api_server.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -606,6 +607,32 @@ class _WorkerTimeoutAdapter(_ArrowOnlyAdapter):
         return _WorkerTimeoutCursor()
 
 
+class _UncancellableSlowCursor:
+    def __init__(self, entered: threading.Event, release: threading.Event):
+        self.entered = entered
+        self.release = release
+
+    def execute(self, _sql: str):
+        self.entered.set()
+        assert self.release.wait(timeout=5)
+        return _ArrowOnlyResult()
+
+    def close(self):
+        return None
+
+
+class _UncancellableSlowAdapter(_ArrowOnlyAdapter):
+    def __init__(self):
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def cursor(self):
+        return _UncancellableSlowCursor(self.entered, self.release)
+
+    def cancel(self, _handle):
+        return CancellationOutcome(False, False, "test adapter cannot cancel; warehouse work may continue")
+
+
 def test_execution_timeout_cancels_and_records_diagnostic():
     adapter = _CancellableAdapter()
     layer = SemanticLayer(connection=adapter, auto_register=False)
@@ -628,6 +655,31 @@ def test_execution_timeout_cancels_and_records_diagnostic():
     assert event.timed_out is True
     assert event.cancelled is True
     assert event.error == "QueryExecutionTimeout"
+
+
+def test_timed_out_cache_leader_result_is_not_inserted():
+    adapter = _UncancellableSlowAdapter()
+    layer = SemanticLayer(connection=adapter, auto_register=False)
+    app = create_app(
+        layer,
+        execution_timeout_seconds=0.05,
+        max_concurrent_queries=1,
+        max_queued_queries=0,
+        result_cache_mb=1,
+    )
+    client = TestClient(app)
+
+    response = client.post("/raw", json={"query": "SELECT 1"})
+
+    assert response.status_code == 504
+    assert adapter.entered.is_set()
+    adapter.release.set()
+    deadline = time.monotonic() + 1
+    while app.state.query_admission.stats()["active"] and time.monotonic() < deadline:
+        time.sleep(0.001)
+
+    assert app.state.query_admission.stats()["active"] == 0
+    assert app.state.result_cache.stats()["entries"] == 0
 
 
 def test_worker_timeout_error_is_not_swallowed_as_poll_timeout():

--- a/tests/server/test_api_server.py
+++ b/tests/server/test_api_server.py
@@ -575,6 +575,19 @@ class _CancellableAdapter(_ArrowOnlyAdapter):
         return CancellationOutcome(True, True, "duckdb cancellation requested via test handle")
 
 
+class _WorkerTimeoutCursor:
+    def execute(self, _sql: str):
+        raise TimeoutError("warehouse statement timed out")
+
+    def close(self):
+        return None
+
+
+class _WorkerTimeoutAdapter(_ArrowOnlyAdapter):
+    def cursor(self):
+        return _WorkerTimeoutCursor()
+
+
 def test_execution_timeout_cancels_and_records_diagnostic():
     adapter = _CancellableAdapter()
     layer = SemanticLayer(connection=adapter, auto_register=False)
@@ -597,6 +610,19 @@ def test_execution_timeout_cancels_and_records_diagnostic():
     assert event.timed_out is True
     assert event.cancelled is True
     assert event.error == "QueryExecutionTimeout"
+
+
+def test_worker_timeout_error_is_not_swallowed_as_poll_timeout():
+    adapter = _WorkerTimeoutAdapter()
+    layer = SemanticLayer(connection=adapter, auto_register=False)
+    client = TestClient(create_app(layer, execution_timeout_seconds=1.0))
+
+    with pytest.raises(TimeoutError, match="warehouse statement timed out"):
+        client.post("/raw", json={"query": "SELECT 1"})
+
+    event = layer.query_telemetry.history()[0]
+    assert event.error == "TimeoutError"
+    assert event.timed_out is False
 
 
 def test_sql_with_semicolon_in_string_literal(tmp_path):

--- a/tests/server/test_connection.py
+++ b/tests/server/test_connection.py
@@ -1,5 +1,8 @@
 """Tests for PostgreSQL wire protocol connection handling."""
 
+import threading
+import time
+
 import pytest
 
 from sidemantic import Dimension, Metric, Model, SemanticLayer
@@ -122,17 +125,15 @@ def test_dml_passthrough():
 
 @pytest.mark.parametrize("statement", ["BEGIN", "BEGIN TRANSACTION;", "COMMIT", "ROLLBACK WORK"])
 def test_transaction_control_is_not_wrapped_as_select(statement):
-    pytest.importorskip("riffq")
+    from tests.optional_dep_stubs import ensure_fake_riffq
+
+    ensure_fake_riffq()
     pytest.importorskip("pyarrow")
     from unittest.mock import MagicMock
 
     from sidemantic.server.connection import SemanticLayerConnection
 
-    cursor = MagicMock()
-    reader = object()
-    cursor.execute.return_value.fetch_record_batch.return_value = reader
     layer = MagicMock()
-    layer.adapter.cursor.return_value = cursor
 
     conn = SemanticLayerConnection.__new__(SemanticLayerConnection)
     conn.layer = layer
@@ -143,8 +144,72 @@ def test_transaction_control_is_not_wrapped_as_select(statement):
 
     conn._handle_query(statement, callback)
 
-    cursor.execute.assert_called_once_with(statement.strip().removesuffix(";"))
-    conn.send_reader.assert_called_once_with(reader, callback)
+    layer.adapter.cursor.assert_not_called()
+    reader, sent_callback = conn.send_reader.call_args.args
+    assert reader.read_all().num_rows == 0
+    assert sent_callback is callback
+
+
+def test_pg_wire_timeout_returns_before_uncancellable_worker_finishes(monkeypatch):
+    from tests.optional_dep_stubs import ensure_fake_riffq
+
+    ensure_fake_riffq()
+    pytest.importorskip("pyarrow")
+    from unittest.mock import MagicMock
+
+    from sidemantic.core.query_telemetry import QueryTelemetry
+    from sidemantic.db.base import CancellationOutcome
+    from sidemantic.server.connection import SemanticLayerConnection
+    from sidemantic.server.query_execution import QueryAdmission, QueryLimits
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def blocking_execute(*args, **kwargs):
+        kwargs["control"].register(args[0].adapter, kwargs["cursor"])
+        worker_started.set()
+        assert release_worker.wait(timeout=2)
+        raise RuntimeError("worker released")
+
+    monkeypatch.setattr("sidemantic.server.connection.execute_bounded", blocking_execute)
+    monkeypatch.setattr("sidemantic.server.connection.QueryRewriter.rewrite", lambda *args, **kwargs: "SELECT 1")
+
+    cursor = MagicMock()
+    layer = MagicMock()
+    layer.adapter.cursor.return_value = cursor
+    layer.adapter.cancel.return_value = CancellationOutcome(
+        supported=False,
+        cancelled=False,
+        diagnostic="test adapter cannot cancel an in-flight query; warehouse work may continue",
+    )
+    layer.graph.models = {}
+    layer.dialect = "duckdb"
+    layer.query_telemetry = QueryTelemetry()
+
+    conn = SemanticLayerConnection.__new__(SemanticLayerConnection)
+    conn.layer = layer
+    conn.user_attrs_map = {}
+    conn.session_user = None
+    conn.connection_id = 1
+    conn.query_limits = QueryLimits(execution_timeout_seconds=0.05)
+    conn.query_admission = QueryAdmission(1, 0)
+    conn._active_controls = set()
+    conn._active_controls_lock = threading.Lock()
+
+    started = time.monotonic()
+    try:
+        with pytest.raises(TimeoutError, match="warehouse work may continue"):
+            conn._handle_query("SELECT 1", MagicMock())
+        assert worker_started.is_set()
+        assert time.monotonic() - started < 0.5
+    finally:
+        release_worker.set()
+
+    deadline = time.monotonic() + 1
+    while conn.query_admission.stats()["active"] and time.monotonic() < deadline:
+        time.sleep(0.001)
+    assert conn.query_admission.stats()["active"] == 0
+    cursor.close.assert_called_once()
 
 
 def test_query_error_raises_exception():

--- a/tests/server/test_connection.py
+++ b/tests/server/test_connection.py
@@ -123,6 +123,35 @@ def test_dml_passthrough():
     assert "reader" in captured
 
 
+@pytest.mark.parametrize("statement", ["SHOW TABLES", "SHOW TABLES;"])
+def test_show_passthrough_is_not_wrapped_as_select(statement):
+    from tests.optional_dep_stubs import ensure_fake_riffq
+
+    ensure_fake_riffq()
+    pytest.importorskip("pyarrow")
+    from unittest.mock import MagicMock
+
+    from sidemantic.server.connection import SemanticLayerConnection
+
+    reader = MagicMock()
+    cursor = MagicMock()
+    cursor.execute.return_value.fetch_record_batch.return_value = reader
+    layer = MagicMock()
+    layer.adapter.cursor.return_value = cursor
+
+    conn = SemanticLayerConnection.__new__(SemanticLayerConnection)
+    conn.layer = layer
+    conn.user_attrs_map = {}
+    conn.session_user = None
+    conn.send_reader = MagicMock()
+    callback = MagicMock()
+
+    conn._handle_query(statement, callback)
+
+    cursor.execute.assert_called_once_with("SHOW TABLES")
+    conn.send_reader.assert_called_once_with(reader, callback)
+
+
 @pytest.mark.parametrize("statement", ["BEGIN", "BEGIN TRANSACTION;", "COMMIT", "ROLLBACK WORK"])
 def test_transaction_control_is_not_wrapped_as_select(statement):
     from tests.optional_dep_stubs import ensure_fake_riffq

--- a/tests/server/test_connection.py
+++ b/tests/server/test_connection.py
@@ -152,7 +152,19 @@ def test_show_passthrough_is_not_wrapped_as_select(statement):
     conn.send_reader.assert_called_once_with(reader, callback)
 
 
-@pytest.mark.parametrize("statement", ["BEGIN", "BEGIN TRANSACTION;", "COMMIT", "ROLLBACK WORK"])
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "BEGIN",
+        "BEGIN TRANSACTION;",
+        "BEGIN READ ONLY",
+        "START TRANSACTION ISOLATION LEVEL READ COMMITTED",
+        "COMMIT",
+        "COMMIT AND CHAIN",
+        "END TRANSACTION",
+        "ROLLBACK WORK",
+    ],
+)
 def test_transaction_control_is_not_wrapped_as_select(statement):
     from tests.optional_dep_stubs import ensure_fake_riffq
 

--- a/tests/server/test_connection.py
+++ b/tests/server/test_connection.py
@@ -197,8 +197,11 @@ def test_pg_wire_timeout_returns_before_uncancellable_worker_finishes(monkeypatc
     def blocking_execute(*args, **kwargs):
         kwargs["control"].register(args[0].adapter, kwargs["cursor"])
         worker_started.set()
-        assert release_worker.wait(timeout=2)
-        raise RuntimeError("worker released")
+        try:
+            assert release_worker.wait(timeout=2)
+            raise RuntimeError("worker released")
+        finally:
+            kwargs["cursor"].close()
 
     monkeypatch.setattr("sidemantic.server.connection.execute_bounded", blocking_execute)
     monkeypatch.setattr("sidemantic.server.connection.QueryRewriter.rewrite", lambda *args, **kwargs: "SELECT 1")
@@ -239,6 +242,63 @@ def test_pg_wire_timeout_returns_before_uncancellable_worker_finishes(monkeypatc
         time.sleep(0.001)
     assert conn.query_admission.stats()["active"] == 0
     cursor.close.assert_called_once()
+
+
+def test_pg_wire_bounded_query_closes_cursor_once(monkeypatch):
+    from tests.optional_dep_stubs import ensure_fake_riffq
+
+    ensure_fake_riffq()
+    pa = pytest.importorskip("pyarrow")
+    from unittest.mock import MagicMock
+
+    from sidemantic.core.query_telemetry import QueryTelemetry
+    from sidemantic.server.connection import SemanticLayerConnection
+    from sidemantic.server.query_execution import QueryAdmission, QueryLimits
+
+    class NonIdempotentCursor:
+        def __init__(self):
+            self.close_count = 0
+
+        def execute(self, _sql):
+            reader = pa.table({"value": [1]}).to_reader()
+
+            class Result:
+                def fetch_record_batch(self):
+                    return reader
+
+            return Result()
+
+        def close(self):
+            self.close_count += 1
+            if self.close_count > 1:
+                raise RuntimeError("cursor closed twice")
+
+    cursor = NonIdempotentCursor()
+    layer = MagicMock()
+    layer.adapter.cursor.return_value = cursor
+    layer.adapter.configure_statement_timeout.return_value = "test timeout configured"
+    layer.graph.models = {}
+    layer.dialect = "duckdb"
+    layer.query_telemetry = QueryTelemetry()
+
+    monkeypatch.setattr("sidemantic.server.connection.QueryRewriter.rewrite", lambda *args, **kwargs: "SELECT 1")
+
+    conn = SemanticLayerConnection.__new__(SemanticLayerConnection)
+    conn.layer = layer
+    conn.user_attrs_map = {}
+    conn.session_user = None
+    conn.connection_id = 1
+    conn.query_limits = QueryLimits()
+    conn.query_admission = QueryAdmission(1, 0)
+    conn._active_controls = set()
+    conn._active_controls_lock = threading.Lock()
+    conn.send_reader = MagicMock()
+
+    conn._handle_query("SELECT 1", MagicMock())
+
+    assert cursor.close_count == 1
+    assert conn.query_admission.stats()["active"] == 0
+    conn.send_reader.assert_called_once()
 
 
 def test_query_error_raises_exception():

--- a/tests/server/test_connection.py
+++ b/tests/server/test_connection.py
@@ -301,6 +301,60 @@ def test_pg_wire_bounded_query_closes_cursor_once(monkeypatch):
     conn.send_reader.assert_called_once()
 
 
+def test_pg_wire_disconnect_cancels_query_waiting_for_admission(monkeypatch):
+    from tests.optional_dep_stubs import ensure_fake_riffq
+
+    ensure_fake_riffq()
+    pytest.importorskip("pyarrow")
+    from unittest.mock import MagicMock
+
+    from sidemantic.server.connection import SemanticLayerConnection
+    from sidemantic.server.query_execution import QueryAdmission, QueryLimits
+
+    monkeypatch.setattr("sidemantic.server.connection.QueryRewriter.rewrite", lambda *args, **kwargs: "SELECT 1")
+
+    cursor = MagicMock()
+    layer = MagicMock()
+    layer.adapter.cursor.return_value = cursor
+    layer.graph.models = {}
+    layer.dialect = "duckdb"
+
+    admission = QueryAdmission(1, 1)
+    assert admission.acquire(0.1) == "acquired"
+
+    conn = SemanticLayerConnection.__new__(SemanticLayerConnection)
+    conn.layer = layer
+    conn.user_attrs_map = {}
+    conn.session_user = None
+    conn.query_limits = QueryLimits(queue_timeout_seconds=1)
+    conn.query_admission = admission
+    conn._active_controls = set()
+    conn._active_controls_lock = threading.Lock()
+
+    errors = []
+
+    def run_query():
+        try:
+            conn._handle_query("SELECT 1", MagicMock())
+        except BaseException as exc:  # noqa: BLE001 - capture for assertion
+            errors.append(exc)
+
+    query = threading.Thread(target=run_query)
+    query.start()
+    deadline = time.monotonic() + 1
+    while admission.stats()["queued"] != 1 and time.monotonic() < deadline:
+        time.sleep(0.001)
+
+    conn.handle_disconnect("127.0.0.1", 5432, callback=lambda _ok: None)
+    admission.release()
+    query.join(timeout=1)
+
+    assert isinstance(errors[0], ConnectionAbortedError)
+    cursor.execute.assert_not_called()
+    assert admission.stats() == {"active": 0, "queued": 0}
+    assert not conn._active_controls
+
+
 def test_query_error_raises_exception():
     """_handle_query should raise on errors, not return error as data rows."""
     pytest.importorskip("riffq")
@@ -312,6 +366,7 @@ def test_query_error_raises_exception():
 
     mock_layer = MagicMock()
     # Query work now runs on a per-request cursor obtained from the adapter.
+    mock_layer.adapter.cursor.return_value.execute_stream = None
     mock_layer.adapter.cursor.return_value.execute.side_effect = Exception("test error")
     mock_layer.graph = SemanticGraph()
     mock_layer.dialect = "duckdb"

--- a/tests/server/test_connection.py
+++ b/tests/server/test_connection.py
@@ -120,6 +120,33 @@ def test_dml_passthrough():
     assert "reader" in captured
 
 
+@pytest.mark.parametrize("statement", ["BEGIN", "BEGIN TRANSACTION;", "COMMIT", "ROLLBACK WORK"])
+def test_transaction_control_is_not_wrapped_as_select(statement):
+    pytest.importorskip("riffq")
+    pytest.importorskip("pyarrow")
+    from unittest.mock import MagicMock
+
+    from sidemantic.server.connection import SemanticLayerConnection
+
+    cursor = MagicMock()
+    reader = object()
+    cursor.execute.return_value.fetch_record_batch.return_value = reader
+    layer = MagicMock()
+    layer.adapter.cursor.return_value = cursor
+
+    conn = SemanticLayerConnection.__new__(SemanticLayerConnection)
+    conn.layer = layer
+    conn.user_attrs_map = {}
+    conn.session_user = None
+    conn.send_reader = MagicMock()
+    callback = MagicMock()
+
+    conn._handle_query(statement, callback)
+
+    cursor.execute.assert_called_once_with(statement.strip().removesuffix(";"))
+    conn.send_reader.assert_called_once_with(reader, callback)
+
+
 def test_query_error_raises_exception():
     """_handle_query should raise on errors, not return error as data rows."""
     pytest.importorskip("riffq")

--- a/tests/server/test_query_execution.py
+++ b/tests/server/test_query_execution.py
@@ -90,6 +90,39 @@ class _StreamingLimitAdapter(_ControlCommandAdapter):
         return Reader()
 
 
+class _CancellationProbe:
+    def __init__(self):
+        self.calls = 0
+
+    def cancel(self):
+        self.calls += 1
+
+
+class _BlockingFallbackAdapter(_StreamingLimitAdapter):
+    def __init__(self):
+        super().__init__()
+        self.query_started = threading.Event()
+        self.release_query = threading.Event()
+        self.execute_calls = 0
+        self.connection = _CancellationProbe()
+
+    @property
+    def raw_connection(self):
+        return self.connection
+
+    def execute(self, sql):
+        self.execute_calls += 1
+        if self.execute_calls == 1:
+            self.query_started.set()
+            assert self.release_query.wait(timeout=2)
+        return object()
+
+    def fetch_record_batch(self, result):
+        import pyarrow as pa
+
+        return pa.table({"value": [1]}).to_reader()
+
+
 def test_query_limits_validate_conservative_values():
     limits = QueryLimits()
 
@@ -164,3 +197,51 @@ def test_fallback_cursor_enforces_byte_limit_before_full_materialization():
         )
 
     assert adapter.statements == ["SELECT payload"]
+
+
+def test_queued_fallback_cancellation_does_not_cancel_connection_owner():
+    adapter = _BlockingFallbackAdapter()
+    layer = SimpleNamespace(adapter=adapter)
+    first_results = []
+    first_errors = []
+    second_errors = []
+    second_control = QueryExecutionControl()
+
+    def run_first():
+        try:
+            first_results.append(
+                execute_bounded(layer, "SELECT 1", limits=QueryLimits(), control=QueryExecutionControl())
+            )
+        except Exception as exc:
+            first_errors.append(exc)
+
+    def run_second():
+        try:
+            execute_bounded(layer, "SELECT 2", limits=QueryLimits(), control=second_control)
+        except Exception as exc:
+            second_errors.append(exc)
+
+    first = threading.Thread(target=run_first)
+    first.start()
+    assert adapter.query_started.wait(timeout=1)
+
+    second = threading.Thread(target=run_second)
+    second.start()
+    time.sleep(0.05)
+    outcome = second_control.cancel()
+
+    assert outcome.cancelled is False
+    assert adapter.connection.calls == 0
+
+    adapter.release_query.set()
+    first.join(timeout=1)
+    second.join(timeout=1)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert first_errors == []
+    assert first_results[0].row_count == 1
+    assert len(second_errors) == 1
+    assert "cancelled before acquiring" in str(second_errors[0])
+    assert adapter.execute_calls == 1
+    assert adapter.connection.calls == 0

--- a/tests/server/test_query_execution.py
+++ b/tests/server/test_query_execution.py
@@ -2,11 +2,18 @@
 
 import threading
 import time
+from types import SimpleNamespace
 
 import pytest
 
 from sidemantic.db.base import BaseDatabaseAdapter
-from sidemantic.server.query_execution import QueryAdmission, QueryExecutionControl, QueryLimits
+from sidemantic.server.query_execution import (
+    QueryAdmission,
+    QueryExecutionControl,
+    QueryLimits,
+    QueryResponseTooLargeError,
+    execute_bounded,
+)
 
 
 class _ControlCommandAdapter(BaseDatabaseAdapter):
@@ -52,6 +59,35 @@ class _ControlCommandAdapter(BaseDatabaseAdapter):
 
     def close(self):
         return None
+
+
+class _StreamingLimitAdapter(_ControlCommandAdapter):
+    @property
+    def dialect(self):
+        return "test"
+
+    def execute(self, sql):
+        self.statements.append(sql)
+        return object()
+
+    def fetch_record_batch(self, result):
+        import pyarrow as pa
+
+        batch = pa.record_batch([["x" * 1024]], names=["payload"])
+
+        class Reader:
+            schema = batch.schema
+
+            def __iter__(self):
+                yield batch
+
+            def read_all(self):
+                raise AssertionError("bounded serving must not call read_all()")
+
+            def close(self):
+                return None
+
+        return Reader()
 
 
 def test_query_limits_validate_conservative_values():
@@ -113,3 +149,18 @@ def test_statement_timeout_requires_positive_value():
 
     with pytest.raises(ValueError, match="must be positive"):
         adapter.configure_statement_timeout(adapter.cursor(), 0)
+
+
+def test_fallback_cursor_enforces_byte_limit_before_full_materialization():
+    adapter = _StreamingLimitAdapter()
+    layer = SimpleNamespace(adapter=adapter)
+
+    with pytest.raises(QueryResponseTooLargeError):
+        execute_bounded(
+            layer,
+            "SELECT payload",
+            limits=QueryLimits(max_response_bytes=32),
+            control=QueryExecutionControl(),
+        )
+
+    assert adapter.statements == ["SELECT payload"]

--- a/tests/server/test_query_execution.py
+++ b/tests/server/test_query_execution.py
@@ -162,6 +162,19 @@ def test_limit_query_sql_hoists_order_from_tsql_set_queries(operator):
     )
 
 
+def test_limit_query_sql_hoists_tsql_set_query_offset_and_fetch():
+    bounded = limit_query_sql(
+        "SELECT 1 AS value UNION SELECT 2 AS value ORDER BY value OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY",
+        10,
+        "tsql",
+    )
+
+    assert bounded == (
+        "SELECT * FROM (SELECT 1 AS value UNION SELECT 2 AS value) AS _sidemantic_bounded "
+        "ORDER BY value OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY"
+    )
+
+
 @pytest.mark.parametrize("sql", ["EXPLAIN SELECT 1", "DESCRIBE facts", "PRAGMA version"])
 def test_limit_query_sql_passes_row_producing_commands_through(sql):
     assert limit_query_sql(sql, 10, "duckdb") == sql

--- a/tests/server/test_query_execution.py
+++ b/tests/server/test_query_execution.py
@@ -153,6 +153,11 @@ def test_limit_query_sql_preserves_smaller_tsql_limit():
     assert bounded == "SELECT TOP 5 value FROM facts ORDER BY value"
 
 
+@pytest.mark.parametrize("sql", ["EXPLAIN SELECT 1", "DESCRIBE facts", "PRAGMA version"])
+def test_limit_query_sql_passes_row_producing_commands_through(sql):
+    assert limit_query_sql(sql, 10, "duckdb") == sql
+
+
 def test_admission_rejects_when_bounded_queue_is_full():
     admission = QueryAdmission(max_concurrent=1, max_queued=1)
     assert admission.acquire(timeout=0.1) == "acquired"

--- a/tests/server/test_query_execution.py
+++ b/tests/server/test_query_execution.py
@@ -1,0 +1,115 @@
+"""Tests for server query admission and cancellation diagnostics."""
+
+import threading
+import time
+
+import pytest
+
+from sidemantic.db.base import BaseDatabaseAdapter
+from sidemantic.server.query_execution import QueryAdmission, QueryExecutionControl, QueryLimits
+
+
+class _ControlCommandAdapter(BaseDatabaseAdapter):
+    def __init__(self):
+        self.statements = []
+        self.control_cursor_closed = False
+
+    @property
+    def dialect(self):
+        return "postgres"
+
+    @property
+    def raw_connection(self):
+        return self
+
+    def execute(self, sql):
+        self.statements.append(sql)
+        adapter = self
+
+        class Result:
+            class Cursor:
+                def close(self):
+                    adapter.control_cursor_closed = True
+
+            cursor = Cursor()
+
+        return Result()
+
+    def fetch_record_batch(self, result):
+        raise AssertionError("session control commands must not be materialized")
+
+    def executemany(self, sql, params):
+        raise NotImplementedError
+
+    def fetchone(self, result):
+        raise NotImplementedError
+
+    def get_tables(self):
+        return []
+
+    def get_columns(self, table_name, schema=None):
+        return []
+
+    def close(self):
+        return None
+
+
+def test_query_limits_validate_conservative_values():
+    limits = QueryLimits()
+
+    assert limits.max_rows == 10_000
+    assert limits.max_response_bytes == 16 * 1024 * 1024
+    assert limits.execution_timeout_seconds == 30.0
+    assert limits.max_concurrent_queries == 4
+    assert limits.max_queued_queries == 16
+
+
+def test_admission_rejects_when_bounded_queue_is_full():
+    admission = QueryAdmission(max_concurrent=1, max_queued=1)
+    assert admission.acquire(timeout=0.1) == "acquired"
+
+    waiter_result = []
+
+    def wait_for_slot():
+        waiter_result.append(admission.acquire(timeout=1.0))
+
+    waiter = threading.Thread(target=wait_for_slot)
+    waiter.start()
+    deadline = time.monotonic() + 1
+    while admission.stats()["queued"] != 1 and time.monotonic() < deadline:
+        time.sleep(0.001)
+
+    assert admission.stats() == {"active": 1, "queued": 1}
+    assert admission.acquire(timeout=0.1) == "full"
+    admission.release()
+    waiter.join(timeout=1)
+
+    assert waiter_result == ["acquired"]
+    admission.release()
+
+
+def test_cancellation_without_execution_handle_is_explicit():
+    control = QueryExecutionControl()
+
+    outcome = control.cancel()
+
+    assert outcome.supported is False
+    assert outcome.cancelled is False
+    assert "not available yet" in outcome.diagnostic
+
+
+def test_statement_timeout_control_command_does_not_materialize_rows():
+    adapter = _ControlCommandAdapter()
+
+    diagnostic = adapter.configure_statement_timeout(adapter.cursor(), 2.5)
+
+    assert diagnostic is None
+    assert adapter.statements == ["SET statement_timeout = 2500"]
+    assert adapter.control_cursor_closed is True
+
+
+def test_statement_timeout_requires_positive_value():
+    adapter = _ControlCommandAdapter()
+
+    with pytest.raises(ValueError, match="must be positive"):
+        adapter.configure_statement_timeout(adapter.cursor(), 0)

--- a/tests/server/test_query_execution.py
+++ b/tests/server/test_query_execution.py
@@ -13,6 +13,7 @@ from sidemantic.server.query_execution import (
     QueryLimits,
     QueryResponseTooLargeError,
     execute_bounded,
+    limit_query_sql,
 )
 
 
@@ -131,6 +132,13 @@ def test_query_limits_validate_conservative_values():
     assert limits.execution_timeout_seconds == 30.0
     assert limits.max_concurrent_queries == 4
     assert limits.max_queued_queries == 16
+
+
+def test_limit_query_sql_uses_target_dialect_syntax():
+    bounded = limit_query_sql("SELECT value FROM facts", 10, "tsql")
+
+    assert bounded == "SELECT TOP 11 * FROM (SELECT value AS value FROM facts) AS _sidemantic_bounded"
+    assert " LIMIT " not in bounded
 
 
 def test_admission_rejects_when_bounded_queue_is_full():

--- a/tests/server/test_query_execution.py
+++ b/tests/server/test_query_execution.py
@@ -137,8 +137,20 @@ def test_query_limits_validate_conservative_values():
 def test_limit_query_sql_uses_target_dialect_syntax():
     bounded = limit_query_sql("SELECT value FROM facts", 10, "tsql")
 
-    assert bounded == "SELECT TOP 11 * FROM (SELECT value AS value FROM facts) AS _sidemantic_bounded"
+    assert bounded == "SELECT TOP 11 value FROM facts"
     assert " LIMIT " not in bounded
+
+
+def test_limit_query_sql_keeps_tsql_order_by_at_top_level():
+    bounded = limit_query_sql("SELECT value FROM facts ORDER BY value", 10, "tsql")
+
+    assert bounded == "SELECT TOP 11 value FROM facts ORDER BY value"
+
+
+def test_limit_query_sql_preserves_smaller_tsql_limit():
+    bounded = limit_query_sql("SELECT TOP 5 value FROM facts ORDER BY value", 10, "tsql")
+
+    assert bounded == "SELECT TOP 5 value FROM facts ORDER BY value"
 
 
 def test_admission_rejects_when_bounded_queue_is_full():

--- a/tests/server/test_query_execution.py
+++ b/tests/server/test_query_execution.py
@@ -153,6 +153,15 @@ def test_limit_query_sql_preserves_smaller_tsql_limit():
     assert bounded == "SELECT TOP 5 value FROM facts ORDER BY value"
 
 
+@pytest.mark.parametrize("operator", ["UNION", "EXCEPT", "INTERSECT"])
+def test_limit_query_sql_hoists_order_from_tsql_set_queries(operator):
+    bounded = limit_query_sql(f"SELECT 1 AS value {operator} SELECT 2 AS value ORDER BY value", 10, "tsql")
+
+    assert bounded == (
+        f"SELECT TOP 11 * FROM (SELECT 1 AS value {operator} SELECT 2 AS value) AS _sidemantic_bounded ORDER BY value"
+    )
+
+
 @pytest.mark.parametrize("sql", ["EXPLAIN SELECT 1", "DESCRIBE facts", "PRAGMA version"])
 def test_limit_query_sql_passes_row_producing_commands_through(sql):
     assert limit_query_sql(sql, 10, "duckdb") == sql

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -699,6 +699,21 @@ def test_duckdb_serving_access_mode_defaults_read_only_and_allows_write_opt_in()
     assert "threads=2" in safe
 
 
+def test_duckdb_access_mode_preserves_repeated_query_parameters():
+    from urllib.parse import parse_qsl, urlsplit
+
+    connection = "duckdb:////tmp/warehouse.duckdb?init_sql=LOAD+httpfs&init_sql=ATTACH+%27other.db%27"
+
+    safe = cli_module._with_duckdb_access_mode(connection)
+
+    assert safe is not None
+    assert parse_qsl(urlsplit(safe).query) == [
+        ("init_sql", "LOAD httpfs"),
+        ("init_sql", "ATTACH 'other.db'"),
+        ("read_only", "true"),
+    ]
+
+
 def test_duckdb_memory_access_mode_stays_writable():
     assert cli_module._with_duckdb_access_mode("duckdb:///:memory:") == "duckdb:///:memory:"
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -714,6 +714,22 @@ def test_duckdb_access_mode_preserves_repeated_query_parameters():
     ]
 
 
+@pytest.mark.parametrize(
+    "connection",
+    [
+        "duckdb:///path/to/warehouse.duckdb",
+        "duckdb:///relative.duckdb",
+        "duckdb:////tmp/warehouse.duckdb",
+    ],
+)
+def test_duckdb_access_mode_preserves_url_slashes(connection):
+    safe = cli_module._with_duckdb_access_mode(connection)
+
+    assert safe is not None
+    assert safe.startswith(f"{connection}?")
+    assert safe.endswith("read_only=true")
+
+
 def test_duckdb_memory_access_mode_stays_writable():
     assert cli_module._with_duckdb_access_mode("duckdb:///:memory:") == "duckdb:///:memory:"
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -196,6 +196,21 @@ def test_query_dry_run_emits_sql(tmp_path):
     assert "count" in result.stdout.lower()
 
 
+@pytest.mark.parametrize("command", ["query", "rewrite"])
+def test_compile_only_commands_do_not_open_missing_duckdb(command, tmp_path):
+    _write_min_model(tmp_path)
+    missing_db = tmp_path / "not-created.duckdb"
+    args = [command, "SELECT order_count FROM orders", "--models", str(tmp_path), "--db", str(missing_db)]
+    if command == "query":
+        args.append("--dry-run")
+
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 0, result.output
+    assert "select" in result.stdout.lower()
+    assert not missing_db.exists()
+
+
 def test_explain_sql_outputs_planner_json(tmp_path):
     _write_min_model(tmp_path)
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -579,13 +579,14 @@ def test_serve_calls_start_server(monkeypatch, tmp_path):
     called = {}
     events = []
 
-    def fake_start_server(layer, host, port, username, password, user_attrs_map=None):
+    def fake_start_server(layer, host, port, username, password, user_attrs_map=None, **kwargs):
         events.append("start")
         called["layer"] = layer
         called["host"] = host
         called["port"] = port
         called["username"] = username
         called["password"] = password
+        called.update(kwargs)
 
     monkeypatch.setattr("sidemantic.server.server.start_server", fake_start_server)
     monkeypatch.setattr("sidemantic.cli_contract.emit_warning", lambda _message: events.append("warning"))
@@ -658,12 +659,13 @@ pg_server:
 """
     )
 
-    def fake_start_server(layer, host, port, username, password, user_attrs_map=None):
+    def fake_start_server(layer, host, port, username, password, user_attrs_map=None, **kwargs):
         called["layer"] = layer
         called["host"] = host
         called["port"] = port
         called["username"] = username
         called["password"] = password
+        called.update(kwargs)
 
     monkeypatch.setattr("sidemantic.server.server.start_server", fake_start_server)
 
@@ -686,6 +688,21 @@ def test_cross_library_chart_renderer_is_not_a_cli_product_surface():
     assert "No such command 'chart'" in result.output
 
 
+def test_duckdb_serving_access_mode_defaults_read_only_and_allows_write_opt_in():
+    connection = "duckdb:////tmp/warehouse.duckdb?threads=2"
+
+    safe = cli_module._with_duckdb_access_mode(connection)
+    writable = cli_module._with_duckdb_access_mode(connection, read_only=False)
+
+    assert safe is not None and "read_only=true" in safe
+    assert writable is not None and "read_only=false" in writable
+    assert "threads=2" in safe
+
+
+def test_duckdb_memory_access_mode_stays_writable():
+    assert cli_module._with_duckdb_access_mode("duckdb:///:memory:") == "duckdb:///:memory:"
+
+
 def test_api_serve_calls_start_server(monkeypatch, tmp_path):
     pytest.importorskip("fastapi")
     called = {}
@@ -700,6 +717,13 @@ def test_api_serve_calls_start_server(monkeypatch, tmp_path):
         serve_ui=True,
         result_cache_mb=0,
         result_cache_ttl=60.0,
+        max_rows=10_000,
+        max_response_bytes=16 * 1024 * 1024,
+        execution_timeout_seconds=30.0,
+        max_concurrent_queries=4,
+        max_queued_queries=16,
+        queue_timeout_seconds=5.0,
+        query_history_size=1000,
         require_user_attrs=False,
         enforce_visibility=False,
         user_header="X-Sidemantic-User",
@@ -714,6 +738,13 @@ def test_api_serve_calls_start_server(monkeypatch, tmp_path):
         called["serve_ui"] = serve_ui
         called["result_cache_mb"] = result_cache_mb
         called["result_cache_ttl"] = result_cache_ttl
+        called["max_rows"] = max_rows
+        called["max_response_bytes"] = max_response_bytes
+        called["execution_timeout_seconds"] = execution_timeout_seconds
+        called["max_concurrent_queries"] = max_concurrent_queries
+        called["max_queued_queries"] = max_queued_queries
+        called["queue_timeout_seconds"] = queue_timeout_seconds
+        called["query_history_size"] = query_history_size
         called["require_user_attrs"] = require_user_attrs
         called["enforce_visibility"] = enforce_visibility
         called["user_header"] = user_header
@@ -745,6 +776,8 @@ def test_api_serve_calls_start_server(monkeypatch, tmp_path):
     assert called["auth_token"] == "secret"
     assert called["cors_origins"] == ["https://app.example.com"]
     assert called["max_request_body_bytes"] == 2048
+    assert called["max_rows"] == 10_000
+    assert called["max_concurrent_queries"] == 4
     assert called["dashboard"] is None
 
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -211,6 +211,10 @@ def test_compile_only_commands_do_not_open_missing_duckdb(command, tmp_path):
     assert not missing_db.exists()
 
 
+def test_compile_only_dialect_maps_mssql_adbc_to_tsql():
+    assert cli_module._compile_only_dialect(None, "adbc://mssql?uri=ignored", None) == "tsql"
+
+
 def test_explain_sql_outputs_planner_json(tmp_path):
     _write_min_model(tmp_path)
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -404,6 +404,7 @@ models:
     layer = SemanticLayer(connection=f"duckdb:///{db_path}", auto_register=False)
     layer.adapter.execute("CREATE TABLE orders (id INTEGER, status VARCHAR)")
     layer.adapter.execute("INSERT INTO orders VALUES (1, 'completed'), (2, 'pending')")
+    layer.adapter.close()
 
     spec_path = tmp_path / "dashboard.yml"
     spec_path.write_text(


### PR DESCRIPTION
Adds bounded query execution with row, byte, timeout, concurrency, and queue policies for HTTP and PostgreSQL serving. Adds best-effort cancellation, process-local sanitized telemetry, and read-only DuckDB serving defaults while preserving explicit writable refresh workflows. Includes focused tests and operator documentation.