### PR TITLE
Make semantic keys explicit

### DIFF
--- a/sidemantic/adapters/lookml.py
+++ b/sidemantic/adapters/lookml.py
@@ -2060,7 +2060,7 @@ class LookMLAdapter(BaseAdapter):
 
         # Parse dimensions with resolved SQL
         dimensions = []
-        primary_key = "id"  # default
+        primary_key = None
 
         for dim_def in dimension_defs:
             dim = self._parse_dimension(dim_def, resolved_dimension_sql)
@@ -2400,7 +2400,7 @@ class LookMLAdapter(BaseAdapter):
         # Build kwargs conditionally so that unset scalars don't appear in
         # model_fields_set. This matters for refinements: merge_model treats
         # every field in model_fields_set as an explicit child override, so
-        # passing table=None or primary_key="id" would erase the base view's
+        # passing table=None or an unknown primary key would erase the base view's
         # real values.
         model_kwargs: dict = {
             "name": name,
@@ -2417,7 +2417,7 @@ class LookMLAdapter(BaseAdapter):
             model_kwargs["description"] = desc
         if extends is not None:
             model_kwargs["extends"] = extends
-        if primary_key != "id":
+        if primary_key is not None:
             model_kwargs["primary_key"] = primary_key
         if model_meta:
             model_kwargs["meta"] = model_meta

--- a/sidemantic/core/model.py
+++ b/sidemantic/core/model.py
@@ -35,10 +35,10 @@ class Model(BaseModel):
     # Relationships
     relationships: list[Relationship] = Field(default_factory=list, description="Relationships to other models")
 
-    # Primary key - single column or list for composite keys. None means "no known primary key"
-    # (e.g. a fact or disconnected table imported from a format that does not declare one); such a
-    # model contributes no key column to joins rather than a fabricated default.
-    primary_key: str | list[str] | None = Field(default="id", description="Primary key column(s)")
+    # Primary key - single column or list for composite keys. None means "no known primary key".
+    # Keys are never inferred here: callers and adapters must preserve the source model's actual
+    # declaration rather than manufacturing an ``id`` column that may not exist.
+    primary_key: str | list[str] | None = Field(default=None, description="Primary key column(s), if known")
 
     # Unique key constraints
     unique_keys: list[list[str]] | None = Field(None, description="Unique key constraints (each is a list of columns)")

--- a/sidemantic/core/relationship.py
+++ b/sidemantic/core/relationship.py
@@ -21,7 +21,7 @@ class Relationship(BaseModel):
         description="Type of relationship"
     )
     foreign_key: str | list[str] | None = Field(
-        default=None, description="Foreign key column(s) (defaults to {name}_id for many_to_one)"
+        default=None, description="Foreign key column(s); required for keyed relationships unless sql is provided"
     )
     primary_key: str | list[str] | None = Field(
         default=None,
@@ -47,27 +47,22 @@ class Relationship(BaseModel):
     metadata: dict[str, Any] | None = Field(None, description="Adapter-specific metadata payload")
 
     @property
-    def sql_expr(self) -> str:
-        """Get SQL expression for the foreign key (first column for composite keys)."""
+    def sql_expr(self) -> str | None:
+        """Get the first explicitly declared foreign-key column, if any."""
         if self.foreign_key:
             if isinstance(self.foreign_key, list):
-                return self.foreign_key[0] if self.foreign_key else f"{self.name}_id"
+                return self.foreign_key[0] if self.foreign_key else None
             return self.foreign_key
-
-        # Default: {name}_id for many_to_one
-        if self.type == "many_to_one":
-            return f"{self.name}_id"
-        else:
-            return "id"
+        return None
 
     @property
-    def related_key(self) -> str:
-        """Get the key in the related model (first column for composite keys)."""
+    def related_key(self) -> str | None:
+        """Get the first explicitly declared related key, if any."""
         if self.primary_key:
             if isinstance(self.primary_key, list):
-                return self.primary_key[0] if self.primary_key else "id"
+                return self.primary_key[0] if self.primary_key else None
             return self.primary_key
-        return "id"
+        return None
 
     @property
     def foreign_key_columns(self) -> list[str]:
@@ -75,10 +70,7 @@ class Relationship(BaseModel):
         if self.type == "cross":
             return []
         if self.foreign_key is None:
-            # Default: {name}_id for many_to_one
-            if self.type == "many_to_one":
-                return [f"{self.name}_id"]
-            return ["id"]
+            return []
         if isinstance(self.foreign_key, str):
             return [self.foreign_key]
         return self.foreign_key
@@ -89,7 +81,7 @@ class Relationship(BaseModel):
         if self.type == "cross":
             return []
         if self.primary_key is None:
-            return ["id"]
+            return []
         if isinstance(self.primary_key, str):
             return [self.primary_key]
         return self.primary_key

--- a/sidemantic/core/semantic_graph.py
+++ b/sidemantic/core/semantic_graph.py
@@ -261,6 +261,12 @@ class SemanticGraph:
             relationship_type: str,
             custom_condition: str | None = None,
         ) -> None:
