### PR TITLE
Stabilize CLI checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
             cat "$tmpdir/serve.err" >&2
             exit 1
           fi
-          grep -q "sidemantic\\[serve\\]" "$tmpdir/serve.err"
+          grep -q "sidemantic\\[api\\]" "$tmpdir/serve.err"
 
   update-schema:
     name: Update JSON Schema

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,21 @@
 """Pytest configuration and fixtures."""
 
-import os
-
 import pytest
-
-# Test captured output against Sidemantic's default policy even when the host
-# runner requests colored logs. Individual color tests opt back in explicitly.
-os.environ.pop("FORCE_COLOR", None)
+from typer import rich_utils as typer_rich_utils
 
 from sidemantic import SemanticLayer
+
+
+@pytest.fixture(autouse=True)
+def isolate_cli_color_environment(monkeypatch: pytest.MonkeyPatch):
+    """Keep host color settings from leaking into captured CLI output."""
+
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+
+    # Typer snapshots GitHub Actions' color preference when rich_utils is
+    # imported. Restore automatic stream detection for tests while still
+    # allowing individual FORCE_COLOR tests to opt in dynamically.
+    monkeypatch.setattr(typer_rich_utils, "FORCE_TERMINAL", None)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Isolates CLI color state between tests and updates the base-install assertion to match the current API extra.