### PR TITLE
Salvage pre-aggregation filter fix and query generator rework

### DIFF
--- a/sidemantic/core/pre_aggregation.py
+++ b/sidemantic/core/pre_aggregation.py
@@ -229,20 +229,36 @@ class PreAggregation(BaseModel):
                         # PERCENTILE) are not re-aggregatable. Skip them (the matcher likewise
                         # never routes complete-expression measures to a rollup).
                         continue
-                    # Generate aggregation expression
+                    # Generate aggregation expression. Metric filters belong inside
+                    # the aggregate input, exactly as they do for live queries; a
+                    # rollup must never materialize an unfiltered value for a
+                    # filtered semantic metric.
                     agg_type = measure.agg.upper()
-                    if agg_type == "COUNT" and not measure.sql:
+                    filter_sql = " AND ".join(
+                        condition.replace("{model}.", "").replace("{model}", "")
+                        for condition in (measure.filters or [])
+                    )
+                    measure_input = measure.sql_expr
+                    if filter_sql:
+                        if agg_type == "COUNT" and not measure.sql:
+                            measure_input = f"CASE WHEN {filter_sql} THEN 1 ELSE NULL END"
+                        else:
+                            measure_input = f"CASE WHEN {filter_sql} THEN {measure_input} ELSE NULL END"
+
+                    if agg_type == "COUNT" and not measure.sql and not filter_sql:
                         # COUNT(*) case
                         select_exprs.append(f"COUNT(*) as {measure_name}_raw")
+                    elif agg_type == "COUNT" and not measure.sql:
+                        select_exprs.append(f"COUNT({measure_input}) as {measure_name}_raw")
                     elif agg_type == "AVG":
                         # Store AVG as additive sum state. A compatible count
                         # measure must also be present before query planning can
                         # roll this up safely.
-                        select_exprs.append(f"SUM({measure.sql_expr}) as {measure_name}_raw")
+                        select_exprs.append(f"SUM({measure_input}) as {measure_name}_raw")
                     elif agg_type == "COUNT_DISTINCT":
-                        select_exprs.append(f"COUNT(DISTINCT {measure.sql_expr}) as {measure_name}_raw")
+                        select_exprs.append(f"COUNT(DISTINCT {measure_input}) as {measure_name}_raw")
                     else:
-                        select_exprs.append(f"{agg_type}({measure.sql_expr}) as {measure_name}_raw")
+                        select_exprs.append(f"{agg_type}({measure_input}) as {measure_name}_raw")
 
         # A rollup that projects nothing would render "SELECT  FROM ... GROUP BY " (invalid
         # SQL). This happens when its measures are all non-materializable (agg=None: derived or
@@ -270,8 +286,9 @@ class PreAggregation(BaseModel):
 
         sql = f"""SELECT
   {select_str}
-FROM {from_clause}{where_clause}
-GROUP BY {group_by_str}"""
+FROM {from_clause}{where_clause}"""
+        if group_by_str:
+            sql += f"\nGROUP BY {group_by_str}"
 
         return sql
 
@@ -754,6 +771,11 @@ GROUP BY {group_by_str}"""
         if not table_exists:
             connection.execute(f"CREATE TABLE {table_name} AS {incremental_sql}")
         else:
+            # A lookback reprocesses an overlapping watermark range. Delete that
+            # range before inserting its replacement so repeated refreshes remain
+            # idempotent instead of accumulating duplicate rollup rows.
+            if lookback:
+                connection.execute(f"DELETE FROM {table_name} WHERE {watermark_column} >= {watermark_str}")
             connection.execute(f"INSERT INTO {table_name} {incremental_sql}")
 
         # Get new watermark

--- a/sidemantic/core/preagg_matcher.py
+++ b/sidemantic/core/preagg_matcher.py
@@ -135,7 +135,15 @@ class PreAggregationMatcher:
             if not metric:
                 return False
 
-            if metric.agg in ("count_distinct", "approx_count_distinct"):
+            if metric.agg in {
+                "count_distinct",
+                "approx_count_distinct",
+                "median",
+                "stddev",
+                "stddev_pop",
+                "variance",
+                "variance_pop",
+            }:
                 if metric.name not in (preagg.measures or []):
                     return False
                 if not self._is_exact_grain(preagg, query_dimensions, query_granularity):
@@ -262,8 +270,11 @@ class PreAggregationMatcher:
             # plain integer, so it is not safely rollup-derivable either.
             return False
 
-        # Default: allow if present
-        return True
+        # Non-decomposable aggregates are guarded by an exact-grain check in
+        # can_satisfy_query. Unknown aggregation kinds are never assumed additive.
+        if agg_type in {"median", "stddev", "stddev_pop", "variance", "variance_pop"}:
+            return True
+        return False
 
     def _complex_metric_derivable(self, query_metric: Metric, preagg: PreAggregation) -> bool:
         preagg_measures = set(preagg.measures or [])

--- a/sidemantic/core/semantic_graph.py
+++ b/sidemantic/core/semantic_graph.py
@@ -1,5 +1,6 @@
 """Semantic graph for managing models and relationships."""
 
+import re
 from collections import deque
 from dataclasses import dataclass
 from typing import Any
@@ -35,6 +36,29 @@ def _custom_join_condition(sql: str | None) -> str | None:
     return None
 
 
+def _normalized_join_condition(sql: str | None) -> str | None:
+    """Canonicalize simple equality conjunctions for path de-duplication.
+
+    Reciprocal relationship declarations generate the same custom join once as
+    ``from.x = to.x`` and once as ``to.x = from.x``. Equality and AND are
+    commutative, so normalize those shapes while leaving opaque predicates
+    distinct. This prevents a declared reciprocal edge from looking like a
+    second semantic path without hiding genuinely different join predicates.
+    """
+    if sql is None:
+        return None
+    conjuncts = re.split(r"\s+AND\s+", sql.strip(), flags=re.IGNORECASE)
+    normalized: list[str] = []
+    for conjunct in conjuncts:
+        comparison = re.fullmatch(r"\s*(.+?)\s*=\s*(.+?)\s*", conjunct)
+        if comparison and not any(operator in conjunct for operator in ("!=", "<=", ">=", "<>")):
+            sides = sorted(re.sub(r"\s+", "", side) for side in comparison.groups())
+            normalized.append("=".join(sides))
+        else:
+            normalized.append(re.sub(r"\s+", " ", conjunct.strip()))
+    return " AND ".join(sorted(normalized))
+
+
 @dataclass
 class JoinPath:
     """Represents a join between two models."""
@@ -58,6 +82,10 @@ class JoinPath:
         return self.to_columns[0] if self.to_columns else ""
 
 
+class AmbiguousJoinPathError(ValueError):
+    """Raised when two models have more than one equally short semantic join path."""
+
+
 class SemanticGraph:
     """Semantic graph managing models, metrics, and join relationships.
 
@@ -75,10 +103,15 @@ class SemanticGraph:
         self._version = 0
         self._adjacency_dirty = True
         self._adjacency: dict[str, list[tuple[str, list[str], list[str], str, str | None]]] = {}
+        # Relationship discovery sits on several planner hot paths. Cache successful
+        # paths and misses until the graph changes; ambiguity errors are cached as text
+        # so repeat compiles remain deterministic and cheap.
+        self._relationship_path_cache: dict[tuple[str, str], tuple[JoinPath, ...] | str] = {}
 
     def _mark_dirty(self) -> None:
         self._version += 1
         self._adjacency_dirty = True
+        self._relationship_path_cache.clear()
 
     def add_model(self, model: Model) -> None:
         """Add a model to the graph.
@@ -252,6 +285,7 @@ class SemanticGraph:
         if not hasattr(self, "_adjacency"):
             self._adjacency = {}
         self._adjacency.clear()
+        self._relationship_path_cache.clear()
 
         def add_edge(
             from_model: str,
@@ -363,7 +397,7 @@ class SemanticGraph:
                 )
 
     def find_relationship_path(self, from_model: str, to_model: str) -> list[JoinPath]:
-        """Find join path between two models using BFS.
+        """Find the unique shortest join path between two models.
 
         Args:
             from_model: Source model name
@@ -374,6 +408,7 @@ class SemanticGraph:
 
         Raises:
             ValueError: If no join path exists
+            AmbiguousJoinPathError: If multiple equally short paths exist
         """
         if from_model == to_model:
             return []
@@ -387,23 +422,55 @@ class SemanticGraph:
         if to_model not in self.models:
             raise KeyError(f"Model {to_model} not found")
 
-        # BFS to find shortest path
-        queue = deque([(from_model, [])])
-        visited = {from_model}
+        cache_key = (from_model, to_model)
+        cached = self._relationship_path_cache.get(cache_key)
+        if isinstance(cached, str):
+            if cached.startswith("Ambiguous join paths"):
+                raise AmbiguousJoinPathError(cached)
+            raise ValueError(cached)
+        if cached is not None:
+            return list(cached)
+
+        # Enumerate every shortest simple path instead of returning the first BFS
+        # hit. A first-hit path makes answers depend on model registration order in
+        # a diamond graph; failing with both routes is safer and lets a future view
+        # contract pin a path explicitly.
+        queue = deque([(from_model, tuple(), frozenset({from_model}))])
+        shortest_length: int | None = None
+        candidates: dict[tuple[object, ...], tuple[JoinPath, ...]] = {}
+
+        def edge_sort_key(edge):
+            next_model, from_keys, to_keys, relationship_type, custom_condition = edge
+            return next_model, tuple(from_keys), tuple(to_keys), relationship_type, custom_condition or ""
+
+        def path_signature(path: tuple[JoinPath, ...]) -> tuple[object, ...]:
+            return tuple(
+                (
+                    hop.from_model,
+                    hop.to_model,
+                    # A custom predicate is the authoritative join contract. Reciprocal
+                    # declarations can infer different fallback key metadata even though
+                    # they describe the same physical edge, so do not let those unused
+                    # columns manufacture a second semantic path.
+                    tuple(hop.from_columns) if hop.custom_condition is None else (),
+                    tuple(hop.to_columns) if hop.custom_condition is None else (),
+                    hop.relationship,
+                    _normalized_join_condition(hop.custom_condition),
+                )
+                for hop in path
+            )
 
         while queue:
-            current, path = queue.popleft()
-
-            if current not in self._adjacency:
+            current, path, visited = queue.popleft()
+            if shortest_length is not None and len(path) >= shortest_length:
                 continue
 
-            for next_model, from_keys, to_keys, relationship_type, custom_condition in self._adjacency[current]:
+            for next_model, from_keys, to_keys, relationship_type, custom_condition in sorted(
+                self._adjacency.get(current, []), key=edge_sort_key
+            ):
                 if next_model in visited:
                     continue
-
-                visited.add(next_model)
-
-                new_path = path + [
+                new_path = path + (
                     JoinPath(
                         from_model=current,
                         to_model=next_model,
@@ -411,15 +478,33 @@ class SemanticGraph:
                         to_columns=to_keys,
                         relationship=relationship_type,
                         custom_condition=custom_condition,
-                    )
-                ]
-
+                    ),
+                )
                 if next_model == to_model:
-                    return new_path
+                    shortest_length = len(new_path)
+                    candidates[path_signature(new_path)] = new_path
+                elif shortest_length is None or len(new_path) < shortest_length:
+                    queue.append((next_model, new_path, visited | {next_model}))
 
-                queue.append((next_model, new_path))
+        if not candidates:
+            message = f"No join path found between {from_model} and {to_model}"
+            self._relationship_path_cache[cache_key] = message
+            raise ValueError(message)
 
-        raise ValueError(f"No join path found between {from_model} and {to_model}")
+        ordered_candidates = [candidates[key] for key in sorted(candidates, key=repr)]
+        if len(ordered_candidates) > 1:
+            routes = [" -> ".join([from_model, *(hop.to_model for hop in path)]) for path in ordered_candidates]
+            message = (
+                f"Ambiguous join paths between {from_model} and {to_model}: "
+                + "; ".join(routes)
+                + ". Define a unique relationship route before querying these models."
+            )
+            self._relationship_path_cache[cache_key] = message
+            raise AmbiguousJoinPathError(message)
+
+        selected = ordered_candidates[0]
+        self._relationship_path_cache[cache_key] = selected
+        return list(selected)
 
     def find_all_models_for_query(self, dimensions: list[str], measures: list[str]) -> set[str]:
         """Find all models needed for a query.

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -133,6 +133,10 @@ class SemanticLayer:
         self.graph = SemanticGraph()
         self._sql_rewrite_cache: dict[tuple[object, ...], str] = {}
         self._sql_rewrite_cache_limit = 256
+        # SQLGenerator owns the expensive graph/path/filter planning caches. Reuse
+        # one per query-affecting configuration instead of constructing a fresh,
+        # empty cache for every compile request.
+        self._python_generators: dict[tuple[object, ...], SQLGenerator] = {}
         # Monotonic counter bumped whenever the model/metric graph or query-affecting
         # config mutates. Included in result-cache keys so cached Arrow results are
         # invalidated the moment the layer definition changes.
@@ -688,39 +692,28 @@ class SemanticLayer:
         )
         used_preagg = "used_preagg=true" in routing_sql
 
-        if post_process:
-            sql = self.compile(
-                metrics=metrics,
-                dimensions=dimensions,
-                filters=filters,
-                segments=segments,
-                order_by=order_by,
-                limit=limit,
-                ungrouped=ungrouped,
-                parameters=parameters,
-                use_preaggregations=use_preaggregations,
-                post_process=post_process,
-                timezone=timezone,
-                user_attributes=user_attributes,
-            )
-        else:
-            sql = routing_sql
+        # `routing_sql` is already the complete semantic compile. Post-processing
+        # only wraps it, so compiling the same query a second time wastes the most
+        # expensive planner path and can never change routing.
+        sql = self._apply_post_process(routing_sql, post_process)
 
         def recompile_raw():
-            return self.compile(
+            raw_sql = self.compile(
                 metrics=metrics,
                 dimensions=dimensions,
                 filters=filters,
                 segments=segments,
                 order_by=order_by,
                 limit=limit,
+                offset=offset,
                 ungrouped=ungrouped,
                 parameters=parameters,
                 use_preaggregations=False,
-                post_process=post_process,
                 timezone=timezone,
+                with_totals=with_totals,
                 user_attributes=user_attributes,
             )
+            return self._apply_post_process(raw_sql, post_process)
 
         return self._execute_with_preagg_fallback(
             sql, recompile_raw, use_preaggs=use_preaggs, strict=strict, used_preagg=used_preagg
@@ -1029,14 +1022,7 @@ class SemanticLayer:
         with_totals: bool = False,
         user_attributes: dict | None = None,
     ) -> str:
-        generator = SQLGenerator(
-            self.graph,
-            dialect=dialect or self.dialect,
-            preagg_database=self.preagg_database,
-            preagg_schema=self.preagg_schema,
-            timezone=timezone,
-            allow_non_additive_unsafe=self.allow_non_additive_unsafe,
-        )
+        generator = self._python_generator(dialect=dialect, timezone=timezone)
 
         return generator.generate(
             metrics=metrics,
@@ -1054,6 +1040,32 @@ class SemanticLayer:
             user_attributes=user_attributes,
         )
 
+    def _python_generator(self, *, dialect: str | None = None, timezone: str | None = None) -> SQLGenerator:
+        """Return a persistent planner for one query-affecting configuration."""
+        key = (
+            dialect or self.dialect,
+            self.preagg_database,
+            self.preagg_schema,
+            timezone,
+            self.allow_non_additive_unsafe,
+        )
+        generator = self._python_generators.get(key)
+        if generator is None:
+            generator = SQLGenerator(
+                self.graph,
+                dialect=dialect or self.dialect,
+                preagg_database=self.preagg_database,
+                preagg_schema=self.preagg_schema,
+                timezone=timezone,
+                allow_non_additive_unsafe=self.allow_non_additive_unsafe,
+            )
+            # Configuration combinations are naturally tiny (usually one
+            # dialect plus UTC/local timezone). Bound unusual dynamic callers.
+            if len(self._python_generators) >= 16:
+                self._python_generators.pop(next(iter(self._python_generators)))
+            self._python_generators[key] = generator
+        return generator
+
     def _security_participating_models(
         self,
         metrics: list[str] | None,
@@ -1067,7 +1079,7 @@ class SemanticLayer:
         ``_enforce_security`` iterates over. Segments are named filters on a model, so a
         ``model.segment`` reference also makes that model participate.
         """
-        generator = SQLGenerator(self.graph, dialect=self.dialect)
+        generator = self._python_generator()
         model_names = list(generator._find_required_models(metrics or [], dimensions or [], filters or []))
         for segment_ref in segments or []:
             if "." in segment_ref:
@@ -1240,12 +1252,7 @@ class SemanticLayer:
                     sql = sql.replace("TIMESTAMP_TRUNC(", "DATE_TRUNC(")
 
             if "-- sidemantic:" not in sql:
-                generator = SQLGenerator(
-                    self.graph,
-                    dialect=dialect or self.dialect,
-                    preagg_database=self.preagg_database,
-                    preagg_schema=self.preagg_schema,
-                )
+                generator = self._python_generator(dialect=dialect)
                 segment_filters = generator._resolve_segments(segments or [])
                 all_filters = list(filters or []) + segment_filters
                 model_names = generator._find_required_models(metrics or [], dimensions or [], all_filters)
@@ -1337,12 +1344,7 @@ class SemanticLayer:
 
         use_preaggs = use_preaggregations if use_preaggregations is not None else self.use_preaggregations
 
-        generator = SQLGenerator(
-            self.graph,
-            dialect=dialect or self.dialect,
-            preagg_database=self.preagg_database,
-            preagg_schema=self.preagg_schema,
-        )
+        generator = self._python_generator(dialect=dialect)
         segment_filters = generator._resolve_segments(segments)
         all_filters = filters + segment_filters
         model_names = generator._find_required_models(metrics, dimensions, all_filters)

--- a/sidemantic/dashboard.py
+++ b/sidemantic/dashboard.py
@@ -21,7 +21,17 @@ from sidemantic.viz import CrossfilterDashboard, CrossfilterTab, _unique_field_a
 
 DASHBOARD_SCHEMA = "sidemantic.dashboard.v1"
 TS_SCHEMA = "sidemantic.schema.v1"
-VALID_CHART_TYPES = {"auto", "bar", "line", "area", "scatter", "point"}
+VALID_CHART_TYPES = {
+    "area",
+    "auto",
+    "bar",
+    "kpi",
+    "leaderboard",
+    "line",
+    "point",
+    "scatter",
+    "table",
+}
 VALID_RENDERERS = {"vega-lite", "plotly", "observable-plot", "d3", "crossfilter"}
 TIME_GRANULARITIES = ["second", "minute", "hour", "day", "week", "month", "quarter", "year"]
 __all__ = [
@@ -128,9 +138,6 @@ class DashboardDocument:
             if not isinstance(charts, list) or not charts:
                 errors.append(f"{path}.charts must be a non-empty list")
                 continue
-            if len(charts) != 1:
-                errors.append(f"{path}.charts currently supports exactly one chart in the canonical dashboard UI")
-
             chart_ids: set[str] = set()
             for chart_index, chart in enumerate(charts):
                 chart_path = f"{path}.charts[{chart_index}]"
@@ -161,6 +168,13 @@ class DashboardDocument:
         errors = self.validate(layer)
         if errors:
             raise DashboardSpecError("; ".join(errors))
+        multi_chart_tabs = [str(tab["id"]) for tab in self.tabs if len(tab["charts"]) != 1]
+        if multi_chart_tabs:
+            raise DashboardSpecError(
+                "The experimental crossfilter adapter supports exactly one chart per tab; "
+                f"tabs {', '.join(multi_chart_tabs)} contain multiple charts. "
+                "Use `sidemantic dashboard serve` for the canonical multi-chart dashboard UI."
+            )
 
         tabs: list[CrossfilterTab] = []
         for tab in self.tabs:
@@ -268,7 +282,7 @@ export type Metric = typeof {schema_name}.metrics[number];
 export type Dimension = typeof {schema_name}.dimensions[number];
 export type SemanticField = typeof {schema_name}.fields[number];
 export type DashboardRenderer = "vega-lite" | "plotly" | "observable-plot" | "d3" | "crossfilter";
-export type ChartType = "auto" | "bar" | "line" | "area" | "scatter" | "point";
+export type ChartType = "auto" | "kpi" | "bar" | "line" | "area" | "leaderboard" | "table" | "scatter" | "point";
 
 export interface FieldValueMap {{
 {value_map}
@@ -320,6 +334,10 @@ export type DashboardChart = {{
   query: ChartQuery;
   encoding?: ChartEncoding;
   interactions?: ChartInteractions;
+  layout?: {{
+    colSpan?: 1 | 2;
+    rowSpan?: number;
+  }};
 }};
 
 export type ChartQuery = {{
@@ -377,6 +395,9 @@ def _validate_chart(
     execute_sql: bool = False,
 ) -> list[str]:
     errors: list[str] = []
+    chart_id = chart.get("id")
+    if not isinstance(chart_id, str) or not chart_id:
+        errors.append(f"{path}.id is required")
     chart_type = str(chart.get("type") or "auto")
     if chart_type not in VALID_CHART_TYPES:
         errors.append(f"{path}.type must be one of: {', '.join(sorted(VALID_CHART_TYPES))}")

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -14,13 +14,6 @@ from sidemantic.core.symmetric_aggregate import build_symmetric_aggregate_sql
 from sidemantic.sql.aggregation_detection import sql_has_aggregate
 from sidemantic.validation import QueryValidationError
 
-# Dialects whose SQL supports the QUALIFY clause natively. Semi-additive
-# (non_additive_dimension) handling emits a QUALIFY into each affected model's CTE
-# to keep only the last (or first) snapshot per group; dialects without QUALIFY
-# (e.g. postgres, mysql) are rejected rather than served an equivalent subquery in
-# this first cut. See SQLGenerator._plan_semi_additive.
-_QUALIFY_DIALECTS = frozenset({"duckdb", "snowflake", "bigquery", "databricks", "spark", "clickhouse"})
-
 
 @lru_cache(maxsize=4096)
 def _quote_identifier_cached(name: str, dialect: str, is_simple: bool) -> str:
@@ -121,7 +114,8 @@ class SQLGenerator:
             allow_non_additive_unsafe: When True, skip the semi-additive rewrite for
                 metrics that declare a non_additive_dimension and aggregate them naively
                 over ALL snapshots (over-aggregated, wrong results). By default the generator
-                implements semi-additive handling (QUALIFY last/first snapshot per group);
+                implements semi-additive handling by selecting the last/first snapshot per
+                entity and grouping window;
                 this flag opts back into the old, naive behavior explicitly (default: False)
         """
         self.graph = graph
@@ -170,29 +164,17 @@ class SQLGenerator:
         base_model_name: str,
         model_names: list[str],
         parsed_dims: list[tuple[str, str | None]] | None = None,
-    ) -> dict[str, tuple[str, str]]:
+    ) -> dict[str, dict[str, tuple[str, str, tuple[str, ...] | None]]]:
         """Plan semi-additive (non_additive_dimension) handling for a grouped query.
 
         A measure with ``non_additive_dimension`` must be aggregated over only the
         rows at the last (max) — or first (min) — value of that time dimension per
         group, so an account-balance snapshot is summed across accounts but NOT
-        double-counted across days. We implement this by emitting a QUALIFY into the
-        owning model's CTE (see ``_build_model_cte``) that keeps only those rows.
+        double-counted across days. The entity-isolation select computes a separate
+        window marker for each semi-additive leaf after joins and typed-PK
+        deduplication. Ordinary additive leaves retain every row.
 
-        Returns a mapping ``model_name -> (non_additive_dimension_name, window)`` for
-        the models that need a semi-additive QUALIFY. ``window`` is "min" or "max".
-
-        Raises ``UnsupportedMetricError`` only for cases we do NOT implement:
-
-        - a dialect without QUALIFY (postgres, mysql, ...), since we don't emit the
-          equivalent subquery/self-join in this first cut; and
-        - the combination of semi-additive handling with fan-out symmetric aggregation
-          for the SAME model. These two rewrites don't compose safely: symmetric
-          aggregation deduplicates fan-out rows via SUM(DISTINCT hash+value) at the
-          OUTER aggregation, while semi-additive filtering must happen at the INNER
-          (pre-join) grain. Applying the QUALIFY to the fanned-out CTE would filter on
-          a post-fan-out max and the two corrections would silently interfere, so we
-          refuse rather than emit wrong SQL.
+        Returns ``model -> metric -> (dimension, window, groupings)``.
 
         When ``allow_non_additive_unsafe`` is set we skip the rewrite entirely and
         return an empty plan — the measure is then aggregated naively (over ALL
@@ -200,7 +182,7 @@ class SQLGenerator:
         hatch: it now means "skip correct handling, aggregate naively", not "opt out
         of a guard".
         """