+            # Invalid/unknown key pairs are not graph edges. Structural validation reports the
+            # actionable cause; omitting the edge prevents compilation from producing ``JOIN ON``
+            # predicates with fabricated or empty columns when validation is bypassed.
+            if relationship_type != "cross" and custom_condition is None:
+                if not from_keys or not to_keys or len(from_keys) != len(to_keys):
+                    return
             if from_model not in self._adjacency:
                 self._adjacency[from_model] = []
             self._adjacency[from_model].append((to_model, from_keys, to_keys, relationship_type, custom_condition))

--- a/sidemantic/core/semantic_graph.py
+++ b/sidemantic/core/semantic_graph.py
@@ -68,6 +68,7 @@ class SemanticGraph:
     def __init__(self):
         self.models: dict[str, Model] = {}
         self.metrics: dict[str, Metric] = {}
+        self.metric_owners: dict[str, str] = {}
         self.table_calculations: dict[str, TableCalculation] = {}
         self.parameters: dict[str, Parameter] = {}
         self.import_warnings: list[dict[str, object]] = []
@@ -103,16 +104,21 @@ class SemanticGraph:
 
         self._mark_dirty()
 
-    def add_metric(self, measure: Metric) -> None:
+    def add_metric(self, measure: Metric, model_name: str | None = None) -> None:
         """Add a measure to the graph.
 
         Args:
             measure: Metric to add
+            model_name: Optional owning model for a graph-addressable model metric
         """
         if measure.name in self.metrics:
             raise ValueError(f"Measure {measure.name} already exists")
+        if model_name is not None and model_name not in self.models:
+            raise ValueError(f"Model {model_name} not found for measure {measure.name}")
 
         self.metrics[measure.name] = measure
+        if model_name is not None:
+            self.metric_owners[measure.name] = model_name
         self._mark_dirty()
 
     def add_table_calculation(self, calc: TableCalculation) -> None:

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -1415,16 +1415,23 @@ class SemanticLayer:
             pk_columns = set(model.primary_key_columns)
             for candidate in candidates:
                 preagg = next((p for p in model.pre_aggregations if p.name == candidate.name), None)
-                if candidate.selected and (preagg is None or not pk_columns.issubset(set(preagg.dimensions or []))):
+                if candidate.selected and (
+                    not pk_columns or preagg is None or not pk_columns.issubset(set(preagg.dimensions or []))
+                ):
                     candidate.selected = False
             if not any(c.selected for c in candidates):
+                reason = (
+                    "ungrouped query, model has no declared primary key for unique rows"
+                    if not pk_columns
+                    else "ungrouped query, no rollup carries the primary key for unique rows"
+                )
                 return QueryPlan(
                     sql=sql,
                     model=model_name,
                     metrics=bare_metrics,
                     dimensions=bare_dims,
                     used_preaggregation=False,
-                    routing_reason="ungrouped query, no rollup carries the primary key for unique rows",
+                    routing_reason=reason,
                     candidates=candidates,
                 )
 

