### PR TITLE
Fix query-history import and history-driven model generation

### DIFF
--- a/sidemantic-rs/src/main.rs
+++ b/sidemantic-rs/src/main.rs
@@ -2361,10 +2361,15 @@ fn build_preagg_query_history_sql(
     context: &str,
 ) -> CliResult<String> {
     match dialect {
+        // QUERY_HISTORY applies RESULT_LIMIT (default 100, max 10000) BEFORE the outer
+        // WHERE/LIMIT, so always request the max and let the outer LIMIT trim.
+        // The NOT ILIKE guard keeps this fetch query (which contains the marker
+        // literal) from matching itself on subsequent runs.
         "snowflake" => Ok(format!(
             "SELECT query_text \
-             FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY(END_TIME_RANGE_START => DATEADD('day', -{days_back}, CURRENT_TIMESTAMP()))) \
+             FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY(END_TIME_RANGE_START => DATEADD('day', -{days_back}, CURRENT_TIMESTAMP()), RESULT_LIMIT => 10000)) \
              WHERE query_text LIKE '%-- sidemantic:%' \
+               AND query_text NOT ILIKE '%INFORMATION_SCHEMA.QUERY_HISTORY%' \
                AND execution_status = 'SUCCESS' \
              ORDER BY start_time DESC \
              LIMIT {limit}"
@@ -2378,6 +2383,7 @@ fn build_preagg_query_history_sql(
                    AND job_type = 'QUERY' \
                    AND state = 'DONE' \
                    AND query LIKE '%-- sidemantic:%' \
+                   AND NOT REGEXP_CONTAINS(UPPER(query), r'INFORMATION_SCHEMA\\.JOBS_BY_PROJECT') \
                  ORDER BY creation_time DESC \
                  LIMIT {limit}"
             ))
@@ -2387,7 +2393,8 @@ fn build_preagg_query_history_sql(
              FROM system.query.history \
              WHERE start_time >= CURRENT_TIMESTAMP() - INTERVAL {days_back} DAYS \
                AND statement_text LIKE '%-- sidemantic:%' \
-               AND status = 'FINISHED' \
+               AND LOWER(statement_text) NOT LIKE '%system.query.history%' \
+               AND execution_status = 'FINISHED' \
              ORDER BY start_time DESC \
              LIMIT {limit}"
         )),
@@ -2396,7 +2403,9 @@ fn build_preagg_query_history_sql(
              FROM system.query_log \
              WHERE event_time >= now() - INTERVAL {days_back} DAY \
                AND query LIKE '%-- sidemantic:%' \
+               AND lower(query) NOT LIKE '%system.query_log%' \
                AND type = 'QueryFinish' \
+               AND is_initial_query = 1 \
                AND exception = '' \
              ORDER BY event_time DESC \
              LIMIT {limit}"

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -898,8 +898,10 @@ def migrator(
             return queries_from_history
 
         if queries and (str(queries) == "-" or queries.is_file()):
+            from sidemantic.core.migrator import split_sql_statements
+
             content = read_text_input(queries, label="migration SQL")
-            return [query.strip() for query in content.split(";") if query.strip()]
+            return split_sql_statements(content)
         return None
 
     # Bootstrap mode - generate models from queries
@@ -2680,12 +2682,19 @@ def preagg_recommend(
     """
     Show pre-aggregation recommendations based on query patterns.
 
+    Query-history import requires a warehouse with a queryable history
+    (Snowflake, BigQuery, Databricks, or ClickHouse); for DuckDB and other
+    adapters, pass a query log with --queries instead.
+
     Examples:
       sidemantic preagg recommend --connection "bigquery://project/dataset"
-      sidemantic preagg recommend --db data.db --min-count 50 --top 10
+      sidemantic preagg recommend --connection "snowflake://..." --min-count 50 --top 10
       sidemantic preagg recommend --queries queries.sql --min-score 0.5
     """
     from sidemantic.core.preagg_recommender import PreAggregationRecommender
+
+    if queries is not None and (connection or db):
+        raise typer.BadParameter("--queries and --connection/--db are mutually exclusive")
 
     try:
         output_format = resolve_output_format(json_output=json_output)
@@ -2713,8 +2722,10 @@ def preagg_recommend(
                 recommender.fetch_and_parse_query_history(adapter, days_back=days_back, limit=limit)
         elif queries:
             if str(queries) == "-":
+                from sidemantic.core.migrator import split_sql_statements
+
                 sql = read_text_input(queries, label="query log")
-                recommender.parse_query_log([query.strip() for query in sql.split(";") if query.strip()])
+                recommender.parse_query_log(split_sql_statements(sql))
             elif not queries.exists():
                 raise InvocationError(f"Query source does not exist: {queries}")
             elif queries.is_file():
@@ -2726,6 +2737,11 @@ def preagg_recommend(
         # Print summary
         summary = recommender.get_summary()
         emit_diagnostic(f"✓ Analyzed {summary['total_queries']} queries")
+        if summary.get("queries_skipped"):
+            emit_diagnostic(
+                f"Skipped {summary['queries_skipped']} of {summary['queries_seen']} queries "
+                "(no usable sidemantic instrumentation)"
+            )
         emit_diagnostic(f"Found {summary['unique_patterns']} unique patterns")
         emit_diagnostic(f"{summary['patterns_above_threshold']} patterns above threshold")
 
@@ -2818,13 +2834,20 @@ def preagg_apply(
 
     Analyzes query patterns and automatically adds pre-aggregation definitions to model YAML files.
 
+    Query-history import requires a warehouse with a queryable history
+    (Snowflake, BigQuery, Databricks, or ClickHouse); for DuckDB and other
+    adapters, pass a query log with --queries instead.
+
     Examples:
       sidemantic preagg apply models/ --connection "bigquery://project/dataset"
-      sidemantic preagg apply models/ --db data.db --top 5
+      sidemantic preagg apply models/ --connection "snowflake://..." --top 5
       sidemantic preagg apply models/ --queries queries.sql --dry-run
     """
     from sidemantic.core.preagg_management import apply_recommendations_to_yaml
     from sidemantic.core.preagg_recommender import PreAggregationRecommender
+
+    if queries is not None and (connection or db):
+        raise typer.BadParameter("--queries and --connection/--db are mutually exclusive")
 
     try:
         output_format = resolve_output_format(json_output=json_output)
@@ -2854,8 +2877,10 @@ def preagg_apply(
                 recommender.fetch_and_parse_query_history(adapter, days_back=days_back, limit=limit)
         elif queries:
             if str(queries) == "-":
+                from sidemantic.core.migrator import split_sql_statements
+
                 sql = read_text_input(queries, label="query log")
-                recommender.parse_query_log([query.strip() for query in sql.split(";") if query.strip()])
+                recommender.parse_query_log(split_sql_statements(sql))
             elif not queries.exists():
                 raise InvocationError(f"Query source does not exist: {queries}")
             elif queries.is_file():

--- a/sidemantic/core/migrator.py
+++ b/sidemantic/core/migrator.py
@@ -54,6 +54,74 @@ def _normalize_agg_name(node) -> str:
     return _AGG_NAME_MAP.get(type(node).__name__.lower(), type(node).__name__.lower())
 
 
+def split_sql_statements(content: str) -> list[str]:
+    """Split SQL text on statement-separating semicolons.
+
+    Semicolons inside string literals, quoted identifiers, and comments do not
+    terminate a statement; a naive ``str.split(";")`` corrupts such queries.
+    """
+    statements: list[str] = []
+    current: list[str] = []
+    i = 0
+    n = len(content)
+    while i < n:
+        ch = content[i]
+        if ch in ("'", '"', "`"):
+            quote = ch
+            current.append(ch)
+            i += 1
+            while i < n:
+                if content[i] == "\\" and i + 1 < n:
+                    current.append(content[i : i + 2])
+                    i += 2
+                    continue
+                current.append(content[i])
+                if content[i] == quote:
+                    if i + 1 < n and content[i + 1] == quote:
+                        # Doubled-quote escape stays inside the literal
+                        current.append(content[i + 1])
+                        i += 2
+                        continue
+                    i += 1
+                    break
+                i += 1
+            continue
+        if content[i : i + 2] == "--":
+            end = content.find("\n", i)
+            comment = content[i:] if end == -1 else content[i:end]
+            stripped = comment.rstrip()
+            if stripped.endswith(";"):
+                # Query logs join statements with ';' after a trailing
+                # instrumentation comment (markers are emitted as a suffix
+                # line); a comment-final ';' is a statement separator.
+                current.append(stripped[:-1])
+                statements.append("".join(current))
+                current = []
+            else:
+                current.append(comment)
+            if end == -1:
+                break
+            i = end
+            continue
+        if content[i : i + 2] == "/*":
+            end = content.find("*/", i + 2)
+            if end == -1:
+                current.append(content[i:])
+                break
+            current.append(content[i : end + 2])
+            i = end + 2
+            continue
+        if ch == ";":
+            statements.append("".join(current))
+            current = []
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+    statements.append("".join(current))
+    return [statement.strip() for statement in statements if statement.strip()]
+
+
 @dataclass
 class QueryAnalysis:
     """Analysis of a single SQL query."""
@@ -242,9 +310,7 @@ class Migrator:
 
         for sql_file in folder.glob(pattern):
             content = sql_file.read_text()
-            # Split by semicolon for multi-query files
-            file_queries = [q.strip() for q in content.split(";") if q.strip()]
-            queries.extend(file_queries)
+            queries.extend(split_sql_statements(content))
 
         return self.analyze_queries(queries)
 
@@ -262,6 +328,12 @@ class Migrator:
         try:
             # Parse SQL
             parsed = sqlglot.parse_one(query, read=self.dialect)
+
+            # Warehouse history is full of DDL/DML (CREATE/INSERT/COPY/MERGE);
+            # analyzing those would generate models for staging/audit tables.
+            if not isinstance(parsed, exp.Query):
+                analysis.parse_error = "Not a SELECT query (skipped)"
+                return analysis
 
             # Extract components
             self._extract_tables(parsed, analysis)
@@ -289,10 +361,14 @@ class Migrator:
 
     def _extract_tables(self, parsed: exp.Expression, analysis: QueryAnalysis) -> None:
         """Extract table references and aliases, including subquery aliases."""
+        # CTE aliases look like table references but are not physical tables;
+        # treating them as tables generates junk models named after the alias.
+        cte_names = {cte.alias_or_name for cte in parsed.find_all(exp.CTE) if cte.alias_or_name}
+
         # Find the main FROM clause
         from_clause = parsed.find(exp.From)
         if from_clause:
-            if isinstance(from_clause.this, exp.Table):
+            if isinstance(from_clause.this, exp.Table) and from_clause.this.name not in cte_names:
                 analysis.from_table = from_clause.this.name
                 analysis.from_alias = from_clause.this.alias or None
                 if analysis.from_alias:
@@ -320,7 +396,7 @@ class Migrator:
         # Collect all tables and their aliases
         for table in parsed.find_all(exp.Table):
             table_name = table.name
-            if table_name:
+            if table_name and table_name not in cte_names:
                 analysis.tables.add(table_name)
                 if table.alias:
                     analysis.table_aliases[table.alias] = table_name
@@ -464,8 +540,15 @@ class Migrator:
                                 table_name = analysis.table_aliases[table_name]
 
                     # Infer table if not found
-                    if not table_name and len(analysis.tables) == 1:
-                        table_name = list(analysis.tables)[0]
+                    if not table_name:
+                        if len(analysis.tables) == 1:
+                            table_name = list(analysis.tables)[0]
+                        elif self.table_columns:
+                            # Multi-table query: attribute only when information_schema
+                            # confirms exactly one candidate table has this column.
+                            matches = [t for t in analysis.tables if col_name in self.table_columns.get(t, set())]
+                            if len(matches) == 1:
+                                table_name = matches[0]
 
                     # Store aggregation
                     agg_tuple = (agg_name, col_name, table_name or "")
@@ -724,12 +807,18 @@ class Migrator:
                     fk_column = right.name
                     pk_table = left_table
                     pk_column = left.name
-                else:
-                    # Can't determine - use left as FK
+                elif left_is_fk and right_is_fk:
+                    # Both look like FKs (e.g. o.customer_id = c.customer_id):
+                    # direction is ambiguous; keep left-as-FK behavior.
                     fk_table = left_table
                     fk_column = left.name
                     pk_table = right_table
                     pk_column = right.name
+                else:
+                    # Neither side looks like a key and information_schema has no
+                    # answer; an arbitrary col = col equality (e.g. a value
+                    # correlation) is not evidence of a relationship.
+                    return
 
             # Infer primary key column if not from information_schema
             if pk_column and not self.foreign_keys:
@@ -876,91 +965,91 @@ class Migrator:
                 for select_expr in select.expressions:
                     # Get alias if present
                     metric_name = None
-                if isinstance(select_expr, exp.Alias):
-                    metric_name = select_expr.alias
-                    inner_expr = select_expr.this
-                else:
-                    inner_expr = select_expr
+                    if isinstance(select_expr, exp.Alias):
+                        metric_name = select_expr.alias
+                        inner_expr = select_expr.this
+                    else:
+                        inner_expr = select_expr
 
-                # Check if this is a window function
-                if not isinstance(inner_expr, exp.Window):
-                    continue
+                    # Check if this is a window function
+                    if not isinstance(inner_expr, exp.Window):
+                        continue
 
-                # Extract the base aggregation inside the window
-                agg_func = inner_expr.this
-                if not isinstance(agg_func, exp.AggFunc):
-                    # Skip non-aggregation window functions (ROW_NUMBER, RANK, etc.)
-                    continue
+                    # Extract the base aggregation inside the window
+                    agg_func = inner_expr.this
+                    if not isinstance(agg_func, exp.AggFunc):
+                        # Skip non-aggregation window functions (ROW_NUMBER, RANK, etc.)
+                        continue
 
-                # Get aggregation type and column
-                agg_type = _normalize_agg_name(agg_func)
+                    # Get aggregation type and column
+                    agg_type = _normalize_agg_name(agg_func)
 
-                # Extract column from aggregation
-                col_expr = agg_func.this
-                if col_expr is None:
-                    # No column expression - skip this window function
-                    continue
-                elif isinstance(col_expr, exp.Column):
-                    col_name = col_expr.name
-                    table_name = col_expr.table if col_expr.table else ""
-                    if table_name and table_name in analysis.table_aliases:
-                        table_name = analysis.table_aliases[table_name]
-                elif isinstance(col_expr, exp.Star):
-                    col_name = "*"
-                    table_name = ""
-                else:
-                    # Complex expression
-                    col_name = str(col_expr)
-                    table_name = ""
-                    # Try to infer table
-                    columns = list(col_expr.find_all(exp.Column))
-                    if columns:
-                        table_name = columns[0].table if columns[0].table else ""
+                    # Extract column from aggregation
+                    col_expr = agg_func.this
+                    if col_expr is None:
+                        # No column expression - skip this window function
+                        continue
+                    elif isinstance(col_expr, exp.Column):
+                        col_name = col_expr.name
+                        table_name = col_expr.table if col_expr.table else ""
                         if table_name and table_name in analysis.table_aliases:
                             table_name = analysis.table_aliases[table_name]
-
-                # Infer table if not found
-                if not table_name and len(analysis.tables) == 1:
-                    table_name = list(analysis.tables)[0]
-
-                # Generate base metric reference
-                if agg_type == "count" and col_name == "*":
-                    base_metric_name = "count"
-                elif agg_type == "count_distinct":
-                    base_metric_name = f"{col_name}_count"
-                else:
-                    base_metric_name = f"{agg_type}_{col_name}"
-
-                # Build base metric reference in model.metric format
-                base_metric_ref = f"{table_name}.{base_metric_name}" if table_name else base_metric_name
-
-                # Analyze OVER clause
-                cumulative_params = self._analyze_window_spec(inner_expr, analysis)
-
-                # Generate metric name if not aliased
-                if not metric_name:
-                    if cumulative_params.get("window"):
-                        metric_name = f"rolling_{base_metric_name}"
-                    elif cumulative_params.get("grain_to_date"):
-                        grain = cumulative_params["grain_to_date"]
-                        metric_name = f"{grain}_to_date_{base_metric_name}"
+                    elif isinstance(col_expr, exp.Star):
+                        col_name = "*"
+                        table_name = ""
                     else:
-                        metric_name = f"running_{base_metric_name}"
+                        # Complex expression
+                        col_name = str(col_expr)
+                        table_name = ""
+                        # Try to infer table
+                        columns = list(col_expr.find_all(exp.Column))
+                        if columns:
+                            table_name = columns[0].table if columns[0].table else ""
+                            if table_name and table_name in analysis.table_aliases:
+                                table_name = analysis.table_aliases[table_name]
 
-                # Store cumulative metric info
-                cumulative_metric = {
-                    "name": metric_name,
-                    "base_metric": base_metric_ref,
-                    "table": table_name,
-                    **cumulative_params,
-                }
+                    # Infer table if not found
+                    if not table_name and len(analysis.tables) == 1:
+                        table_name = list(analysis.tables)[0]
 
-                analysis.cumulative_metrics.append(cumulative_metric)
+                    # Generate base metric reference
+                    if agg_type == "count" and col_name == "*":
+                        base_metric_name = "count"
+                    elif agg_type == "count_distinct":
+                        base_metric_name = f"{col_name}_count"
+                    else:
+                        base_metric_name = f"{agg_type}_{col_name}"
 
-                # Mark the base aggregation as being part of a cumulative metric
-                # so it doesn't get added as a standalone metric
-                base_agg_tuple = (agg_type, col_name, table_name)
-                analysis.aggregations_in_cumulative.add(base_agg_tuple)
+                    # Build base metric reference in model.metric format
+                    base_metric_ref = f"{table_name}.{base_metric_name}" if table_name else base_metric_name
+
+                    # Analyze OVER clause
+                    cumulative_params = self._analyze_window_spec(inner_expr, analysis)
+
+                    # Generate metric name if not aliased
+                    if not metric_name:
+                        if cumulative_params.get("window"):
+                            metric_name = f"rolling_{base_metric_name}"
+                        elif cumulative_params.get("grain_to_date"):
+                            grain = cumulative_params["grain_to_date"]
+                            metric_name = f"{grain}_to_date_{base_metric_name}"
+                        else:
+                            metric_name = f"running_{base_metric_name}"
+
+                    # Store cumulative metric info
+                    cumulative_metric = {
+                        "name": metric_name,
+                        "base_metric": base_metric_ref,
+                        "table": table_name,
+                        **cumulative_params,
+                    }
+
+                    analysis.cumulative_metrics.append(cumulative_metric)
+
+                    # Mark the base aggregation as being part of a cumulative metric
+                    # so it doesn't get added as a standalone metric
+                    base_agg_tuple = (agg_type, col_name, table_name)
+                    analysis.aggregations_in_cumulative.add(base_agg_tuple)
         except (AttributeError, TypeError, KeyError):
             # If there are any issues extracting window functions, just skip them
             # This ensures the analyzer doesn't fail on complex window function queries
@@ -1033,11 +1122,47 @@ class Migrator:
         return params
 
     def _extract_filters(self, parsed: exp.Expression, analysis: QueryAnalysis) -> None:
-        """Extract WHERE clause filters."""
-        for where in parsed.find_all(exp.Where):
-            filter_expr = str(where.this)
-            if filter_expr:
-                analysis.filters.append(filter_expr)
+        """Extract WHERE clause filters that belong to the query pipeline.
+
+        Follows the FROM/JOIN chain through CTEs and derived tables, whose row
+        filters apply to the final result. Predicate subqueries (IN/EXISTS/...)
+        are excluded: re-applying their inner WHERE at the top level changes the
+        result set of a rewrite.
+        """
+        root = parsed
+        while isinstance(root, exp.Subquery):
+            root = root.this
+        if not isinstance(root, exp.Select):
+            return
+
+        ctes = {cte.alias_or_name: cte.this for cte in parsed.find_all(exp.CTE) if cte.alias_or_name}
+        visited_ctes: set[str] = set()
+
+        def add_pipeline_filters(select: exp.Select) -> None:
+            where = select.args.get("where")
+            if where is not None:
+                filter_expr = str(where.this)
+                if filter_expr:
+                    analysis.filters.append(filter_expr)
+
+            sources = []
+            # sqlglot >= 30 stores the FROM clause under "from_"
+            from_clause = select.args.get("from_") or select.args.get("from")
+            if from_clause is not None:
+                sources.append(from_clause.this)
+            for join in select.args.get("joins") or []:
+                sources.append(join.this)
+
+            for source in sources:
+                if isinstance(source, exp.Subquery) and isinstance(source.this, exp.Select):
+                    add_pipeline_filters(source.this)
+                elif isinstance(source, exp.Table) and source.name in ctes and source.name not in visited_ctes:
+                    visited_ctes.add(source.name)
+                    inner = ctes[source.name]
+                    if isinstance(inner, exp.Select):
+                        add_pipeline_filters(inner)
+
+        add_pipeline_filters(root)
 
     def _extract_having(self, parsed: exp.Expression, analysis: QueryAnalysis) -> None:
         """Extract HAVING clause."""
@@ -1072,6 +1197,17 @@ class Migrator:
                 except ValueError:
                     pass
 
+    @staticmethod
+    def _metric_matches_column(metric, col_name: str) -> bool:
+        """Whether an existing metric covers an aggregated column reference.
+
+        COUNT(*) only matches row-count metrics (no sql or sql="*"), never
+        COUNT(col): the two differ on NULLs, e.g. after LEFT JOINs.
+        """
+        if col_name == "*":
+            return metric.sql in (None, "", "*")
+        return metric.sql == col_name
+
     def _check_coverage(self, analysis: QueryAnalysis) -> None:
         """Check if query can be rewritten and identify gaps."""
         # Check if all tables are in the semantic layer as models
@@ -1092,7 +1228,7 @@ class Migrator:
                 # Check if metric exists
                 metric_found = False
                 for metric in model.metrics:
-                    if metric.agg == agg_type and col_name in (metric.sql, "*"):
+                    if metric.agg == agg_type and self._metric_matches_column(metric, col_name):
                         metric_found = True
                         break
 
@@ -1161,7 +1297,7 @@ class Migrator:
             if model_name:
                 model = self.layer.graph.models[model_name]
                 for metric in model.metrics:
-                    if metric.agg == agg_type and col_name in (metric.sql, "*"):
+                    if metric.agg == agg_type and self._metric_matches_column(metric, col_name):
                         metrics.append(f"{model_name}.{metric.name}")
                         break
 

--- a/sidemantic/core/preagg_recommender.py
+++ b/sidemantic/core/preagg_recommender.py
@@ -59,6 +59,8 @@ class PreAggregationRecommender:
         self.min_query_count = min_query_count
         self.min_benefit_score = min_benefit_score
         self.patterns: dict[QueryPattern, int] = defaultdict(int)
+        self.queries_seen = 0
+        self.queries_matched = 0
 
     def parse_query_log(self, queries: list[str]) -> None:
         """Parse instrumented queries and extract patterns.
@@ -67,8 +69,10 @@ class PreAggregationRecommender:
             queries: List of SQL queries with instrumentation comments
         """
         for query in queries:
+            self.queries_seen += 1
             pattern = self._extract_pattern(query)
             if pattern:
+                self.queries_matched += 1
                 self.patterns[pattern] += 1
 
     def parse_query_log_file(self, file_path: str) -> None:
@@ -77,13 +81,12 @@ class PreAggregationRecommender:
         Args:
             file_path: Path to file containing queries
         """
+        from sidemantic.core.migrator import split_sql_statements
+
         with open(file_path) as f:
             content = f.read()
 
-        # Split by semicolon for multi-query files
-        queries = [q.strip() for q in content.split(";") if q.strip()]
-
-        self.parse_query_log(queries)
+        self.parse_query_log(split_sql_statements(content))
 
     def fetch_and_parse_query_history(self, connection: Any, days_back: int = 7, limit: int = 1000) -> None:
         """Fetch query history from database and parse for pre-aggregation patterns.
@@ -140,6 +143,12 @@ class PreAggregationRecommender:
         dimensions = [d for d in dimensions if d]
         granularities = [g for g in granularities if g]
 
+        # Queries already served by a pre-aggregation must not feed new
+        # recommendations: they would keep re-recommending existing rollups
+        # and inflate benefit scores with already-optimized traffic.
+        if parts.get("used_preagg", "").lower() == "true":
+            return None
+
         # Only track single-model queries (multi-model queries can't use pre-aggs currently)
         if len(models) != 1:
             return None
@@ -191,7 +200,7 @@ class PreAggregationRecommender:
         # Sort by benefit score descending
         recommendations.sort(key=lambda r: r.estimated_benefit_score, reverse=True)
 
-        if top_n:
+        if top_n is not None:
             recommendations = recommendations[:top_n]
 
         return recommendations
@@ -244,6 +253,11 @@ class PreAggregationRecommender:
         """
         parts = []
 
+        # Prefix with the model so names stay unique across models even after
+        # leaf-name stripping below.
+        if pattern.model:
+            parts.append(pattern.model.split(".")[-1])
+
         # Add granularity if present
         if pattern.granularities:
             # Use the finest granularity for naming
@@ -262,7 +276,12 @@ class PreAggregationRecommender:
             if len(dims) <= 2:
                 parts.extend([d.split(".")[-1] for d in dims])
             else:
-                parts.append(f"{len(dims)}dims")
+                # Collapsing to a bare count would collide for distinct dimension
+                # sets of the same size; add a stable digest of the full set.
+                import hashlib
+
+                digest = hashlib.md5("_".join(dims).encode()).hexdigest()[:6]
+                parts.append(f"{len(dims)}dims_{digest}")
 
         # Add metric indicator
         if len(pattern.metrics) == 1:
@@ -306,9 +325,9 @@ class PreAggregationRecommender:
                     time_dimension = dim_name
                     break
 
-            if not time_dimension and dimensions:
-                # Fallback: use first dimension
-                time_dimension = dimensions[0].split(".")[-1]
+            # If no dimension looks like a time column, leave time_dimension
+            # unset rather than declaring an arbitrary (likely categorical)
+            # dimension as time-truncated, which would corrupt the rollup.
 
             # Use finest granularity
             if time_dimension:
@@ -346,7 +365,17 @@ class PreAggregationRecommender:
 
         return {
             "total_queries": total_queries,
+            "queries_seen": self.queries_seen,
+            "queries_skipped": self.queries_seen - self.queries_matched,
             "unique_patterns": unique_patterns,
             "models": dict(model_counts),
-            "patterns_above_threshold": sum(1 for p, c in self.patterns.items() if c >= self.min_query_count),
+            # Mirror get_recommendations: both the count threshold and the
+            # benefit-score floor must pass, or this count overstates what the
+            # recommendation list will actually contain.
+            "patterns_above_threshold": sum(
+                1
+                for pattern, count in self.patterns.items()
+                if count >= self.min_query_count
+                and self._calculate_benefit_score(pattern, count) >= self.min_benefit_score
+            ),
         }

--- a/sidemantic/db/bigquery.py
+++ b/sidemantic/db/bigquery.py
@@ -179,9 +179,11 @@ class BigQueryAdapter(BaseDatabaseAdapter):
         """
         days_back, limit = validate_query_history_params(days_back, limit)
         instrumentation_filter = "AND query LIKE '%-- sidemantic:%'" if instrumented_only else ""
+        # Region qualifiers are lowercase (`region-us`); Client.location is often "US".
+        location = (self.client.location or "us").lower()
         sql = f"""
         SELECT query
-        FROM `{self.project_id}.region-{self.client.location}.INFORMATION_SCHEMA.JOBS_BY_PROJECT`
+        FROM `{self.project_id}.region-{location}.INFORMATION_SCHEMA.JOBS_BY_PROJECT`
         WHERE creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {days_back} DAY)
           AND job_type = 'QUERY'
           AND state = 'DONE'

--- a/sidemantic/db/clickhouse.py
+++ b/sidemantic/db/clickhouse.py
@@ -231,6 +231,7 @@ class ClickHouseAdapter(BaseDatabaseAdapter):
         FROM system.query_log
         WHERE event_time >= now() - INTERVAL {days_back} DAY
           AND type = 'QueryFinish'
+          AND is_initial_query = 1
           AND exception = ''
           AND lower(query) NOT LIKE '%system.query_log%'
           {instrumentation_filter}

--- a/sidemantic/db/databricks.py
+++ b/sidemantic/db/databricks.py
@@ -192,7 +192,7 @@ class DatabricksAdapter(BaseDatabaseAdapter):
         SELECT statement_text
         FROM system.query.history
         WHERE start_time >= CURRENT_TIMESTAMP() - INTERVAL {days_back} DAYS
-          AND status = 'FINISHED'
+          AND execution_status = 'FINISHED'
           AND LOWER(statement_text) NOT LIKE '%system.query.history%'
           {instrumentation_filter}
         ORDER BY start_time DESC

--- a/sidemantic/db/snowflake.py
+++ b/sidemantic/db/snowflake.py
@@ -235,10 +235,14 @@ class SnowflakeAdapter(BaseDatabaseAdapter):
         """
         days_back, limit = validate_query_history_params(days_back, limit, max_days_back=7)
         instrumentation_filter = "AND query_text LIKE '%-- sidemantic:%'" if instrumented_only else ""
+        # QUERY_HISTORY applies RESULT_LIMIT (default 100, max 10000) BEFORE the outer
+        # WHERE/LIMIT, so rows removed by the filters below still consume its budget.
+        # Always request the max and let the outer LIMIT trim to the caller's limit.
         sql = f"""
         SELECT query_text
         FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY(
-            END_TIME_RANGE_START => DATEADD('day', -{days_back}, CURRENT_TIMESTAMP())
+            END_TIME_RANGE_START => DATEADD('day', -{days_back}, CURRENT_TIMESTAMP()),
+            RESULT_LIMIT => 10000
         ))
         WHERE execution_status = 'SUCCESS'
           AND query_text NOT ILIKE '%INFORMATION_SCHEMA.QUERY_HISTORY%'

--- a/sidemantic/man/sidemantic.1
+++ b/sidemantic/man/sidemantic.1
@@ -686,7 +686,9 @@ sidemantic preagg recommend [OPTIONS]
 .PP
 Show pre\-aggregation recommendations based on query patterns.
 .PP
-Examples: sidemantic preagg recommend \-\-connection "bigquery://project/dataset" sidemantic preagg recommend \-\-db data.db \-\-min\-count 50 \-\-top 10 sidemantic preagg recommend \-\-queries queries.sql \-\-min\-score 0.5
+Query\-history import requires a warehouse with a queryable history (Snowflake, BigQuery, Databricks, or ClickHouse); for DuckDB and other adapters, pass a query log with \-\-queries instead.
+.PP
+Examples: sidemantic preagg recommend \-\-connection "bigquery://project/dataset" sidemantic preagg recommend \-\-connection "snowflake://..." \-\-min\-count 50 \-\-top 10 sidemantic preagg recommend \-\-queries queries.sql \-\-min\-score 0.5
 .SS OPTIONS
 .TP
 \fB\-\-queries, \-q PATH\fR
@@ -725,7 +727,9 @@ Apply pre\-aggregation recommendations to model YAML files.
 .PP
 Analyzes query patterns and automatically adds pre\-aggregation definitions to model YAML files.
 .PP
-Examples: sidemantic preagg apply models/ \-\-connection "bigquery://project/dataset" sidemantic preagg apply models/ \-\-db data.db \-\-top 5 sidemantic preagg apply models/ \-\-queries queries.sql \-\-dry\-run
+Query\-history import requires a warehouse with a queryable history (Snowflake, BigQuery, Databricks, or ClickHouse); for DuckDB and other adapters, pass a query log with \-\-queries instead.
+.PP
+Examples: sidemantic preagg apply models/ \-\-connection "bigquery://project/dataset" sidemantic preagg apply models/ \-\-connection "snowflake://..." \-\-top 5 sidemantic preagg apply models/ \-\-queries queries.sql \-\-dry\-run
 .SS OPTIONS
 .TP
 \fB\-\-queries, \-q PATH\fR

--- a/tests/db/test_query_history_validation.py
+++ b/tests/db/test_query_history_validation.py
@@ -55,3 +55,77 @@ def test_snowflake_query_history_enforces_information_schema_lookback_limit():
 
     with pytest.raises(ValueError, match="days_back must be <= 7"):
         adapter.get_query_history(days_back=8, limit=10)
+
+
+class _CapturedResult:
+    def fetchall(self):
+        return []
+
+
+def _capture_sql(adapter):
+    captured = {}
+
+    def execute(sql):
+        captured["sql"] = sql
+        return _CapturedResult()
+
+    adapter.execute = execute
+    return captured
+
+
+def test_snowflake_query_history_requests_max_result_limit():
+    """QUERY_HISTORY applies RESULT_LIMIT (default 100) before the outer WHERE/LIMIT.
+
+    Without an explicit RESULT_LIMIT the import silently caps at 100 rows no
+    matter what limit the caller asked for.
+    """
+    adapter = SnowflakeAdapter.__new__(SnowflakeAdapter)
+    captured = _capture_sql(adapter)
+
+    adapter.get_query_history(days_back=7, limit=1000)
+
+    assert "RESULT_LIMIT => 10000" in captured["sql"]
+    assert "LIMIT 1000" in captured["sql"]
+
+
+def test_databricks_query_history_uses_execution_status_column():
+    """system.query.history has execution_status, not status."""
+    adapter = DatabricksAdapter.__new__(DatabricksAdapter)
+    captured = _capture_sql(adapter)
+
+    adapter.get_query_history(days_back=7, limit=100)
+
+    assert "execution_status = 'FINISHED'" in captured["sql"]
+    assert " status = " not in captured["sql"]
+
+
+def test_clickhouse_query_history_filters_initial_queries():
+    """Distributed subqueries must not pollute the import on clusters."""
+    from types import SimpleNamespace
+
+    adapter = ClickHouseAdapter.__new__(ClickHouseAdapter)
+    captured = {}
+
+    def query(sql):
+        captured["sql"] = sql
+        return SimpleNamespace(result_rows=[])
+
+    adapter.client = SimpleNamespace(query=query)
+
+    adapter.get_query_history(days_back=7, limit=100)
+
+    assert "is_initial_query = 1" in captured["sql"]
+
+
+def test_bigquery_query_history_lowercases_region_qualifier():
+    """INFORMATION_SCHEMA region qualifiers are lowercase (region-us)."""
+    from types import SimpleNamespace
+
+    adapter = BigQueryAdapter.__new__(BigQueryAdapter)
+    adapter.project_id = "my-project"
+    adapter.client = SimpleNamespace(location="US")
+    captured = _capture_sql(adapter)
+
+    adapter.get_query_history(days_back=7, limit=100)
+
+    assert "`my-project.region-us.INFORMATION_SCHEMA.JOBS_BY_PROJECT`" in captured["sql"]

--- a/tests/optimizations/test_preagg_recommender.py
+++ b/tests/optimizations/test_preagg_recommender.py
@@ -163,7 +163,7 @@ def test_recommendation_name_generation():
     )
 
     name = recommender._generate_name(pattern)
-    assert name == "day_status_revenue"
+    assert name == "orders_day_status_revenue"
 
     # Pattern with multiple metrics
     pattern2 = QueryPattern(
@@ -174,7 +174,31 @@ def test_recommendation_name_generation():
     )
 
     name2 = recommender._generate_name(pattern2)
-    assert name2 == "status_2metrics"
+    assert name2 == "orders_status_2metrics"
+
+    # Distinct >2-dimension sets of the same shape must not collide
+    pattern3 = QueryPattern(
+        model="orders",
+        metrics=frozenset(["orders.revenue"]),
+        dimensions=frozenset(["orders.a", "orders.b", "orders.c"]),
+        granularities=frozenset(),
+    )
+    pattern4 = QueryPattern(
+        model="orders",
+        metrics=frozenset(["orders.revenue"]),
+        dimensions=frozenset(["orders.x", "orders.y", "orders.z"]),
+        granularities=frozenset(),
+    )
+    assert recommender._generate_name(pattern3) != recommender._generate_name(pattern4)
+
+    # Same-name dimensions on different models must not collide either
+    pattern5 = QueryPattern(
+        model="customers",
+        metrics=frozenset(["customers.revenue"]),
+        dimensions=frozenset(["customers.status"]),
+        granularities=frozenset(["day"]),
+    )
+    assert recommender._generate_name(pattern) != recommender._generate_name(pattern5)
 
 
 def test_generate_preagg_definition():
@@ -194,7 +218,7 @@ def test_generate_preagg_definition():
     # Generate pre-aggregation definition
     preagg = recommender.generate_preagg_definition(recommendations[0])
 
-    assert preagg.name == "day_created_at_revenue"
+    assert preagg.name == "orders_day_created_at_revenue"
     assert "revenue" in preagg.measures
     assert preagg.time_dimension == "created_at"
     assert preagg.granularity == "day"
@@ -388,3 +412,61 @@ def test_fetch_and_parse_query_history_filters_non_instrumented():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def test_used_preagg_queries_do_not_feed_recommendations():
+    """Traffic already served by a pre-agg must not re-recommend it."""
+    recommender = PreAggregationRecommender(min_query_count=1)
+
+    recommender.parse_query_log(
+        [
+            "SELECT revenue FROM orders_preagg -- sidemantic: models=orders metrics=orders.revenue dimensions=orders.status used_preagg=true",
+            "SELECT revenue FROM orders -- sidemantic: models=orders metrics=orders.revenue dimensions=orders.region",
+        ]
+    )
+
+    recommendations = recommender.get_recommendations()
+    assert len(recommendations) == 1
+    assert recommendations[0].pattern.dimensions == frozenset(["orders.region"])
+
+
+def test_top_n_zero_returns_no_recommendations():
+    recommender = PreAggregationRecommender(min_query_count=1)
+    recommender.parse_query_log(["SELECT revenue FROM orders -- sidemantic: models=orders metrics=orders.revenue"])
+
+    assert recommender.get_recommendations(top_n=0) == []
+
+
+def test_summary_reports_skipped_queries_and_score_threshold():
+    recommender = PreAggregationRecommender(min_query_count=1, min_benefit_score=0.99)
+    recommender.parse_query_log(
+        [
+            "SELECT 1",  # not instrumented
+            "SELECT revenue FROM orders -- sidemantic: models=orders metrics=orders.revenue",
+        ]
+    )
+
+    summary = recommender.get_summary()
+    assert summary["queries_seen"] == 2
+    assert summary["queries_skipped"] == 1
+    assert summary["total_queries"] == 1
+    # patterns_above_threshold must honor the benefit-score floor like
+    # get_recommendations does
+    assert summary["patterns_above_threshold"] == len(recommender.get_recommendations())
+
+
+def test_time_dimension_not_forced_onto_categorical_dimension():
+    """Granularity without a time-like dimension must not truncate a categorical."""
+    recommender = PreAggregationRecommender(min_query_count=1)
+    recommender.parse_query_log(
+        [
+            "SELECT revenue FROM orders -- sidemantic: models=orders metrics=orders.revenue dimensions=orders.status granularities=day"
+        ]
+    )
+
+    recommendations = recommender.get_recommendations()
+    preagg = recommender.generate_preagg_definition(recommendations[0])
+
+    assert preagg.time_dimension is None
+    assert preagg.granularity is None
+    assert preagg.dimensions == ["status"]

--- a/tests/test_migrator_edge_cases.py
+++ b/tests/test_migrator_edge_cases.py
@@ -249,8 +249,13 @@ def test_generate_rewritten_query_with_cte():
 
     sql = rewritten["query_1"]
 
-    # Should preserve CTE structure
-    assert "WITH" in sql or "high_value" in sql
+    # The rewrite targets the underlying physical table; the CTE alias is not a
+    # real table and must not appear as one.
+    assert "FROM orders" in sql
+    assert "high_value" not in sql
+    # The CTE's row filter is part of the query pipeline and must be preserved
+    analysis = report.query_analyses[0]
+    assert any("amount > 100" in f for f in analysis.filters)
 
 
 def test_generate_models_implicit_join():

--- a/tests/test_migrator_generation.py
+++ b/tests/test_migrator_generation.py
@@ -1260,3 +1260,141 @@ def test_cross_model_derived_metric_in_rewritten_query():
 
     # Cross-model derived metric should appear in the rewritten query
     assert "revenue_per_customer" in sql
+
+
+def test_window_function_detected_in_any_select_position():
+    """Cumulative metrics must be found even when the window fn is not the last projection."""
+    layer = SemanticLayer(auto_register=False)
+    analyzer = Migrator(layer)
+
+    report = analyzer.analyze_queries(
+        [
+            """
+            SELECT SUM(amount) OVER (ORDER BY order_date) AS running_total, status
+            FROM orders
+            """
+        ]
+    )
+
+    analysis = report.query_analyses[0]
+    assert analysis.parse_error is None
+    assert len(analysis.cumulative_metrics) == 1
+    assert analysis.cumulative_metrics[0]["name"] == "running_total"
+
+
+def test_non_select_statements_are_skipped():
+    """DDL/DML from warehouse history must not generate models."""
+    layer = SemanticLayer(auto_register=False)
+    analyzer = Migrator(layer)
+
+    report = analyzer.analyze_queries(
+        [
+            "CREATE TABLE staging_orders AS SELECT * FROM orders",
+            "INSERT INTO audit_log VALUES (1, 'x')",
+            "DELETE FROM temp_table WHERE id = 1",
+            "SELECT status, SUM(amount) FROM orders GROUP BY status",
+        ]
+    )
+    models = analyzer.generate_models(report)
+
+    assert report.parseable_queries == 1
+    assert set(models) == {"orders"}
+
+
+def test_cte_aliases_are_not_treated_as_tables():
+    layer = SemanticLayer(auto_register=False)
+    analyzer = Migrator(layer)
+
+    report = analyzer.analyze_queries(
+        [
+            """
+            WITH recent AS (SELECT * FROM orders WHERE order_date >= '2025-01-01')
+            SELECT status, SUM(amount) FROM recent GROUP BY status
+            """
+        ]
+    )
+    models = analyzer.generate_models(report)
+
+    assert "recent" not in models
+    assert "orders" in models
+
+
+def test_subquery_where_does_not_leak_into_filters():
+    """Inner predicates re-applied at the outer level would change the result set."""
+    layer = SemanticLayer(auto_register=False)
+    analyzer = Migrator(layer)
+
+    report = analyzer.analyze_queries(
+        [
+            """
+            SELECT status, SUM(amount)
+            FROM orders
+            WHERE customer_id IN (SELECT id FROM customers WHERE region = 'US')
+            GROUP BY status
+            """
+        ]
+    )
+
+    analysis = report.query_analyses[0]
+    # Exactly one top-level filter: the IN predicate. The inner WHERE must not
+    # surface as a second standalone filter (it may appear inside the IN text).
+    assert len(analysis.filters) == 1
+    assert analysis.filters[0].startswith("customer_id IN")
+
+
+def test_count_star_not_covered_by_count_column_metric():
+    """COUNT(*) and COUNT(col) differ on NULLs; one must not satisfy the other."""
+    from sidemantic import Dimension, Metric, Model
+
+    layer = SemanticLayer(auto_register=False)
+    layer.graph.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            dimensions=[Dimension(name="status", sql="status", type="categorical")],
+            metrics=[Metric(name="cust_count", agg="count", sql="customer_id")],
+        )
+    )
+    analyzer = Migrator(layer)
+
+    report = analyzer.analyze_queries(["SELECT status, COUNT(*) FROM orders GROUP BY status"])
+    analysis = report.query_analyses[0]
+
+    assert ("orders", "count", "*") in analysis.missing_metrics
+    assert not analysis.can_rewrite
+
+
+def test_no_relationship_from_non_key_equality():
+    """An arbitrary col = col correlation is not evidence of a relationship."""
+    layer = SemanticLayer(auto_register=False)
+    analyzer = Migrator(layer)
+
+    report = analyzer.analyze_queries(
+        [
+            """
+            SELECT o.status, SUM(o.amount)
+            FROM orders o, customers c
+            WHERE o.code = c.code
+            GROUP BY o.status
+            """
+        ]
+    )
+
+    assert report.query_analyses[0].relationships == []
+
+
+def test_split_sql_statements_respects_literals_and_comments():
+    from sidemantic.core.migrator import split_sql_statements
+
+    content = """
+    -- sidemantic: models=orders metrics=orders.revenue
+    SELECT * FROM orders WHERE note = 'a;b';
+    /* block; comment */
+    SELECT * FROM customers;
+    """
+    statements = split_sql_statements(content)
+
+    assert len(statements) == 2
+    assert "'a;b'" in statements[0]
+    assert "-- sidemantic:" in statements[0]
+    assert statements[1].startswith("/* block; comment */")


### PR DESCRIPTION
Adversarial review of the query-history-to-semantic-models pipeline (`migrate generate --history`, `preagg recommend`/`apply`) turned up two showstoppers in the history import itself plus a set of generation-correctness bugs. This fixes the confirmed findings and adds regression tests for each.

## Warehouse history import (Python adapters + Rust CLI)

- **Databricks import always failed**: the query filtered on a `status` column that does not exist in `system.query.history`; the column is `execution_status` ([docs](https://docs.databricks.com/aws/en/admin/system-tables/query-history)).
- **Snowflake silently capped every import at 100 rows**: `INFORMATION_SCHEMA.QUERY_HISTORY` applies `RESULT_LIMIT` (default 100) *before* the outer `WHERE`/`LIMIT` ([docs](https://docs.snowflake.com/en/sql-reference/functions/query_history)). Now requests the max (10000) and lets the outer `LIMIT` trim to the caller's `--limit`.
- BigQuery: lowercase the `region-` qualifier (`Client.location` is commonly `"US"`, region qualifiers are lowercase).
- ClickHouse: filter `is_initial_query = 1` so distributed subqueries do not pollute imports on clusters.
- Rust CLI (`build_preagg_query_history_sql`): same fixes, plus the self-exclusion filters the Python adapters already had -- the Rust fetch query contains the `-- sidemantic:` literal and matched itself on every subsequent run.

## Migrator (history-driven model generation)

- An indentation bug made window/cumulative-metric extraction inspect only the **last** SELECT projection; `SUM(x) OVER (...)` anywhere else was silently lost.
- Non-SELECT statements (CREATE/INSERT/DELETE/COPY -- abundant in real history) no longer generate junk models for staging/audit/temp tables.
- Filter extraction is now pipeline-aware: it follows CTEs and derived tables referenced from the FROM chain (their row filters legitimately apply to the result) but excludes IN/EXISTS predicate subqueries, whose inner WHERE was previously re-applied at the top level and changed rewrite semantics.
- CTE aliases are no longer treated as physical tables (no more models named after a WITH alias).
- `COUNT(*)` is no longer considered covered by a `COUNT(col)` metric (different NULL semantics).
- Unqualified aggregates in multi-table queries are attributed only when information_schema confirms exactly one candidate table, instead of being silently dropped or guessed.
- Arbitrary non-key `col = col` equalities no longer fabricate relationships; both-`_id` implicit joins keep the existing behavior.
- Statement splitting (folder/file/stdin/query-log paths) now uses a quote- and comment-aware lexer: semicolons inside string literals no longer corrupt queries, while a comment-final `;` still separates entries in instrumented logs (markers are emitted as a suffix line, so that is the real log shape).

## Pre-aggregation recommender + CLI

- `used_preagg=true` traffic is excluded, so already-materialized rollups stop being re-recommended with scores inflated by their own traffic.
- Suggested names are model-prefixed, and >2-dimension sets include a stable digest, so distinct patterns cannot collide inside one model's YAML.
- A granularity with no time-like dimension no longer declares an arbitrary categorical column as the time dimension.
- `--top 0` returns nothing instead of everything; the summary reports skipped-query counts and `patterns_above_threshold` now honors the benefit-score floor like `get_recommendations` does.
- `--queries` with `--connection`/`--db` is rejected instead of silently ignoring the connection; docstrings stop advertising `--db` for history import (DuckDB has no query history -- that documented invocation always crashed).

Manpage regenerated for the docstring changes.

## Verification

- Full Python suite: 5989 passed, 58 skipped
- 15 new regression tests: adapter SQL shape (RESULT_LIMIT, execution_status, is_initial_query, region case), window-fn position, non-SELECT skip, CTE-alias exclusion, subquery filter leak, COUNT(*) coverage, non-key relationship, splitter, used_preagg, name collisions, time-dim fallback, top 0, summary accuracy
- `cargo check --features adbc-exec` clean

Known issue deliberately left out: schema/database qualifiers are still stripped from table identity (`analytics.orders` and `raw.orders` merge into one model). Real bug, but it is a cross-cutting refactor of table identity and model naming that deserves its own PR.