-        plan: dict[str, tuple[str, str]] = {}
+        plan: dict[str, dict[str, tuple[str, str, tuple[str, ...] | None]]] = {}
 
         # Collect requested semi-additive measures and their owning models. Traverse metric
         # dependencies so a graph-level/derived metric that WRAPS a model measure declaring
@@ -233,23 +215,6 @@ class SQLGenerator:
         if self.allow_non_additive_unsafe:
             return plan
 
-        # Lazy import to avoid a circular import (semantic_layer imports this module).
-        from sidemantic.core.semantic_layer import UnsupportedMetricError
-
-        if self.dialect not in _QUALIFY_DIALECTS:
-            reference = semi_additive[0][0]
-            raise UnsupportedMetricError(
-                f"Metric '{reference}' declares non_additive_dimension, which is handled "
-                f"with a QUALIFY clause, but dialect '{self.dialect}' has no QUALIFY support. "
-                "Semi-additive handling is currently implemented only for "
-                f"{sorted(_QUALIFY_DIALECTS)}. Pre-aggregate this metric upstream, or pass "
-                "allow_non_additive_unsafe=True to query it anyway (naive, over-aggregated)."
-            )
-
-        # Fan-out detection: a model whose measures are computed with symmetric
-        # aggregation cannot also carry a semi-additive QUALIFY (see docstring).
-        fanout = self._has_fanout_joins(base_model_name, [m for m in model_names if m != base_model_name])
-
         for reference, metric in semi_additive:
             # Resolve the owning model of this measure.
             try:
@@ -266,23 +231,11 @@ class SQLGenerator:
             if owning_model is None:
                 owning_model = base_model_name
 
-            if fanout.get(owning_model, False):
-                raise UnsupportedMetricError(
-                    f"Metric '{reference}' declares non_additive_dimension "
-                    f"'{metric.non_additive_dimension}' and is also computed under a fan-out "
-                    "(one-to-many) join that requires symmetric aggregation. These two "
-                    "corrections operate at different grains (semi-additive filters rows "
-                    "before the join; symmetric aggregation deduplicates after it) and do not "
-                    "compose safely, so this combination is unsupported. Query the "
-                    "semi-additive metric without the fan-out join, pre-aggregate it upstream, "
-                    "or pass allow_non_additive_unsafe=True (naive, incorrect)."
-                )
-
             # If the query groups by the non-additive dimension at its RAW grain, each
             # group is already a single snapshot value, so the measure is additive within
-            # the group and no QUALIFY is needed. But a COARSER grain (e.g. day__month)
-            # still spans many snapshots per bucket, so it must keep the QUALIFY (partitioned
-            # by the truncated bucket) -- otherwise a month-end-balance-style query silently
+            # the group and no window marker is needed. But a COARSER grain (e.g. day__month)
+            # still spans many snapshots per bucket, so it keeps a marker partitioned by
+            # the truncated bucket; otherwise a month-end-balance-style query silently
             # sums every daily snapshot in the month. Only the raw-grain case is additive.
             grouped_by_non_additive_raw = False
             for dim_ref, gran in parsed_dims or []:
@@ -298,19 +251,7 @@ class SQLGenerator:
             window = getattr(metric, "non_additive_window", "max") or "max"
             groupings = getattr(metric, "non_additive_window_groupings", None)
             proposed = (metric.non_additive_dimension, window, tuple(groupings) if groupings else None)
-            existing = plan.get(owning_model)
-            if existing is not None and existing != proposed:
-                # A single model CTE carries one QUALIFY, so two semi-additive metrics on the
-                # same model that need different (dimension, window) snapshots cannot both be
-                # served correctly here (e.g. opening balance with min and closing with max).
-                # Refuse rather than silently applying only the last plan.
-                raise UnsupportedMetricError(
-                    f"Model '{owning_model}' is queried with conflicting semi-additive metrics: "
-                    f"one needs non_additive ({existing[0]!r}, window={existing[1]!r}) and another "
-                    f"needs ({proposed[0]!r}, window={proposed[1]!r}). A single model CTE can carry "
-                    "only one snapshot rule. Query them in separate requests, or pre-aggregate upstream."
-                )
-            plan[owning_model] = proposed
+            plan.setdefault(owning_model, {})[metric.name] = proposed
 
         return plan
 
@@ -322,6 +263,12 @@ class SQLGenerator:
             "var_pop": "VAR_POP",
             "approx_count_distinct": "APPROX_COUNT_DISTINCT",
         }.get(agg, agg.upper())
+
+    def _safe_divide_sql(self, numerator: str, denominator: str) -> str:
+        """Build fractional division without PostgreSQL integer truncation."""
+        if self.dialect == "postgres":
+            return f"CAST(({numerator}) AS DOUBLE PRECISION) / NULLIF(({denominator}), 0)"
+        return f"({numerator}) / NULLIF({denominator}, 0)"
 
     @staticmethod
     def _model_from_clause(model) -> str:
@@ -584,6 +531,66 @@ class SQLGenerator:
             except Exception:
                 result.append(f)
         return result
+
+    def _rewrite_filter_for_model_source(self, filter_sql: str, model) -> str:
+        """Resolve a pushed semantic filter against the model's raw source.
+
+        CTE ``WHERE`` clauses run before their projected aliases exist. A filter on
+        ``orders.created_at__month`` or a computed dimension therefore cannot refer
+        to ``created_at__month``/the dimension name; it must repeat the underlying
+        ``DATE_TRUNC`` or dimension SQL expression.
+        """
+        model_name = model.name
+        source_alias = "t" if model.sql else None
+        resolved_filter = filter_sql.replace("{model}.", f"{model_name}.").replace("{model}", model_name)
+        try:
+            parsed = _parse_fragment(resolved_filter, self.dialect)
+        except Exception:
+            return resolved_filter
+
+        for column in list(parsed.find_all(exp.Column)):
+            table_name = column.table
+            if table_name and table_name.replace("_cte", "") != model_name:
+                continue
+
+            dimension_name = column.name
+            granularity = None
+            dimension = model.get_dimension(dimension_name)
+            if dimension is None and "__" in dimension_name:
+                candidate_name, candidate_granularity = dimension_name.rsplit("__", 1)
+                candidate = model.get_dimension(candidate_name)
+                if candidate is not None and candidate.type == "time":
+                    dimension_name = candidate_name
+                    granularity = candidate_granularity
+                    dimension = candidate
+
+            if dimension is None:
+                column.set("table", exp.to_identifier(source_alias) if source_alias else None)
+                continue
+
+            self._ensure_sql_dimension(model_name, dimension)
+            replacement_sql = self._dimension_base_expr(dimension)
+            effective_granularity = granularity
+            if dimension.type == "time" and effective_granularity is None:
+                effective_granularity = dimension.granularity
+            if effective_granularity:
+                replacement_sql = self._date_trunc(effective_granularity, replacement_sql)
+            if source_alias:
+                replacement_sql = replacement_sql.replace("{model}", source_alias)
+            else:
+                replacement_sql = replacement_sql.replace("{model}.", "").replace("{model}", "")
+
+            try:
+                replacement = _parse_fragment(replacement_sql, self.dialect)
+            except Exception:
+                continue
+            for replacement_column in replacement.find_all(exp.Column):
+                replacement_table = replacement_column.table
+                if replacement_table and replacement_table.replace("_cte", "") == model_name:
+                    replacement_column.set("table", exp.to_identifier(source_alias) if source_alias else None)
+            column.replace(replacement)
+
+        return parsed.sql(dialect=self.dialect)
 
     def _quote_alias(self, name: str) -> str:
         """Quote an identifier for use as a SQL alias.
@@ -993,12 +1000,9 @@ class SQLGenerator:
         parameters = parameters or {}
         aliases = aliases or {}
 
-        # Semi-additive (non_additive_dimension) metrics are handled below by injecting
-        # a QUALIFY into the owning model's CTE (see _plan_semi_additive / _build_model_cte).
-        # The plan (and any UnsupportedMetricError for unimplemented dialects or the
-        # semi-additive + symmetric-aggregate combination) is computed once model_names
-        # is known; a non-empty plan also forces the live CTE path (pre-aggregations do
-        # not model per-group last-snapshot filtering).
+        # Semi-additive metrics are handled below with per-leaf window markers after
+        # joins and entity isolation. A non-empty plan forces the live CTE path because
+        # materialized rollups do not encode query-grain snapshot selection.
 
         # Pre-aggregations are materialized with UTC time buckets, so a timezone-bucketed
         # query cannot be served from a rollup without returning wrong (UTC) buckets. Force a
@@ -1173,12 +1177,12 @@ class SQLGenerator:
         # Find all models needed for the query
         model_names = self._find_required_models(metrics, dimensions, filters)
 
-        # Plan semi-additive handling. Raises for unimplemented cases (non-QUALIFY
-        # dialect, or semi-additive combined with fan-out symmetric aggregation on the
-        # same model). A non-empty plan forces the live CTE path (below) so the QUALIFY
-        # can be injected; pre-aggregation routing is skipped for these queries.
+        # Plan semi-additive handling for grouped queries. Raw/ungrouped rows are not
+        # aggregated across snapshots and therefore need no snapshot rewrite.
         semi_additive_plan = (
-            self._plan_semi_additive(metrics, model_names[0], model_names, parsed_dims) if model_names else {}
+            self._plan_semi_additive(metrics, model_names[0], model_names, parsed_dims)
+            if model_names and not ungrouped
+            else {}
         )
         if semi_additive_plan:
             use_preaggregations = False
@@ -1206,9 +1210,9 @@ class SQLGenerator:
 
         # Check if we need symmetric aggregation (pre-aggregation approach)
         # This is needed when metrics come from different models at different join levels.
-        # Skip this fan-out path for semi-additive queries: _plan_semi_additive already
-        # rejected any semi-additive measure whose owning model is fanned out, so a
-        # surviving plan must be served by the standard CTE path (which injects QUALIFY).
+        # Multi-fact splitting currently cannot carry a semi-additive leaf alongside a
+        # second metric model. The entity-isolation path below supports fanout dimensions
+        # on a single metric model, but cross-fact snapshot composition is rejected there.
         if not semi_additive_plan and self._needs_preaggregation_for_fanout(metrics, dimensions):
             return self._cache_generate_result(
                 cache_key,
@@ -1351,6 +1355,7 @@ class SQLGenerator:
             ungrouped=ungrouped,
             aliases=aliases,
             with_totals=with_totals,
+            semi_additive_plan=semi_additive_plan,
         )
 
         # Combine CTEs and main query
@@ -1901,7 +1906,7 @@ class SQLGenerator:
         all_models: set[str] | None = None,
         metric_filter_columns: set[str] | None = None,
         ungrouped: bool = False,
-        semi_additive: tuple[str, str] | None = None,
+        semi_additive: dict[str, tuple[str, str, tuple[str, ...] | None]] | None = None,
     ) -> str:
         """Build CTE SQL for a model with optional filter pushdown.
 
@@ -1914,10 +1919,9 @@ class SQLGenerator:
             all_models: All models in query (for determining if joins needed)
             metric_filter_columns: Columns needed for metric-level filters
             ungrouped: Whether the query is returning raw ungrouped rows
-            semi_additive: Optional ``(non_additive_dimension_name, window)`` for a
-                semi-additive measure owned by this model. When set, a QUALIFY is added
-                so only rows at the last (window="max") or first ("min") value of that
-                time dimension per group survive. See ``_plan_semi_additive``.
+            semi_additive: Per-measure snapshot plans owned by this model. Their
+                time/grouping dimensions are projected for the joined entity stage;
+                no model-wide row filter is applied here.
 
         Returns:
             CTE SQL string
@@ -1932,14 +1936,14 @@ class SQLGenerator:
             model_name, dimensions, filters, order_by, metric_filter_columns
         )
 
-        # Semi-additive handling needs the non_additive_dimension column projected into
-        # this CTE (aliased to its dimension name) so the QUALIFY below can reference it,
-        # even when the query does not group by it. Declared window_groupings must also be
-        # projected so the QUALIFY can partition per those dimensions.
+        # Semi-additive handling needs the snapshot and declared grouping dimensions
+        # projected into the entity-isolation stage even when the query does not group
+        # by them.
         if semi_additive is not None:
-            needed_dimensions.add(semi_additive[0])
-            for grouping_col in semi_additive[2] or ():
-                needed_dimensions.add(grouping_col)
+            for non_additive_dim, _window, groupings in semi_additive.values():
+                needed_dimensions.add(non_additive_dim)
+                for grouping_col in groupings or ():
+                    needed_dimensions.add(grouping_col)
 
         # Build SELECT columns
         select_cols = []
@@ -1952,7 +1956,12 @@ class SQLGenerator:
                 select_cols.append(f"{self._quote_identifier(column)} AS {self._quote_alias(column)}")
                 columns_added.add(column)
 
-        include_primary_keys = needs_keyed_joins or ungrouped or bool(model.sql)
+        # Multi-model queries may need to isolate multiplied measures at their
+        # declared entity grain even for a CROSS join (which has no keyed join
+        # columns). Keep typed PK columns available for that exact deduplication.
+        include_primary_keys = (
+            len(all_models) > 1 or needs_keyed_joins or ungrouped or bool(model.sql) or bool(semi_additive)
+        )
         if include_primary_keys:
             for pk_col in model.primary_key_columns:
                 add_passthrough_column(pk_col)
@@ -2341,73 +2350,9 @@ class SQLGenerator:
         # Build WHERE clause for pushed-down filters
         where_clause = ""
         if filters:
-            # Process filters - replace model_cte references with direct column names using SQLGlot
-            processed_filters = []
-            for f in filters:
-                try:
-                    parsed = _parse_fragment(f, self.dialect)
-                    # Remove table qualifiers (model_name_cte. or model_name.)
-                    for col in parsed.find_all(exp.Column):
-                        if col.table:
-                            clean_table = col.table.replace("_cte", "")
-                            if clean_table == model_name:
-                                col.set("table", None)
-                    processed_filter = parsed.sql(dialect=self.dialect)
-                    processed_filters.append(processed_filter)
-                except Exception:
-                    # If parsing fails, use original filter
-                    processed_filters.append(f)
+            processed_filters = [self._rewrite_filter_for_model_source(f, model) for f in filters]
 
             where_clause = f"\n  WHERE {' AND '.join(processed_filters)}"
