### PR TITLE
Fix parser expression boundaries across adapters

### DIFF
--- a/sidemantic/adapters/bsl_expr.py
+++ b/sidemantic/adapters/bsl_expr.py
@@ -14,8 +14,12 @@ Uses Python's ast module for parsing since these are valid Python expressions.
 """
 
 import ast
+import keyword
 import re
 from dataclasses import dataclass
+
+import sqlglot
+from sqlglot import exp
 
 
 @dataclass
@@ -130,6 +134,14 @@ def _expr_to_sql(node: ast.AST) -> str | None:
             return ".".join(attrs)
         return None
 
+    if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.BitAnd, ast.BitOr)):
+        left = _expr_to_sql(node.left)
+        right = _expr_to_sql(node.right)
+        if left is not None and right is not None:
+            operator = "AND" if isinstance(node.op, ast.BitAnd) else "OR"
+            return f"({left}) {operator} ({right})"
+        return None
+
     if isinstance(node, ast.BinOp):
         return _binop_to_sql(node)
 
@@ -140,17 +152,78 @@ def _expr_to_sql(node: ast.AST) -> str | None:
         if isinstance(node.value, str):
             escaped = node.value.replace("'", "''")
             return f"'{escaped}'"
+        if isinstance(node.value, bool):
+            return "TRUE" if node.value else "FALSE"
+        if node.value is None:
+            return "NULL"
         if isinstance(node.value, (int, float)):
             return str(node.value)
 
     # Python parses -5 as UnaryOp(USub, Constant(5))
-    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+    if isinstance(node, ast.UnaryOp):
         operand = _expr_to_sql(node.operand)
         if operand is not None:
-            return f"-{operand}"
+            if isinstance(node.op, ast.USub):
+                return f"-{operand}"
+            if isinstance(node.op, ast.Invert):
+                return f"NOT ({operand})"
 
     if isinstance(node, ast.Name) and node.id == "_":
         return None
+
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "getattr"
+        and len(node.args) == 2
+        and isinstance(node.args[1], ast.Constant)
+        and isinstance(node.args[1].value, str)
+    ):
+        base = "" if isinstance(node.args[0], ast.Name) and node.args[0].id == "_" else _expr_to_sql(node.args[0])
+        if base is not None:
+            identifier = '"' + node.args[1].value.replace('"', '""') + '"'
+            return f"{base}.{identifier}" if base else identifier
+
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+        args = [_expr_to_sql(arg) for arg in node.args]
+        if all(arg is not None for arg in args):
+            if node.func.id.upper() == "CAST" and len(args) == 2 and isinstance(node.args[1], ast.Constant):
+                return f"CAST({args[0]} AS {node.args[1].value})"
+            if node.func.id.upper() == "IS" and len(args) == 2:
+                return f"{args[0]} IS {args[1]}"
+            return f"{node.func.id.upper()}({', '.join(args)})"
+
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+        value = _expr_to_sql(node.func.value)
+        if (
+            node.func.attr == "isin"
+            and value is not None
+            and len(node.args) == 1
+            and isinstance(node.args[0], ast.List)
+        ):
+            values = [_expr_to_sql(item) for item in node.args[0].elts]
+            if all(item is not None for item in values):
+                return f"{value} IN ({', '.join(values)})"
+        args = [_expr_to_sql(arg) for arg in node.args]
+        if value is None or any(arg is None for arg in args):
+            return None
+        if node.func.attr == "isnull" and not args:
+            return f"{value} IS NULL"
+        if node.func.attr == "notnull" and not args:
+            return f"{value} IS NOT NULL"
+        if node.func.attr == "between" and len(args) == 2:
+            return f"{value} BETWEEN {args[0]} AND {args[1]}"
+        if node.func.attr in {"like", "ilike"} and len(args) == 1:
+            return f"{value} {node.func.attr.upper()} {args[0]}"
+        if node.func.attr in DATE_METHODS and not args:
+            return f"EXTRACT({node.func.attr.upper()} FROM {value})"
+
+    if isinstance(node, ast.IfExp):
+        condition = _expr_to_sql(node.test)
+        true = _expr_to_sql(node.body)
+        false = _expr_to_sql(node.orelse)
+        if condition is not None and true is not None and false is not None:
+            return f"CASE WHEN {condition} THEN {true} ELSE {false} END"
 
     return None
 
@@ -407,6 +480,13 @@ def _calc_node_to_sql(node: ast.AST) -> str | None:
                 return None
             return f"{node.func.id.upper()}({', '.join(args)})"
 
+    if isinstance(node, ast.IfExp):
+        condition = _calc_node_to_sql(node.test)
+        true = _calc_node_to_sql(node.body)
+        false = _calc_node_to_sql(node.orelse)
+        if condition is not None and true is not None and false is not None:
+            return f"CASE WHEN {condition} THEN {true} ELSE {false} END"
+
     return None
 
 
@@ -436,35 +516,145 @@ def _sql_to_bsl_expr(sql: str, agg: str | None) -> str:
     no original BSL expression is available. For BSL->BSL roundtrip,
     the adapter stores and reuses the original expression instead.
     """
-    # Simple column + aggregation (the common case for cross-format)
-    if not any(f" {op} " in sql for op in ["+", "-", "*", "/", "%", "=", "!=", "<", ">", "<=", ">="]):
-        base = f"_.{sql}"
-        if agg:
-            method = AGG_TO_METHOD_MAP.get(agg)
-            if method:
-                return f"{base}.{method}()"
-        return base
-
-    # Compound or comparison SQL: prefix column-like tokens with _.,
-    # and convert SQL operators to Python equivalents
-    sql_to_py_op = {"=": "==", "<>": "!="}
-    parts = re.split(r"(\s*(?:[+\-*/%]|[<>!=]=?|<>)\s*)", sql)
-    bsl_parts = []
-    for part in parts:
-        stripped = part.strip()
-        if re.match(r"^[a-zA-Z_]\w*(\.\w+)*$", stripped):
-            bsl_parts.append(f"_.{stripped}")
-        elif stripped in sql_to_py_op:
-            bsl_parts.append(part.replace(stripped, sql_to_py_op[stripped]))
-        else:
-            bsl_parts.append(part)
-    inner = "".join(bsl_parts)
+    tree = None
+    inner = None
+    if re.fullmatch(r"\s*\[[^]]+]\s*", sql):
+        dialects = ("tsql",)
+    elif "`" in sql:
+        dialects = ("bigquery", "spark")
+    else:
+        dialects = (None, "duckdb", "snowflake", "bigquery", "postgres", "tsql")
+    for dialect in dialects:
+        try:
+            tree = sqlglot.parse_one(sql, read=dialect)
+        except Exception:
+            continue
+        inner = _render_sql_node_as_bsl(tree)
+        if inner is not None:
+            break
+    if inner is None:
+        return sql
 
     if agg:
         method = AGG_TO_METHOD_MAP.get(agg)
         if method:
+            if isinstance(tree, exp.Column):
+                return f"{inner}.{method}()"
             return f"({inner}).{method}()"
     return inner
+
+
+_SQL_BINARY_TO_BSL = {
+    exp.Add: "+",
+    exp.Sub: "-",
+    exp.Mul: "*",
+    exp.Div: "/",
+    exp.Mod: "%",
+    exp.EQ: "==",
+    exp.NEQ: "!=",
+    exp.GT: ">",
+    exp.GTE: ">=",
+    exp.LT: "<",
+    exp.LTE: "<=",
+}
+
+
+def _bsl_column(column: exp.Column) -> str:
+    rendered = "_"
+    for part in column.parts:
+        if re.fullmatch(r"[A-Za-z_]\w*", part.name) and not keyword.iskeyword(part.name):
+            rendered += f".{part.name}"
+        else:
+            rendered = f"getattr({rendered}, {part.name!r})"
+    return rendered
+
+
+def _render_sql_node_as_bsl(node: exp.Expression | None) -> str | None:
+    """Render a SQLGlot expression as a syntactically valid deferred BSL expression."""
+    if node is None:
+        return None
+    if isinstance(node, exp.Column):
+        return _bsl_column(node)
+    if isinstance(node, exp.Literal):
+        return repr(node.this) if node.is_string else str(node.this)
+    if isinstance(node, exp.Null):
+        return "None"
+    if isinstance(node, exp.Boolean):
+        return "True" if node.this else "False"
+    if isinstance(node, exp.Paren):
+        inner = _render_sql_node_as_bsl(node.this)
+        return f"({inner})" if inner is not None else None
+    if isinstance(node, exp.Neg):
+        value = _render_sql_node_as_bsl(node.this)
+        return f"-{value}" if value is not None else None
+    for node_type, operator in _SQL_BINARY_TO_BSL.items():
+        if isinstance(node, node_type):
+            left = _render_sql_node_as_bsl(node.this)
+            right = _render_sql_node_as_bsl(node.expression)
+            return f"{left} {operator} {right}" if left is not None and right is not None else None
+    if isinstance(node, (exp.And, exp.Or)):
+        left = _render_sql_node_as_bsl(node.this)
+        right = _render_sql_node_as_bsl(node.expression)
+        operator = "&" if isinstance(node, exp.And) else "|"
+        return f"({left}) {operator} ({right})" if left is not None and right is not None else None
+    if isinstance(node, exp.Not):
+        if isinstance(node.this, exp.Is) and isinstance(node.this.expression, exp.Null):
+            value = _render_sql_node_as_bsl(node.this.this)
+            return f"{value}.notnull()" if value is not None else None
+        value = _render_sql_node_as_bsl(node.this)
+        return f"~({value})" if value is not None else None
+    if isinstance(node, exp.Is):
+        value = _render_sql_node_as_bsl(node.this)
+        other = node.expression
+        if value is not None and isinstance(other, exp.Null):
+            return f"{value}.isnull()"
+        rendered_other = _render_sql_node_as_bsl(other)
+        return f"IS({value}, {rendered_other})" if value is not None and rendered_other is not None else None
+    if isinstance(node, exp.Between):
+        value = _render_sql_node_as_bsl(node.this)
+        low = _render_sql_node_as_bsl(node.args.get("low"))
+        high = _render_sql_node_as_bsl(node.args.get("high"))
+        return f"{value}.between({low}, {high})" if value is not None and low is not None and high is not None else None
+    if isinstance(node, exp.In) and node.args.get("query") is None:
+        value = _render_sql_node_as_bsl(node.this)
+        items = [_render_sql_node_as_bsl(item) for item in node.expressions]
+        if value is not None and all(item is not None for item in items):
+            return f"{value}.isin([{', '.join(items)}])"
+    if isinstance(node, (exp.Like, exp.ILike)):
+        value = _render_sql_node_as_bsl(node.this)
+        pattern = _render_sql_node_as_bsl(node.expression)
+        method = "ilike" if isinstance(node, exp.ILike) else "like"
+        return f"{value}.{method}({pattern})" if value is not None and pattern is not None else None
+    if isinstance(node, exp.Extract):
+        value = _render_sql_node_as_bsl(node.expression)
+        part = str(node.this).lower()
+        if value is not None and part in DATE_METHODS:
+            return f"{value}.{part}()"
+        return None
+    if isinstance(node, exp.DPipe):
+        left = _render_sql_node_as_bsl(node.this)
+        right = _render_sql_node_as_bsl(node.expression)
+        return f"CONCAT({left}, {right})" if left is not None and right is not None else None
+    if isinstance(node, exp.Case):
+        default = _render_sql_node_as_bsl(node.args.get("default")) or "None"
+        result = default
+        for branch in reversed(node.args.get("ifs") or []):
+            condition = _render_sql_node_as_bsl(branch.this)
+            true = _render_sql_node_as_bsl(branch.args.get("true"))
+            if condition is None or true is None:
+                return None
+            result = f"{true} if {condition} else {result}"
+        return f"({result})"
+    if isinstance(node, exp.Cast):
+        value = _render_sql_node_as_bsl(node.this)
+        target = str(node.args.get("to"))
+        return f"CAST({value}, {target!r})" if value is not None else None
+    if isinstance(node, exp.Func):
+        name = node.name if isinstance(node, exp.Anonymous) else node.sql_name()
+        args = [_render_sql_node_as_bsl(child) for child in node.iter_expressions()]
+        if all(arg is not None for arg in args):
+            return f"{name.upper()}({', '.join(args)})"
+    return None
 
 
 def parse_bsl_expr(expr: str) -> ParsedExpr:
@@ -492,7 +682,7 @@ def parse_bsl_expr(expr: str) -> ParsedExpr:
     """
     expr = expr.strip()
 
-    if not expr.startswith("_.") and not expr.startswith("("):
+    if not expr.startswith("_.") and not expr.startswith("(") and not expr.startswith("getattr("):
         # Not a BSL expression, might be a calc measure reference
         return ParsedExpr(column=expr)
 
@@ -524,7 +714,10 @@ def parse_bsl_expr(expr: str) -> ParsedExpr:
 
         # Case 1b: Method call on compound expression like (_.a - _.b).sum()
         base = node.func.value
-        if isinstance(base, (ast.BinOp, ast.Compare)) and method in AGG_METHOD_MAP:
+        if (
+            isinstance(base, (ast.BinOp, ast.Compare, ast.Call, ast.IfExp, ast.UnaryOp, ast.BoolOp))
+            and method in AGG_METHOD_MAP
+        ):
             sql_expr = _expr_to_sql(base)
             if sql_expr:
                 return ParsedExpr(column=sql_expr, aggregation=method)

--- a/sidemantic/adapters/cube.py
+++ b/sidemantic/adapters/cube.py
@@ -15,6 +15,7 @@ from sidemantic.core.pre_aggregation import Index, PreAggregation, RefreshKey
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.security import SecurityPolicy
 from sidemantic.core.semantic_graph import SemanticGraph
+from sidemantic.sql.fragment import replace_outside_sql_protected, rewrite_sql_column_spans
 
 
 class CubeImportWarning(UserWarning):
@@ -84,20 +85,10 @@ _CUBE_MEMBER_RE = re.compile(r"\$?\{([^}]+)\}(?:\.(\w+))?")
 # literal therefore has group(1) is None.
 _CUBE_MEMBER_OR_STRING_RE = re.compile(r"'(?:[^']|'')*'|" + _CUBE_MEMBER_RE.pattern)
 
-# Matches a single-quoted string literal OR a literal ``{model}`` placeholder. Used on export
-# to translate ``{model}`` back to ``${CUBE}`` only outside quoted strings, so a ``{model}``
-# occurring inside a literal (e.g. ``label = '{model}'``) is preserved verbatim and survives an
-# import->export round-trip (import already skips quoted literals when normalizing).
-_MODEL_OR_STRING_RE = re.compile(r"'(?:[^']|'')*'|\{model\}")
-
 
 def _model_placeholder_to_cube(sql: str) -> str:
-    """Replace ``{model}`` with ``${CUBE}`` everywhere except inside single-quoted literals."""
-
-    def repl(match: re.Match) -> str:
-        return "${CUBE}" if match.group(0) == "{model}" else match.group(0)
-
-    return _MODEL_OR_STRING_RE.sub(repl, sql)
+    """Replace executable ``{model}`` placeholders without changing quoted text/comments."""
+    return replace_outside_sql_protected(sql, "{model}", "${CUBE}")
 
 
 def _split_cube_ref(inner: str, trailing: str | None) -> tuple[str, str | None]:
@@ -1481,20 +1472,13 @@ class CubeAdapter(BaseAdapter):
         """
         if sql is None:
             return None
-        out = _model_placeholder_to_cube(sql)
 
-        # Match a single-quoted string literal OR a qualified member token. Literals are
-        # returned verbatim (group(1) is None), so 'orders.total' inside a string is never
-        # rewritten; only real member tokens outside quotes are wrapped.
-        pattern = re.compile(r"'(?:[^']|'')*'|(?<![\w.${])([A-Za-z_]\w*\.[A-Za-z_]\w*)\b")
+        def _wrap(column, source: str) -> str | None:
+            canonical = ".".join(part.name for part in column.parts)
+            return f"${{{source}}}" if canonical in known_members else None
 
-        def _wrap(match: re.Match) -> str:
-            token = match.group(1)
-            if token is None:
-                return match.group(0)
-            return f"${{{token}}}" if token in known_members else match.group(0)
-
-        return pattern.sub(_wrap, out)
+        rewritten = rewrite_sql_column_spans(sql, _wrap, mask_protected=True)
+        return _model_placeholder_to_cube(rewritten if rewritten is not None else sql)
 
     def export(self, graph: SemanticGraph, output_path: str | Path) -> None:
         """Export semantic graph to Cube YAML format.

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -12,7 +12,7 @@ from sidemantic.core.model import Model
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.sql.lookml_expression import (
-    parse_lookml_expression,
+    lookml_expression_has_subquery,
     replace_lookml_placeholders,
     strip_aggregate_all,
     strip_lookml_model_qualifiers,
@@ -1339,12 +1339,7 @@ class LookMLAdapter(BaseAdapter):
     @staticmethod
     def _has_subquery(sql: str) -> bool:
         """True only when parsed executable SQL contains an actual SELECT node."""
-        from sqlglot import exp
-
-        parsed = parse_lookml_expression(sql or "")
-        if parsed is None:
-            return False
-        return parsed.tree.find(exp.Select) is not None
+        return lookml_expression_has_subquery(sql or "")
 
     @staticmethod
     def _strip_all_modifier(sql: str) -> str:

--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -11,7 +11,12 @@ from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_graph import SemanticGraph
-from sidemantic.sql.lookml_expression import replace_lookml_placeholders, strip_lookml_model_qualifiers
+from sidemantic.sql.lookml_expression import (
+    parse_lookml_expression,
+    replace_lookml_placeholders,
+    strip_aggregate_all,
+    strip_lookml_model_qualifiers,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1333,48 +1338,18 @@ class LookMLAdapter(BaseAdapter):
 
     @staticmethod
     def _has_subquery(sql: str) -> bool:
-        """True if ``sql`` contains a SELECT outside any quoted token.
+        """True only when parsed executable SQL contains an actual SELECT node."""
+        from sqlglot import exp
 
-        A raw ``\\bselect\\b`` scan also matches the word inside a VALUE
-        (``SUM(CASE WHEN status = 'select' THEN amount END)``) or inside a quoted IDENTIFIER for a
-        column named after a reserved word (``SUM(${TABLE}."select")``, ``SUM(`select`)``), inside a
-        SQL COMMENT (``/* select paid rows */ SUM(amount)``), or inside a LookML ``${...}`` field
-        reference to a column named ``select`` (``SUM(${select})``) -- none is a subquery, and all
-        are valid inline aggregates. This runs on the RAW SQL before refs are resolved, so blank out
-        every quoted form, every comment, AND every ``${...}`` placeholder first -- in one left-to-
-        right pass so a comment inside a string (or a quote inside a comment) is consumed by
-        whichever opens first, leaving only real SQL keywords.
-        """
-        stripped = re.sub(
-            r"""'(?:[^']|'')*'|"(?:[^"]|"")*"|`[^`]*`|\[[^\]]*\]|--[^\n]*|/\*[\s\S]*?\*/|\$\{[^}]*\}""",
-            " ",
-            sql or "",
-        )
-        return bool(re.search(r"(?is)\bselect\b", stripped))
+        parsed = parse_lookml_expression(sql or "")
+        if parsed is None:
+            return False
+        return parsed.tree.find(exp.Select) is not None
 
     @staticmethod
     def _strip_all_modifier(sql: str) -> str:
-        """Drop an explicit ``ALL`` aggregate modifier (``COUNT(ALL x)`` -> ``COUNT(x)``) OUTSIDE
-        string literals and quoted identifiers.
-
-        ``ALL`` is the default modifier and changes nothing, but sqlglot cannot parse it, so
-        normalizing it away keeps exported SQL round-trippable and the column check accurate. A
-        string literal like ``'(ALL users)'`` is DATA, not a modifier, so the substitution runs only
-        on the segments outside any quoted token (``(`` must precede ``ALL`` regardless, so
-        ``= ALL (SELECT ...)`` and a column named ``all`` are already untouched).
-
-        A LEADING ``ALL`` is also dropped: a metric SQL that IS the bare aggregate argument
-        (``Metric(agg="stddev", sql="ALL {model}.amount")``) has no ``(`` yet, and wrapping it as
-        ``STDDEV(ALL amount)`` is likewise unparseable, so the exported measure would not round-trip.
-        """
-        parts = re.split(r"""('(?:[^']|'')*'|"(?:[^"]|"")*"|`[^`]*`|\[[^\]]*\])""", sql or "")
-        for i in range(0, len(parts), 2):  # even indices are outside any quoted token
-            parts[i] = re.sub(r"(?i)\(\s*ALL\s+", "(", parts[i])
-        # Only the first outside-quotes segment can hold the string's start; a `\s+` after ALL keeps
-        # a column named `all` (or an `all(` function) untouched.
-        if parts:
-            parts[0] = re.sub(r"(?i)^\s*ALL\s+", "", parts[0])
-        return "".join(parts)
+        """Drop a syntactic aggregate ``ALL`` modifier through the shared token boundary."""
+        return strip_aggregate_all(sql or "")
 
     @classmethod
     def _mixed_is_aggregate_safe(cls, sql: str, is_dim_ref, dim_sql_lookup: dict[str, str] | None = None) -> bool:

--- a/sidemantic/adapters/malloy.py
+++ b/sidemantic/adapters/malloy.py
@@ -62,6 +62,104 @@ def _sub_outside_quotes(s: str, pattern: str, repl, quotes: tuple[str, ...] = ("
     return "".join(out)
 
 
+def _outside_quotes(s: str, position: int, quotes: tuple[str, ...] = ("'", '"', "`")) -> bool:
+    quote: str | None = None
+    i = 0
+    while i < position:
+        char = s[i]
+        if quote is not None:
+            if char == "\\":
+                i += 2
+                continue
+            if char == quote:
+                quote = None
+        elif char in quotes:
+            quote = char
+        i += 1
+    return quote is None
+
+
+def _mask_malloy_quoted_text(expr: str) -> str:
+    """Hide literal/quoted-identifier contents while preserving token boundaries."""
+    chars = list(expr)
+    i = 0
+    while i < len(expr):
+        marker = next((quote for quote in ("'''", '"""', "'", '"', "`") if expr.startswith(quote, i)), None)
+        if marker is None:
+            i += 1
+            continue
+        end = i + len(marker)
+        while end < len(expr):
+            if expr.startswith(marker, end):
+                end += len(marker)
+                break
+            if expr[end] == "\\" and len(marker) == 1:
+                end += 2
+            else:
+                end += 1
+        content_start = i + len(marker)
+        content_end = max(content_start, end - len(marker))
+        chars[content_start:content_end] = " " * (content_end - content_start)
+        i = end
+    return "".join(chars)
+
+
+def _protect_malloy_comments(expr: str) -> tuple[str, list[tuple[str, str]]]:
+    """Replace hidden-channel Malloy comments with inert quoted sentinels."""
+    out: list[str] = []
+    replacements: list[tuple[str, str]] = []
+    i = 0
+    quote: str | None = None
+    while i < len(expr):
+        char = expr[i]
+        if quote is not None:
+            out.append(char)
+            if char == "\\" and i + 1 < len(expr):
+                out.append(expr[i + 1])
+                i += 2
+                continue
+            if char == quote:
+                quote = None
+            i += 1
+            continue
+        if char in ("'", '"', "`"):
+            quote = char
+            out.append(char)
+            i += 1
+            continue
+
+        end = None
+        if expr.startswith("/*", i):
+            depth = 1
+            cursor = i + 2
+            while cursor < len(expr) and depth:
+                if expr.startswith("/*", cursor):
+                    depth += 1
+                    cursor += 2
+                elif expr.startswith("*/", cursor):
+                    depth -= 1
+                    cursor += 2
+                else:
+                    cursor += 1
+            end = cursor
+        elif expr.startswith("--", i) or expr.startswith("//", i):
+            newline = expr.find("\n", i + 2)
+            end = len(expr) if newline < 0 else newline
+
+        if end is None:
+            out.append(char)
+            i += 1
+            continue
+        original = expr[i:end]
+        sentinel = f"'__sidemantic_malloy_comment_{len(replacements)}__'"
+        while sentinel in expr:
+            sentinel = f"'__sidemantic_malloy_comment_{len(replacements)}_{len(sentinel)}__'"
+        replacements.append((sentinel, original))
+        out.append(sentinel)
+        i = end
+    return "".join(out), replacements
+
+
 def _normalize_count_calls(s: str) -> str:
     """Rewrite Malloy count syntax to SQL with quote- and paren-aware scanning.
 
@@ -494,7 +592,9 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
 
     def _infer_dimension_type(self, sql: str, name: str) -> str:
         """Infer dimension type from SQL expression and name."""
-        sql_lower = sql.lower() if sql else ""
+        comment_protected, _ = _protect_malloy_comments(sql or "")
+        syntax_sql = _mask_malloy_quoted_text(comment_protected)
+        sql_lower = syntax_sql.lower()
         name_lower = name.lower()
 
         # Time dimension detection
@@ -519,7 +619,7 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             return "time"
 
         # Boolean detection - comparison that yields true/false
-        if re.search(r"[<>=!]+\s*\S", sql):
+        if re.search(r"[<>=!]+\s*\S", syntax_sql):
             # Check if it's a simple comparison (boolean result)
             # But not if it's part of a CASE/pick statement
             if "pick" not in sql_lower and "case" not in sql_lower:
@@ -537,7 +637,7 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
             return "time"
 
         # Numeric detection
-        if re.search(r"[+\-*/]", sql) and "||" not in sql:
+        if re.search(r"[+\-*/]", syntax_sql) and "||" not in syntax_sql:
             return "numeric"
 
         # Name-based time heuristic. Applied last (weakest signal) so an explicit
@@ -705,6 +805,8 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         if not expr:
             return expr
 
+        expr, comment_replacements = _protect_malloy_comments(expr)
+
         # ?? null coalescing -> COALESCE
         if "??" in expr:
             expr = self._transform_null_coalesce(expr)
@@ -712,7 +814,12 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         # ! type assertion: func!type(args) -> func(args)
         # Matches: timestamp_seconds!timestamp(x), left!(s,1), md5!(x), to_base64!(x)
         # Pattern: identifier!identifier( -> identifier(
-        expr = re.sub(r"(\w+)!\w+\(", r"\1(", expr)
+        expr = _sub_outside_quotes(
+            expr,
+            r"(\w+)\s*!\s*(?:\w+\s*)?\(",
+            r"\1(",
+            quotes=("'", '"', "`"),
+        )
 
         # ~ / !~ regex match: field ~ r'pattern' -> REGEXP_MATCHES(field, 'pattern')
         expr = self._transform_regex_match(expr)
@@ -735,14 +842,15 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
                 parts.append("00")
             return f"TIMESTAMP '{m.group(1)} {':'.join(parts)}'"
 
-        expr = re.sub(
+        expr = _sub_outside_quotes(
+            expr,
             r"@(\d{4}-\d{2}-\d{2})[ T](\d{2}(?::\d{2}(?::\d{2}(?:[.,]\d+)?)?)?)(?:\[[^\]]+\])?",
             _timestamp_literal,
-            expr,
+            quotes=("'", '"', "`"),
         )
-        expr = re.sub(r"@(\d{4}-\d{2}-\d{2})", r"DATE '\1'", expr)
-        expr = re.sub(r"@(\d{4}-\d{2})(?!\d)", r"DATE '\1-01'", expr)
-        expr = re.sub(r"@(\d{4})(?![-\d])", r"DATE '\1-01-01'", expr)
+        expr = _sub_outside_quotes(expr, r"@(\d{4}-\d{2}-\d{2})", r"DATE '\1'", quotes=("'", '"', "`"))
+        expr = _sub_outside_quotes(expr, r"@(\d{4}-\d{2})(?!\d)", r"DATE '\1-01'", quotes=("'", '"', "`"))
+        expr = _sub_outside_quotes(expr, r"@(\d{4})(?![-\d])", r"DATE '\1-01-01'", quotes=("'", '"', "`"))
 
         # now -> CURRENT_TIMESTAMP (only when it's the entire expression or clearly standalone)
         if expr.strip() == "now":
@@ -751,15 +859,21 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         # & (and-tree): expands partial conditions with the base field
         # e.g., "field < 2031 & > -8000" -> "field < 2031 AND field > -8000"
         # e.g., "status != 'Cancelled' & 'Returned'" -> "status != 'Cancelled' AND status != 'Returned'"
-        if " & " in expr and "?" not in expr:
+        and_parts = self._split_top_level_operator(expr, "&")
+        apply_parts = self._split_top_level_operator(expr, "?")
+        if len(and_parts) > 1 and len(apply_parts) == 1:
             expr = self._transform_and_tree(expr)
 
         # | (or-tree / alternatives): used with ? apply operator
         # e.g., "field ? 'a' | 'b'" -> "field IN ('a', 'b')"
         # Only transform the simple value-matching pattern, not general uses of |
-        if " ? " in expr and " | " in expr and "pick" not in expr.lower():
+        value_parts = self._split_top_level_operator(apply_parts[1], "|") if len(apply_parts) == 2 else []
+        has_pick_syntax = any(keyword == "pick" for _, _, keyword in self._scan_keywords(expr, ("pick",)))
+        if len(apply_parts) == 2 and len(value_parts) > 1 and not has_pick_syntax:
             expr = self._transform_or_tree(expr)
 
+        for sentinel, comment in comment_replacements:
+            expr = expr.replace(sentinel, comment)
         return expr
 
     @staticmethod
@@ -853,19 +967,36 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         (``lower(name) ~ r'x'``) are preserved. Matches are rewritten
         right-to-left so earlier offsets stay valid.
         """
-        pattern = re.compile(r"(!?~)\s+r(['\"])(.*?)\2")
-        for m in reversed(list(pattern.finditer(expr))):
-            end = m.start()
+        prefix_pattern = re.compile(r"(!?~)\s+r(?=['\"])")
+        matches: list[tuple[re.Match, int, str]] = []
+        for match in prefix_pattern.finditer(expr):
+            if not _outside_quotes(expr, match.start()):
+                continue
+            quote_pos = match.end()
+            quote = expr[quote_pos]
+            close = quote_pos + 1
+            while close < len(expr):
+                if expr[close] == "\\":
+                    close += 2
+                    continue
+                if expr[close] == quote:
+                    matches.append((match, close + 1, expr[quote_pos + 1 : close]))
+                    break
+                close += 1
+
+        for match, match_end, raw_pattern in reversed(matches):
+            end = match.start()
             while end > 0 and expr[end - 1] == " ":
                 end -= 1
             operand_start = self._left_operand_start(expr, end)
             if operand_start is None:
                 continue
             operand = expr[operand_start:end]
-            replacement = f"REGEXP_MATCHES({operand}, '{m.group(3)}')"
-            if m.group(1) == "!~":
+            sql_pattern = raw_pattern.replace("'", "''")
+            replacement = f"REGEXP_MATCHES({operand}, '{sql_pattern}')"
+            if match.group(1) == "!~":
                 replacement = f"NOT {replacement}"
-            expr = expr[:operand_start] + replacement + expr[m.end() :]
+            expr = expr[:operand_start] + replacement + expr[match_end:]
         return expr
 
     def _transform_null_coalesce(self, expr: str) -> str:
@@ -962,6 +1093,42 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         parts.append("".join(buf))
         return parts
 
+    @classmethod
+    def _split_top_level_operator(cls, expr: str, operator: str) -> list[str]:
+        """Split on a single Malloy operator token regardless of whitespace."""
+        parts: list[str] = []
+        start = 0
+        quote: str | None = None
+        depth = 0
+        i = 0
+        while i < len(expr):
+            char = expr[i]
+            if quote is not None:
+                if char == "\\" and i + 1 < len(expr):
+                    i += 2
+                    continue
+                if char == quote:
+                    quote = None
+                i += 1
+                continue
+            if char in ("'", '"', "`"):
+                quote = char
+            elif char in "([{":
+                depth += 1
+            elif char in ")]}":
+                depth -= 1
+            elif (
+                depth == 0
+                and char == operator
+                and (i == 0 or expr[i - 1] != operator)
+                and (i + 1 == len(expr) or expr[i + 1] != operator)
+            ):
+                parts.append(expr[start:i])
+                start = i + 1
+            i += 1
+        parts.append(expr[start:])
+        return parts
+
     def _transform_and_tree(self, expr: str) -> str:
         """Transform Malloy & (and-tree) to SQL AND with expanded base field.
 
@@ -972,7 +1139,7 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
         Only splits on a top-level `&` (not one inside a string literal such as
         "label = 'A & B'").
         """
-        parts = [p.strip() for p in self._split_top_level(expr, " & ")]
+        parts = [p.strip() for p in self._split_top_level_operator(expr, "&")]
         if len(parts) < 2:
             return expr
 
@@ -1005,16 +1172,15 @@ class MalloyModelVisitor(MalloyParserVisitor):  # type: ignore[misc]
 
         Only handles the value-matching pattern: field ? value1 | value2 | ...
         """
-        # Match: field ? value1 | value2 | ...
-        match = re.match(r"^(.+?)\s*\?\s*(.+)$", expr)
-        if not match:
+        apply_parts = self._split_top_level_operator(expr, "?")
+        if len(apply_parts) != 2:
             return expr
 
-        base_field = match.group(1).strip()
-        values_str = match.group(2).strip()
+        base_field = apply_parts[0].strip()
+        values_str = apply_parts[1].strip()
 
         # Split on | and collect values
-        values = [v.strip() for v in values_str.split("|")]
+        values = [value.strip() for value in self._split_top_level_operator(values_str, "|")]
         if len(values) < 2:
             return expr
 

--- a/sidemantic/adapters/snowflake.py
+++ b/sidemantic/adapters/snowflake.py
@@ -1,9 +1,10 @@
 """Snowflake Cortex Semantic Model adapter for importing/exporting semantic models."""
 
-import re
 from pathlib import Path
 
+import sqlglot
 import yaml
+from sqlglot import exp
 
 from sidemantic.adapters.base import BaseAdapter
 from sidemantic.core.dimension import Dimension
@@ -12,37 +13,7 @@ from sidemantic.core.model import Model
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.segment import Segment
 from sidemantic.core.semantic_graph import SemanticGraph
-
-# Common SQL keywords to skip when qualifying column names
-_SQL_KEYWORDS = {
-    "AND",
-    "OR",
-    "NOT",
-    "IN",
-    "IS",
-    "NULL",
-    "TRUE",
-    "FALSE",
-    "LIKE",
-    "BETWEEN",
-    "CASE",
-    "WHEN",
-    "THEN",
-    "ELSE",
-    "END",
-    "AS",
-    "FROM",
-    "WHERE",
-    "SELECT",
-    "SUM",
-    "COUNT",
-    "AVG",
-    "MIN",
-    "MAX",
-    "MEDIAN",
-    "DISTINCT",
-    "NULLIF",
-}
+from sidemantic.sql.fragment import parse_sql_fragment, rewrite_sql_column_spans
 
 
 def _qualify_columns(sql_expr: str) -> str:
@@ -60,48 +31,47 @@ def _qualify_columns(sql_expr: str) -> str:
     if not sql_expr:
         return sql_expr
 
-    # Skip if already has {model} references
-    if "{model}" in sql_expr:
-        return sql_expr
+    def qualify(column: exp.Column, source: str) -> str | None:
+        return f"{{model}}.{source}" if len(column.parts) == 1 else None
 
-    # First, protect string literals by replacing them with numeric placeholders
-    # Numbers can't be identifiers so they won't be matched by the pattern
-    string_literals = []
+    rewritten = rewrite_sql_column_spans(sql_expr, qualify, dialect="snowflake", mask_kinds={"placeholder"})
+    return rewritten if rewritten is not None else sql_expr
 
-    def save_string(match):
-        idx = len(string_literals)
-        string_literals.append(match.group(0))
-        # Use 0x prefix to make it look like a number, won't be matched as identifier
-        return f"0x{idx:08x}"
 
-    # Match single-quoted strings (handling escaped quotes)
-    protected_expr = re.sub(r"'(?:[^'\\]|\\.)*'", save_string, sql_expr)
+_SIMPLE_AGGREGATES = {
+    exp.Sum: "sum",
+    exp.Count: "count",
+    exp.Avg: "avg",
+    exp.Min: "min",
+    exp.Max: "max",
+    exp.Median: "median",
+}
 
-    # Pattern to match potential column names
-    # Uses word boundaries \b to match complete identifiers only
-    # Negative lookbehind for dot prevents matching already-qualified names
-    # We check for function calls (followed by parenthesis) in the replace function
-    pattern = r"(?<![.\w])\b([a-zA-Z_][a-zA-Z0-9_]*)\b"
 
-    def replace_column(match):
-        col = match.group(1)
-        # Skip if it's a SQL keyword or function name
-        if col.upper() in _SQL_KEYWORDS:
-            return col
-        # Check if this is followed by a parenthesis (function call)
-        end_pos = match.end()
-        remaining = protected_expr[end_pos:].lstrip()
-        if remaining.startswith("("):
-            return col
-        return "{model}." + col
+def _simple_aggregate(sql_expr: str) -> tuple[str, str] | None:
+    """Return an outer aggregate and its source argument, if the whole expression is one."""
+    tree = parse_sql_fragment(sql_expr, "snowflake")
+    if tree is None:
+        return None
+    agg = next((name for node_type, name in _SIMPLE_AGGREGATES.items() if isinstance(tree, node_type)), None)
+    if agg is None:
+        return None
+    try:
+        tokens = sqlglot.tokenize(sql_expr, dialect="snowflake")
+    except Exception:
+        return None
+    if len(tokens) < 3 or tokens[1].token_type != sqlglot.tokens.TokenType.L_PAREN:
+        return None
+    if tokens[-1].token_type != sqlglot.tokens.TokenType.R_PAREN:
+        return None
 
-    result = re.sub(pattern, replace_column, protected_expr)
-
-    # Restore string literals
-    for i, literal in enumerate(string_literals):
-        result = result.replace(f"0x{i:08x}", literal)
-
-    return result
+    argument_start = tokens[2].start
+    if isinstance(tree, exp.Count) and isinstance(tree.this, exp.Distinct):
+        if len(tokens) < 4 or tokens[2].token_type != sqlglot.tokens.TokenType.DISTINCT:
+            return None
+        agg = "count_distinct"
+        argument_start = tokens[3].start
+    return agg, sql_expr[argument_start : tokens[-1].start].strip()
 
 
 class SnowflakeAdapter(BaseAdapter):
@@ -466,39 +436,18 @@ class SnowflakeAdapter(BaseAdapter):
 
         expr = metric_def.get("expr", "")
 
-        # Snowflake metrics contain full aggregate expressions like "SUM(amount)"
-        # Check if this is a simple aggregation or complex expression
-
-        # Count how many aggregate function calls are in the expression
-        agg_pattern = r"\b(SUM|COUNT|AVG|MIN|MAX|MEDIAN)\s*\("
-        agg_matches = re.findall(agg_pattern, expr, re.IGNORECASE)
-
-        if len(agg_matches) == 1:
-            # Single aggregation - try to parse it
-            # Simple pattern: just one aggregation wrapping the whole expression
-            simple_agg_pattern = r"^\s*(SUM|COUNT|AVG|MIN|MAX|MEDIAN)\s*\((.+)\)\s*$"
-            match = re.match(simple_agg_pattern, expr, re.IGNORECASE | re.DOTALL)
-
-            if match:
-                agg_func = match.group(1).lower()
-                inner_expr = match.group(2).strip()
-
-                # Handle COUNT(DISTINCT col)
-                if agg_func == "count":
-                    distinct_match = re.match(r"^\s*DISTINCT\s+(.+)$", inner_expr, re.IGNORECASE)
-                    if distinct_match:
-                        agg_func = "count_distinct"
-                        inner_expr = distinct_match.group(1).strip()
-
-                return Metric(
-                    name=name,
-                    agg=agg_func,
-                    sql=inner_expr,
-                    description=metric_def.get("description"),
-                    synonyms=metric_def.get("synonyms"),
-                    metadata=self._metric_metadata(metric_def),
-                    public=self._public_from_access_modifier(metric_def),
-                )
+        simple_aggregate = _simple_aggregate(expr)
+        if simple_aggregate is not None:
+            agg_func, inner_expr = simple_aggregate
+            return Metric(
+                name=name,
+                agg=agg_func,
+                sql=inner_expr,
+                description=metric_def.get("description"),
+                synonyms=metric_def.get("synonyms"),
+                metadata=self._metric_metadata(metric_def),
+                public=self._public_from_access_modifier(metric_def),
+            )
 
         # Complex expression (multiple aggregations or couldn't parse simple one)
         # Mark as derived. Table-scoped metrics qualify bare column references with

--- a/sidemantic/adapters/tableau.py
+++ b/sidemantic/adapters/tableau.py
@@ -147,6 +147,74 @@ def _has_lod_or_table_calc(formula: str) -> bool:
     return False
 
 
+def _protect_tableau_literals_and_strip_comments(formula: str) -> tuple[str, list[tuple[str, str, bool]]]:
+    """Protect Tableau strings/field tokens and remove ``//`` comments."""
+    out: list[str] = []
+    replacements: list[tuple[str, str, bool]] = []
+    used_sentinels: set[str] = set()
+    i = 0
+    while i < len(formula):
+        if formula.startswith("//", i):
+            end = formula.find("\n", i + 2)
+            if end < 0:
+                break
+            out.append("\n")
+            i = end + 1
+            continue
+        if formula[i] == "[":
+            end = formula.find("]", i + 1)
+            if end >= 0:
+                field_name = formula[i + 1 : end]
+                if end + 2 < len(formula) and formula[end + 1 : end + 3] == ".[":
+                    qualified_end = formula.find("]", end + 3)
+                    if qualified_end >= 0:
+                        field_name = formula[end + 3 : qualified_end]
+                        end = qualified_end
+                nonce = len(replacements)
+                sentinel = f'"__sidemantic_tableau_field_{nonce}__"'
+                while sentinel in formula or sentinel in used_sentinels:
+                    nonce += 1
+                    sentinel = f'"__sidemantic_tableau_field_{nonce}__"'
+                used_sentinels.add(sentinel)
+                replacements.append((sentinel, _quote_identifier_if_needed(_normalize_column_name(field_name)), False))
+                out.append(sentinel)
+                i = end + 1
+                continue
+        quote = formula[i]
+        if quote not in ("'", '"'):
+            out.append(quote)
+            i += 1
+            continue
+
+        end = i + 1
+        value: list[str] = []
+        while end < len(formula):
+            if formula[end] == quote:
+                if end + 1 < len(formula) and formula[end + 1] == quote:
+                    value.append(quote)
+                    end += 2
+                    continue
+                end += 1
+                break
+            value.append(formula[end])
+            end += 1
+
+        if quote == "'":
+            normalized = formula[i:end]
+        else:
+            normalized = "'" + "".join(value).replace("'", "''") + "'"
+        nonce = len(replacements)
+        sentinel = f"'__sidemantic_tableau_literal_{nonce}__'"
+        while sentinel in formula or sentinel[1:-1] in formula or sentinel in used_sentinels:
+            nonce += 1
+            sentinel = f"'__sidemantic_tableau_literal_{nonce}__'"
+        used_sentinels.add(sentinel)
+        replacements.append((sentinel, normalized, True))
+        out.append(sentinel)
+        i = end
+    return "".join(out), replacements
+
+
 def _find_matching_paren(s: str, open_pos: int) -> int:
     """Find the position of the matching closing paren, handling nesting.
 
@@ -446,16 +514,14 @@ def _translate_formula(formula: str | None) -> tuple[str | None, bool]:
     if formula is None:
         return (None, True)
 
-    # Check for untranslatable constructs
-    if _has_lod_or_table_calc(formula):
+    protected, protected_replacements = _protect_tableau_literals_and_strip_comments(formula)
+
+    # All syntax decisions share the same lexical boundary. Unsupported-looking
+    # text inside a literal or comment is never visible to the checks below.
+    if _has_lod_or_table_calc(protected):
         return (formula, False)
 
-    # Strip // comments before translation (they can contain IF/THEN keywords)
-    # Must be string-aware to preserve '://' inside string literals
-    result = _strip_comments(formula).strip()
-
-    # Convert Tableau double-quoted string literals to SQL single quotes
-    result = _convert_double_quotes(result)
+    result = protected.strip()
 
     # Replace [Field] references with quoted column names (string-literal-aware)
     result = _replace_field_refs(result)
@@ -507,6 +573,12 @@ def _translate_formula(formula: str | None) -> tuple[str | None, bool]:
     # Convert + to || when adjacent to a string literal ('...')
     result = _convert_string_concat(result)
 
+    for sentinel, replacement, may_be_unquoted in protected_replacements:
+        result = result.replace(sentinel, replacement)
+        # DATEADD consumes quotes around its date-part argument. Preserve that
+        # intentional behavior when the argument was protected by a sentinel.
+        if may_be_unquoted:
+            result = result.replace(sentinel[1:-1], replacement[1:-1])
     return (result, True)
 
 

--- a/sidemantic/adapters/thoughtspot.py
+++ b/sidemantic/adapters/thoughtspot.py
@@ -59,8 +59,6 @@ _TML_DOT_REF = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)
 _BARE_IDENTIFIER = re.compile(r"(?<![\w.])([A-Za-z_][A-Za-z0-9_]*)(?![\w.])(?!\s*\()")
 # A quoted string literal (single or double quoted, with doubled-quote escapes).
 _STRING_LITERAL = re.compile(r"'(?:[^']|'')*'|\"(?:[^\"]|\"\")*\"")
-# Split a join predicate into conjuncts on a word-boundary `AND` (case-insensitive).
-_AND_SPLIT = re.compile(r"\bAND\b", re.IGNORECASE)
 # A plain `=` equality operator (not part of `<=`, `>=`, `!=`, `<>`, or `==`).
 _EQUALITY_OP = re.compile(r"(?<![<>=!])=(?![=])")
 
@@ -225,7 +223,7 @@ def _extract_all_join_refs(
         return None
 
     pairs: list[tuple[tuple[str | None, str], tuple[str | None, str]]] = []
-    for conjunct in _AND_SPLIT.split(expr):
+    for conjunct in _split_join_conjunctions(expr):
         # A plain equality has exactly one `=` (not part of `<=`/`>=`/`!=`).
         equalities = _EQUALITY_OP.findall(conjunct)
         if len(equalities) != 1:
@@ -243,6 +241,185 @@ def _extract_all_join_refs(
                 right = (table_path_lookup[right[0]], right[1])
         pairs.append((left, right))
     return pairs
+
+
+def _split_join_conjunctions(expr: str) -> list[str]:
+    """Split top-level AND tokens while respecting TML identifiers and literals."""
+    text = _strip_join_outer_parentheses(_strip_join_comments(expr).strip())
+
+    result: list[str] = []
+    start = 0
+    depth = 0
+    quote: str | None = None
+    in_brackets = False
+    i = 0
+    while i < len(text):
+        char = text[i]
+        if quote is not None:
+            if char == quote:
+                if i + 1 < len(text) and text[i + 1] == quote:
+                    i += 2
+                    continue
+                quote = None
+            i += 1
+            continue
+        if in_brackets:
+            if char == "]":
+                if i + 1 < len(text) and text[i + 1] == "]":
+                    i += 2
+                    continue
+                in_brackets = False
+            i += 1
+            continue
+        if char in ("'", '"'):
+            quote = char
+            i += 1
+            continue
+        if char == "[":
+            in_brackets = True
+            i += 1
+            continue
+        if char == "(":
+            depth += 1
+            i += 1
+            continue
+        if char == ")":
+            depth = max(0, depth - 1)
+            i += 1
+            continue
+        if (
+            depth == 0
+            and text[i : i + 3].upper() == "AND"
+            and (i == 0 or not (text[i - 1].isalnum() or text[i - 1] == "_"))
+            and (i + 3 == len(text) or not (text[i + 3].isalnum() or text[i + 3] == "_"))
+        ):
+            result.append(text[start:i].strip())
+            start = i + 3
+            i += 3
+            continue
+        i += 1
+    result.append(text[start:].strip())
+
+    flattened: list[str] = []
+    for item in result:
+        stripped = _strip_join_outer_parentheses(item)
+        if stripped != item:
+            flattened.extend(_split_join_conjunctions(stripped))
+        else:
+            flattened.append(item)
+    return flattened
+
+
+def _strip_join_comments(expr: str) -> str:
+    """Remove SQL comments without interpreting markers inside TML refs or strings."""
+    out: list[str] = []
+    i = 0
+    quote: str | None = None
+    in_brackets = False
+    while i < len(expr):
+        char = expr[i]
+        if quote is not None:
+            out.append(char)
+            if char == quote:
+                if i + 1 < len(expr) and expr[i + 1] == quote:
+                    out.append(expr[i + 1])
+                    i += 2
+                    continue
+                quote = None
+            i += 1
+            continue
+        if in_brackets:
+            out.append(char)
+            if char == "]":
+                if i + 1 < len(expr) and expr[i + 1] == "]":
+                    out.append(expr[i + 1])
+                    i += 2
+                    continue
+                in_brackets = False
+            i += 1
+            continue
+        if char in ("'", '"'):
+            quote = char
+            out.append(char)
+            i += 1
+            continue
+        if char == "[":
+            in_brackets = True
+            out.append(char)
+            i += 1
+            continue
+        if expr.startswith("--", i):
+            end = expr.find("\n", i + 2)
+            if end < 0:
+                break
+            out.append(" ")
+            i = end
+            continue
+        if expr.startswith("/*", i):
+            depth = 1
+            i += 2
+            while i < len(expr) and depth:
+                if expr.startswith("/*", i):
+                    depth += 1
+                    i += 2
+                elif expr.startswith("*/", i):
+                    depth -= 1
+                    i += 2
+                else:
+                    i += 1
+            out.append(" ")
+            continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def _strip_join_outer_parentheses(text: str) -> str:
+    """Remove only balanced parentheses that enclose an entire TML predicate."""
+    while text.startswith("(") and text.endswith(")"):
+        depth = 0
+        encloses_all = True
+        quote: str | None = None
+        in_brackets = False
+        index = 0
+        while index < len(text):
+            char = text[index]
+            if quote is not None:
+                if char == quote:
+                    if index + 1 < len(text) and text[index + 1] == quote:
+                        index += 2
+                        continue
+                    quote = None
+                index += 1
+                continue
+            if in_brackets:
+                if char == "]":
+                    if index + 1 < len(text) and text[index + 1] == "]":
+                        index += 2
+                        continue
+                    in_brackets = False
+                index += 1
+                continue
+            if char in ("'", '"'):
+                quote = char
+                index += 1
+                continue
+            if char == "[":
+                in_brackets = True
+                index += 1
+                continue
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0 and index != len(text) - 1:
+                    encloses_all = False
+                    break
+            index += 1
+        if not encloses_all or depth != 0:
+            break
+        text = text[1:-1].strip()
+    return text
 
 
 def _split_sql_identifier(sql: str | None) -> tuple[str | None, str | None]:

--- a/sidemantic/sql/fragment.py
+++ b/sidemantic/sql/fragment.py
@@ -1,0 +1,224 @@
+"""Small SQL-fragment parsing helpers shared by adapters and query generation.
+
+SQLGlot owns syntax classification.  Rewrites are applied to source spans so the
+surrounding dialect spelling, comments, literals, and quoted identifiers remain
+byte-for-byte unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+
+import sqlglot
+from sqlglot import exp
+from sqlglot.dialects import Dialect
+from sqlglot.optimizer.scope import build_scope
+
+
+def _quoted_end(sql: str, start: int, closing: str) -> int:
+    i = start + 1
+    while i < len(sql):
+        if sql[i] == closing:
+            if i + 1 < len(sql) and sql[i + 1] == closing:
+                i += 2
+                continue
+            return i + 1
+        if sql[i] == "\\" and closing in {"'", '"', "`"}:
+            i += 2
+            continue
+        i += 1
+    return len(sql)
+
+
+def protected_sql_spans(sql: str) -> Iterator[tuple[int, int, str]]:
+    """Yield non-code SQL spans as ``(start, end, kind)`` triples.
+
+    This lexical boundary deliberately recognizes only quoting/comment forms;
+    semantic decisions remain SQLGlot's responsibility.
+    """
+    i = 0
+    while i < len(sql):
+        if sql.startswith("--", i):
+            end = sql.find("\n", i + 2)
+            end = len(sql) if end < 0 else end
+            yield i, end, "comment"
+            i = end
+            continue
+        if sql.startswith("/*", i):
+            depth = 1
+            end = i + 2
+            while end < len(sql) and depth:
+                if sql.startswith("/*", end):
+                    depth += 1
+                    end += 2
+                elif sql.startswith("*/", end):
+                    depth -= 1
+                    end += 2
+                else:
+                    end += 1
+            yield i, end, "comment"
+            i = end
+            continue
+        ch = sql[i]
+        if ch in "'\"`":
+            end = _quoted_end(sql, i, ch)
+            yield i, end, "string" if ch == "'" else "quoted_identifier"
+            i = end
+            continue
+        if ch == "[":
+            end = _quoted_end(sql, i, "]")
+            yield i, end, "quoted_identifier"
+            i = end
+            continue
+        if ch == "$":
+            if sql.startswith("${", i):
+                end = sql.find("}", i + 2)
+                if end >= 0:
+                    yield i, end + 1, "placeholder"
+                    i = end + 1
+                    continue
+            marker_end = sql.find("$", i + 1)
+            if marker_end >= 0:
+                marker = sql[i : marker_end + 1]
+                tag = marker[1:-1]
+                if not tag or (tag[0].isalpha() or tag[0] == "_") and all(c.isalnum() or c == "_" for c in tag):
+                    end_marker = sql.find(marker, marker_end + 1)
+                    if end_marker >= 0:
+                        end = end_marker + len(marker)
+                        yield i, end, "string"
+                        i = end
+                        continue
+        if sql.startswith("{model}", i):
+            yield i, i + len("{model}"), "placeholder"
+            i += len("{model}")
+            continue
+        i += 1
+
+
+def mask_sql_literals_comments_and_quoted_identifiers(
+    sql: str, *, kinds: set[str] | frozenset[str] | None = None
+) -> str:
+    """Mask non-code spans without changing source offsets.
+
+    Literal/identifier spans become a numeric atom and padding; comments become
+    spaces.  The resulting expression remains parseable for normal SQL fragments
+    while every executable token retains its original offset.
+    """
+    chars = list(sql)
+    for start, end, kind in protected_sql_spans(sql):
+        if kinds is not None and kind not in kinds:
+            continue
+        if kind == "comment":
+            replacement = " " * (end - start)
+        elif kind == "placeholder":
+            replacement = "m" + " " * (end - start - 1)
+        else:
+            replacement = "0" + " " * (end - start - 1)
+        chars[start:end] = replacement
+    return "".join(chars)
+
+
+def parse_sql_fragment(
+    sql: str,
+    dialect: str | None = None,
+    *,
+    mask_protected: bool = False,
+    mask_kinds: set[str] | frozenset[str] | None = None,
+) -> exp.Expression | None:
+    source = (
+        mask_sql_literals_comments_and_quoted_identifiers(sql, kinds=mask_kinds)
+        if mask_protected or mask_kinds is not None
+        else sql
+    )
+    dialects = (dialect,) if dialect is not None else (None, "snowflake", "bigquery", "postgres", "duckdb", "tsql")
+    for candidate in dialects:
+        try:
+            return sqlglot.parse_one(source, read=candidate)
+        except Exception:
+            continue
+    return None
+
+
+ColumnResolver = Callable[[exp.Column, str], str | None]
+
+
+def _column_is_bound_in_select(column: exp.Column, dialect: str | None = None) -> bool:
+    """Return whether a column is owned by its nearest nested SELECT scope."""
+    select = column.find_ancestor(exp.Select)
+    if select is None:
+        return False
+    if not column.table:
+        return True
+
+    try:
+        scope = build_scope(select)
+    except Exception:
+        return False
+    if scope is None:
+        return False
+    qualifier = column.parts[-2]
+    for source_name, source in scope.references:
+        alias = source.args.get("alias")
+        source_identifier = alias.this if alias is not None else source.args.get("this")
+        if dialect is None:
+            # An unknown fragment dialect cannot determine quoted-name folding;
+            # fail safely by treating a case-insensitive alias match as local.
+            if source_name.casefold() == qualifier.name.casefold():
+                return True
+            continue
+        source_identifier = (
+            source_identifier
+            if isinstance(source_identifier, exp.Identifier)
+            else exp.to_identifier(source_name, quoted=False)
+        )
+        dialect_impl = Dialect.get_or_raise(dialect)
+        normalized_source = dialect_impl.normalize_identifier(source_identifier.copy()).name
+        normalized_qualifier = dialect_impl.normalize_identifier(qualifier.copy()).name
+        if normalized_source == normalized_qualifier:
+            return True
+    return False
+
+
+def rewrite_sql_column_spans(
+    sql: str,
+    resolver: ColumnResolver,
+    *,
+    dialect: str | None = None,
+    mask_protected: bool = False,
+    mask_kinds: set[str] | frozenset[str] | None = None,
+) -> str | None:
+    """Rewrite SQLGlot-classified columns while preserving all untouched text."""
+    tree = parse_sql_fragment(sql, dialect, mask_protected=mask_protected, mask_kinds=mask_kinds)
+    if tree is None:
+        return None
+
+    replacements: dict[tuple[int, int], str] = {}
+    for column in tree.find_all(exp.Column):
+        if _column_is_bound_in_select(column, dialect):
+            continue
+        parts = list(column.parts)
+        if not parts or any("start" not in part.meta or "end" not in part.meta for part in parts):
+            continue
+        start = parts[0].meta["start"]
+        end = parts[-1].meta["end"] + 1
+        replacement = resolver(column, sql[start:end])
+        if replacement is not None:
+            replacements[(start, end)] = replacement
+
+    rewritten = sql
+    for (start, end), replacement in sorted(replacements.items(), reverse=True):
+        rewritten = rewritten[:start] + replacement + rewritten[end:]
+    return rewritten
+
+
+def replace_outside_sql_protected(sql: str, old: str, new: str) -> str:
+    """Replace literal placeholder text only in executable SQL spans."""
+    out: list[str] = []
+    cursor = 0
+    for start, end, kind in protected_sql_spans(sql):
+        out.append(sql[cursor:start].replace(old, new))
+        protected = sql[start:end]
+        out.append(new if kind == "placeholder" and protected == old else protected)
+        cursor = end
+    out.append(sql[cursor:].replace(old, new))
+    return "".join(out)

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -12,6 +12,7 @@ from sidemantic.core.preagg_matcher import PreAggregationMatcher
 from sidemantic.core.semantic_graph import SemanticGraph, _relationship_local_key_columns
 from sidemantic.core.symmetric_aggregate import build_symmetric_aggregate_sql
 from sidemantic.sql.aggregation_detection import sql_has_aggregate
+from sidemantic.sql.fragment import _column_is_bound_in_select, parse_sql_fragment, rewrite_sql_column_spans
 from sidemantic.validation import QueryValidationError
 
 # Dialects whose SQL supports the QUALIFY clause natively. Semi-additive
@@ -2914,38 +2915,35 @@ class SQLGenerator:
 
     def _split_where_having_filters(self, filters: list[str], model_names: list[str]) -> tuple[list[str], list[str]]:
         """Split query-level filters into row filters and aggregate filters."""
-        import re
-
         where_filters = []
         having_filters = []
+        models = {name: self.graph.get_model(name) for name in model_names}
 
         for filter_expr in filters:
+            parsed = parse_sql_fragment(filter_expr, self.dialect)
+            if parsed is None:
+                # A filter we cannot classify must stay a row predicate. Moving it
+                # to HAVING based on textual guesses silently changes semantics.
+                where_filters.append(filter_expr)
+                continue
+
             references_metric = False
-
-            for model_name in model_names:
-                model_obj = self.graph.get_model(model_name)
-                pattern = f"{model_name}\\.([a-zA-Z_][a-zA-Z0-9_]*)"
-                matches = re.findall(pattern, filter_expr)
-                for field_name in matches:
-                    if model_obj.get_metric(field_name):
-                        references_metric = True
-                        break
-                if references_metric:
-                    break
-
             references_window_dim = False
-            if references_metric:
-                for model_name in model_names:
-                    model_obj = self.graph.get_model(model_name)
-                    if not model_obj:
-                        continue
-                    for field_name in re.findall(f"{model_name}\\.([a-zA-Z_][a-zA-Z0-9_]*)", filter_expr):
-                        dim = model_obj.get_dimension(field_name)
-                        if dim and getattr(dim, "window", None) is not None:
-                            references_window_dim = True
-                            break
-                    if references_window_dim:
-                        break
+            for column in parsed.find_all(exp.Column):
+                if _column_is_bound_in_select(column, self.dialect):
+                    continue
+                parts = list(column.parts)
+                if len(parts) != 2:
+                    continue
+                model_name, field_name = (part.name for part in parts)
+                model_obj = models.get(model_name)
+                if model_obj is None:
+                    continue
+                if model_obj.get_metric(field_name):
+                    references_metric = True
+                dimension = model_obj.get_dimension(field_name)
+                if dimension and getattr(dimension, "window", None) is not None:
+                    references_window_dim = True
 
             if references_metric and not references_window_dim:
                 having_filters.append(filter_expr)
@@ -2956,45 +2954,25 @@ class SQLGenerator:
 
     def _add_where_filters_to_query(self, query, where_filters: list[str], model_names: list[str]):
         """Add row-level filters with CTE-qualified field references."""
-        import re
+        models = {name: self.graph.get_model(name) for name in model_names}
 
         for filter_expr in where_filters:
-            parsed_filter = filter_expr
-            for model_name in model_names:
-                model_obj = self.graph.get_model(model_name)
 
-                parts = []
-                in_quotes = False
-                current = ""
+            def replace_field(column: exp.Column, _source: str) -> str | None:
+                parts = list(column.parts)
+                if len(parts) != 2:
+                    return None
+                model_name, field_name = (part.name for part in parts)
+                model_obj = models.get(model_name)
+                if model_obj is None:
+                    return None
+                if model_obj.get_metric(field_name):
+                    return self._cte_ref(model_name, f"{field_name}_raw")
+                return self._cte_ref(model_name, field_name)
 
-                for char in parsed_filter:
-                    if char == "'":
-                        if current:
-                            parts.append((current, in_quotes))
-                            current = ""
-                        in_quotes = not in_quotes
-                        parts.append(("'", False))
-                    else:
-                        current += char
-                if current:
-                    parts.append((current, in_quotes))
-
-                pattern = f"{model_name}\\.([a-zA-Z_][a-zA-Z0-9_]*)"
-
-                def replace_field(match):
-                    field_name = match.group(1)
-                    if model_obj.get_metric(field_name):
-                        return self._cte_ref(model_name, f"{field_name}_raw")
-                    return self._cte_ref(model_name, field_name)
-
-                result_parts = []
-                for part, is_quoted in parts:
-                    if is_quoted or part == "'":
-                        result_parts.append(part)
-                    else:
-                        result_parts.append(re.sub(pattern, replace_field, part))
-
-                parsed_filter = "".join(result_parts)
+            parsed_filter = rewrite_sql_column_spans(filter_expr, replace_field, dialect=self.dialect)
+            if parsed_filter is None:
+                parsed_filter = filter_expr
 
             query = query.where(parsed_filter)
 

--- a/sidemantic/sql/lookml_expression.py
+++ b/sidemantic/sql/lookml_expression.py
@@ -249,6 +249,18 @@ def protect_lookml_sql(sql: str) -> ProtectedLookMLSQL:
             out.append(sql[i:end])
             i = end
             continue
+        if ch == "$" and not sql.startswith("${", i):
+            marker_end = sql.find("$", i + 1)
+            if marker_end >= 0:
+                marker = sql[i : marker_end + 1]
+                tag = marker[1:-1]
+                if not tag or (tag[0].isalpha() or tag[0] == "_") and all(c.isalnum() or c == "_" for c in tag):
+                    end_marker = sql.find(marker, marker_end + 1)
+                    if end_marker >= 0:
+                        end = end_marker + len(marker)
+                        out.append(sql[i:end])
+                        i = end
+                        continue
         if sql.startswith("{{", i) or sql.startswith("{%", i):
             close = "}}" if sql.startswith("{{", i) else "%}"
             end = sql.find(close, i + 2)
@@ -714,3 +726,35 @@ def restore_outer_aggregate_all(sql: str) -> str:
         restored = protected.text[: token.end + 1] + "ALL " + protected.text[token.end + 1 :]
         return protected.restore(restored)
     return sql
+
+
+def strip_aggregate_all(sql: str) -> str:
+    """Remove syntactic aggregate ``ALL`` modifiers while preserving comments."""
+    protected = protect_lookml_sql(sql)
+    try:
+        tokens = sqlglot.tokenize(protected.text)
+    except Exception:
+        return sql
+
+    remove: list[tuple[int, int]] = []
+    for index, token in enumerate(tokens):
+        if token.token_type != TokenType.ALL:
+            continue
+        is_leading = index == 0 and len(tokens) >= 2
+        is_function_modifier = (
+            index >= 2
+            and index + 1 < len(tokens)
+            and tokens[index - 1].token_type == TokenType.L_PAREN
+            and tokens[index + 1].token_type != TokenType.R_PAREN
+        )
+        if not (is_leading or is_function_modifier):
+            continue
+        end = token.end + 1
+        while end < len(protected.text) and protected.text[end].isspace():
+            end += 1
+        remove.append((token.start, end))
+
+    stripped = protected.text
+    for start, end in reversed(remove):
+        stripped = stripped[:start] + stripped[end:]
+    return protected.restore(stripped)

--- a/sidemantic/sql/lookml_expression.py
+++ b/sidemantic/sql/lookml_expression.py
@@ -16,6 +16,7 @@ from sqlglot import exp
 from sqlglot.tokens import TokenType
 
 from sidemantic.sql.aggregation_detection import _ANONYMOUS_AGGREGATE_FUNCTIONS
+from sidemantic.sql.fragment import mask_sql_literals_comments_and_quoted_identifiers
 
 _PROTECTED_PREFIX = "__sidemantic_lookml_fragment_"
 
@@ -429,6 +430,29 @@ def parse_lookml_expression(
     if best is None:
         return None
     return ParsedLookMLSQL(protected, best[1], best[2])
+
+
+def lookml_expression_has_subquery(sql: str) -> bool:
+    """Whether executable LookML SQL contains a real ``SELECT``.
+
+    Prefer the parsed AST.  Some otherwise valid SQL fragments cannot be parsed
+    after Liquid control tags are replaced by identifier sentinels, however.  In
+    that case SQLGlot's tokenizer provides the conservative syntax boundary after
+    strings, quoted identifiers, comments, dollar literals, and LookML fragments
+    have been hidden.  This fails closed for genuine subqueries without reviving
+    the old false positives from literal or template contents.
+    """
+    parsed = parse_lookml_expression(sql)
+    if parsed is not None:
+        return parsed.tree.find(exp.Select) is not None
+
+    protected = protect_lookml_sql(sql)
+    masked = mask_sql_literals_comments_and_quoted_identifiers(protected.text)
+    try:
+        tokens = sqlglot.Tokenizer().tokenize(masked)
+    except Exception:
+        return False
+    return any(token.token_type is TokenType.SELECT for token in tokens)
 
 
 ColumnResolver = Callable[[str, tuple[str, ...], bool], str | None]

--- a/tests/adapters/bsl/test_parsing.py
+++ b/tests/adapters/bsl/test_parsing.py
@@ -1,5 +1,7 @@
 """Unit tests for BSL adapter and expression parser."""
 
+import ast
+
 import pytest
 
 from sidemantic.adapters.bsl import BSLAdapter
@@ -1512,6 +1514,57 @@ class TestBSLCompoundExpressions:
     def test_sql_to_bsl_expr_compound_mean(self):
         result = _sql_to_bsl_expr("total_claim_cost - payer_coverage", "avg")
         assert result == "(_.total_claim_cost - _.payer_coverage).mean()"
+
+    def test_sql_to_bsl_expr_recursively_qualifies_function_arguments(self):
+        assert _sql_to_bsl_expr("COALESCE(a, 0) - b", "sum") == "(COALESCE(_.a, 0) - _.b).sum()"
+
+    def test_sql_to_bsl_expr_recursively_qualifies_parenthesized_operands(self):
+        assert _sql_to_bsl_expr("(a + b) / c", "sum") == "((_.a + _.b) / _.c).sum()"
+
+    def test_sql_to_bsl_expr_recursively_qualifies_case_columns(self):
+        result = _sql_to_bsl_expr("CASE WHEN status = 'paid' THEN amount ELSE 0 END", "sum")
+        assert result == ("((_.amount if _.status == 'paid' else 0)).sum()")
+        ast.parse(result, mode="eval")
+        assert bsl_to_sql(result) == ("CASE WHEN status = 'paid' THEN amount ELSE 0 END", "sum", None)
+
+    @pytest.mark.parametrize(
+        ("sql", "expected"),
+        [
+            ("a IS NULL", "(_.a.isnull()).sum()"),
+            ("a BETWEEN 1 AND b", "(_.a.between(1, _.b)).sum()"),
+            ("a IN (1, b)", "(_.a.isin([1, _.b])).sum()"),
+            ("a LIKE 'x%'", "(_.a.like('x%')).sum()"),
+            ("a IS NOT NULL", "(_.a.notnull()).sum()"),
+            ("EXTRACT(YEAR FROM created_at)", "(_.created_at.year()).sum()"),
+            ("a || b", "(CONCAT(_.a, _.b)).sum()"),
+            ("CAST(a AS INT)", "(CAST(_.a, 'INT')).sum()"),
+            ("-a", "(-_.a).sum()"),
+            ("COALESCE(a, NULL)", "(COALESCE(_.a, None)).sum()"),
+            ("a IS TRUE", "(IS(_.a, True)).sum()"),
+        ],
+    )
+    def test_sql_to_bsl_expr_predicates_are_qualified_and_valid(self, sql, expected):
+        result = _sql_to_bsl_expr(sql, "sum")
+        assert result == expected
+        ast.parse(result, mode="eval")
+        roundtrip_sql, roundtrip_agg, _ = bsl_to_sql(result)
+        assert roundtrip_sql is not None
+        assert roundtrip_agg == "sum"
+
+    @pytest.mark.parametrize(
+        ("sql", "expected", "roundtrip"),
+        [
+            ('"class"', "getattr(_, 'class').sum()", '"class"'),
+            ('"order amount"', "getattr(_, 'order amount').sum()", '"order amount"'),
+            ("`class`", "getattr(_, 'class').sum()", '"class"'),
+            ("[class]", "getattr(_, 'class').sum()", '"class"'),
+        ],
+    )
+    def test_sql_to_bsl_expr_uses_valid_python_for_quoted_or_keyword_columns(self, sql, expected, roundtrip):
+        result = _sql_to_bsl_expr(sql, "sum")
+        assert result == expected
+        ast.parse(result, mode="eval")
+        assert bsl_to_sql(result) == (roundtrip, "sum", None)
 
 
 class TestBSLBooleanExpressions:

--- a/tests/adapters/cube/test_correctness_fixes.py
+++ b/tests/adapters/cube/test_correctness_fixes.py
@@ -17,9 +17,41 @@ import pytest
 import yaml
 
 from sidemantic import SemanticLayer
-from sidemantic.adapters.cube import CubeAdapter, CubeImportWarning, _normalize_cube_sql
+from sidemantic.adapters.cube import CubeAdapter, CubeImportWarning, _model_placeholder_to_cube, _normalize_cube_sql
 from sidemantic.core.preagg_matcher import GRANULARITY_HIERARCHY
 from sidemantic.core.relationship import Relationship
+
+
+def test_derived_export_only_rewrites_executable_semantic_member_references():
+    convert = CubeAdapter._derived_sql_to_cube
+    known = {"orders.total"}
+
+    assert convert('"orders.total" + orders.total', known) == '"orders.total" + ${orders.total}'
+    assert convert("`orders.total` + orders.total", known) == "`orders.total` + ${orders.total}"
+    assert convert("[orders.total] + orders.total", known) == "[orders.total] + ${orders.total}"
+    assert convert("orders.total /* orders.total */", known) == "${orders.total} /* orders.total */"
+    assert convert("orders.total = $$orders.total$$", known) == "${orders.total} = $$orders.total$$"
+    assert convert("orders.total = $tag$orders.total$tag$", known) == ("${orders.total} = $tag$orders.total$tag$")
+    assert convert("orders . total", known) == "${orders . total}"
+    assert convert("orders/* member */.total", known) == "${orders/* member */.total}"
+    assert convert("(SELECT orders.total FROM audit AS orders)", known) == (
+        "(SELECT orders.total FROM audit AS orders)"
+    )
+    assert convert("(SELECT orders.total FROM audit AS ORDERS)", known) == (
+        "(SELECT orders.total FROM audit AS ORDERS)"
+    )
+
+
+def test_model_placeholder_export_uses_the_same_sql_lexical_boundary():
+    sql = "{model}.amount = '{model}' AND \"{model}\" = `{model}` AND [{model}] = $$ {model} $$ /* {model} */"
+
+    assert _model_placeholder_to_cube(sql) == (
+        "${CUBE}.amount = '{model}' AND \"{model}\" = `{model}` AND [{model}] = $$ {model} $$ /* {model} */"
+    )
+    assert _model_placeholder_to_cube("${model}.amount + {model}.tax") == "${model}.amount + ${CUBE}.tax"
+    assert _model_placeholder_to_cube("{model}.x /* outer /* inner */ {model}.y */") == (
+        "${CUBE}.x /* outer /* inner */ {model}.y */"
+    )
 
 
 def _parse(yaml_text: str):

--- a/tests/adapters/lookml/test_sql_expression.py
+++ b/tests/adapters/lookml/test_sql_expression.py
@@ -43,6 +43,28 @@ def test_placeholder_conversion_and_qualifier_stripping_are_lexical():
     )
 
 
+def test_subquery_detection_ignores_postgres_dollar_quoted_literals():
+    detect = LookMLAdapter._has_subquery
+
+    assert not detect("SUM(IFF(note = $$select$$, amount, 0))")
+    assert not detect("SUM(IFF(note = $tag$select$tag$, amount, 0))")
+    assert detect("SUM(amount) / NULLIF((SELECT SUM(amount) FROM orders), 0)")
+
+
+def test_all_modifier_stripping_uses_syntax_tokens():
+    strip = LookMLAdapter._strip_all_modifier
+
+    assert strip("COUNT(ALL amount)") == "COUNT(amount)"
+    assert strip("ALL {model}.amount") == "{model}.amount"
+    assert strip("COUNT(note = $$ALL amount$$)") == "COUNT(note = $$ALL amount$$)"
+    assert strip("COUNT(note /* (ALL amount) */)") == "COUNT(note /* (ALL amount) */)"
+    assert strip("COUNT(ALL /* why */ amount)") == "COUNT(/* why */ amount)"
+    assert strip("ALL /* why */ {model}.amount") == "/* why */ {model}.amount"
+    assert strip("ROUND(SUM(ALL amount), 2)") == "ROUND(SUM(amount), 2)"
+    assert strip("SUM(amount) + COUNT(ALL id)") == "SUM(amount) + COUNT(id)"
+    assert strip("CASE WHEN x THEN SUM(ALL amount) END") == "CASE WHEN x THEN SUM(amount) END"
+
+
 def test_column_rewrite_preserves_templates_literals_and_foreign_qualifiers():
     sql = "{model}.status = {{ status }} AND customers.status != 'status'"
 

--- a/tests/adapters/lookml/test_sql_expression.py
+++ b/tests/adapters/lookml/test_sql_expression.py
@@ -51,6 +51,16 @@ def test_subquery_detection_ignores_postgres_dollar_quoted_literals():
     assert detect("SUM(amount) / NULLIF((SELECT SUM(amount) FROM orders), 0)")
 
 
+def test_subquery_detection_fails_closed_for_unparseable_liquid_sql():
+    detect = LookMLAdapter._has_subquery
+
+    assert detect(
+        "SUM(amount) / (SELECT SUM(amount) FROM orders WHERE {% condition status %} status {% endcondition %})"
+    )
+    assert not detect("SUM({% condition select %} amount {% endcondition %})")
+    assert not detect("SUM(amount) /* SELECT {% condition status %} */")
+
+
 def test_all_modifier_stripping_uses_syntax_tokens():
     strip = LookMLAdapter._strip_all_modifier
 

--- a/tests/adapters/malloy/test_audit_regressions.py
+++ b/tests/adapters/malloy/test_audit_regressions.py
@@ -7,7 +7,7 @@ through MalloyAdapter end-to-end so the assertions exercise the real visitor.
 import tempfile
 from pathlib import Path
 
-from sidemantic.adapters.malloy import MalloyAdapter
+from sidemantic.adapters.malloy import MalloyAdapter, MalloyModelVisitor
 
 
 def _parse(src: str):
@@ -249,6 +249,45 @@ def test_and_tree_preserves_string_literal():
 def test_and_tree_still_expands_top_level():
     sql = _dim_sql("source: o is duckdb.table('o') extend {\n  dimension: r is value < 2031 & > -8000\n}\n", "r")
     assert sql == "value < 2031 AND value > -8000"
+
+
+def test_and_tree_ignores_question_mark_inside_literal():
+    assert MalloyModelVisitor()._transform_malloy_expr("status != 'Cancelled?' & 'Returned'") == (
+        "status != 'Cancelled?' AND status != 'Returned'"
+    )
+
+
+def test_or_tree_ignores_pick_keyword_inside_literal():
+    assert MalloyModelVisitor()._transform_malloy_expr("note ? 'pick me' | 'other'") == "note IN ('pick me', 'other')"
+
+
+def test_tree_operators_do_not_require_surrounding_whitespace():
+    transform = MalloyModelVisitor()._transform_malloy_expr
+    assert transform("note?'a'|'b'") == "note IN ('a', 'b')"
+    assert transform("status!='x'&'y'") == "status!='x' AND status != 'y'"
+
+
+def test_type_assertion_spacing_is_normalized_only_in_syntax():
+    transform = MalloyModelVisitor()._transform_malloy_expr
+    assert transform("timestamp_seconds ! timestamp (x)") == "timestamp_seconds(x)"
+    assert transform("timestamp_seconds!timestamp (x)") == "timestamp_seconds(x)"
+    assert transform("'timestamp_seconds ! timestamp (x)'") == "'timestamp_seconds ! timestamp (x)'"
+
+
+def test_post_parse_rewrites_ignore_hidden_comment_tokens():
+    transform = MalloyModelVisitor()._transform_malloy_expr
+    assert transform("amount + 1 /* name ~ r'x' @2024-01-01 */") == "amount + 1 /* name ~ r'x' @2024-01-01 */"
+    assert transform("amount -- name ~ r'x'\n + tax") == "amount -- name ~ r'x'\n + tax"
+    assert transform("amount // timestamp_seconds!timestamp(x)\n + tax") == (
+        "amount // timestamp_seconds!timestamp(x)\n + tax"
+    )
+
+
+def test_dimension_type_inference_ignores_syntax_looking_literal_contents():
+    infer = MalloyModelVisitor()._infer_dimension_type
+    assert infer("'a+b'", "label") == "categorical"
+    assert infer("'x=y'", "label") == "categorical"
+    assert infer("'date_trunc'", "label") == "categorical"
 
 
 # --- regex ~ must consume only its own field operand ---

--- a/tests/adapters/malloy/test_edge_cases.py
+++ b/tests/adapters/malloy/test_edge_cases.py
@@ -2,7 +2,22 @@
 
 from pathlib import Path
 
-from sidemantic.adapters.malloy import MalloyAdapter
+from sidemantic.adapters.malloy import MalloyAdapter, MalloyModelVisitor
+
+
+def test_expression_transforms_ignore_malloy_syntax_inside_strings():
+    transform = MalloyModelVisitor()._transform_malloy_expr
+
+    assert transform("'@2024-01-01'") == "'@2024-01-01'"
+    assert transform("note = '@2024-01-01'") == "note = '@2024-01-01'"
+    assert transform("'timestamp_seconds!timestamp(x)'") == "'timestamp_seconds!timestamp(x)'"
+    assert transform("note = '@2024-01-01' AND created_at >= @2024-01-01") == (
+        "note = '@2024-01-01' AND created_at >= DATE '2024-01-01'"
+    )
+    assert transform("timestamp_seconds!timestamp(x)") == "timestamp_seconds(x)"
+    assert transform("\"name ~ r'x'\"") == "\"name ~ r'x'\""
+    assert transform("note ? 'a | b' | 'c'") == "note IN ('a | b', 'c')"
+    assert transform(r"name ~ r'a\'b'") == r"REGEXP_MATCHES(name, 'a\''b')"
 
 
 class TestEdgeCases:

--- a/tests/adapters/snowflake/test_sql_fragments.py
+++ b/tests/adapters/snowflake/test_sql_fragments.py
@@ -1,0 +1,31 @@
+"""Regression tests for Snowflake expression parsing boundaries."""
+
+from sidemantic.adapters.snowflake import SnowflakeAdapter, _qualify_columns
+
+
+def test_qualify_columns_only_rewrites_real_snowflake_columns():
+    assert _qualify_columns("CAST(amount AS NUMBER)") == "CAST({model}.amount AS NUMBER)"
+    assert _qualify_columns("amount::NUMBER") == "{model}.amount::NUMBER"
+    assert _qualify_columns("EXTRACT(YEAR FROM created_at)") == "EXTRACT(YEAR FROM {model}.created_at)"
+    assert _qualify_columns("CURRENT_DATE") == "CURRENT_DATE"
+    assert _qualify_columns('"order amount" + tax') == '{model}."order amount" + {model}.tax'
+    assert _qualify_columns("amount /* tax */ + fee") == "{model}.amount /* tax */ + {model}.fee"
+    assert _qualify_columns("note = $$amount$$") == "{model}.note = $$amount$$"
+    assert _qualify_columns("note = '{model}' AND amount > 0") == ("{model}.note = '{model}' AND {model}.amount > 0")
+    assert _qualify_columns("{model}.amount + tax") == "{model}.amount + {model}.tax"
+    assert _qualify_columns("${TABLE}.amount + tax") == "${TABLE}.amount + {model}.tax"
+    assert _qualify_columns("(SELECT MAX(amount) FROM audit)") == "(SELECT MAX(amount) FROM audit)"
+
+
+def test_simple_aggregate_detection_uses_the_parsed_outer_expression():
+    adapter = SnowflakeAdapter()
+    nested = adapter._parse_metric({"name": "net", "expr": "SUM(COALESCE(amount, 0) - discount)"})
+    quoted = adapter._parse_metric({"name": "labeled", "expr": 'SUM("order amount")'})
+    aggregate_text = adapter._parse_metric(
+        {"name": "literal_text", "expr": "IFF(note = 'SUM(amount)', SUM(amount), 0)"}
+    )
+
+    assert nested.agg == "sum" and nested.sql == "COALESCE(amount, 0) - discount"
+    assert quoted.agg == "sum" and quoted.sql == '"order amount"'
+    assert aggregate_text.type == "derived"
+    assert aggregate_text.sql == "IFF({model}.note = 'SUM(amount)', SUM({model}.amount), 0)"

--- a/tests/adapters/tableau/test_formula.py
+++ b/tests/adapters/tableau/test_formula.py
@@ -208,6 +208,23 @@ def test_username_not_translated():
     assert not ok
 
 
+def test_function_looking_text_inside_literals_is_not_transformed_or_rejected():
+    assert _translate_formula("'COUNTD([x])'") == ("'COUNTD([x])'", True)
+    assert _translate_formula("'LEN([name])'") == ("'LEN([name])'", True)
+    assert _translate_formula("'USERNAME()'") == ("'USERNAME()'", True)
+
+
+def test_comments_cannot_trigger_unsupported_function_detection():
+    sql, ok = _translate_formula("// USERNAME() and RUNNING_SUM([x])\nLEN([name])")
+    assert ok
+    assert sql == "LENGTH(name)"
+
+
+def test_function_looking_bracketed_fields_are_lexically_protected():
+    for field in ("USERNAME()", "RUNNING_SUM(x)", "COUNTD(x)", "LEN(name)"):
+        assert _translate_formula(f"[{field}]") == (f'"{field}"', True)
+
+
 def test_isnull():
     """ISNULL(x) -> (x IS NULL)."""
     sql, ok = _translate_formula("ISNULL([has_extract])")

--- a/tests/adapters/thoughtspot/test_parsing.py
+++ b/tests/adapters/thoughtspot/test_parsing.py
@@ -6,12 +6,49 @@ from pathlib import Path
 import yaml
 
 from sidemantic import SemanticLayer
-from sidemantic.adapters.thoughtspot import ThoughtSpotAdapter
+from sidemantic.adapters.thoughtspot import ThoughtSpotAdapter, _extract_all_join_refs
 from sidemantic.loaders import load_from_directory
 
 # =============================================================================
 # BASIC PARSING TESTS
 # =============================================================================
+
+
+def test_join_conjunction_split_ignores_and_inside_bracketed_identifiers():
+    expr = "[a::x] = [b::y] AND [a::label AND code] = [b::label AND code]"
+
+    assert _extract_all_join_refs(expr) == [
+        (("a", "x"), ("b", "y")),
+        (("a", "label AND code"), ("b", "label AND code")),
+    ]
+
+
+def test_join_conjunction_split_ignores_and_inside_strings_and_parentheses():
+    expr = "[a::x] = [b::y] AND ([a::label] = [b::label]) AND 'left AND right' = 'left AND right'"
+
+    assert _extract_all_join_refs(expr) == [
+        (("a", "x"), ("b", "y")),
+        (("a", "label"), ("b", "label")),
+    ]
+
+
+def test_join_conjunction_split_flattens_nested_parenthesized_groups():
+    expr = "[a::x] = [b::x] AND ([a::y] = [b::y] AND [a::z] = [b::z])"
+
+    assert _extract_all_join_refs(expr) == [
+        (("a", "x"), ("b", "x")),
+        (("a", "y"), ("b", "y")),
+        (("a", "z"), ("b", "z")),
+    ]
+
+
+def test_join_conjunction_split_ignores_and_inside_comments():
+    block = "[a::x] = [b::x] /* AND ignored */ AND [a::y] = [b::y]"
+    line = "[a::x] = [b::x] -- AND ignored\nAND [a::y] = [b::y]"
+    expected = [(("a", "x"), ("b", "x")), (("a", "y"), ("b", "y"))]
+
+    assert _extract_all_join_refs(block) == expected
+    assert _extract_all_join_refs(line) == expected
 
 
 def test_import_real_thoughtspot_examples():

--- a/tests/metrics/test_filters.py
+++ b/tests/metrics/test_filters.py
@@ -1,8 +1,10 @@
 """Test metric-level filters."""
 
 import duckdb
+from sqlglot import exp
 
 from sidemantic import Dimension, Metric, Model, SemanticLayer
+from sidemantic.sql.generator import SQLGenerator
 from tests.utils import df_rows
 
 
@@ -352,6 +354,87 @@ def test_mixed_filters_separate_where_and_having(layer):
     assert "status = 'completed'" in sql
     assert "HAVING" in sql
     assert "revenue > 100" in sql
+
+
+def test_filter_classification_ignores_metric_names_in_non_column_tokens():
+    layer = SemanticLayer()
+    layer.add_model(
+        Model(
+            name="orders",
+            table="orders_table",
+            dimensions=[Dimension(name="status", type="categorical")],
+            metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        )
+    )
+    generator = SQLGenerator(layer.graph)
+    predicates = [
+        "orders.status = 'orders.revenue'",
+        '"orders.revenue" = 1',
+        "orders.status = 'paid' -- orders.revenue",
+        "orders.status = $$orders.revenue$$",
+    ]
+
+    assert generator._split_where_having_filters(predicates, ["orders"]) == (predicates, [])
+    assert generator._split_where_having_filters(["orders.revenue > 100"], ["orders"]) == (
+        [],
+        ["orders.revenue > 100"],
+    )
+
+
+def test_where_filter_rewrite_only_changes_semantic_columns():
+    layer = SemanticLayer()
+    layer.add_model(
+        Model(
+            name="orders",
+            table="orders_table",
+            dimensions=[Dimension(name="status", type="categorical")],
+            metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        )
+    )
+    generator = SQLGenerator(layer.graph, dialect="postgres")
+    predicate = (
+        "orders.status = 'orders.revenue' "
+        'AND "orders.revenue" = "orders.revenue" '
+        "AND orders.status <> $$orders.status$$ /* orders.revenue */"
+    )
+
+    query = generator._add_where_filters_to_query(exp.select("*"), [predicate], ["orders"])
+    rendered = query.sql(dialect="postgres")
+
+    assert rendered.count("orders_cte.status") == 2
+    assert "'orders.revenue'" in rendered
+    assert rendered.count('"orders.revenue"') == 2
+    assert "$$orders.status$$" in rendered
+    assert "orders.revenue" in rendered.split("/*", 1)[1]
+
+
+def test_filter_classification_and_rewrite_respect_nested_select_alias_scope():
+    layer = SemanticLayer()
+    layer.add_model(
+        Model(
+            name="orders",
+            table="orders_table",
+            dimensions=[Dimension(name="status", type="categorical")],
+            metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        )
+    )
+    generator = SQLGenerator(layer.graph)
+    metric_predicate = "EXISTS (SELECT 1 FROM audit AS orders WHERE orders.revenue > 100)"
+    row_predicate = "EXISTS (SELECT 1 FROM audit AS orders WHERE orders.status = 'paid')"
+
+    assert generator._split_where_having_filters([metric_predicate], ["orders"]) == ([metric_predicate], [])
+    uppercase_alias = "EXISTS (SELECT 1 FROM audit AS ORDERS WHERE orders.revenue > 100)"
+    assert generator._split_where_having_filters([uppercase_alias], ["orders"]) == ([uppercase_alias], [])
+    rendered = generator._add_where_filters_to_query(exp.select("*"), [row_predicate], ["orders"]).sql()
+    assert "orders.status = 'paid'" in rendered
+    assert "orders_cte" not in rendered
+
+    snowflake_generator = SQLGenerator(layer.graph, dialect="snowflake")
+    quoted_folded_alias = 'EXISTS (SELECT 1 FROM audit AS "ORDERS" WHERE orders.revenue > 100)'
+    assert snowflake_generator._split_where_having_filters([quoted_folded_alias], ["orders"]) == (
+        [quoted_folded_alias],
+        [],
+    )
 
 
 def test_metric_level_filters_use_case_when(layer):


### PR DESCRIPTION
Fix parser and scanner correctness issues across the core SQL generator, Snowflake, Malloy, Tableau, Cube, LookML, BSL, and ThoughtSpot. Adds a format-neutral SQL fragment boundary plus regressions for quoted text, comments, dialect constructs, nested expressions, and composite joins.

This is stacked on #269 and should be reviewed and merged after it.