--- a/sidemantic/mcp_server.py
+++ b/sidemantic/mcp_server.py
@@ -134,7 +134,7 @@ def _format_join_condition(model_name: str, rel, models: dict[str, Any]) -> str 
         return None
 
     if rel.type == "many_to_one":
-        fk = rel.foreign_key or f"{related_name}_id"
+        fk = rel.foreign_key
         pk = rel.primary_key or related_model.primary_key
         return _format_join_key_pairs(model_name, _key_columns(fk), related_name, _key_columns(pk))
 
@@ -179,6 +179,8 @@ def _format_join_condition(model_name: str, rel, models: dict[str, Any]) -> str 
 
 
 def _key_columns(value: Any) -> list[str]:
+    if value is None:
+        return []
     if isinstance(value, list):
         return [str(column) for column in value]
     return [str(value)]
@@ -716,6 +718,7 @@ def get_semantic_graph() -> dict[str, Any]:
         model_info: dict[str, Any] = {
             "name": model_name,
             "table": model.table,
+            "primary_key": _visible_dimension_name(model, model.primary_key, layer.enforce_visibility),
             "dimensions": [d.name for d in model.dimensions if not layer.enforce_visibility or d.public],
             "metrics": [m.name for m in model.metrics if not layer.enforce_visibility or m.public],
             "relationships": [{"name": r.name, "type": r.type} for r in model.relationships],
@@ -725,8 +728,6 @@ def get_semantic_graph() -> dict[str, Any]:
         visible_segments = [s.name for s in model.segments if not layer.enforce_visibility or s.public]
         if visible_segments:
             model_info["segments"] = visible_segments
-        if primary_key := _visible_dimension_name(model, model.primary_key, layer.enforce_visibility):
-            model_info["primary_key"] = primary_key
         if default_time_dimension := _visible_dimension_name(
             model, model.default_time_dimension, layer.enforce_visibility
         ):

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -1530,6 +1530,9 @@ class SQLGenerator:
                 return
 
             # It's a graph-level metric, need to resolve its dependencies.
+            owning_model = self.graph.metric_owners.get(metric_ref)
+            if owning_model:
+                add_model(owning_model)
             if metric.type == "ratio":
                 if metric.numerator:
                     collect_models_from_metric(metric.numerator)
@@ -1787,7 +1790,7 @@ class SQLGenerator:
             """Recursively extract filter columns from a metric and its dependencies."""
             # Extract from the metric's own filters
             if metric.filters:
-                filter_model_name = None
+                filter_model_name = self.graph.metric_owners.get(metric.name)
                 deps = metric.get_dependencies(self.graph)
                 for dep in deps:
                     try:
@@ -3528,6 +3531,9 @@ class SQLGenerator:
         """
         if model_context and model_context in self.graph.models:
             return model_context
+        owning_model = self.graph.metric_owners.get(metric.name)
+        if owning_model:
+            return owning_model
         if metric.sql:
             try:
                 parsed = _parse_fragment(metric.sql, self.dialect)
@@ -6205,7 +6211,8 @@ LEFT JOIN {preagg_table} AS {rollup_alias}
             # dimensions; otherwise the stored rows are aggregated and must not
             # be served ungrouped. Fall through to raw tables.
             preagg_dims = set(preagg.dimensions or [])
-            if not set(model.primary_key_columns).issubset(preagg_dims):
+            primary_key_columns = set(model.primary_key_columns)
+            if not primary_key_columns or not primary_key_columns.issubset(preagg_dims):
                 return None
 
         # Generate SQL against pre-aggregation table

--- a/tests/adapters/metricflow/test_parsing.py
+++ b/tests/adapters/metricflow/test_parsing.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 import pytest
 
+from sidemantic import Metric, Model
 from sidemantic.adapters.metricflow import MetricFlowAdapter
+from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.sql.generator import SQLGenerator
 
 # =============================================================================
@@ -1032,6 +1034,28 @@ def test_metricflow_inline_constant_count_anchored_to_model():
             assert "count" in sql.lower()
     finally:
         path.unlink(missing_ok=True)
+
+
+def test_metricflow_keyless_inline_count_planner_contract():
+    """Keyless inline row counts retain model context without a fabricated key."""
+    graph = SemanticGraph()
+    graph.add_model(Model(name="events", table="events"))
+    graph.add_metric(Metric(name="row_count", agg="count"), model_name="events")
+    graph.add_metric(
+        Metric(name="active_count", agg="count", filters=["status = 'active'"]),
+        model_name="events",
+    )
+
+    generator = SQLGenerator(graph)
+    row_count_sql = generator.generate(metrics=["row_count"])
+    assert "events" in row_count_sql.lower()
+    assert "count(*)" in row_count_sql.lower()
+    assert ".none" not in row_count_sql.lower()
+
+    active_count_sql = generator.generate(metrics=["active_count"])
+    assert "status as status" in active_count_sql.lower()
+    assert "events_cte.status = 'active'" in active_count_sql.lower()
+    assert ".none" not in active_count_sql.lower()
 
 
 def test_metricflow_inline_exprless_non_count_uses_metric_column():

--- a/tests/adapters/test_added_fixture_coverage.py
+++ b/tests/adapters/test_added_fixture_coverage.py
@@ -550,10 +550,9 @@ def _pick_execution_query(graph):
         execution_model_name, requires_model_override = _execution_model_name(model.name)
         base_requires_sql_override = bool(model.sql)
 
-        primary_keys = model.primary_key if isinstance(model.primary_key, list) else [model.primary_key]
-        if any(not isinstance(pk, str) or not pk.strip() for pk in primary_keys):
-            continue
-        base_column_types = {pk: "INTEGER" for pk in primary_keys}
+        # Isolated model queries do not require an entity key. Unknown identity is represented by
+        # an empty list rather than inventing an ``id`` column for execution fixtures.
+        base_column_types = {pk: "INTEGER" for pk in model.primary_key_columns}
 
         def pick_metric_candidate():
             for metric in model.metrics:

--- a/tests/adapters/thoughtspot/test_roundtrip.py
+++ b/tests/adapters/thoughtspot/test_roundtrip.py
@@ -71,6 +71,7 @@ def test_thoughtspot_export_one_to_many_join_direction(tmp_path: Path):
     model = Model(
         name="customers",
         table="customers",
+        primary_key="id",
         relationships=[Relationship(name="orders", type="one_to_many", foreign_key="customer_id")],
     )
     graph = SemanticGraph()

--- a/tests/joins/test_composite_key_joins.py
+++ b/tests/joins/test_composite_key_joins.py
@@ -470,9 +470,9 @@ def test_relationship_foreign_key_columns_multi():
 
 
 def test_relationship_foreign_key_columns_default():
-    """Test foreign_key_columns defaults to {name}_id for many_to_one."""
+    """Unknown relationship foreign keys remain explicit."""
     rel = Relationship(name="customers", type="many_to_one")
-    assert rel.foreign_key_columns == ["customers_id"]
+    assert rel.foreign_key_columns == []
 
 
 def test_relationship_primary_key_columns_single():
@@ -492,9 +492,9 @@ def test_relationship_primary_key_columns_multi():
 
 
 def test_relationship_primary_key_columns_default():
-    """Test primary_key_columns defaults to [id]."""
+    """Unknown relationship primary keys remain explicit."""
     rel = Relationship(name="customers", type="many_to_one")
-    assert rel.primary_key_columns == ["id"]
+    assert rel.primary_key_columns == []
 
 
 if __name__ == "__main__":

--- a/tests/native-fixtures/relationship_default_keys/models/models.yml
+++ b/tests/native-fixtures/relationship_default_keys/models/models.yml
@@ -13,8 +13,10 @@ models:
     relationships:
       - name: orders
         type: one_to_many
+        foreign_key: id
       - name: profiles
         type: one_to_one
+        foreign_key: id
 
   - name: orders
     table: orders
@@ -42,6 +44,7 @@ models:
     relationships:
       - name: accounts
         type: many_to_one
+        foreign_key: accounts_id
 
   - name: accounts
     table: accounts

--- a/tests/optimizations/test_pre_aggregations.py
+++ b/tests/optimizations/test_pre_aggregations.py
@@ -2362,6 +2362,40 @@ def test_ungrouped_rollup_without_pk_falls_to_raw(layer):
     assert plan.used_preaggregation is False
 
 
+def test_ungrouped_keyless_model_falls_to_raw(layer):
+    """An empty key set is not evidence that an aggregate rollup preserves detail rows."""
+    layer.use_preaggregations = True
+    layer.conn.execute("CREATE TABLE orders (status VARCHAR, amount DECIMAL(10, 2))")
+    layer.conn.execute("CREATE TABLE orders_preagg_by_status (status VARCHAR, revenue_raw DECIMAL(10, 2))")
+    model = Model(
+        name="orders",
+        table="orders",
+        dimensions=[Dimension(name="status", type="categorical", sql="status")],
+        metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        pre_aggregations=[PreAggregation(name="by_status", measures=["revenue"], dimensions=["status"])],
+    )
+    layer.add_model(model)
+
+    sql = layer.compile(
+        metrics=["orders.revenue"],
+        dimensions=["orders.status"],
+        ungrouped=True,
+    )
+
+    assert "orders_preagg_by_status" not in sql
+    assert "orders_cte" in sql
+    assert "used_preagg=true" not in sql
+
+    plan = layer.explain(
+        metrics=["orders.revenue"],
+        dimensions=["orders.status"],
+        ungrouped=True,
+        use_preaggregations=True,
+    )
+    assert plan.used_preaggregation is False
+    assert plan.routing_reason == "ungrouped query, model has no declared primary key for unique rows"
+
+
 def test_ungrouped_composite_pk_partial_rollup_falls_to_raw(layer):
     """A rollup carrying only part of a composite primary key cannot guarantee unique rows."""
     layer.use_preaggregations = True

--- a/tests/queries/test_basic.py
+++ b/tests/queries/test_basic.py
@@ -6,6 +6,7 @@ import sqlglot
 from sqlglot import exp
 
 from sidemantic import Dimension, Metric, Model, Relationship, Segment, SemanticLayer
+from sidemantic.validation import QueryValidationError
 from tests.utils import df_rows
 
 
@@ -799,6 +800,33 @@ def test_direct_many_to_many_without_target_key_joins_on_model_pk():
     # Local side joins on A's primary key; it never references a raw a_id column (A has none).
     assert re.search(r"a_cte\.id\b", sql)
     assert "a_cte.a_id" not in sql
+
+
+def test_keyless_direct_many_to_many_has_no_join_path_when_queried():
+    """An incomplete keyless relationship is ignored until a query actually needs that join."""
+    layer = SemanticLayer()
+    layer.add_model(
+        Model(
+            name="a",
+            table="a",
+            metrics=[Metric(name="cnt", agg="count")],
+            relationships=[Relationship(name="b", type="many_to_many", foreign_key="a_id")],
+        )
+    )
+    layer.add_model(
+        Model(
+            name="b",
+            table="b",
+            primary_key="a_id",
+            dimensions=[Dimension(name="label", type="categorical")],
+        )
+    )
+
+    sql = layer.compile(metrics=["a.cnt"])
+    assert "a_cte" in sql
+
+    with pytest.raises(QueryValidationError, match="No join path found between models"):
+        layer.compile(metrics=["a.cnt"], dimensions=["b.label"])
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -513,7 +513,7 @@ def test_get_semantic_graph(demo_layer):
     assert "metrics" in model
     assert "segments" in model
     assert "completed_orders" in model["segments"]
-    assert model["primary_key"] == "id"
+    assert model["primary_key"] is None
 
 
 def test_get_models_enriched(demo_layer):
@@ -522,7 +522,7 @@ def test_get_models_enriched(demo_layer):
     model = result["models"][0]
 
     # Check new fields
-    assert model["primary_key"] == "id"
+    assert model["primary_key"] is None
     assert model["description"] == "All customer orders"
 
     # Check segments are included

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -1,5 +1,7 @@
 """Test relationship property methods and edge cases."""
 
+import pytest
+
 from sidemantic.core.model import Model
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_graph import SemanticGraph
@@ -11,22 +13,19 @@ def test_relationship_sql_expr_with_explicit_foreign_key():
     assert rel.sql_expr == "cust_id"
 
 
-def test_relationship_sql_expr_default_many_to_one():
-    """Test sql_expr property defaults to {name}_id for many_to_one."""
+def test_relationship_sql_expr_does_not_invent_many_to_one_key():
     rel = Relationship(name="customers", type="many_to_one")
-    assert rel.sql_expr == "customers_id"
+    assert rel.sql_expr is None
 
 
-def test_relationship_sql_expr_default_one_to_many():
-    """Test sql_expr property defaults to 'id' for one_to_many."""
+def test_relationship_sql_expr_does_not_invent_one_to_many_key():
     rel = Relationship(name="orders", type="one_to_many")
-    assert rel.sql_expr == "id"
+    assert rel.sql_expr is None
 
 
-def test_relationship_sql_expr_default_one_to_one():
-    """Test sql_expr property defaults to 'id' for one_to_one."""
+def test_relationship_sql_expr_does_not_invent_one_to_one_key():
     rel = Relationship(name="profile", type="one_to_one")
-    assert rel.sql_expr == "id"
+    assert rel.sql_expr is None
 
 
 def test_relationship_related_key_with_explicit_primary_key():
@@ -35,10 +34,9 @@ def test_relationship_related_key_with_explicit_primary_key():
     assert rel.related_key == "customer_uid"
 
 
-def test_relationship_related_key_default():
-    """Test related_key property defaults to 'id'."""
+def test_relationship_related_key_is_unknown_when_omitted():
     rel = Relationship(name="customers", type="many_to_one")
-    assert rel.related_key == "id"
+    assert rel.related_key is None
 
 
 def test_relationship_many_to_many():
@@ -68,21 +66,21 @@ def test_relationship_all_fields():
     assert rel.related_key == "organization_id"
 
 
-def test_relationship_default_column_lists_match_native_contract():
+def test_relationship_omitted_column_lists_remain_unknown():
     many_to_one = Relationship(name="customers", type="many_to_one")
-    assert many_to_one.foreign_key_columns == ["customers_id"]
-    assert many_to_one.primary_key_columns == ["id"]
+    assert many_to_one.foreign_key_columns == []
+    assert many_to_one.primary_key_columns == []
 
     one_to_many = Relationship(name="orders", type="one_to_many")
-    assert one_to_many.foreign_key_columns == ["id"]
-    assert one_to_many.primary_key_columns == ["id"]
+    assert one_to_many.foreign_key_columns == []
+    assert one_to_many.primary_key_columns == []
 
     one_to_one = Relationship(name="profile", type="one_to_one")
-    assert one_to_one.foreign_key_columns == ["id"]
-    assert one_to_one.primary_key_columns == ["id"]
+    assert one_to_one.foreign_key_columns == []
+    assert one_to_one.primary_key_columns == []
 
 
-def test_graph_many_to_one_omitted_keys_use_name_id_and_target_primary_key():
+def test_graph_many_to_one_omitted_foreign_key_is_not_joinable():
     graph = SemanticGraph()
     graph.add_model(
         Model(
@@ -94,14 +92,11 @@ def test_graph_many_to_one_omitted_keys_use_name_id_and_target_primary_key():
     )
     graph.add_model(Model(name="customers", table="customers", primary_key="customer_uid"))
 
-    path = graph.find_relationship_path("orders", "customers")
-
-    assert [(step.from_columns, step.to_columns, step.relationship) for step in path] == [
-        (["customers_id"], ["customer_uid"], "many_to_one")
-    ]
+    with pytest.raises(ValueError, match="No join path"):
+        graph.find_relationship_path("orders", "customers")
 
 
-def test_graph_one_to_many_omitted_keys_default_to_id_columns():
+def test_graph_one_to_many_omitted_foreign_key_is_not_joinable():
     graph = SemanticGraph()
     graph.add_model(
         Model(
@@ -113,14 +108,11 @@ def test_graph_one_to_many_omitted_keys_default_to_id_columns():
     )
     graph.add_model(Model(name="orders", table="orders", primary_key="id"))
 
-    path = graph.find_relationship_path("customers", "orders")
-
-    assert [(step.from_columns, step.to_columns, step.relationship) for step in path] == [
-        (["id"], ["id"], "one_to_many")
-    ]
+    with pytest.raises(ValueError, match="No join path"):
+        graph.find_relationship_path("customers", "orders")
 
 
-def test_graph_one_to_one_omitted_keys_default_to_id_columns():
+def test_graph_one_to_one_omitted_keys_are_not_joinable():
     graph = SemanticGraph()
     graph.add_model(
         Model(
@@ -132,11 +124,8 @@ def test_graph_one_to_one_omitted_keys_default_to_id_columns():
     )
     graph.add_model(Model(name="profiles", table="profiles", primary_key="id"))
 
-    path = graph.find_relationship_path("users", "profiles")
-
-    assert [(step.from_columns, step.to_columns, step.relationship) for step in path] == [
-        (["id"], ["id"], "one_to_one")
-    ]
+    with pytest.raises(ValueError, match="No join path"):
+        graph.find_relationship_path("users", "profiles")
 
 
 def test_graph_explicit_foreign_key_omitted_primary_key_uses_target_primary_key():
@@ -162,3 +151,68 @@ def test_graph_explicit_foreign_key_omitted_primary_key_uses_target_primary_key(
     assert [(step.from_columns, step.to_columns, step.relationship) for step in path] == [
         (["vendor_ref"], ["vendor_uid"], "many_to_one")
     ]
+
+
+def test_graph_mismatched_composite_key_arity_is_not_joinable():
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            primary_key="order_id",
+            relationships=[
+                Relationship(
+                    name="customers",
+                    type="many_to_one",
+                    foreign_key=["customer_id", "tenant_id"],
+                    primary_key="customer_id",
+                )
+            ],
+        )
+    )
+    graph.add_model(Model(name="customers", table="customers", primary_key="customer_id"))
+
+    with pytest.raises(ValueError, match="No join path"):
+        graph.find_relationship_path("orders", "customers")
+
+
+def test_graph_custom_sql_relationship_does_not_require_structured_keys():
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            relationships=[
+                Relationship(
+                    name="customers",
+                    type="many_to_one",
+                    sql="{from}.customer_id = {to}.customer_id",
+                )
+            ],
+        )
+    )
+    graph.add_model(Model(name="customers", table="customers"))
+
+    path = graph.find_relationship_path("orders", "customers")
+
+    assert len(path) == 1
+    assert path[0].custom_condition == "{from}.customer_id = {to}.customer_id"
+
+
+def test_graph_cross_relationship_does_not_require_structured_keys():
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            relationships=[Relationship(name="calendar", type="cross")],
+        )
+    )
+    graph.add_model(Model(name="calendar", table="calendar"))
+
+    path = graph.find_relationship_path("orders", "calendar")
+
+    assert len(path) == 1
+    assert path[0].relationship == "cross"
+    assert path[0].from_columns == []
+    assert path[0].to_columns == []

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -13,9 +13,8 @@ from sidemantic.validation import (
 from sidemantic.validation_runner import validate_directory
 
 
-def test_model_has_default_primary_key(layer):
-    """Test that models have a default primary key."""
-    # Model without explicit primary_key should default to "id"
+def test_model_without_primary_key_remains_explicitly_keyless(layer):
+    """Models must not manufacture an ``id`` key when none was declared."""
     model = Model(
         name="orders",
         table="orders",
@@ -25,7 +24,8 @@ def test_model_has_default_primary_key(layer):
     )
 
     layer.add_model(model)
-    assert model.primary_key == "id"
+    assert model.primary_key is None
+    assert model.primary_key_columns == []
 
 
 def test_model_validation_no_table(layer):


### PR DESCRIPTION
Foundational replacement for #274. Makes model and relationship keys explicit, preserves source-declared LookML keys, and prevents incomplete join edges.

This is the base of a stacked change and must remain draft and blocked until the keyless planner-safety follow-up lands. Do not merge independently.