-
-        # Build QUALIFY clause for semi-additive (non_additive_dimension) measures.
-        # Keep only the rows at the last (window="max") or first ("min") value of the
-        # non-additive time dimension per group. Referencing the CTE's own SELECT aliases
-        # here is valid under QUALIFY in DuckDB and the other _QUALIFY_DIALECTS.
-        qualify_clause = ""
-        if semi_additive is not None:
-            non_additive_dim, window, groupings = semi_additive
-            time_col = self._quote_identifier(non_additive_dim)
-
-            partition_aliases: list[str] = []
-            seen_partition: set[str] = set()
-
-            def _add_partition(alias: str) -> None:
-                if alias not in seen_partition:
-                    seen_partition.add(alias)
-                    partition_aliases.append(self._quote_identifier(alias))
-
-            if groupings:
-                # Declared window_groupings (MetricFlow): the snapshot is taken per these
-                # dimensions regardless of the query's grouping (e.g. balance-per-user).
-                for grouping_col in groupings:
-                    _add_partition(grouping_col)
-                # A coarser grain of the non-additive dim requested by the query still scopes
-                # the snapshot to that bucket (month-end balance per user).
-                for dim_ref, gran in dimensions:
-                    if dim_ref == f"{model_name}.{non_additive_dim}" and gran is not None:
-                        _add_partition(f"{non_additive_dim}__{gran}")
-            else:
-                # No declared groupings: partition by the query's other grouping dimensions
-                # for THIS model (e.g. account/region), excluding the raw non-additive axis.
-                for dim_ref, gran in dimensions:
-                    if not dim_ref.startswith(model_name + "."):
-                        continue
-                    dim_name = dim_ref.split(".", 1)[1]
-                    if dim_name == non_additive_dim and gran is None:
-                        # The non-additive time dim at its RAW grain is the window axis, never a
-                        # partition key. A coarser grain of it (day__month) IS a partition key.
-                        continue
-                    _add_partition(f"{dim_name}__{gran}" if gran else dim_name)
-
-            agg = "MAX" if window == "max" else "MIN"
-            if partition_aliases:
-                partition_sql = ", ".join(partition_aliases)
-                window_expr = f"{agg}({time_col}) OVER (PARTITION BY {partition_sql})"
-            else:
-                # No other grouping dimensions: one global last/first snapshot.
-                window_expr = f"{agg}({time_col}) OVER ()"
-            qualify_clause = f"\n  QUALIFY {time_col} = {window_expr}"
 
         # Build CTE
         if not select_cols:
@@ -2419,7 +2364,7 @@ class SQLGenerator:
         select_str = ",\n    ".join(select_cols)
         cte_sql = (
             f"{self._quote_identifier(self._cte_name(model_name))} AS "
-            f"(\n  SELECT\n    {select_str}\n  FROM {from_clause}{where_clause}{qualify_clause}\n)"
+            f"(\n  SELECT\n    {select_str}\n  FROM {from_clause}{where_clause}\n)"
         )
 
         return cte_sql
@@ -2776,8 +2721,13 @@ class SQLGenerator:
         # Start with first CTE
         from_clause = cte_names[0]
 
-        # Join remaining CTEs
+        # Join remaining CTEs. Each new CTE must join against the coalesced
+        # dimension key from *all* CTEs already in the result. Joining every
+        # CTE only to the first one splits a logical key when that key is absent
+        # from the first CTE but present in two later CTEs (both later joins see
+        # a NULL first key and produce separate FULL OUTER rows).
         join_clauses = []
+        joined_ctes = [cte_names[0]]
         for cte_name in cte_names[1:]:
             if not parsed_dims:
                 # No dimensions - use CROSS JOIN (each CTE returns single row)
@@ -2789,12 +2739,14 @@ class SQLGenerator:
                     dim_name = dim_ref.split(".")[1] if "." in dim_ref else dim_ref
                     col_name = dimension_output_name(dim_ref, dim_name, gran)
                     # NULL-safe equality that works for all column types
-                    lhs = exp.Column(this=col_name, table=cte_names[0])
+                    joined_columns = [exp.Column(this=col_name, table=joined_cte) for joined_cte in joined_ctes]
+                    lhs = exp.func("COALESCE", *joined_columns) if len(joined_columns) > 1 else joined_columns[0]
                     rhs = exp.Column(this=col_name, table=cte_name)
                     join_conditions.append(exp.NullSafeEQ(this=lhs, expression=rhs).sql(dialect=self._dialect_instance))
 
                 join_clause = " AND ".join(join_conditions)
                 join_clauses.append(f"FULL OUTER JOIN {cte_name} ON {join_clause}")
+            joined_ctes.append(cte_name)
 
         # Combine into final query
         select_str = ",\n  ".join(select_exprs)
@@ -2954,6 +2906,30 @@ class SQLGenerator:
 
         return where_filters, having_filters
 
+    def _rewrite_having_filter(
+        self,
+        filter_expr: str,
+        metric_expressions: dict[str, str],
+    ) -> str:
+        """Replace semantic metric references with their aggregate expressions."""
+        try:
+            parsed = _parse_fragment(filter_expr, self.dialect)
+        except Exception:
+            return filter_expr
+
+        for column in list(parsed.find_all(exp.Column)):
+            qualified_ref = f"{column.table.replace('_cte', '')}.{column.name}" if column.table else None
+            replacement_sql = metric_expressions.get(qualified_ref) if qualified_ref else None
+            if replacement_sql is None and not column.table:
+                replacement_sql = metric_expressions.get(column.name)
+            if replacement_sql is None:
+                continue
+            try:
+                column.replace(_parse_fragment(replacement_sql, self.dialect))
+            except Exception:
+                continue
+        return parsed.sql(dialect=self.dialect)
+
     def _add_where_filters_to_query(self, query, where_filters: list[str], model_names: list[str]):
         """Add row-level filters with CTE-qualified field references."""
         import re
@@ -3000,6 +2976,466 @@ class SQLGenerator:
 
         return query
 
+    def _fanout_safe_metric_plan(
+        self,
+        metrics: list[str],
+        symmetric_agg_needed: dict[str, bool],
+        semi_additive_plan: dict[str, dict[str, tuple[str, str, tuple[str, ...] | None]]] | None = None,
+    ) -> tuple[str, list[tuple[str, object, str | None]], list[tuple[str, object]]] | None:
+        """Return a dependency-aware entity-isolation plan for one metric model.
+
+        Hash-based symmetric aggregates are intrinsically lossy: floating-point
+        values lose precision next to the large hash term, fixed-width hashes can
+        collide, and concatenated composite keys are not injective. For the common
+        live-query case, isolate the owning model's real primary-key rows first and
+        aggregate those rows in an outer query instead.
+
+        Multi-fact queries already recurse through one child query per metric model,
+        so limiting one isolation branch to one owning model also covers those
+        queries without mixing PK grains in a single DISTINCT row set.
+        """
+        planned_outputs: list[tuple[str, object, str | None]] = []
+        leaf_metrics: dict[str, tuple[str, object]] = {}
+        metric_models: set[str] = set()
+        supported_aggs = {
+            "sum",
+            "avg",
+            "count",
+            "count_distinct",
+            "approx_count_distinct",
+            "min",
+            "max",
+            "median",
+            "stddev",
+            "stddev_pop",
+            "variance",
+            "variance_pop",
+        }
+
+        def resolve_reference(reference: str, model_context: str | None) -> tuple[str | None, object] | None:
+            if "." not in reference and model_context:
+                context_model = self.graph.get_model(model_context)
+                local_metric = context_model.get_metric(reference)
+                if local_metric is not None:
+                    return model_context, local_metric
+            try:
+                resolved_model_name, resolved_metric = self.graph.resolve_metric_reference(reference)
+            except KeyError:
+                return None
+            if resolved_metric is None:
+                return None
+            return resolved_model_name, resolved_metric
+
+        def collect_leaves(
+            metric,
+            metric_context: str | None,
+            stack: set[int],
+        ) -> bool:
+            identity = id(metric)
+            if identity in stack:
+                return False
+            stack = {*stack, identity}
+
+            if getattr(metric, "sql_is_complete", False):
+                if metric_context is None or not metric.sql or semi_additive_plan:
+                    return False
+                try:
+                    parsed = _parse_fragment(
+                        metric.sql.replace("{model}.", "").replace("{model}", ""),
+                        self.dialect,
+                    )
+                except Exception:
+                    return False
+                if any(
+                    column.table and column.table.replace("_cte", "") != metric_context
+                    for column in parsed.find_all(exp.Column)
+                ):
+                    return False
+                columns = self._complete_sql_columns(metric)
+                if metric.filters and not columns:
+                    # A zero-column aggregate such as COUNT(*) cannot honor a
+                    # separate metric filter by nulling its input columns.
+                    return False
+                canonical_ref = f"{metric_context}.{metric.name}"
+                leaf_metrics.setdefault(canonical_ref, (canonical_ref, metric))
+                metric_models.add(metric_context)
+                return True
+            if metric.agg:
+                if metric_context is None or metric.agg not in supported_aggs:
+                    return False
+                canonical_ref = f"{metric_context}.{metric.name}"
+                leaf_metrics.setdefault(canonical_ref, (canonical_ref, metric))
+                metric_models.add(metric_context)
+                return True
+            if metric.type == "ratio":
+                if not metric.numerator or not metric.denominator:
+                    return False
+                for dependency in (metric.numerator, metric.denominator):
+                    resolved = resolve_reference(dependency, metric_context)
+                    if resolved is None or not collect_leaves(resolved[1], resolved[0] or metric_context, stack):
+                        return False
+                return True
+            if metric.type == "derived" or (not metric.type and metric.sql):
+                if not metric.sql or "__bsl_all(" in metric.sql or sql_has_aggregate(metric.sql, self.dialect):
+                    return False
+                for dependency in metric.get_dependencies(self.graph, metric_context):
+                    resolved = resolve_reference(dependency, metric_context)
+                    if resolved is None or not collect_leaves(resolved[1], resolved[0] or metric_context, stack):
+                        return False
+                return True
+            return False
+
+        for metric_ref in metrics:
+            resolved = resolve_reference(metric_ref, None)
+            if resolved is None:
+                return None
+            resolved_model_name, metric = resolved
+            if not collect_leaves(metric, resolved_model_name, set()):
+                return None
+            planned_outputs.append((metric_ref, metric, resolved_model_name))
+
+        if len(metric_models) != 1:
+            return None
+        model_name = next(iter(metric_models))
+        if not symmetric_agg_needed.get(model_name, False) and model_name not in (semi_additive_plan or {}):
+            return None
+
+        model = self.graph.get_model(model_name)
+        self._require_primary_key(model_name, model.primary_key_columns, "to isolate measures across a fan-out join")
+        return model_name, planned_outputs, list(leaf_metrics.values())
+
+    def _build_fanout_safe_select(
+        self,
+        base_model_name: str,
+        other_models: list[str],
+        parsed_dims: list[tuple[str, str | None]],
+        metric_model_name: str,
+        planned_outputs: list[tuple[str, object, str | None]],
+        leaf_metrics: list[tuple[str, object]],
+        filters: list[str] | None,
+        models_with_filters: set[str],
+        order_by: list[str] | None,
+        limit: int | None,
+        offset: int | None,
+        aliases: dict[str, str],
+        with_totals: bool,
+        semi_additive_plan: dict[str, tuple[str, str, tuple[str, ...] | None]] | None = None,
+    ) -> str:
+        """Aggregate one model from an exact DISTINCT dimension+PK row set.
+
+        The inner query applies joins and row filters, then keeps one row for each
+        requested dimension grain, typed primary-key tuple, and set of raw measure
+        values. The outer query performs ordinary aggregates over those entity
+        rows. This is the same correctness shape as Cube's multiplied-measure/key
+        subqueries and avoids all numeric/hash cancellation tricks.
+        """
+        entity_alias = "__sidemantic_entity"
+        dedup_alias = "__sidemantic_dedup"
+        dim_internal_names = [f"__sidemantic_dim_{idx}" for idx in range(len(parsed_dims))]
+        model = self.graph.get_model(metric_model_name)
+        pk_internal_names = [f"__sidemantic_pk_{idx}" for idx in range(len(model.primary_key_columns))]
+        metric_internal_names = [f"__sidemantic_metric_{idx}" for idx in range(len(leaf_metrics))]
+        complete_column_internal_names: dict[int, dict[str, str]] = {}
+        for leaf_idx, (_metric_ref, measure) in enumerate(leaf_metrics):
+            if not getattr(measure, "sql_is_complete", False):
+                continue
+            complete_column_internal_names[id(measure)] = {
+                column_name: f"__sidemantic_complete_{leaf_idx}_{column_idx}"
+                for column_idx, (column_name, _quoted) in enumerate(self._complete_sql_columns(measure))
+            }
+        semi_field_internal_names: dict[str, str] = {}
+        for non_additive_dim, _window, groupings in (semi_additive_plan or {}).values():
+            for field_name in (non_additive_dim, *(groupings or ())):
+                semi_field_internal_names.setdefault(
+                    field_name,
+                    f"__sidemantic_snapshot_field_{len(semi_field_internal_names)}",
+                )
+
+        inner_select_exprs: list[str] = []
+        for (dim_ref, gran), internal_name in zip(parsed_dims, dim_internal_names, strict=True):
+            dim_model_name, dim_name = dim_ref.split(".", 1)
+            cte_col_name = f"{dim_name}__{gran}" if gran else dim_name
+            inner_select_exprs.append(
+                f"{self._cte_ref(dim_model_name, cte_col_name)} AS {self._quote_alias(internal_name)}"
+            )
+        for pk_col, internal_name in zip(model.primary_key_columns, pk_internal_names, strict=True):
+            inner_select_exprs.append(
+                f"{self._cte_ref(metric_model_name, pk_col)} AS {self._quote_alias(internal_name)}"
+            )
+        for (_metric_ref, measure), internal_name in zip(leaf_metrics, metric_internal_names, strict=True):
+            if getattr(measure, "sql_is_complete", False):
+                for column_name, complete_internal_name in complete_column_internal_names[id(measure)].items():
+                    source_name = self._complete_sql_raw_alias(measure.name, column_name)
+                    inner_select_exprs.append(
+                        f"{self._cte_ref(metric_model_name, source_name)} "
+                        f"AS {self._quote_alias(complete_internal_name)}"
+                    )
+                continue
+            inner_select_exprs.append(
+                f"{self._cte_ref(metric_model_name, f'{measure.name}_raw')} AS {self._quote_alias(internal_name)}"
+            )
+        for field_name, internal_name in semi_field_internal_names.items():
+            inner_select_exprs.append(
+                f"{self._cte_ref(metric_model_name, field_name)} AS {self._quote_alias(internal_name)}"
+            )
+
+        inner_query = (
+            select(*inner_select_exprs).distinct().from_(self._quote_identifier(self._cte_name(base_model_name)))
+        )
+        inner_query = self._add_join_paths_to_query(inner_query, base_model_name, other_models, models_with_filters)
+        where_filters, having_filters = self._split_where_having_filters(
+            filters or [], [base_model_name] + other_models
+        )
+        inner_query = self._add_where_filters_to_query(inner_query, where_filters, [base_model_name] + other_models)
+
+        # Snapshot only the semi-additive leaves. This extra stage is deliberately
+        # after the joined DISTINCT entity rows: fanout duplicates are gone, related
+        # dimensions are available for the window partition, and ordinary additive
+        # leaves still see every entity row. Different snapshot metrics may use
+        # different min/max dimensions in the same query.
+        aggregation_source = inner_query
+        if semi_additive_plan:
+            entity_table = self._quote_identifier(entity_alias)
+            snapshot_select_exprs: list[str] = []
+            for internal_name in (*dim_internal_names, *pk_internal_names):
+                source_ref = f"{entity_table}.{self._quote_identifier(internal_name)}"
+                snapshot_select_exprs.append(f"{source_ref} AS {self._quote_alias(internal_name)}")
+
+            for idx, (_metric_ref, measure) in enumerate(leaf_metrics):
+                internal_name = metric_internal_names[idx]
+                raw_ref = f"{entity_table}.{self._quote_identifier(internal_name)}"
+                snapshot = semi_additive_plan.get(measure.name)
+                if snapshot is not None:
+                    non_additive_dim, window, groupings = snapshot
+                    time_internal = semi_field_internal_names[non_additive_dim]
+                    time_ref = f"{entity_table}.{self._quote_identifier(time_internal)}"
+                    partition_refs: list[str] = []
+
+                    def add_partition(internal: str) -> None:
+                        ref = f"{entity_table}.{self._quote_identifier(internal)}"
+                        if ref not in partition_refs:
+                            partition_refs.append(ref)
+
+                    if groupings:
+                        for grouping in groupings:
+                            add_partition(semi_field_internal_names[grouping])
+                        # Month-end-per-account needs both the declared entity and
+                        # the requested coarser time bucket in its window partition.
+                        for dim_idx, (dim_ref, gran) in enumerate(parsed_dims):
+                            if dim_ref == f"{metric_model_name}.{non_additive_dim}" and gran is not None:
+                                add_partition(dim_internal_names[dim_idx])
+                    else:
+                        # Query-grain snapshots partition by every requested
+                        # dimension, including dimensions reached through joins.
+                        for dim_idx, (dim_ref, gran) in enumerate(parsed_dims):
+                            if dim_ref == f"{metric_model_name}.{non_additive_dim}" and gran is None:
+                                continue
+                            add_partition(dim_internal_names[dim_idx])
+
+                    aggregate = "MAX" if window == "max" else "MIN"
+                    partition_sql = f"PARTITION BY {', '.join(partition_refs)}" if partition_refs else ""
+                    window_sql = f"{aggregate}({time_ref}) OVER ({partition_sql})"
+                    raw_ref = f"CASE WHEN {time_ref} = {window_sql} THEN {raw_ref} ELSE NULL END"
+                snapshot_select_exprs.append(f"{raw_ref} AS {self._quote_alias(internal_name)}")
+
+            aggregation_source = select(*snapshot_select_exprs).from_(inner_query.subquery(entity_alias))
+
+        # Match the standard select path's collision and alias contract.
+        field_names: dict[str, list[str]] = {}
+        for dim_ref, gran in parsed_dims:
+            dim_model_name, dim_name = dim_ref.split(".", 1)
+            field_name = f"{dim_name}__{gran}" if gran else dim_name
+            field_names.setdefault(field_name, []).append(dim_model_name)
+        for metric_ref, metric, metric_context in planned_outputs:
+            owner = metric_context or (metric_ref.split(".", 1)[0] if "." in metric_ref else "")
+            field_names.setdefault(metric.name, []).append(owner)
+        has_collision = {name: len(owners) > 1 for name, owners in field_names.items()}
+
+        output_aliases: dict[str, str] = {}
+        outer_select_exprs: list[str] = []
+        dedup_table = self._quote_identifier(dedup_alias)
+
+        for idx, (dim_ref, gran) in enumerate(parsed_dims):
+            dim_model_name, dim_name = dim_ref.split(".", 1)
+            base_alias = f"{dim_name}__{gran}" if gran else dim_name
+            full_ref = f"{dim_ref}__{gran}" if gran else dim_ref
+            alias = aliases.get(full_ref)
+            if alias is None:
+                alias = f"{dim_model_name}_{base_alias}" if has_collision.get(base_alias, False) else base_alias
+            internal_ref = f"{dedup_table}.{self._quote_identifier(dim_internal_names[idx])}"
+            outer_select_exprs.append(f"{internal_ref} AS {self._quote_alias(alias)}")
+            output_aliases[full_ref] = alias
+            output_aliases[dim_ref] = alias
+            output_aliases[base_alias] = alias
+
+        def aggregate_entity_rows(measure, raw_ref: str) -> str:
+            agg = measure.agg
+            if agg == "count":
+                aggregate = f"COUNT({raw_ref})"
+            elif agg == "count_distinct":
+                # With no explicit expression this metric means distinct entity
+                # PK. Entity rows are already unique by the typed PK tuple, so a
+                # plain count avoids composite-key serialization entirely.
+                aggregate = f"COUNT({raw_ref})" if not measure.sql else f"COUNT(DISTINCT {raw_ref})"
+            elif agg == "approx_count_distinct":
+                aggregate = f"COUNT({raw_ref})" if not measure.sql else f"APPROX_COUNT_DISTINCT({raw_ref})"
+            else:
+                aggregate = f"{agg.upper()}({raw_ref})"
+            return self._wrap_with_fill_nulls(aggregate, measure)
+
+        def complete_sql_over_entity_rows(measure) -> str:
+            """Retarget an opaque aggregate to the exact deduplicated entity rows."""
+            formula = (measure.sql or "").replace("{model}.", "").replace("{model}", "")
+            try:
+                parsed = _parse_fragment(formula, self.dialect)
+            except Exception as exc:
+                raise ValueError(f"Complete SQL metric {measure.name} could not be parsed safely") from exc
+
+            column_names = complete_column_internal_names.get(id(measure), {})
+            for column in parsed.find_all(exp.Column):
+                try:
+                    internal_name = column_names[column.name]
+                except KeyError as exc:
+                    raise ValueError(
+                        f"Complete SQL metric {measure.name} references unsupported column {column.sql()}"
+                    ) from exc
+                column.set(
+                    "this",
+                    exp.to_identifier(internal_name, quoted=not self._is_simple_identifier(internal_name)),
+                )
+                column.set(
+                    "table",
+                    exp.to_identifier(dedup_alias, quoted=not self._is_simple_identifier(dedup_alias)),
+                )
+
+            entity_formula = parsed.sql(dialect=self.dialect)
+            if parsed_dims and not sql_has_aggregate(measure.sql or "", self.dialect):
+                entity_formula = f"ANY_VALUE({entity_formula})"
+            return entity_formula
+
+        leaf_aggregate_by_id: dict[int, str] = {}
+        for idx, (_leaf_ref, measure) in enumerate(leaf_metrics):
+            if getattr(measure, "sql_is_complete", False):
+                continue
+            raw_ref = f"{dedup_table}.{self._quote_identifier(metric_internal_names[idx])}"
+            leaf_aggregate_by_id[id(measure)] = aggregate_entity_rows(measure, raw_ref)
+
+        def resolve_calculation_reference(reference: str, model_context: str | None):
+            if "." not in reference and model_context:
+                local_metric = self.graph.get_model(model_context).get_metric(reference)
+                if local_metric is not None:
+                    return model_context, local_metric
+            try:
+                return self.graph.resolve_metric_reference(reference)
+            except KeyError as exc:
+                raise ValueError(f"Metric {reference} not found") from exc
+
+        def build_calculated_metric(metric, model_context: str | None, stack: set[int] | None = None) -> str:
+            stack = set() if stack is None else stack
+            if id(metric) in stack:
+                raise ValueError(f"Circular metric dependency involving {metric.name}")
+            stack = {*stack, id(metric)}
+
+            if getattr(metric, "sql_is_complete", False):
+                return complete_sql_over_entity_rows(metric)
+            if metric.agg:
+                try:
+                    return leaf_aggregate_by_id[id(metric)]
+                except KeyError as exc:
+                    raise ValueError(f"Metric {metric.name} was not planned at the entity grain") from exc
+            if metric.type == "ratio":
+                if not metric.numerator or not metric.denominator:
+                    raise ValueError(f"Ratio metric {metric.name} requires numerator and denominator")
+                numerator_context, numerator = resolve_calculation_reference(metric.numerator, model_context)
+                denominator_context, denominator = resolve_calculation_reference(metric.denominator, model_context)
+                numerator_sql = build_calculated_metric(numerator, numerator_context or model_context, stack)
+                denominator_sql = build_calculated_metric(denominator, denominator_context or model_context, stack)
+                return self._safe_divide_sql(numerator_sql, denominator_sql)
+            if metric.type == "derived" or (not metric.type and metric.sql):
+                if not metric.sql:
+                    raise ValueError(f"Derived metric {metric.name} missing sql")
+                formula = metric.sql
+                dependencies = sorted(metric.get_dependencies(self.graph, model_context), key=len, reverse=True)
+                import re
+
+                for dependency in dependencies:
+                    dependency_context, dependency_metric = resolve_calculation_reference(dependency, model_context)
+                    dependency_sql = build_calculated_metric(
+                        dependency_metric, dependency_context or model_context, stack
+                    )
+                    if "." in dependency:
+                        qualified_pattern = r"\b" + re.escape(dependency) + r"\b"
+                        if re.search(qualified_pattern, formula):
+                            formula = re.sub(qualified_pattern, f"({dependency_sql})", formula)
+                        else:
+                            bare_name = dependency.split(".", 1)[1]
+                            formula = re.sub(
+                                r"(?<!\.)\b" + re.escape(bare_name) + r"\b",
+                                f"({dependency_sql})",
+                                formula,
+                            )
+                    else:
+                        formula = re.sub(
+                            r"(?<!\.)\b" + re.escape(dependency) + r"\b",
+                            f"({dependency_sql})",
+                            formula,
+                        )
+                return formula
+            raise ValueError(f"Metric {metric.name} cannot be planned at the entity grain")
+
+        having_metric_expressions: dict[str, str] = {}
+        for metric_ref, metric, metric_context in planned_outputs:
+            if metric_ref in aliases:
+                alias = aliases[metric_ref]
+            elif has_collision.get(metric.name, False):
+                alias = f"{metric_model_name}_{metric.name}"
+            else:
+                alias = metric.name
+            aggregate = build_calculated_metric(metric, metric_context or metric_model_name)
+            aggregate = self._wrap_with_fill_nulls(aggregate, metric)
+            outer_select_exprs.append(f"{aggregate} AS {self._quote_alias(alias)}")
+            output_aliases[metric_ref] = alias
+            output_aliases[metric.name] = alias
+            having_metric_expressions[metric_ref] = aggregate
+            having_metric_expressions.setdefault(metric.name, aggregate)
+
+        if with_totals and parsed_dims:
+            first_dim = f"{dedup_table}.{self._quote_identifier(dim_internal_names[0])}"
+            outer_select_exprs.append(f"GROUPING({first_dim}) AS _is_total")
+
+        outer_query = select(*outer_select_exprs).from_(aggregation_source.subquery(dedup_alias))
+        if parsed_dims:
+            if with_totals:
+                positions = ", ".join(str(i) for i in range(1, len(parsed_dims) + 1))
+                outer_query = outer_query.group_by(f"GROUPING SETS (({positions}), ())")
+            else:
+                outer_query = outer_query.group_by(*range(1, len(parsed_dims) + 1))
+
+        # Preserve the existing public filter syntax (model.metric predicates),
+        # while using the real aggregate expression on dialects that do not allow
+        # SELECT aliases in HAVING.
+        for filter_expr in having_filters:
+            outer_query = outer_query.having(self._rewrite_having_filter(filter_expr, having_metric_expressions))
+
+        if order_by:
+            order_exprs: list[str] = []
+            for field in order_by:
+                parts = field.rsplit(" ", 1)
+                field_ref = parts[0] if len(parts) == 2 and parts[1].upper() in {"ASC", "DESC"} else field
+                direction = f" {parts[1].upper()}" if field_ref != field else ""
+                output_alias = output_aliases.get(field_ref)
+                if output_alias is None and "." in field_ref:
+                    output_alias = output_aliases.get(field_ref.split(".", 1)[1])
+                output_alias = output_alias or field_ref
+                order_exprs.append(f"{self._quote_alias(output_alias)}{direction}")
+            outer_query = outer_query.order_by(*order_exprs)
+        if limit is not None:
+            outer_query = outer_query.limit(limit)
+        if offset is not None:
+            outer_query = outer_query.offset(offset)
+
+        return outer_query.sql(dialect=self.dialect, pretty=True)
+
     def _build_main_select(
         self,
         base_model_name: str,
@@ -3014,6 +3450,7 @@ class SQLGenerator:
         ungrouped: bool = False,
         aliases: dict[str, str] | None = None,
         with_totals: bool = False,
+        semi_additive_plan: dict[str, dict[str, tuple[str, str, tuple[str, ...] | None]]] | None = None,
     ) -> str:
         """Build main SELECT using SQLGlot builder API.
 
@@ -3030,6 +3467,7 @@ class SQLGenerator:
             ungrouped: If True, return raw rows without aggregation
             aliases: Custom aliases for fields (dict mapping field reference to alias)
             with_totals: If True, add a grand-total row (all dims NULL) via GROUPING SETS
+            semi_additive_plan: Per-model, per-leaf snapshot rules
 
         Returns:
             SQL SELECT statement
@@ -3038,26 +3476,77 @@ class SQLGenerator:
         # Detect if symmetric aggregates are needed
         symmetric_agg_needed = self._has_fanout_joins(base_model_name, other_models)
 
-        dimension_models = {dim_ref.split(".")[0] for dim_ref, _ in parsed_dims if "." in dim_ref}
+        # Any joined row source can multiply a metric model, including a model
+        # introduced only by a WHERE filter. Cross and many-to-many paths are
+        # multiplying by definition; a one-to-many hop multiplies the upstream
+        # model even when no dimension from the downstream model is selected.
+        row_context_models = {base_model_name, *other_models}
         metric_models = set()
         for metric_ref in metrics:
-            try:
-                metric_model_name, _ = self.graph.resolve_metric_reference(metric_ref)
-            except KeyError:
-                metric_model_name = None
-            if metric_model_name:
-                metric_models.add(metric_model_name)
+            metric_models.update(self._find_required_models([metric_ref], []))
         for metric_model in metric_models:
-            for dimension_model in dimension_models:
-                if metric_model == dimension_model:
+            for context_model in row_context_models:
+                if metric_model == context_model:
                     continue
                 try:
-                    join_path = self.graph.find_relationship_path(metric_model, dimension_model)
+                    join_path = self.graph.find_relationship_path(metric_model, context_model)
                 except ValueError:
                     continue
-                if any(jp.relationship == "one_to_many" for jp in join_path):
+                if any(jp.relationship in {"one_to_many", "many_to_many", "cross"} for jp in join_path):
                     symmetric_agg_needed[metric_model] = True
                     break
+
+        fanout_safe_plan = self._fanout_safe_metric_plan(metrics, symmetric_agg_needed, semi_additive_plan)
+        if fanout_safe_plan is not None and not ungrouped:
+            metric_model_name, planned_outputs, leaf_metrics = fanout_safe_plan
+            return self._build_fanout_safe_select(
+                base_model_name=base_model_name,
+                other_models=other_models,
+                parsed_dims=parsed_dims,
+                metric_model_name=metric_model_name,
+                planned_outputs=planned_outputs,
+                leaf_metrics=leaf_metrics,
+                filters=filters,
+                models_with_filters=models_with_filters,
+                order_by=order_by,
+                limit=limit,
+                offset=offset,
+                aliases=aliases or {},
+                with_totals=with_totals,
+                semi_additive_plan=(semi_additive_plan or {}).get(metric_model_name),
+            )
+
+        unsafe_complete_metrics: list[str] = []
+        if not ungrouped:
+            for metric_ref in metrics:
+                try:
+                    resolved_model_name, resolved_metric = self.graph.resolve_metric_reference(metric_ref)
+                except KeyError:
+                    continue
+                if (
+                    resolved_model_name
+                    and resolved_metric
+                    and getattr(resolved_metric, "sql_is_complete", False)
+                    and symmetric_agg_needed.get(resolved_model_name, False)
+                ):
+                    unsafe_complete_metrics.append(metric_ref)
+        if unsafe_complete_metrics:
+            from sidemantic.core.semantic_layer import UnsupportedMetricError
+
+            raise UnsupportedMetricError(
+                "Opaque complete-SQL metrics cannot be evaluated safely across this fan-out join: "
+                f"{', '.join(unsafe_complete_metrics)}. Use a parseable aggregate over columns from its owning "
+                "model, or query the metric without the multiplying relationship."
+            )
+
+        if semi_additive_plan and not ungrouped:
+            from sidemantic.core.semantic_layer import UnsupportedMetricError
+
+            raise UnsupportedMetricError(
+                "Semi-additive metrics in this query span multiple metric models or use an "
+                "unsupported opaque aggregate expression. Query each metric model separately "
+                "or define the snapshot leaf as a simple aggregate/derived dependency."
+            )
 
         # Check for dimension/metric name collisions across models
         # If there are collisions, prefix with model name
@@ -3091,6 +3580,7 @@ class SQLGenerator:
         # Build SELECT columns
         select_exprs = []
         output_aliases: dict[str, str] = {}
+        having_metric_expressions: dict[str, str] = {}
 
         # Add dimensions
         for dim_ref, gran in parsed_dims:
@@ -3137,6 +3627,8 @@ class SQLGenerator:
                 select_exprs.append(f"{metric_expr} AS {self._quote_alias(alias)}")
                 output_aliases[metric_ref] = alias
                 output_aliases[resolved_metric.name] = alias
+                having_metric_expressions[metric_ref] = metric_expr
+                having_metric_expressions.setdefault(resolved_metric.name, metric_expr)
             elif resolved_metric and resolved_model_name:
                 # It's a measure reference (model.measure)
                 model_name = resolved_model_name
@@ -3166,6 +3658,8 @@ class SQLGenerator:
                         metric_expr = self._build_complete_sql_expr(measure, model_name, grouped)
                         metric_expr = self._wrap_with_fill_nulls(metric_expr, measure)
                         select_exprs.append(f"{metric_expr} AS {self._quote_alias(alias)}")
+                        having_metric_expressions[metric_ref] = metric_expr
+                        having_metric_expressions.setdefault(measure_name, metric_expr)
                         continue
 
                     # Complex metric types (derived, ratio) can be built inline
@@ -3178,6 +3672,8 @@ class SQLGenerator:
                         metric_expr = self._build_metric_sql(measure, model_name)
                         metric_expr = self._wrap_with_fill_nulls(metric_expr, measure)
                         select_exprs.append(f"{metric_expr} AS {self._quote_alias(alias)}")
+                        having_metric_expressions[metric_ref] = metric_expr
+                        having_metric_expressions.setdefault(measure_name, metric_expr)
                     elif not measure.agg:
                         # Unknown metric type that needs special handling
                         raise ValueError(
@@ -3186,9 +3682,10 @@ class SQLGenerator:
                         )
                     elif ungrouped:
                         # For ungrouped queries, select raw column without aggregation
-                        select_exprs.append(
-                            f"{self._cte_ref(model_name, f'{measure_name}_raw')} AS {self._quote_alias(alias)}"
-                        )
+                        metric_expr = self._cte_ref(model_name, f"{measure_name}_raw")
+                        select_exprs.append(f"{metric_expr} AS {self._quote_alias(alias)}")
+                        having_metric_expressions[metric_ref] = metric_expr
+                        having_metric_expressions.setdefault(measure_name, metric_expr)
                     else:
                         # Simple aggregation measures
                         # Check if this model needs symmetric aggregates
@@ -3224,6 +3721,8 @@ class SQLGenerator:
                             agg_expr = self._build_measure_aggregation_sql(model_name, measure)
 
                         select_exprs.append(f"{agg_expr} AS {self._quote_alias(alias)}")
+                        having_metric_expressions[metric_ref] = agg_expr
+                        having_metric_expressions.setdefault(measure_name, agg_expr)
                 else:
                     # Try as metric
                     metric = self.graph.get_metric(metric_ref)
@@ -3233,6 +3732,8 @@ class SQLGenerator:
                         select_exprs.append(f"{metric_expr} AS {self._quote_alias(metric.name)}")
                         output_aliases[metric_ref] = metric.name
                         output_aliases[metric.name] = metric.name
+                        having_metric_expressions[metric_ref] = metric_expr
+                        having_metric_expressions.setdefault(metric.name, metric_expr)
             else:
                 # It's a metric reference (just metric name)
                 metric = self.graph.get_metric(metric_ref)
@@ -3242,6 +3743,8 @@ class SQLGenerator:
                     select_exprs.append(f"{metric_expr} AS {self._quote_alias(metric.name)}")
                     output_aliases[metric_ref] = metric.name
                     output_aliases[metric.name] = metric.name
+                    having_metric_expressions[metric_ref] = metric_expr
+                    having_metric_expressions.setdefault(metric.name, metric_expr)
                 else:
                     raise ValueError(f"Metric {metric_ref} not found")
 
@@ -3273,8 +3776,6 @@ class SQLGenerator:
         where_filters, having_filters = self._split_where_having_filters(
             filters or [], [base_model_name] + other_models
         )
-        import re
-
         # Add WHERE clause (dimension filters only - metric-level filters are in CASE WHEN)
         query = self._add_where_filters_to_query(query, where_filters, [base_model_name] + other_models)
 
@@ -3294,21 +3795,7 @@ class SQLGenerator:
         # Add HAVING clause (metric filters applied after aggregation)
         if having_filters:
             for filter_expr in having_filters:
-                # Replace model.metric_name with metric_name (the aggregated column alias)
-                parsed_having = filter_expr
-                for model_name in [base_model_name] + other_models:
-                    model_obj = self.graph.get_model(model_name)
-                    # Replace model.field with just field (aggregated column name)
-                    pattern = f"{model_name}\\.([a-zA-Z_][a-zA-Z0-9_]*)"
-
-                    def replace_metric_ref(match):
-                        field_name = match.group(1)
-                        # Just use the metric name (it's the SELECT alias)
-                        return field_name
-
-                    parsed_having = re.sub(pattern, replace_metric_ref, parsed_having)
-
-                query = query.having(parsed_having)
+                query = query.having(self._rewrite_having_filter(filter_expr, having_metric_expressions))
 
         # Add ORDER BY
         if order_by:
@@ -3392,6 +3879,57 @@ class SQLGenerator:
             return offset_map[comparison_type].get(time_granularity, 1)
 
         return 1
+
+    @staticmethod
+    def _parse_period_interval(value: str | None) -> tuple[int, str] | None:
+        if not value:
+            return None
+        parts = value.strip().split()
+        if len(parts) != 2:
+            return None
+        try:
+            amount = int(parts[0])
+        except ValueError:
+            return None
+        unit = parts[1].lower().rstrip("s")
+        if amount <= 0 or unit not in {"day", "week", "month", "quarter", "year"}:
+            return None
+        if unit == "quarter":
+            return amount * 3, "month"
+        return amount, unit
+
+    def _comparison_period_interval(self, metric, time_granularity: str | None) -> tuple[int, str] | None:
+        explicit = self._parse_period_interval(metric.time_offset)
+        if explicit is not None:
+            return explicit
+        comparison_type = metric.comparison_type or "prior_period"
+        intervals = {
+            "dod": (1, "day"),
+            "wow": (1, "week"),
+            "mom": (1, "month"),
+            "qoq": (3, "month"),
+            "yoy": (1, "year"),
+        }
+        if comparison_type == "prior_period":
+            return (1, time_granularity) if time_granularity else None
+        return intervals.get(comparison_type)
+
+    def _exact_period_lookup_sql(
+        self,
+        value_expr: str,
+        time_expr: str,
+        partition_clause: str,
+        interval: tuple[int, str] | None,
+    ) -> str | None:
+        """Lookup a value at an exact calendar offset using a value-based frame."""
+        if interval is None or self.dialect not in {"duckdb", "postgres"}:
+            return None
+        amount, unit = interval
+        interval_sql = self._build_interval(str(amount), unit)
+        return (
+            f"MAX({value_expr}) OVER ({partition_clause}ORDER BY {time_expr} "
+            f"RANGE BETWEEN {interval_sql} PRECEDING AND {interval_sql} PRECEDING)"
+        )
 
     def _offset_window_to_lag_rows(self, offset_window: str | None, time_granularity: str | None) -> int:
         """Convert a ratio offset_window (e.g. '3 months') to a row-based LAG offset.
@@ -3631,7 +4169,10 @@ class SQLGenerator:
         if agg_func == "SUM":
             return f"SUM(SUM({raw_col})) OVER ()"
         if agg_func == "AVG":
-            return f"(SUM(SUM({raw_col})) OVER ()) / NULLIF(SUM(COUNT({raw_col})) OVER (), 0)"
+            return self._safe_divide_sql(
+                f"SUM(SUM({raw_col})) OVER ()",
+                f"SUM(COUNT({raw_col})) OVER ()",
+            )
         if agg_func == "MIN":
             return f"MIN(MIN({raw_col})) OVER ()"
         if agg_func == "MAX":
@@ -3793,7 +4334,7 @@ class SQLGenerator:
             num_expr = resolve_ratio_ref(metric.numerator)
             denom_expr = resolve_ratio_ref(metric.denominator)
 
-            return f"({num_expr}) / NULLIF({denom_expr}, 0)"
+            return self._safe_divide_sql(num_expr, denom_expr)
 
         elif metric.agg:
             # Graph-level simple aggregations (e.g., SUM(orders.amount))
@@ -4190,7 +4731,7 @@ class SQLGenerator:
             else:
                 dim_model_name = model_name
                 dim_name = dim_ref_str
-            alias = dim_name
+            alias = f"{dim_name}__{granularity}" if granularity else dim_name
 
             if alias in entity_dim_aliases:
                 continue  # Already included
@@ -5011,6 +5552,19 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
         def metric_ref_alias(metric_ref: str) -> str:
             return metric_ref.split(".", 1)[1] if "." in metric_ref else metric_ref
 
+        def advanced_output_alias(metric_ref: str, metric_obj=None) -> str:
+            if metric_ref in aliases:
+                return aliases[metric_ref]
+            if "." in metric_ref:
+                model_name, metric_name = metric_ref.split(".", 1)
+                try:
+                    model = self.graph.get_model(model_name)
+                except KeyError:
+                    model = None
+                if model and model.get_metric(metric_name) is metric_obj:
+                    return metric_name
+            return metric_ref
+
         def canonical_ref(metric_ref: str, model_context: str | None = None) -> str:
             if "." in metric_ref:
                 return metric_ref
@@ -5185,6 +5739,58 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
                 else:
                     add_unique(base_metrics, metric_ref)
 
+        parsed_dims = self._parse_dimension_refs(dimensions)
+        post_window_aliases: dict[str, str] = {}
+        for dim_ref, granularity in parsed_dims:
+            dim_name = dim_ref.split(".", 1)[1] if "." in dim_ref else dim_ref
+            output_name = f"{dim_name}__{granularity}" if granularity else dim_name
+            full_ref = f"{dim_ref}__{granularity}" if granularity else dim_ref
+            post_window_aliases[full_ref] = output_name
+            post_window_aliases[dim_ref] = output_name
+
+        advanced_metric_refs = {
+            *cumulative_metrics,
+            *time_comparison_metrics,
+            *offset_ratio_metrics,
+        }
+        for metric_ref in advanced_metric_refs:
+            metric_context = metric_ref.split(".", 1)[0] if "." in metric_ref else None
+            metric_obj, _ = resolve_metric_ref(metric_ref, metric_context)
+            output_name = advanced_output_alias(metric_ref, metric_obj)
+            post_window_aliases[metric_ref] = output_name
+            if "." not in metric_ref:
+                post_window_aliases.setdefault(metric_ref_alias(metric_ref), output_name)
+
+        def filter_requires_post_window(filter_expr: str) -> bool:
+            try:
+                parsed_filter = _parse_fragment(filter_expr, self.dialect)
+            except Exception:
+                return False
+            for column in parsed_filter.find_all(exp.Column):
+                full_ref = f"{column.table.replace('_cte', '')}.{column.name}" if column.table else column.name
+                if full_ref in advanced_metric_refs:
+                    return True
+                if not column.table:
+                    continue
+                model_name = column.table.replace("_cte", "")
+                try:
+                    model = self.graph.get_model(model_name)
+                except KeyError:
+                    continue
+                dimension_name = column.name.rsplit("__", 1)[0]
+                dimension = model.get_dimension(dimension_name)
+                if dimension and dimension.type == "time" and full_ref in post_window_aliases:
+                    return True
+            return False
+
+        inner_filters: list[str] = []
+        post_window_filters: list[str] = []
+        for filter_expr in filters or []:
+            if filter_requires_post_window(filter_expr):
+                post_window_filters.append(filter_expr)
+            else:
+                inner_filters.append(filter_expr)
+
         # When cumulative dependencies are needed to build time comparison base
         # expressions, precompute them in the inner query and skip re-computing
         # them in the outer window pass.
@@ -5248,14 +5854,11 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
         inner_query = self.generate(
             metrics=base_metrics,
             dimensions=dimensions,
-            filters=filters,
+            filters=inner_filters,
             order_by=None,  # Apply ordering in outer query
             limit=None,  # Apply limit in outer query
             use_preaggregations=use_preaggregations,
         )
-
-        # Parse dimensions for outer SELECT
-        parsed_dims = self._parse_dimension_refs(dimensions)
 
         def sql_identifier(name: str) -> str:
             import re
@@ -5318,7 +5921,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
                 denom_expr = build_time_comparison_base_expression(
                     metric_obj.denominator, resolved_context, visited.copy()
                 )
-                return f"({num_expr}) / NULLIF({denom_expr}, 0)"
+                return self._safe_divide_sql(num_expr, denom_expr)
 
             return metric_column(canon_ref)
 
@@ -5350,6 +5953,37 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
         # Track cumulative window expressions for inclusion in LAG CTE path
         cumulative_window_entries = []  # (window_expr, alias)
 
+        # Cumulative windows must restart for every requested non-time group.
+        # Without this partition, a query grouped by (date, region) accumulates
+        # one region's values into the next region's running/rolling result.
+        cumulative_partition_columns = []
+        for dim_ref, gran in parsed_dims:
+            dim_name = dim_ref.split(".")[1] if "." in dim_ref else dim_ref
+            model_name = dim_ref.split(".")[0] if "." in dim_ref else None
+            dimension = None
+            if model_name:
+                model = self.graph.get_model(model_name)
+                dimension = model.get_dimension(dim_name) if model else None
+            else:
+                matches = [
+                    candidate.get_dimension(dim_name)
+                    for candidate in self.graph.models.values()
+                    if candidate.get_dimension(dim_name) is not None
+                ]
+                if len(matches) == 1:
+                    dimension = matches[0]
+
+            if dimension is not None and dimension.type == "time":
+                continue
+            alias = f"{dim_name}__{gran}" if gran else dim_name
+            cumulative_partition_columns.append(f"base.{sql_identifier(alias)}")
+
+        def cumulative_window_clause(*, extra_partitions: list[str] | None = None) -> str:
+            partitions = [*cumulative_partition_columns, *(extra_partitions or [])]
+            if not partitions:
+                return ""
+            return f"PARTITION BY {', '.join(partitions)} "
+
         # Add cumulative metrics with window functions
         for m in cumulative_metrics:
             # Handle both qualified (model.measure) and unqualified references
@@ -5369,7 +6003,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
                         pass
                 # Use just the measure name as alias if it's model.measure, otherwise full name
                 # Quote to handle any special characters
-                metric_alias = self._quote_alias(measure_name if metric and "." not in metric.name else m)
+                metric_alias = self._quote_alias(advanced_output_alias(m, metric))
             else:
                 metric = self.graph.get_metric(m)
                 # Quote to handle dotted metric names
@@ -5404,7 +6038,10 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
             if metric.window_expression:
                 order_col = time_dim
                 frame = metric.window_frame or "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"
-                window_expr = f"{metric.window_expression} OVER (ORDER BY {order_col} {frame}) AS {metric_alias}"
+                window_value = (
+                    f"{metric.window_expression} OVER ({cumulative_window_clause()}ORDER BY {order_col} {frame})"
+                )
+                window_expr = f"{self._wrap_with_fill_nulls(window_value, metric)} AS {metric_alias}"
                 select_exprs.append(window_expr)
                 cumulative_window_entries.append((window_expr, metric_alias))
                 continue
@@ -5454,21 +6091,38 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
                 grain = metric.grain_to_date
                 partition = self._date_trunc(grain, time_dim)
 
-                window_expr = f"{agg_func}({base_col}) OVER (PARTITION BY {partition} ORDER BY {time_dim} ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS {metric_alias}"
+                window_value = (
+                    f"{agg_func}({base_col}) OVER ("
+                    f"{cumulative_window_clause(extra_partitions=[partition])}"
+                    f"ORDER BY {time_dim} ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"
+                )
             elif metric.window:
                 # Parse window (e.g., "7 days")
                 window_parts = metric.window.split()
                 if len(window_parts) == 2:
                     num, unit = window_parts
                     # For date-based windows, use RANGE
-                    window_expr = f"{agg_func}({base_col}) OVER (ORDER BY {time_dim} RANGE BETWEEN INTERVAL '{num} {unit}' PRECEDING AND CURRENT ROW) AS {metric_alias}"
+                    window_value = (
+                        f"{agg_func}({base_col}) OVER ("
+                        f"{cumulative_window_clause()}ORDER BY {time_dim} "
+                        f"RANGE BETWEEN INTERVAL '{num} {unit}' PRECEDING AND CURRENT ROW)"
+                    )
                 else:
                     # Fallback to rows
-                    window_expr = f"{agg_func}({base_col}) OVER (ORDER BY {time_dim} ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS {metric_alias}"
+                    window_value = (
+                        f"{agg_func}({base_col}) OVER ("
+                        f"{cumulative_window_clause()}ORDER BY {time_dim} "
+                        f"ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"
+                    )
             else:
                 # Running total (unbounded window)
-                window_expr = f"{agg_func}({base_col}) OVER (ORDER BY {time_dim} ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS {metric_alias}"
+                window_value = (
+                    f"{agg_func}({base_col}) OVER ("
+                    f"{cumulative_window_clause()}ORDER BY {time_dim} "
+                    f"ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"
+                )
 
+            window_expr = f"{self._wrap_with_fill_nulls(window_value, metric)} AS {metric_alias}"
             select_exprs.append(window_expr)
             cumulative_window_entries.append((window_expr, metric_alias))
 
@@ -5533,7 +6187,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
                                 time_dim = f"base.{dim_name}"
                                 if gran:
                                     time_dim = f"base.{dim_name}__{gran}"
-                                    time_dim_gran = gran
+                                time_dim_gran = gran or dim.granularity
                                 break
 
                 if not time_dim:
@@ -5573,14 +6227,26 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
                 else:
                     lag_input_expr = metric_column(base_ref)
 
-                # Calculate LAG offset
-                lag_offset = self._calculate_lag_offset(metric.comparison_type, time_dim_gran)
-
-                # Add LAG for base metric (quote alias to handle dotted names)
-                prev_value_alias = self._quote_alias(f"{m}_prev_value")
-                lag_selects.append(
-                    f"LAG({lag_input_expr}, {lag_offset}) OVER ({partition_clause}ORDER BY {time_dim}) AS {prev_value_alias}"
+                # Prefer an exact calendar-offset frame on capable dialects. Unlike
+                # row-count LAG, this returns NULL for a missing month/day and handles
+                # variable month lengths and leap years correctly.
+                exact_lookup = self._exact_period_lookup_sql(
+                    lag_input_expr,
+                    time_dim,
+                    partition_clause,
+                    (
+                        self._comparison_period_interval(metric, time_dim_gran)
+                        if time_dim_gran or metric.time_offset
+                        else None
+                    ),
                 )
+                if exact_lookup is None:
+                    lag_offset = self._calculate_lag_offset(metric.comparison_type, time_dim_gran)
+                    exact_lookup = f"LAG({lag_input_expr}, {lag_offset}) OVER ({partition_clause}ORDER BY {time_dim})"
+
+                # Add prior-period value (quote alias to handle dotted names)
+                prev_value_alias = self._quote_alias(f"{m}_prev_value")
+                lag_selects.append(f"{exact_lookup} AS {prev_value_alias}")
 
             # Add LAG expressions for each offset ratio metric
             for m in offset_ratio_metrics:
@@ -5631,13 +6297,24 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
                 # Get denominator alias
                 denom_alias = metric_ref_alias(metric.denominator)
 
-                # Add LAG for denominator - reference base.denom_alias since it's from inner query
-                # Quote alias to handle dotted names
-                lag_rows = self._offset_window_to_lag_rows(metric.offset_window, time_dim_gran)
-                prev_denom_alias = self._quote_alias(f"{m}_prev_denom")
-                lag_selects.append(
-                    f"LAG(base.{sql_identifier(denom_alias)}, {lag_rows}) OVER ({partition_clause}ORDER BY {time_dim}) AS {prev_denom_alias}"
+                # Add an exact calendar-offset denominator when the time grain is
+                # typed; retain row-LAG compatibility for legacy ungrained/VARCHAR
+                # time dimensions and dialects without interval RANGE frames.
+                denominator_expr = f"base.{sql_identifier(denom_alias)}"
+                interval = self._parse_period_interval(metric.offset_window) if time_dim_gran else None
+                prior_denominator = self._exact_period_lookup_sql(
+                    denominator_expr,
+                    time_dim,
+                    partition_clause,
+                    interval,
                 )
+                if prior_denominator is None:
+                    lag_rows = self._offset_window_to_lag_rows(metric.offset_window, time_dim_gran)
+                    prior_denominator = (
+                        f"LAG({denominator_expr}, {lag_rows}) OVER ({partition_clause}ORDER BY {time_dim})"
+                    )
+                prev_denom_alias = self._quote_alias(f"{m}_prev_denom")
+                lag_selects.append(f"{prior_denominator} AS {prev_denom_alias}")
 
             # Build intermediate CTE - inner_query already has all the columns we need
             # We need to add "base." prefix since we're wrapping inner_query in a FROM (inner_query) AS base
@@ -5664,19 +6341,21 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
 
                 # Quote aliases to handle dotted metric names
                 prev_value_col = self._quote_alias(f"{m}_prev_value")
-                final_alias = self._quote_alias(m)
+                final_alias = self._quote_alias(advanced_output_alias(m, metric))
 
                 # Build calculation based on calculation type
                 calc_type = metric.calculation or "percent_change"
                 if calc_type == "difference":
-                    expr = f"({base_alias} - {prev_value_col}) AS {final_alias}"
+                    value_expr = f"({base_alias} - {prev_value_col})"
                 elif calc_type == "percent_change":
-                    expr = f"(({base_alias} - {prev_value_col}) / NULLIF({prev_value_col}, 0) * 100) AS {final_alias}"
+                    division = self._safe_divide_sql(f"{base_alias} - {prev_value_col}", prev_value_col)
+                    value_expr = f"({division} * 100)"
                 elif calc_type == "ratio":
-                    expr = f"({base_alias} / NULLIF({prev_value_col}, 0)) AS {final_alias}"
+                    value_expr = f"({self._safe_divide_sql(base_alias, prev_value_col)})"
                 else:
                     raise ValueError(f"Unknown calculation type: {calc_type}")
 
+                expr = f"{self._wrap_with_fill_nulls(value_expr, metric)} AS {final_alias}"
                 final_selects.append(expr)
 
             # Add offset ratio metrics
@@ -5690,10 +6369,11 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
 
                 # Quote aliases to handle dotted metric names
                 prev_denom_col = self._quote_alias(f"{m}_prev_denom")
-                final_alias = self._quote_alias(m)
+                final_alias = self._quote_alias(advanced_output_alias(m, metric))
 
                 # Calculate ratio using the lagged value
-                offset_expr = f"{num_alias} / NULLIF({prev_denom_col}, 0) AS {final_alias}"
+                ratio_expr = self._safe_divide_sql(num_alias, prev_denom_col)
+                offset_expr = f"{self._wrap_with_fill_nulls(ratio_expr, metric)} AS {final_alias}"
                 final_selects.append(offset_expr)
 
             # Build final query
@@ -5703,6 +6383,25 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
             # Build outer query without LAG CTE
             select_expr_str = ",\n  ".join(select_exprs)
             outer_query = f"SELECT\n  {select_expr_str}\nFROM (\n{inner_query}\n) AS base"
+
+        if post_window_filters:
+            rewritten_filters: list[str] = []
+            for filter_expr in post_window_filters:
+                try:
+                    parsed_filter = _parse_fragment(filter_expr, self.dialect)
+                    for column in list(parsed_filter.find_all(exp.Column)):
+                        full_ref = f"{column.table.replace('_cte', '')}.{column.name}" if column.table else column.name
+                        output_name = post_window_aliases.get(full_ref)
+                        if output_name is None:
+                            continue
+                        column.set(
+                            "this", exp.to_identifier(output_name, quoted=not self._is_simple_identifier(output_name))
+                        )
+                        column.set("table", exp.to_identifier("windowed"))
+                    rewritten_filters.append(parsed_filter.sql(dialect=self.dialect))
+                except Exception:
+                    rewritten_filters.append(filter_expr)
+            outer_query = f"SELECT *\nFROM (\n{outer_query}\n) AS windowed\nWHERE {' AND '.join(rewritten_filters)}"
 
         # Add ORDER BY if specified
         if order_by:
@@ -5761,7 +6460,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
                 preagg,
                 (metric.denominator or "").split(".")[-1],
             )
-            return f"{numerator} / NULLIF({denominator}, 0)"
+            return self._safe_divide_sql(numerator, denominator)
         if metric.type == "derived" or (not metric.type and not metric.agg and metric.sql):
             return self._preaggregation_derived_metric_expression(model, preagg, metric)
         if metric.agg in {"sum", "count"}:
@@ -5769,7 +6468,7 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
         if metric.agg == "avg":
             matcher = PreAggregationMatcher(model)
             count_measure = matcher._find_count_measure_for_avg(metric, preagg.measures or []) or "count"
-            return f"SUM({raw_col}) / NULLIF(SUM({count_measure}_raw), 0)"
+            return self._safe_divide_sql(f"SUM({raw_col})", f"SUM({count_measure}_raw)")
         if metric.agg in {"min", "max"}:
             return f"{metric.agg.upper()}({raw_col})"
         return f"SUM({raw_col})"
@@ -5938,6 +6637,13 @@ FROM step_1{join_section}{final_group_by}{order_clause}{limit_clause}
                 return None, "multi_hop_remote_dimension_not_supported"
             if path[0].relationship != "many_to_one":
                 return None, "remote_dimension_not_many_to_one"
+            if path[0].custom_condition is not None:
+                # A join-key rollup contains only the relationship keys. Replacing a
+                # custom predicate with key equality would silently widen or narrow the
+                # joined population, so keep the direct semantic plan.
+                return None, "custom_join_predicate_not_supported"
+            if len(path[0].from_columns) != len(path[0].to_columns):
+                return None, "join_key_arity_mismatch"
             if remote_model_name and remote_model_name != dim_model_name:
                 return None, "multiple_remote_models_not_supported"
 

--- a/tests/metrics/test_advanced.py
+++ b/tests/metrics/test_advanced.py
@@ -169,6 +169,38 @@ def test_fill_nulls_with_string():
     assert gadget[1] is None
 
 
+def test_cumulative_fill_nulls_applies_after_window():
+    sales = Model(
+        name="sales",
+        sql="""
+            SELECT DATE '2024-01-01' AS day, NULL::INTEGER AS amount
+            UNION ALL SELECT DATE '2024-01-02', 5
+        """,
+        primary_key="day",
+        dimensions=[Dimension(name="day", sql="day", type="time", granularity="day")],
+        metrics=[Metric(name="amount", agg="sum", sql="amount")],
+    )
+    running_amount = Metric(
+        name="running_amount",
+        type="cumulative",
+        sql="sales.amount",
+        fill_nulls_with=0,
+    )
+    graph = SemanticGraph()
+    graph.add_model(sales)
+    graph.add_metric(running_amount)
+
+    sql = SQLGenerator(graph).generate(
+        metrics=["running_amount"],
+        dimensions=["sales.day"],
+        order_by=["sales.day"],
+    )
+    rows = df_rows(duckdb.connect(":memory:").execute(sql))
+
+    assert "COALESCE(SUM(base.amount) OVER" in sql
+    assert [row[2] for row in rows] == [0, 5]
+
+
 def test_offset_ratio_metric():
     """Test ratio metric with time offset (current / previous period)."""
     sales = Model(
@@ -222,6 +254,37 @@ def test_offset_ratio_metric():
     assert abs(rows[1][2] - 1.5) < 0.01  # Feb
     assert abs(rows[2][2] - 1.333) < 0.01  # Mar
     assert abs(rows[3][2] - 0.9) < 0.01  # Apr
+
+
+def test_offset_ratio_fill_nulls_applies_to_missing_prior_period():
+    sales = Model(
+        name="sales",
+        sql="""
+            SELECT DATE '2024-01-01' AS month, 100 AS revenue
+            UNION ALL SELECT DATE '2024-02-01', 150
+        """,
+        primary_key="month",
+        dimensions=[Dimension(name="month", sql="month", type="time", granularity="month")],
+        metrics=[Metric(name="revenue", agg="sum", sql="revenue")],
+    )
+    growth = Metric(
+        name="growth",
+        type="ratio",
+        numerator="sales.revenue",
+        denominator="sales.revenue",
+        offset_window="1 month",
+        fill_nulls_with=0,
+    )
+    graph = SemanticGraph()
+    graph.add_model(sales)
+    graph.add_metric(growth)
+
+    sql = SQLGenerator(graph).generate(metrics=["growth"], dimensions=["sales.month"])
+    rows = df_rows(duckdb.connect(":memory:").execute(sql))
+
+    assert "COALESCE(" in sql
+    assert rows[0][2] == 0
+    assert abs(rows[1][2] - 1.5) < 0.01
 
 
 def test_offset_ratio_metric_multi_period():
@@ -311,8 +374,7 @@ def test_offset_ratio_metric_uses_base_granularity():
     # Query the base time dimension WITHOUT an explicit __day suffix.
     sql = generator.generate(metrics=["growth"], dimensions=["sales.day"])
 
-    # "7 days" on the dimension's day grain maps to a 7-row LAG, not a 1-row month fallback.
-    assert "LAG(base.revenue, 7)" in sql
+    assert "RANGE BETWEEN INTERVAL '7 day' PRECEDING AND INTERVAL '7 day' PRECEDING" in sql
 
     conn = duckdb.connect(":memory:")
     rows = df_rows(conn.execute(sql))
@@ -542,6 +604,104 @@ def test_mom_difference():
     assert rows[1][2] == 50  # Feb
     assert rows[2][2] == -30  # Mar
     assert rows[3][2] == 60  # Apr
+
+
+def test_time_comparison_fill_nulls_applies_to_missing_prior_period():
+    sales = Model(
+        name="sales",
+        sql="""
+            SELECT DATE '2024-01-01' AS month, 100 AS revenue
+            UNION ALL SELECT DATE '2024-02-01', 150
+        """,
+        primary_key="month",
+        dimensions=[Dimension(name="month", sql="month", type="time", granularity="month")],
+        metrics=[Metric(name="revenue", agg="sum", sql="revenue")],
+    )
+    change = Metric(
+        name="change",
+        type="time_comparison",
+        base_metric="sales.revenue",
+        comparison_type="mom",
+        calculation="difference",
+        fill_nulls_with=0,
+    )
+    graph = SemanticGraph()
+    graph.add_model(sales)
+    graph.add_metric(change)
+
+    sql = SQLGenerator(graph).generate(metrics=["change"], dimensions=["sales.month"])
+    rows = df_rows(duckdb.connect(":memory:").execute(sql))
+
+    assert "COALESCE((revenue - change_prev_value), 0)" in sql
+    assert [row[2] for row in rows] == [0, 50]
+
+
+def test_time_filter_is_applied_after_comparison_history():
+    sales = Model(
+        name="sales",
+        sql="""
+            SELECT '2023-12-01'::DATE AS sale_date, 100 AS revenue
+            UNION ALL SELECT '2024-01-01'::DATE, 150
+            UNION ALL SELECT '2024-02-01'::DATE, 210
+        """,
+        primary_key="sale_date",
+        dimensions=[Dimension(name="sale_date", sql="sale_date", type="time")],
+        metrics=[Metric(name="revenue", agg="sum", sql="revenue")],
+    )
+    comparison = Metric(
+        name="revenue_mom",
+        type="time_comparison",
+        base_metric="sales.revenue",
+        comparison_type="mom",
+        calculation="difference",
+    )
+    graph = SemanticGraph()
+    graph.add_model(sales)
+    graph.add_metric(comparison)
+
+    sql = SQLGenerator(graph).generate(
+        metrics=["revenue_mom"],
+        dimensions=["sales.sale_date__month"],
+        filters=["sales.sale_date__month = DATE '2024-02-01'"],
+    )
+    rows = df_rows(duckdb.connect(":memory:").execute(sql))
+
+    assert len(rows) == 1
+    assert rows[0][0].isoformat() == "2024-02-01"
+    assert rows[0][1:] == (210, 60)
+
+
+def test_month_comparison_does_not_use_previous_available_sparse_row():
+    sales = Model(
+        name="sales",
+        sql="""
+            SELECT DATE '2024-01-01' AS sale_date, 100 AS revenue
+            UNION ALL SELECT DATE '2024-03-01', 180
+        """,
+        primary_key="sale_date",
+        dimensions=[Dimension(name="sale_date", sql="sale_date", type="time")],
+        metrics=[Metric(name="revenue", agg="sum", sql="revenue")],
+    )
+    comparison = Metric(
+        name="revenue_mom",
+        type="time_comparison",
+        base_metric="sales.revenue",
+        comparison_type="mom",
+        calculation="difference",
+    )
+    graph = SemanticGraph()
+    graph.add_model(sales)
+    graph.add_metric(comparison)
+
+    sql = SQLGenerator(graph).generate(
+        metrics=["revenue_mom"],
+        dimensions=["sales.sale_date__month"],
+    )
+    rows = df_rows(duckdb.connect(":memory:").execute(sql))
+
+    assert "RANGE BETWEEN INTERVAL '1 month' PRECEDING AND INTERVAL '1 month' PRECEDING" in sql
+    assert rows[1][0].isoformat() == "2024-03-01"
+    assert rows[1][2] is None
 
 
 def test_dotted_metric_name_alias():

--- a/tests/metrics/test_cohort.py
+++ b/tests/metrics/test_cohort.py
@@ -136,6 +136,42 @@ def test_cohort_with_dimension():
     assert result["EU"] == 1
 
 
+def test_cohort_with_time_grain_uses_grained_output_alias():
+    """Grained cohort dimensions remain addressable by their public output name."""
+    events = Model(
+        name="events",
+        sql="""
+            SELECT 1 AS user_id, 'web' AS platform, DATE '2024-01-01' AS ts
+            UNION ALL SELECT 1, 'mobile', DATE '2024-01-02'
+            UNION ALL SELECT 2, 'web', DATE '2024-02-01'
+            UNION ALL SELECT 2, 'mobile', DATE '2024-02-02'
+            UNION ALL SELECT 3, 'web', DATE '2024-02-03'
+        """,
+        primary_key="user_id",
+        dimensions=[
+            Dimension(name="user_id", sql="user_id", type="categorical"),
+            Dimension(name="platform", sql="platform", type="categorical"),
+            Dimension(name="ts", sql="ts", type="time", granularity="day"),
+        ],
+        metrics=[_make_multi_platform_metric()],
+    )
+    graph = SemanticGraph()
+    graph.add_model(events)
+
+    sql = SQLGenerator(graph).generate(
+        metrics=["events.multi_platform_users"],
+        dimensions=["events.ts__month"],
+        order_by=["events.ts__month"],
+    )
+    result = duckdb.connect(":memory:").execute(sql)
+
+    assert [column[0] for column in result.description] == ["ts__month", "multi_platform_users"]
+    assert [(row[0].isoformat(), row[1]) for row in df_rows(result)] == [
+        ("2024-01-01", 1),
+        ("2024-02-01", 1),
+    ]
+
+
 def test_cohort_outer_agg_without_sql_raises():
     """Non-count outer agg without sql should raise, not emit SUM(*)."""
     events = _make_events_model()

--- a/tests/metrics/test_cumulative.py
+++ b/tests/metrics/test_cumulative.py
@@ -8,6 +8,7 @@ import duckdb
 import pytest
 
 from sidemantic import Dimension, Metric, Model
+from tests.utils import fetch_dicts
 
 
 @pytest.fixture
@@ -169,6 +170,55 @@ def test_cumulative_with_regular_metric(timeseries_db, layer):
     # Day 3
     assert df["total_revenue"].iloc[2] == 200.00
     assert df["running_total"].iloc[2] == 450.00
+
+
+def test_cumulative_partitions_by_requested_non_time_dimensions(layer):
+    """Running totals restart for each categorical group in the query grain."""
+    layer.conn.execute("""
+        CREATE TABLE regional_orders (
+            order_id INTEGER,
+            order_date DATE,
+            region VARCHAR,
+            amount INTEGER
+        )
+    """)
+    layer.conn.execute("""
+        INSERT INTO regional_orders VALUES
+            (1, DATE '2024-01-01', 'North', 10),
+            (2, DATE '2024-01-02', 'North', 20),
+            (3, DATE '2024-01-01', 'South', 100),
+            (4, DATE '2024-01-02', 'South', 200)
+    """)
+    layer.add_model(
+        Model(
+            name="regional_orders",
+            table="regional_orders",
+            primary_key="order_id",
+            dimensions=[
+                Dimension(name="order_date", type="time", granularity="day"),
+                Dimension(name="region", type="categorical"),
+            ],
+            metrics=[Metric(name="daily_revenue", agg="sum", sql="amount")],
+        )
+    )
+    layer.add_metric(
+        Metric(name="regional_running_revenue", type="cumulative", sql="regional_orders.daily_revenue")
+    )
+
+    rows = fetch_dicts(
+        layer.query(
+            metrics=["regional_running_revenue"],
+            dimensions=["regional_orders.order_date", "regional_orders.region"],
+            order_by=["regional_orders.region", "regional_orders.order_date"],
+        )
+    )
+
+    assert [(str(row["order_date"]), row["region"], row["regional_running_revenue"]) for row in rows] == [
+        ("2024-01-01", "North", 10),
+        ("2024-01-02", "North", 30),
+        ("2024-01-01", "South", 100),
+        ("2024-01-02", "South", 300),
+    ]
 
 
 def test_rolling_average(timeseries_db, layer):

--- a/tests/metrics/test_derived.py
+++ b/tests/metrics/test_derived.py
@@ -72,6 +72,29 @@ def test_simple_derived_metric(layer, orders_db):
     assert records[0]["revenue_per_order"] == 187.5
 
 
+def test_postgres_ratio_casts_integer_numerator_before_division(layer):
+    layer.add_model(
+        Model(
+            name="events",
+            table="events",
+            primary_key="id",
+            metrics=[
+                Metric(name="matched", agg="count", sql="matched_id"),
+                Metric(name="total", agg="count"),
+                Metric(name="match_rate", type="ratio", numerator="matched", denominator="total"),
+            ],
+        )
+    )
+
+    sql = layer.compile(metrics=["events.match_rate"], dialect="postgres")
+
+    assert "CAST(" in sql
+    assert "matched_raw" in sql
+    assert "AS DOUBLE PRECISION" in sql
+    assert "/ NULLIF(" in sql
+    assert "total_raw" in sql
+
+
 def test_derived_metric_by_dimension(layer, orders_db):
     """Test derived metric grouped by dimension."""
     layer.conn = orders_db

--- a/tests/metrics/test_filters.py
+++ b/tests/metrics/test_filters.py
@@ -286,7 +286,7 @@ def test_query_level_metric_filters_use_having(layer):
 
     # Should have HAVING clause, not WHERE clause with revenue_raw
     assert "HAVING" in sql
-    assert "revenue > 100" in sql
+    assert "SUM(orders_cte.revenue_raw) > 100" in sql
     # Should NOT filter on raw column before aggregation
     assert "revenue_raw > 100" not in sql
 
@@ -351,7 +351,87 @@ def test_mixed_filters_separate_where_and_having(layer):
     assert "WHERE" in sql
     assert "status = 'completed'" in sql
     assert "HAVING" in sql
-    assert "revenue > 100" in sql
+    assert "SUM(orders_cte.revenue_raw) > 100" in sql
+
+
+def test_postgres_having_repeats_aggregate_instead_of_select_alias(layer):
+    layer.add_model(
+        Model(
+            name="orders",
+            table="orders_table",
+            primary_key="order_id",
+            dimensions=[Dimension(name="region", type="categorical")],
+            metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        )
+    )
+
+    sql = layer.compile(
+        metrics=["orders.revenue"],
+        dimensions=["orders.region"],
+        filters=["orders.revenue > 100"],
+        dialect="postgres",
+    )
+
+    having_sql = sql.split("HAVING", 1)[1]
+    assert "SUM(orders_cte.revenue_raw) > 100" in having_sql
+    assert "HAVING revenue" not in sql
+
+
+def test_structured_filters_resolve_grained_and_computed_dimensions_before_where():
+    layer = SemanticLayer()
+    layer.add_model(
+        Model(
+            name="events",
+            table="events",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="created_at", type="time", sql="occurred_at", granularity="day"),
+                Dimension(name="gross", type="numeric", sql="unit_price * quantity"),
+                Dimension(name="category", type="categorical"),
+            ],
+            metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        )
+    )
+    layer.conn.execute(
+        """
+        CREATE TABLE events (
+            id INTEGER,
+            occurred_at TIMESTAMP,
+            unit_price DOUBLE,
+            quantity INTEGER,
+            category VARCHAR,
+            amount DOUBLE
+        );
+        INSERT INTO events VALUES
+            (1, '2024-01-15 12:00:00', 5, 2, 'A', 10),
+            (2, '2024-02-10 08:00:00', 12, 2, 'A', 24),
+            (3, '2024-02-12 08:00:00', 4, 2, 'B', 8);
+        """
+    )
+    filters = [
+        "events.created_at__month = DATE '2024-02-01'",
+        "events.gross >= 20",
+    ]
+
+    postgres_sql = layer.compile(
+        metrics=["events.revenue"],
+        dimensions=["events.category"],
+        filters=filters,
+        dialect="postgres",
+    )
+    where_sql = postgres_sql.split("WHERE", 1)[1]
+    assert "created_at__month" not in where_sql
+    assert "events.gross" not in where_sql
+    assert "DATE_TRUNC('MONTH', occurred_at)" in where_sql
+    assert "unit_price * quantity >= 20" in where_sql
+
+    assert df_rows(
+        layer.query(
+            metrics=["events.revenue"],
+            dimensions=["events.category"],
+            filters=filters,
+        )
+    ) == [("A", 24.0)]
 
 
 def test_metric_level_filters_use_case_when(layer):

--- a/tests/metrics/test_non_additive_guard.py
+++ b/tests/metrics/test_non_additive_guard.py
@@ -3,10 +3,9 @@
 A measure with ``non_additive_dimension`` must be aggregated over only the rows at
 the last (or first) value of that time dimension per group -- e.g. an account-balance
 snapshot summed across accounts but NOT double-counted across days. The generator
-implements this by injecting a ``QUALIFY`` into the owning model's CTE for QUALIFY
-dialects (DuckDB, Snowflake, BigQuery, ...). It raises ``UnsupportedMetricError`` only
-for cases it does not implement: a dialect without QUALIFY, or the combination of
-semi-additive handling with fan-out symmetric aggregation on the same model.
+uses per-metric window markers after joined rows are deduplicated at the owning
+model's typed primary-key grain, so snapshot metrics and ordinary additive metrics
+can share a query without filtering each other's source rows.
 
 ``allow_non_additive_unsafe=True`` skips the rewrite entirely and aggregates naively
 (over ALL snapshots, i.e. the old, incorrect behavior).
@@ -94,7 +93,8 @@ def test_semi_additive_value_is_last_snapshot():
     # Semi-additive: sum of the last snapshot per account (global last-date window
     # collapses to the single latest snapshot when no other grouping is requested).
     sql = layer.compile(metrics=["accounts.balance"])
-    assert "QUALIFY" in sql
+    assert "__sidemantic_snapshot_field" in sql
+    assert "OVER (" in sql
 
     # Grouped by account: last balance per account, summed -> 150 + 70 + 33 = 253.
     rows = layer.query(
@@ -150,9 +150,9 @@ def test_grouping_by_non_additive_dimension_is_additive():
     layer.add_model(_model(non_additive=True))
     _seed(layer)
 
-    # No QUALIFY should be emitted -- each snapshot_date bucket stands on its own.
+    # No snapshot window should be emitted -- each snapshot_date bucket stands on its own.
     sql = layer.compile(metrics=["accounts.balance"], dimensions=["accounts.snapshot_date"])
-    assert "QUALIFY" not in sql
+    assert "__sidemantic_snapshot_field" not in sql
 
     rows = layer.query(
         metrics=["accounts.balance"], dimensions=["accounts.snapshot_date"], order_by=["accounts.snapshot_date"]
@@ -168,8 +168,8 @@ def test_escape_hatch_reverts_to_naive():
     _seed(layer)
 
     sql = layer.compile(metrics=["accounts.balance"], dimensions=["accounts.account_id"])
-    # No QUALIFY -> aggregates naively over all snapshots (over-counted, unsafe).
-    assert "QUALIFY" not in sql
+    # No snapshot marker -> aggregates naively over all snapshots (over-counted, unsafe).
+    assert "__sidemantic_snapshot_field" not in sql
     rows = layer.query(
         metrics=["accounts.balance"], dimensions=["accounts.account_id"], order_by=["accounts.account_id"]
     ).fetchall()
@@ -182,7 +182,7 @@ def test_query_without_non_additive_metric_unaffected():
     # revenue has no non_additive_dimension, so querying it alone must not raise.
     sql = layer.compile(metrics=["accounts.revenue"], dimensions=["accounts.region"])
     assert "accounts" in sql.lower()
-    assert "QUALIFY" not in sql
+    assert "__sidemantic_snapshot_field" not in sql
 
 
 def test_model_without_non_additive_metric_unaffected():
@@ -190,20 +190,18 @@ def test_model_without_non_additive_metric_unaffected():
     layer.add_model(_model(non_additive=False))
     sql = layer.compile(metrics=["accounts.balance"], dimensions=["accounts.region"])
     assert "accounts" in sql.lower()
-    assert "QUALIFY" not in sql
+    assert "__sidemantic_snapshot_field" not in sql
 
 
-def test_non_qualify_dialect_raises_cleanly():
-    """A dialect without QUALIFY (e.g. postgres) is rejected, not served wrong SQL."""
+def test_semi_additive_compiles_without_qualify_on_postgres():
+    """The portable nested-window shape works on dialects without QUALIFY."""
     layer = SemanticLayer()
     layer.add_model(_model(non_additive=True))
     gen = SQLGenerator(layer.graph, dialect="postgres")
-    with pytest.raises(UnsupportedMetricError) as exc:
-        gen.generate(metrics=["accounts.balance"], dimensions=["accounts.region"])
-    msg = str(exc.value)
-    assert "postgres" in msg
-    assert "QUALIFY" in msg
-    assert "allow_non_additive_unsafe" in msg
+    sql = gen.generate(metrics=["accounts.balance"], dimensions=["accounts.region"])
+
+    assert "OVER (PARTITION BY" in sql
+    assert "QUALIFY" not in sql
 
 
 def test_semi_additive_plus_fanout_symmetric_aggregate_raises():
@@ -248,8 +246,7 @@ def test_semi_additive_plus_fanout_symmetric_aggregate_raises():
     with pytest.raises(UnsupportedMetricError) as exc:
         layer.compile(metrics=["accounts.balance", "transactions.amount"], dimensions=["accounts.region"])
     msg = str(exc.value).lower()
-    assert "symmetric" in msg or "fan-out" in msg
-    assert "compose" in msg
+    assert "multiple metric models" in msg
 
 
 def test_adapter_round_trips_non_additive_dimension():
@@ -308,10 +305,8 @@ def test_semi_additive_window_groupings_partition(monkeypatch):
     assert rows == {"east": 110, "west": 210}
 
 
-def test_conflicting_semi_additive_metrics_raise():
+def test_opening_and_closing_snapshot_metrics_compose():
     from sidemantic import Dimension, Metric, Model, SemanticLayer
-    from sidemantic.core.semantic_layer import UnsupportedMetricError
-
     layer = SemanticLayer()
     con = layer.adapter.conn
     con.execute("CREATE TABLE bal (account VARCHAR, day DATE, balance INTEGER)")
@@ -332,12 +327,16 @@ def test_conflicting_semi_additive_metrics_raise():
             ],
         )
     )
-    with pytest.raises(UnsupportedMetricError, match="conflicting"):
-        layer.compile(metrics=["bal.closing", "bal.opening"])
+    sql = layer.compile(metrics=["bal.closing", "bal.opening"])
+    rows = layer.query(metrics=["bal.closing", "bal.opening"]).fetchall()
+
+    assert "MAX(" in sql
+    assert "MIN(" in sql
+    assert rows == [(110, 100)]
 
 
 def test_graph_metric_wrapping_semi_additive_measure_is_planned():
-    """PR review: a graph metric wrapping a non_additive measure must still emit the QUALIFY."""
+    """A graph metric wrapping a non-additive measure retains its snapshot plan."""
     from sidemantic import Dimension, Metric, Model, SemanticLayer
 
     layer = SemanticLayer()
@@ -362,5 +361,62 @@ def test_graph_metric_wrapping_semi_additive_measure_is_planned():
     )
     layer.add_metric(Metric(name="wrapped_balance", sql="bal.total_balance"))
     sql = layer.compile(metrics=["wrapped_balance"], dimensions=["bal.account"])
-    assert "QUALIFY" in sql
+    assert "__sidemantic_snapshot_field" in sql
     assert dict(layer.query(metrics=["wrapped_balance"], dimensions=["bal.account"]).fetchall()) == {"A": 110, "B": 210}
+
+
+def test_semi_additive_and_additive_metrics_keep_independent_row_sets():
+    """A snapshot metric must not remove rows from additive sibling metrics."""
+    layer = SemanticLayer()
+    layer.add_model(_model(non_additive=True))
+    _seed(layer)
+
+    rows = layer.query(
+        metrics=["accounts.balance", "accounts.revenue"],
+        dimensions=["accounts.account_id"],
+        order_by=["accounts.account_id"],
+    ).fetchall()
+
+    assert rows == [("A", 150.0, 2.0), ("B", 70.0, 2.0), ("C", 33.0, 2.0)]
+
+
+def test_semi_additive_partition_can_use_a_related_dimension():
+    """Joined dimensions participate in the snapshot window at the requested grain."""
+    layer = SemanticLayer()
+    layer.adapter.execute("CREATE TABLE balances (id INT, customer_id INT, day DATE, balance INT, activity INT)")
+    layer.adapter.execute(
+        """INSERT INTO balances VALUES
+        (1, 1, DATE '2026-01-01', 100, 1), (2, 1, DATE '2026-01-02', 110, 1),
+        (3, 2, DATE '2026-01-01', 200, 1), (4, 2, DATE '2026-01-03', 230, 1)"""
+    )
+    layer.adapter.execute("CREATE TABLE customers (id INT, region VARCHAR)")
+    layer.adapter.execute("INSERT INTO customers VALUES (1, 'east'), (2, 'west')")
+    layer.add_model(
+        Model(
+            name="balances",
+            table="balances",
+            primary_key="id",
+            relationships=[Relationship(name="customers", type="many_to_one", foreign_key="customer_id")],
+            dimensions=[Dimension(name="day", type="time", granularity="day")],
+            metrics=[
+                Metric(name="ending_balance", agg="sum", sql="balance", non_additive_dimension="day"),
+                Metric(name="activity", agg="sum", sql="activity"),
+            ],
+        )
+    )
+    layer.add_model(
+        Model(
+            name="customers",
+            table="customers",
+            primary_key="id",
+            dimensions=[Dimension(name="region", type="categorical")],
+        )
+    )
+
+    rows = layer.query(
+        metrics=["balances.ending_balance", "balances.activity"],
+        dimensions=["customers.region"],
+        order_by=["customers.region"],
+    ).fetchall()
+
+    assert rows == [("east", 110, 2), ("west", 230, 2)]

--- a/tests/metrics/test_symmetric_aggs.py
+++ b/tests/metrics/test_symmetric_aggs.py
@@ -1,9 +1,11 @@
 """Tests for symmetric aggregates (fan-out join handling)."""
 
 import duckdb
+import pytest
 
 from sidemantic.core.model import Dimension, Metric, Model, Relationship
 from sidemantic.core.semantic_graph import SemanticGraph
+from sidemantic.core.semantic_layer import UnsupportedMetricError
 from sidemantic.core.symmetric_aggregate import build_symmetric_aggregate_sql
 from sidemantic.sql.generator import SQLGenerator
 from tests.utils import fetch_rows
@@ -326,6 +328,322 @@ def test_symmetric_aggregates_with_data():
     conn.close()
 
 
+def test_fanout_isolates_typed_entity_rows_for_double_sum_avg_and_nulls():
+    """Fanout safety uses typed PK isolation, not lossy hash arithmetic.
+
+    Explicit DOUBLE values used to be added to a roughly 1e31 hash term, which
+    made DuckDB return enormous negative SUM/AVG results through cancellation.
+    The all-NULL group also changed from SQL NULL to zero merely because a
+    one-to-many dimension was present.
+    """
+    conn = duckdb.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE raw_orders (
+            id BIGINT PRIMARY KEY,
+            amount DOUBLE
+        )
+    """)
+    conn.execute("""
+        INSERT INTO raw_orders VALUES
+            (1, 100.25),
+            (2, 50.75),
+            (3, NULL)
+    """)
+    conn.execute("""
+        CREATE TABLE raw_items AS
+        SELECT * FROM (VALUES
+            (1, 1, 'paid'),
+            (2, 1, 'paid'),
+            (3, 2, 'paid'),
+            (4, 3, 'null-only')
+        ) AS t(id, order_id, category)
+    """)
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="raw_orders",
+            primary_key="id",
+            metrics=[
+                Metric(name="revenue", agg="sum", sql="amount"),
+                Metric(name="average_order_value", agg="avg", sql="amount"),
+            ],
+            relationships=[Relationship(name="items", type="one_to_many", sql="id", foreign_key="order_id")],
+        )
+    )
+    graph.add_model(
+        Model(
+            name="items",
+            table="raw_items",
+            primary_key="id",
+            dimensions=[Dimension(name="category", type="categorical")],
+            relationships=[Relationship(name="orders", type="many_to_one", foreign_key="order_id")],
+        )
+    )
+
+    sql = SQLGenerator(graph).generate(
+        metrics=["orders.revenue", "orders.average_order_value"],
+        dimensions=["items.category"],
+        order_by=["items.category"],
+    )
+    rows = conn.execute(sql).fetchall()
+
+    assert "HASH(" not in sql
+    assert "SELECT DISTINCT" in sql
+    assert rows == [("null-only", None, None), ("paid", 151.0, 75.5)]
+    conn.close()
+
+
+def test_fanout_evaluates_complete_sql_over_deduplicated_entity_rows():
+    """Opaque imported aggregates retain their formula without counting join copies."""
+    conn = duckdb.connect(":memory:")
+    conn.execute("CREATE TABLE raw_orders AS SELECT * FROM (VALUES (1, 100.0), (2, 200.0)) t(id, amount)")
+    conn.execute(
+        "CREATE TABLE raw_items AS "
+        "SELECT * FROM (VALUES (1, 1, 'all'), (2, 1, 'all'), (3, 2, 'all')) t(id, order_id, category)"
+    )
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="raw_orders",
+            primary_key="id",
+            metrics=[
+                Metric(
+                    name="average_order_value",
+                    sql="SUM({model}.amount) / COUNT(*)",
+                    sql_is_complete=True,
+                ),
+                Metric(name="opaque_order_count", sql="COUNT(*)", sql_is_complete=True),
+            ],
+            relationships=[Relationship(name="items", type="one_to_many", sql="id", foreign_key="order_id")],
+        )
+    )
+    graph.add_model(
+        Model(
+            name="items",
+            table="raw_items",
+            primary_key="id",
+            dimensions=[Dimension(name="category", type="categorical")],
+            relationships=[Relationship(name="orders", type="many_to_one", foreign_key="order_id")],
+        )
+    )
+
+    sql = SQLGenerator(graph).generate(
+        metrics=["orders.average_order_value", "orders.opaque_order_count"],
+        dimensions=["items.category"],
+    )
+
+    assert "SELECT DISTINCT" in sql
+    assert conn.execute(sql).fetchall() == [("all", 150.0, 2)]
+
+
+def test_fanout_rejects_filtered_zero_column_complete_sql():
+    """A filtered COUNT(*) fails clearly when its filter cannot be moved into entity rows."""
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="raw_orders",
+            primary_key="id",
+            metrics=[
+                Metric(
+                    name="completed_count",
+                    sql="COUNT(*)",
+                    sql_is_complete=True,
+                    filters=["{model}.status = 'completed'"],
+                )
+            ],
+            relationships=[Relationship(name="items", type="one_to_many", sql="id", foreign_key="order_id")],
+        )
+    )
+    graph.add_model(
+        Model(
+            name="items",
+            table="raw_items",
+            primary_key="id",
+            dimensions=[Dimension(name="category", type="categorical")],
+            relationships=[Relationship(name="orders", type="many_to_one", foreign_key="order_id")],
+        )
+    )
+
+    with pytest.raises(UnsupportedMetricError, match="cannot be evaluated safely"):
+        SQLGenerator(graph).generate(
+            metrics=["orders.completed_count"],
+            dimensions=["items.category"],
+        )
+
+
+def test_fanout_typed_composite_keys_do_not_collide_on_delimiters():
+    """Composite keys remain separate even when delimiter concatenation collides."""
+    conn = duckdb.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE raw_orders AS
+        SELECT * FROM (VALUES
+            ('a|b', 'c', 100.0::DOUBLE),
+            ('a', 'b|c', 200.0::DOUBLE)
+        ) AS t(part_a, part_b, amount)
+    """)
+    conn.execute("""
+        CREATE TABLE raw_items AS
+        SELECT * FROM (VALUES
+            (1, 'a|b', 'c', 'all'),
+            (2, 'a|b', 'c', 'all'),
+            (3, 'a', 'b|c', 'all')
+        ) AS t(id, part_a, part_b, category)
+    """)
+
+    join_sql = "{from}.part_a = {to}.part_a AND {from}.part_b = {to}.part_b"
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="raw_orders",
+            primary_key=["part_a", "part_b"],
+            metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+            relationships=[Relationship(name="items", type="one_to_many", sql=join_sql)],
+        )
+    )
+    graph.add_model(
+        Model(
+            name="items",
+            table="raw_items",
+            primary_key="id",
+            dimensions=[Dimension(name="category", type="categorical")],
+            relationships=[Relationship(name="orders", type="many_to_one", sql=join_sql)],
+        )
+    )
+
+    sql = SQLGenerator(graph).generate(metrics=["orders.revenue"], dimensions=["items.category"])
+    assert conn.execute(sql).fetchall() == [("all", 300.0)]
+    assert "CONCAT(" not in sql
+    conn.close()
+
+
+def test_filter_only_sibling_fanout_is_deduplicated_for_non_base_metric():
+    """A one-to-many model introduced only by WHERE cannot multiply a sibling metric."""
+    conn = duckdb.connect(":memory:")
+    conn.execute("CREATE TABLE customers AS SELECT * FROM (VALUES (1, 'east')) AS t(id, region)")
+    conn.execute("""
+        CREATE TABLE orders AS
+        SELECT * FROM (VALUES (1, 1, 100), (2, 1, 50)) AS t(id, customer_id, amount)
+    """)
+    conn.execute("""
+        CREATE TABLE tickets AS
+        SELECT * FROM (VALUES
+            (1, 1, 'open'),
+            (2, 1, 'open'),
+            (3, 1, 'closed')
+        ) AS t(id, customer_id, kind)
+    """)
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="customers",
+            table="customers",
+            primary_key="id",
+            dimensions=[Dimension(name="region", type="categorical")],
+            relationships=[
+                Relationship(name="orders", type="one_to_many", sql="id", foreign_key="customer_id"),
+                Relationship(name="tickets", type="one_to_many", sql="id", foreign_key="customer_id"),
+            ],
+        )
+    )
+    graph.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            primary_key="id",
+            metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+            relationships=[Relationship(name="customers", type="many_to_one", foreign_key="customer_id")],
+        )
+    )
+    graph.add_model(
+        Model(
+            name="tickets",
+            table="tickets",
+            primary_key="id",
+            dimensions=[Dimension(name="kind", type="categorical")],
+            relationships=[Relationship(name="customers", type="many_to_one", foreign_key="customer_id")],
+        )
+    )
+
+    sql = SQLGenerator(graph).generate(
+        metrics=["orders.revenue"],
+        dimensions=["customers.region"],
+        filters=["tickets.kind = 'open'"],
+    )
+    assert conn.execute(sql).fetchall() == [("east", 150)]
+    assert "SELECT DISTINCT" in sql
+    conn.close()
+
+
+def test_derived_and_ratio_metrics_reuse_fanout_safe_leaf_aggregates():
+    """Calculated metrics compose from deduplicated leaves instead of bypassing them."""
+    conn = duckdb.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE raw_orders AS
+        SELECT * FROM (VALUES (1, 100.0::DOUBLE), (2, 200.0::DOUBLE)) AS t(id, amount)
+    """)
+    conn.execute("""
+        CREATE TABLE raw_items AS
+        SELECT * FROM (VALUES
+            (1, 1, 'all'),
+            (2, 1, 'all'),
+            (3, 2, 'all')
+        ) AS t(id, order_id, category)
+    """)
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="raw_orders",
+            primary_key="id",
+            metrics=[
+                Metric(name="revenue", agg="sum", sql="amount"),
+                Metric(name="order_count", agg="count"),
+                Metric(name="double_revenue", type="derived", sql="revenue * 2"),
+            ],
+            relationships=[Relationship(name="items", type="one_to_many", sql="id", foreign_key="order_id")],
+        )
+    )
+    graph.add_model(
+        Model(
+            name="items",
+            table="raw_items",
+            primary_key="id",
+            dimensions=[Dimension(name="category", type="categorical")],
+            relationships=[Relationship(name="orders", type="many_to_one", foreign_key="order_id")],
+        )
+    )
+    graph.add_metric(
+        Metric(
+            name="average_order_value",
+            type="ratio",
+            numerator="orders.revenue",
+            denominator="orders.order_count",
+        )
+    )
+
+    sql = SQLGenerator(graph).generate(
+        metrics=[
+            "orders.revenue",
+            "orders.order_count",
+            "orders.double_revenue",
+            "average_order_value",
+        ],
+        dimensions=["items.category"],
+    )
+    assert conn.execute(sql).fetchall() == [("all", 300.0, 2, 600.0, 150.0)]
+    assert "HASH(" not in sql
+    assert sql.count("SELECT DISTINCT") == 1
+    conn.close()
+
+
 def test_preagg_grain_preserved_with_filters():
     """Test that preagg subqueries preserve the requested dimension grain when filters are applied.
 
@@ -411,6 +729,82 @@ def test_preagg_grain_preserved_with_filters():
     assert rows_sorted[0][2] == 18  # 2024-01-01 total_qty (all items for date)
     assert rows_sorted[1][1] == 150  # 2024-01-02 revenue
     assert rows_sorted[1][2] == 7  # 2024-01-02 total_qty
+
+    conn.close()
+
+
+def test_three_way_preagg_joins_later_ctes_on_coalesced_dimension_key():
+    """Later FULL OUTER joins merge keys that are absent from the first CTE.
+
+    The orders filter removes the pending date from the first pre-aggregation,
+    while both child-model pre-aggregations still contain it. The items and
+    shipments values for that date must land on one row, not two split rows.
+    """
+    conn = duckdb.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE raw_orders AS
+        SELECT * FROM (VALUES
+            (1, DATE '2024-01-01', 100, 'shipped'),
+            (2, DATE '2024-01-02', 200, 'pending')
+        ) AS t(id, order_date, amount, status)
+    """)
+    conn.execute("""
+        CREATE TABLE raw_items AS
+        SELECT * FROM (VALUES (1, 1, 3), (2, 2, 7)) AS t(id, order_id, quantity)
+    """)
+    conn.execute("""
+        CREATE TABLE raw_shipments AS
+        SELECT * FROM (VALUES (1, 1), (2, 2), (3, 2)) AS t(id, order_id)
+    """)
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="raw_orders",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="order_date", type="time"),
+                Dimension(name="status", type="categorical"),
+            ],
+            metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+            relationships=[
+                Relationship(name="items", type="one_to_many", sql="id", foreign_key="order_id"),
+                Relationship(name="shipments", type="one_to_many", sql="id", foreign_key="order_id"),
+            ],
+        )
+    )
+    graph.add_model(
+        Model(
+            name="items",
+            table="raw_items",
+            primary_key="id",
+            metrics=[Metric(name="quantity", agg="sum", sql="quantity")],
+            relationships=[Relationship(name="orders", type="many_to_one", foreign_key="order_id")],
+        )
+    )
+    graph.add_model(
+        Model(
+            name="shipments",
+            table="raw_shipments",
+            primary_key="id",
+            metrics=[Metric(name="shipment_count", agg="count")],
+            relationships=[Relationship(name="orders", type="many_to_one", foreign_key="order_id")],
+        )
+    )
+
+    sql = SQLGenerator(graph).generate(
+        metrics=["orders.revenue", "items.quantity", "shipments.shipment_count"],
+        dimensions=["orders.order_date"],
+        filters=["orders.status = 'shipped'"],
+        order_by=["orders.order_date"],
+    )
+    rows = conn.execute(sql).fetchall()
+
+    assert len(rows) == 2
+    pending_date = next(row for row in rows if str(row[0]) == "2024-01-02")
+    assert pending_date[1] is None
+    assert pending_date[2:] == (7, 2)
 
     conn.close()
 

--- a/tests/optimizations/test_pre_aggregations.py
+++ b/tests/optimizations/test_pre_aggregations.py
@@ -783,14 +783,14 @@ def test_refresh_incremental_with_lookback():
         lookback="5 days",
     )
 
-    # With append mode, we'll have duplicates
+    # Lookback refresh replaces the overlapping range instead of appending duplicates.
     total_revenue = conn.execute("""
         SELECT SUM(total_revenue)
         FROM orders_preagg_daily
         WHERE order_date = DATE '2024-01-05'
     """).fetchone()[0]
 
-    assert total_revenue == 1208  # 104 + 1104 from lookback
+    assert total_revenue == 1104
 
 
 def test_refresh_incremental_uses_update_window_as_default_lookback():
@@ -844,7 +844,7 @@ def test_refresh_incremental_uses_update_window_as_default_lookback():
         WHERE order_date = DATE '2024-01-05'
     """).fetchone()[0]
 
-    assert total_revenue == 1208  # late-arriving 1104 reprocessed because update_window covered it
+    assert total_revenue == 1104  # late-arriving value replaced because update_window covered it
 
 
 def test_explicit_lookback_overrides_update_window():
@@ -1100,6 +1100,61 @@ def test_generate_materialization_sql_no_time_dimension():
     assert "SUM(price) as avg_price_raw" in sql
 
 
+def test_total_rollup_materializes_filtered_metrics_without_empty_group_by():
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE orders AS SELECT * FROM (VALUES "
+        "(1, 'completed', 100), (2, 'pending', 50), (3, 'completed', 25)) "
+        "t(id, status, amount)"
+    )
+    model = Model(
+        name="orders",
+        table="orders",
+        primary_key="id",
+        metrics=[
+            Metric(
+                name="completed_revenue",
+                agg="sum",
+                sql="amount",
+                filters=["{model}.status = 'completed'"],
+            ),
+            Metric(
+                name="completed_count",
+                agg="count",
+                filters=["{model}.status = 'completed'"],
+            ),
+        ],
+    )
+    preagg = PreAggregation(
+        name="totals",
+        measures=["completed_revenue", "completed_count"],
+        dimensions=[],
+    )
+
+    sql = preagg.generate_materialization_sql(model)
+
+    assert "GROUP BY" not in sql
+    assert "SUM(CASE WHEN status = 'completed' THEN amount ELSE NULL END)" in sql
+    assert "COUNT(CASE WHEN status = 'completed' THEN 1 ELSE NULL END)" in sql
+    assert conn.execute(sql).fetchall() == [(125, 2)]
+
+
+def test_non_decomposable_preaggregation_requires_exact_grain():
+    metric = Metric(name="median_price", agg="median", sql="price")
+    preagg = PreAggregation(name="by_category", measures=["median_price"], dimensions=["category"])
+    model = Model(
+        name="products",
+        table="products",
+        dimensions=[Dimension(name="category", type="categorical")],
+        metrics=[metric],
+        pre_aggregations=[preagg],
+    )
+    matcher = PreAggregationMatcher(model)
+
+    assert matcher.can_satisfy_query(preagg, ["median_price"], ["category"])
+    assert not matcher.can_satisfy_query(preagg, ["median_price"], [])
+
+
 def test_avg_preaggregation_rolls_up_with_sum_count_state(layer):
     layer.use_preaggregations = True
     layer.conn.execute("""
@@ -1157,7 +1212,7 @@ def test_avg_preaggregation_rolls_up_with_sum_count_state(layer):
     preagg_rows = layer.adapter.execute(preagg_sql).fetchall()
 
     assert "products_preagg_by_category" in preagg_sql
-    assert "SUM(avg_price_raw) / NULLIF(SUM(count_raw), 0)" in preagg_sql
+    assert "(SUM(avg_price_raw)) / NULLIF(SUM(count_raw), 0)" in preagg_sql
     assert preagg_rows == baseline_rows
 
 
@@ -1245,7 +1300,7 @@ def test_ratio_metric_preaggregation_rebuilds_from_additive_leaves(layer):
     preagg_rows = layer.adapter.execute(preagg_sql).fetchall()
 
     assert "orders_preagg_by_status" in preagg_sql
-    assert "SUM(revenue_raw) / NULLIF(SUM(count_raw), 0)" in preagg_sql
+    assert "(SUM(revenue_raw)) / NULLIF(SUM(count_raw), 0)" in preagg_sql
     assert preagg_rows == baseline_rows
 
 
@@ -2603,10 +2658,13 @@ def test_query_with_post_process_falls_back_to_raw_when_rollup_missing():
     result = layer.query(
         metrics=["orders.revenue"],
         dimensions=["orders.status"],
+        order_by=["orders.status"],
+        offset=1,
         post_process="SELECT * FROM ({inner})",
     )
 
-    assert set(result.fetchall()) == {(0, 120), (1, 90)}  # correct totals from raw fallback
+    # Offset survives both the post-process recompile and the raw-table fallback.
+    assert result.fetchall() == [(1, 90)]
 
 
 def test_is_missing_relation_error_recognizes_bigquery_not_found():

--- a/tests/queries/test_semantic_sql_planner.py
+++ b/tests/queries/test_semantic_sql_planner.py
@@ -2523,6 +2523,39 @@ def test_fanout_join_key_preaggregation_rejects_one_to_many_remote_dimension(sem
     assert candidates["join_key_preaggregation"].reason == "remote_dimension_not_many_to_one"
 
 
+def test_join_key_preaggregation_rejects_custom_relationship_predicate(semantic_layer):
+    orders = semantic_layer.get_model("orders")
+    customers = semantic_layer.get_model("customers")
+    orders.relationships = [
+        Relationship(
+            name="customers",
+            type="many_to_one",
+            foreign_key="customer_id",
+            sql="{from}.customer_id = {to}.id AND {to}.tier = 'premium'",
+        )
+    ]
+    customers.relationships = []
+    semantic_layer.graph.build_adjacency()
+    orders.pre_aggregations = [
+        PreAggregation(
+            name="by_customer",
+            measures=["revenue"],
+            dimensions=["customer_id"],
+        )
+    ]
+    semantic_layer.use_preaggregations = True
+
+    sql = "SELECT orders.revenue, customers.region FROM orders ORDER BY customers.region"
+    explanation = semantic_layer.explain_sql(sql)
+    candidates = _candidate_by_name(explanation)
+
+    assert explanation.chosen_plan == "direct_semantic"
+    assert candidates["join_key_preaggregation"].valid is False
+    assert candidates["join_key_preaggregation"].reason == "custom_join_predicate_not_supported"
+    assert "tier = 'premium'" in explanation.rewritten_sql
+    assert fetch_rows(semantic_layer.sql(sql)) == [("EU", None), ("US", 250.0)]
+
+
 def test_wrapped_window_metric_executes_against_baseline(semantic_layer):
     semantic_layer.add_metric(
         Metric(

--- a/tests/queries/test_sql_rewriter.py
+++ b/tests/queries/test_sql_rewriter.py
@@ -1581,8 +1581,17 @@ def test_compile_post_process(semantic_layer):
     assert "WITH WITH" not in outer_sql
 
 
-def test_query_post_process(semantic_layer):
+def test_query_post_process(semantic_layer, monkeypatch):
     """Test post_process parameter on query()."""
+    original_compile = semantic_layer.compile
+    compile_calls = 0
+
+    def counted_compile(*args, **kwargs):
+        nonlocal compile_calls
+        compile_calls += 1
+        return original_compile(*args, **kwargs)
+
+    monkeypatch.setattr(semantic_layer, "compile", counted_compile)
     result = semantic_layer.query(
         metrics=["orders.revenue"],
         dimensions=["orders.status"],
@@ -1598,6 +1607,7 @@ def test_query_post_process(semantic_layer):
             assert row["tier"] == "high"
         else:
             assert row["tier"] == "low"
+    assert compile_calls == 1
 
 
 def test_post_process_missing_placeholder(semantic_layer):

--- a/tests/queries/test_ungrouped_queries.py
+++ b/tests/queries/test_ungrouped_queries.py
@@ -374,3 +374,27 @@ def test_with_totals_unsupported_window_path_raises(layer):
 
     with pytest.raises(NotImplementedError, match="with_totals is not yet supported"):
         layer.compile(metrics=["cumulative_revenue"], dimensions=["orders.order_date"], with_totals=True)
+
+
+def test_query_post_process_preserves_with_totals(layer):
+    """Wrapping a query must not silently drop its requested grand-total row."""
+    layer.conn.execute(
+        "CREATE TABLE orders (order_id INTEGER, status VARCHAR, region VARCHAR, amount INTEGER, customer_id INTEGER)"
+    )
+    layer.conn.execute(
+        "INSERT INTO orders VALUES (1,'completed','US',10,1),(2,'completed','US',15,2),(3,'pending','EU',10,1)"
+    )
+    layer.add_model(_totals_orders_model())
+
+    rows = fetch_dicts(
+        layer.query(
+            metrics=["orders.revenue"],
+            dimensions=["orders.status"],
+            with_totals=True,
+            post_process="SELECT * FROM ({inner}) AS wrapped_totals",
+        )
+    )
+
+    totals = [row for row in rows if row["_is_total"] == 1]
+    assert len(totals) == 1
+    assert totals[0]["revenue"] == 35

--- a/tests/server/test_api_server.py
+++ b/tests/server/test_api_server.py
@@ -179,7 +179,12 @@ def test_dashboard_endpoint_is_optional_and_authenticated(tmp_path):
                                 "dimensions": ["orders.created_at__day", "orders.status"],
                             },
                             "encoding": {"x": "orders.created_at__day", "y": "orders.order_count"},
-                        }
+                        },
+                        {
+                            "id": "orders_kpi",
+                            "type": "kpi",
+                            "query": {"metrics": ["orders.order_count"]},
+                        },
                     ],
                 }
             ],
@@ -192,6 +197,7 @@ def test_dashboard_endpoint_is_optional_and_authenticated(tmp_path):
     response = configured.get("/dashboard", headers=_auth_headers())
     assert response.status_code == 200
     assert response.json()["title"] == "Orders overview"
+    assert [chart["id"] for chart in response.json()["tabs"][0]["charts"]] == ["orders", "orders_kpi"]
     assert unconfigured.get("/dashboard").status_code == 404
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -15,7 +15,7 @@ from sidemantic import (
     load_from_directory,
 )
 from sidemantic.cli import app
-from sidemantic.dashboard import generate_dashboard_typescript
+from sidemantic.dashboard import DashboardSpecError, generate_dashboard_typescript
 from sidemantic.viz import CrossfilterDashboard, CrossfilterTab
 
 runner = CliRunner()
@@ -238,6 +238,47 @@ def test_dashboard_document_rejects_unknown_fields():
     assert "unknown metric 'orders.revneue'" in errors[0]
 
 
+def test_dashboard_document_accepts_multiple_charts_per_tab_for_canonical_ui():
+    layer = _build_layer()
+    payload = _dashboard_payload()
+    payload["tabs"][0]["charts"].append(
+        {
+            "id": "revenue_kpi",
+            "title": "Revenue",
+            "type": "kpi",
+            "query": {"metrics": ["orders.revenue"]},
+            "layout": {"colSpan": 1},
+        }
+    )
+
+    document = DashboardDocument.from_dict(payload)
+
+    assert document.validate(layer) == []
+    assert len(document.to_dict()["tabs"][0]["charts"]) == 2
+
+    with pytest.raises(DashboardSpecError, match="dashboard serve"):
+        document.to_crossfilter_dashboard(layer)
+
+
+def test_dashboard_document_requires_unique_nonempty_chart_ids():
+    layer = _build_layer()
+    payload = _dashboard_payload()
+    duplicate = dict(payload["tabs"][0]["charts"][0])
+    duplicate["query"] = dict(duplicate["query"])
+    payload["tabs"][0]["charts"].append(duplicate)
+    payload["tabs"].append(
+        {
+            "id": "missing-chart-id",
+            "charts": [{"type": "table", "query": {"metrics": ["orders.order_count"]}}],
+        }
+    )
+
+    errors = DashboardDocument.from_dict(payload).validate(layer)
+
+    assert any("id duplicates 'revenue_trend'" in error for error in errors)
+    assert any("tabs[1].charts[0].id is required" in error for error in errors)
+
+
 def test_dashboard_document_rejects_unknown_order_by_fields():
     layer = _build_layer()
     payload = _dashboard_payload()
@@ -381,6 +422,8 @@ def test_dashboard_typescript_is_generated_from_semantic_layer():
     assert "export function defineDashboard" in ts
     assert '"orders.region": string;' in ts
     assert '"orders.created_at__month": string | Date;' in ts
+    assert '"leaderboard" | "table" | "scatter"' in ts
+    assert "layout?:" in ts
 
 
 def test_dashboard_cli_validate_and_types(monkeypatch, tmp_path):

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -198,6 +198,35 @@ def test_sql_generation_performance(performance_layer):
     assert avg_ms < 15.0, f"SQL generation too slow: {avg_ms:.3f}ms"
 
 
+def test_semantic_layer_reuses_the_warm_sql_planner(performance_layer, monkeypatch):
+    """Repeated public compile calls hit a layer-scoped generator cache."""
+    generator = performance_layer._python_generator()
+    original = generator._build_model_cte
+    calls = 0
+
+    def counted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(generator, "_build_model_cte", counted)
+
+    first = performance_layer.compile(
+        metrics=["orders.revenue"],
+        dimensions=["orders.status"],
+        filters=["orders.status = 'completed'"],
+    )
+    second = performance_layer.compile(
+        metrics=["orders.revenue"],
+        dimensions=["orders.status"],
+        filters=["orders.status = 'completed'"],
+    )
+
+    assert first == second
+    assert performance_layer._python_generator() is generator
+    assert calls == 1
+
+
 def test_multi_join_generation_performance(performance_layer):
     """Measure performance of SQL generation with multiple joins."""
     from sidemantic.sql.generator import SQLGenerator

--- a/tests/test_semantic_graph_errors.py
+++ b/tests/test_semantic_graph_errors.py
@@ -4,7 +4,7 @@ import pytest
 
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
-from sidemantic.core.semantic_graph import SemanticGraph
+from sidemantic.core.semantic_graph import AmbiguousJoinPathError, SemanticGraph
 from sidemantic.core.table_calculation import TableCalculation
 
 
@@ -117,6 +117,77 @@ def test_find_path_no_relationship():
 
     with pytest.raises(ValueError, match="No join path found"):
         graph.find_relationship_path("orders", "customers")
+
+
+def test_find_path_rejects_registration_order_independent_diamond_ambiguity():
+    """Two equally short routes must fail instead of selecting the first declared edge."""
+    from sidemantic.core.relationship import Relationship
+
+    def build_graph(reverse: bool) -> SemanticGraph:
+        first = Relationship(name="c", type="many_to_one", foreign_key="c_id")
+        second = Relationship(name="b", type="many_to_one", foreign_key="b_id")
+        relationships = [first, second] if reverse else [second, first]
+        graph = SemanticGraph()
+        graph.add_model(Model(name="a", table="a", primary_key="id", relationships=relationships))
+        graph.add_model(
+            Model(
+                name="b",
+                table="b",
+                primary_key="id",
+                relationships=[Relationship(name="d", type="many_to_one", foreign_key="d_id")],
+            )
+        )
+        graph.add_model(
+            Model(
+                name="c",
+                table="c",
+                primary_key="id",
+                relationships=[Relationship(name="d", type="many_to_one", foreign_key="d_id")],
+            )
+        )
+        graph.add_model(Model(name="d", table="d", primary_key="id"))
+        return graph
+
+    messages = []
+    for reverse in (False, True):
+        graph = build_graph(reverse)
+        with pytest.raises(AmbiguousJoinPathError) as exc:
+            graph.find_relationship_path("a", "d")
+        messages.append(str(exc.value))
+
+    assert messages[0] == messages[1]
+    assert "a -> b -> d" in messages[0]
+    assert "a -> c -> d" in messages[0]
+
+
+def test_find_path_prefers_a_unique_direct_route_over_longer_alternatives():
+    from sidemantic.core.relationship import Relationship
+
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="a",
+            table="a",
+            primary_key="id",
+            relationships=[
+                Relationship(name="b", type="many_to_one", foreign_key="b_id"),
+                Relationship(name="d", type="many_to_one", foreign_key="d_id"),
+            ],
+        )
+    )
+    graph.add_model(
+        Model(
+            name="b",
+            table="b",
+            primary_key="id",
+            relationships=[Relationship(name="d", type="many_to_one", foreign_key="d_id")],
+        )
+    )
+    graph.add_model(Model(name="d", table="d", primary_key="id"))
+
+    path = graph.find_relationship_path("a", "d")
+
+    assert [(hop.from_model, hop.to_model) for hop in path] == [("a", "d")]
 
 
 def test_auto_register_time_comparison_metric():


### PR DESCRIPTION
Salvages abandoned uncommitted work from the Codex worktree `8244/sidemantic`, last touched 2026-07-19. Rebased onto current main (was 3 commits behind, rebased clean).

Draft because it carries one regression, described below.

## Contents

- **Pre-aggregation filter correctness.** Metric filters are pushed inside the aggregate input, so a rollup never materializes an unfiltered value for a filtered semantic metric. `COUNT` without an explicit `sql` becomes `COUNT(CASE WHEN <filter> THEN 1 ELSE NULL END)`; other aggregates wrap the measure input the same way. Main has no `measure.filters` handling in `pre_aggregation.py` at all.
- **Query generator rework.** `sidemantic/sql/generator.py` +1172/-296, with supporting changes in `semantic_graph.py`, `semantic_layer.py`, `preagg_matcher.py`, and `dashboard.py`.
- **Tests**, including 394 lines of symmetric-aggregate coverage.

The same worktree also held a `webapp` DashboardView feature and rebuilt UI asset bundles. Those are deliberately excluded here and parked on the local branch `dashboard-webapp-hold` in that worktree, to be raised separately.

## Known regression

`tests/queries/test_semantic_sql_planner.py::test_root_semantic_query_preserves_having_metric_filter` fails. It passes on clean main; I verified that in a separate checkout.

The test asserts the literal substring `revenue > 225` appears in the rewritten SQL. The generator now emits `HAVING SUM(orders_cte.revenue_raw) > 225` instead of referencing the metric alias. The output looks semantically correct, so this may be an intentional change whose test was never updated, but I did not want to loosen the assertion without knowing the original intent.

Everything else passes: 682 passed, 2 skipped across `tests/metrics`, `tests/optimizations`, `tests/queries`, `tests/test_dashboard.py`.
