### PR TITLE
Add consumption contract schema types

### DIFF
--- a/sidemantic/__init__.py
+++ b/sidemantic/__init__.py
@@ -4,8 +4,10 @@ from typing import TYPE_CHECKING
 
 __version__ = "0.10.2"
 
+from sidemantic.core.consumption import Explore, SavedQuery, View
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.freshness import Freshness
+from sidemantic.core.governance import Deprecation
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.parameter import Parameter
@@ -21,9 +23,11 @@ Measure = Metric
 
 __all__ = [
     "Dimension",
+    "Deprecation",
     "DashboardDocument",
     "DashboardSpecError",
     "Freshness",
+    "Explore",
     "Measure",  # Backwards compatibility
     "Metric",
     "Model",
@@ -41,7 +45,9 @@ __all__ = [
     "SecurityError",
     "SecurityPolicy",
     "Segment",
+    "SavedQuery",
     "SemanticLayer",
+    "View",
     "load_from_directory",
 ]
 

--- a/sidemantic/core/consumption.py
+++ b/sidemantic/core/consumption.py
@@ -1,0 +1,184 @@
+"""Curated semantic consumption contracts."""
+
+from collections.abc import Collection
+from typing import Any
+
+from pydantic import ConfigDict, Field, model_validator
+
+from sidemantic.core.governance import GovernedObject
+
+
+def expression_field_references(
+    expressions: Collection[str],
+    base_model: str,
+    *,
+    graph_metrics: Collection[str] = (),
+    graph_models: Collection[str] = (),
+) -> set[str]:
+    """Extract and qualify semantic field references from SQL-like expressions."""
+    from sqlglot import exp, parse_one
+
+    references: set[str] = set()
+    semantic_tables = {base_model, *graph_models}
+    for expression in expressions:
+        parsed = parse_one(expression)
+        for column in parsed.find_all(exp.Column):
+            select = column.find_ancestor(exp.Select)
+            if select is not None and column.table not in semantic_tables:
+                if not column.table:
+                    continue
+                local_tables: set[str] = set()
+                for table in select.find_all(exp.Table):
+                    if table.find_ancestor(exp.Select) is select:
+                        local_tables.add(table.name)
+                        local_tables.add(table.alias_or_name)
+                if column.table in local_tables:
+                    continue
+            if column.table:
+                references.add(f"{column.table}.{column.name}")
+            elif column.name in graph_metrics:
+                references.add(column.name)
+            else:
+                references.add(f"{base_model}.{column.name}")
+    return references
+
+
+def qualify_expression_fields(
+    expressions: Collection[str],
+    base_model: str,
+    *,
+    graph_metrics: Collection[str] = (),
+) -> list[str]:
+    """Qualify bare semantic fields in SQL-like contract expressions."""
+    from sqlglot import exp, parse_one
+
+    qualified: list[str] = []
+    for expression in expressions:
+        parsed = parse_one(expression)
+
+        def qualify_column(node: exp.Expression) -> exp.Expression:
+            if (
+                not isinstance(node, exp.Column)
+                or node.table
+                or node.name in graph_metrics
+                or node.find_ancestor(exp.Select, exp.Subquery) is not None
+            ):
+                return node
+            result = node.copy()
+            result.set("table", exp.to_identifier(base_model))
+            return result
+
+        qualified.append(parsed.transform(qualify_column).sql())
+    return qualified
+
+
+def qualify_order_by_fields(
+    expressions: Collection[str],
+    base_model: str,
+    *,
+    graph_metrics: Collection[str] = (),
+) -> list[str]:
+    """Qualify bare semantic fields while preserving ORDER BY direction."""
+    from sqlglot import exp, parse_one
+
+    qualified: list[str] = []
+    for expression in expressions:
+        statement = parse_one(f"SELECT 1 ORDER BY {expression}")
+        ordered = statement.args["order"].expressions
+
+        def qualify_column(node: exp.Expression) -> exp.Expression:
+            if not isinstance(node, exp.Column) or node.table or node.name in graph_metrics:
+                return node
+            result = node.copy()
+            result.set("table", exp.to_identifier(base_model))
+            return result
+
+        qualified.extend(item.transform(qualify_column).sql() for item in ordered)
+    return qualified
+
+
+class Explore(GovernedObject):
+    """Curated entrypoint over one or more models in the semantic graph.
+
+    ``model`` names the base model. Allowed fields constrain callers, defaults
+    populate omitted selections, and ``filters`` are mandatory for every query.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., description="Unique explore name")
+    model: str = Field(..., description="Base model in the physical semantic graph")
+    label: str | None = Field(None, description="Display label")
+    description: str | None = Field(None, description="Human-readable description")
+    allowed_dimensions: list[str] | None = Field(
+        None, description="Dimension allowlist; null means every graph dimension is allowed"
+    )
+    allowed_metrics: list[str] | None = Field(
+        None, description="Metric allowlist; null means every graph metric is allowed"
+    )
+    allowed_filter_fields: list[str] | None = Field(
+        None, description="Field allowlist for caller-supplied filters; null means unrestricted"
+    )
+    allowed_order_by: list[str] | None = Field(
+        None, description="Field allowlist for caller-supplied ordering; null means unrestricted"
+    )
+    default_dimensions: list[str] = Field(default_factory=list)
+    default_metrics: list[str] = Field(default_factory=list)
+    filters: list[str] = Field(default_factory=list, description="Mandatory filters applied to every query")
+    default_filters: list[str] = Field(default_factory=list, description="Filters used when callers omit filters")
+    default_order_by: list[str] = Field(default_factory=list)
+    default_limit: int | None = Field(None, ge=0)
+    max_limit: int | None = Field(None, ge=0)
+    metadata: dict[str, Any] | None = Field(None, description="Source-adapter metadata for lossless round-tripping")
+
+    @model_validator(mode="after")
+    def validate_defaults(self) -> "Explore":
+        def qualify(value: str) -> str:
+            return value if "." in value else f"{self.model}.{value}"
+
+        if self.allowed_dimensions is not None:
+            allowed = {qualify(value) for value in self.allowed_dimensions}
+            outside = sorted(value for value in self.default_dimensions if qualify(value) not in allowed)
+            if outside:
+                raise ValueError(f"default_dimensions are not allowed: {', '.join(outside)}")
+        if self.allowed_metrics is not None:
+            allowed = {qualify(value) for value in self.allowed_metrics}
+            outside = sorted(value for value in self.default_metrics if qualify(value) not in allowed)
+            if outside:
+                raise ValueError(f"default_metrics are not allowed: {', '.join(outside)}")
+        if self.allowed_filter_fields is not None:
+            allowed = {qualify(value) for value in self.allowed_filter_fields}
+            outside = sorted(expression_field_references(self.default_filters, self.model) - allowed)
+            if outside:
+                raise ValueError(f"default_filters reference fields that are not allowed: {', '.join(outside)}")
+        if self.allowed_order_by is not None:
+            allowed = {qualify(value) for value in self.allowed_order_by}
+            outside = sorted(expression_field_references(self.default_order_by, self.model) - allowed)
+            if outside:
+                raise ValueError(f"default_order_by references fields that are not allowed: {', '.join(outside)}")
+        if self.default_limit is not None and self.max_limit is not None and self.default_limit > self.max_limit:
+            raise ValueError("default_limit cannot exceed max_limit")
+        return self
+
+
+# Hex and other tools call this concept a View. Keep one schema and two names.
+View = Explore
+
+
+class SavedQuery(GovernedObject):
+    """Named, immutable structured semantic query."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., description="Unique saved-query name")
+    explore: str | None = Field(None, description="Optional Explore contract governing this query")
+    label: str | None = Field(None, description="Display label")
+    description: str | None = Field(None, description="Human-readable description")
+    dimensions: list[str] = Field(default_factory=list)
+    metrics: list[str] = Field(default_factory=list)
+    filters: list[str] = Field(default_factory=list)
+    segments: list[str] = Field(default_factory=list)
+    order_by: list[str] = Field(default_factory=list)
+    limit: int | None = Field(None, ge=0)
+    parameters: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = Field(None, description="Source-adapter metadata for lossless round-tripping")

--- a/sidemantic/core/freshness.py
+++ b/sidemantic/core/freshness.py
@@ -4,7 +4,7 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
 
 class Freshness(BaseModel):
-    """Model-level freshness policy for live chart/runtime responses.
+    """Freshness expectation for models, metrics, and curated explores.
 
     Prefer ``watermark`` for normal semantic-model usage. ``sql`` is retained as
     an advanced escape hatch when the source freshness marker cannot be expressed

--- a/sidemantic/core/governance.py
+++ b/sidemantic/core/governance.py
@@ -1,0 +1,66 @@
+"""Shared governance metadata for semantic objects."""
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from sidemantic.core.freshness import Freshness
+
+
+class Deprecation(BaseModel):
+    """Lifecycle details for a deprecated semantic object."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    message: str | None = Field(None, description="Human-readable migration guidance")
+    deprecated_at: date | None = Field(None, description="Date the object became deprecated")
+    sunset_at: date | None = Field(None, description="Date after which the object may be removed")
+    replaced_by: str | None = Field(None, description="Replacement semantic object reference")
+
+
+class GovernedObject(BaseModel):
+    """Reusable, non-enforcing governance fields.
+
+    These fields describe trust and lifecycle. They intentionally do not implement
+    authorization; model security policies remain the access-control boundary.
+    """
+
+    owner: str | None = Field(None, description="Accountable person or team")
+    domain: str | None = Field(None, description="Business domain")
+    category: str | None = Field(None, description="Catalog category")
+    tags: list[str] = Field(default_factory=list, description="Searchable catalog tags")
+    status: Literal["draft", "active", "deprecated"] | None = Field(
+        None, description="Semantic object lifecycle status"
+    )
+    certification: Literal["certified", "verified", "uncertified"] | None = Field(
+        None, description="Trust or review state"
+    )
+    deprecation: Deprecation | None = Field(None, description="Deprecation lifecycle and migration guidance")
+    freshness: Freshness | None = Field(None, description="Expected data freshness policy")
+    visibility: Literal["public", "internal", "private"] = Field(
+        "public", description="Catalog visibility; not an authorization policy"
+    )
+
+
+GOVERNANCE_FIELDS = {
+    "owner",
+    "domain",
+    "category",
+    "tags",
+    "status",
+    "certification",
+    "deprecation",
+    "freshness",
+    "visibility",
+}
+
+
+def governance_dict(value: GovernedObject) -> dict:
+    """Return non-default governance fields for metadata/catalog payloads."""
+    return value.model_dump(
+        include=GOVERNANCE_FIELDS,
+        exclude_none=True,
+        exclude_defaults=True,
+        mode="json",
+    )

--- a/sidemantic/core/metric.py
+++ b/sidemantic/core/metric.py
@@ -2,10 +2,12 @@
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
+
+from sidemantic.core.governance import GovernedObject
 
 
-class Metric(BaseModel):
+class Metric(GovernedObject):
     """Measure definition - supports simple aggregations and complex metric types.
 
     Measures can be:
@@ -76,6 +78,10 @@ class Metric(BaseModel):
         Complex expressions like SUM(x) / SUM(y) are preserved as-is.
         """
         if isinstance(data, dict):
+            if data.get("public") is False and "visibility" not in data:
+                data["visibility"] = "private"
+            if data.get("visibility") in {"internal", "private"} and "public" not in data:
+                data["public"] = False
             # Step 1: Handle expr alias
             expr_val = data.get("expr")
             sql_val = data.get("sql")

--- a/sidemantic/core/model.py
+++ b/sidemantic/core/model.py
@@ -2,10 +2,10 @@
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from sidemantic.core.dimension import Dimension
-from sidemantic.core.freshness import Freshness
+from sidemantic.core.governance import GovernedObject
 from sidemantic.core.metric import Metric
 from sidemantic.core.pre_aggregation import PreAggregation
 from sidemantic.core.relationship import Relationship
@@ -13,7 +13,7 @@ from sidemantic.core.security import SecurityPolicy
 from sidemantic.core.segment import Segment
 
 
-class Model(BaseModel):
+class Model(GovernedObject):
     """Model (dataset) definition.
 
     Models are the foundation of the semantic layer, mapping to physical tables
@@ -62,11 +62,6 @@ class Model(BaseModel):
     default_grain: Literal["second", "minute", "hour", "day", "week", "month", "quarter", "year"] | None = Field(
         None, description="Default time granularity when using default_time_dimension"
     )
-    freshness: Freshness | None = Field(
-        None,
-        description="Model-level source freshness policy inherited by live chart runtimes",
-    )
-
     # Auto-discover dimensions from database schema
     auto_dimensions: bool = Field(
         default=False,

--- a/sidemantic/core/semantic_graph.py
+++ b/sidemantic/core/semantic_graph.py
@@ -4,6 +4,7 @@ from collections import deque
 from dataclasses import dataclass
 from typing import Any
 
+from sidemantic.core.consumption import Explore, SavedQuery
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.parameter import Parameter
@@ -71,6 +72,8 @@ class SemanticGraph:
         self.metric_owners: dict[str, str] = {}
         self.table_calculations: dict[str, TableCalculation] = {}
         self.parameters: dict[str, Parameter] = {}
+        self.explores: dict[str, Explore] = {}
+        self.saved_queries: dict[str, SavedQuery] = {}
         self.import_warnings: list[dict[str, object]] = []
         self.metadata: dict[str, Any] = {}
         self._version = 0
@@ -164,6 +167,32 @@ class SemanticGraph:
 
         self.parameters[param.name] = param
         self._mark_dirty()
+
+    def add_explore(self, explore: Explore) -> None:
+        """Add a curated Explore/View consumption contract."""
+        if explore.name in self.explores:
+            raise ValueError(f"Explore {explore.name} already exists")
+        self.explores[explore.name] = explore
+        self._mark_dirty()
+
+    def get_explore(self, name: str) -> Explore:
+        """Get an Explore/View contract by name."""
+        if name not in self.explores:
+            raise KeyError(f"Explore {name} not found")
+        return self.explores[name]
+
+    def add_saved_query(self, saved_query: SavedQuery) -> None:
+        """Add a named structured query contract."""
+        if saved_query.name in self.saved_queries:
+            raise ValueError(f"Saved query {saved_query.name} already exists")
+        self.saved_queries[saved_query.name] = saved_query
+        self._mark_dirty()
+
+    def get_saved_query(self, name: str) -> SavedQuery:
+        """Get a saved query by name."""
+        if name not in self.saved_queries:
+            raise KeyError(f"Saved query {name} not found")
+        return self.saved_queries[name]
 
     def get_parameter(self, name: str) -> Parameter:
         """Get a parameter by name.

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -8,6 +8,13 @@ from pathlib import Path
 
 import yaml
 
+from sidemantic.core.consumption import (
+    Explore,
+    SavedQuery,
+    expression_field_references,
+    qualify_expression_fields,
+    qualify_order_by_fields,
+)
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
 from sidemantic.core.semantic_graph import SemanticGraph
@@ -616,6 +623,36 @@ class SemanticLayer:
         self._sql_rewrite_cache.clear()
         self._generation += 1
 
+    def add_explore(self, explore: Explore) -> None:
+        """Validate and add a curated Explore/View contract."""
+        from sidemantic.validation import validate_explore
+
+        errors, _warnings = validate_explore(explore, self.graph)
+        if errors:
+            raise ValueError(f"Explore '{explore.name}' validation failed:\n" + "\n".join(f"  - {e}" for e in errors))
+        self.graph.add_explore(explore)
+        self._generation += 1
+
+    def add_saved_query(self, saved_query: SavedQuery) -> None:
+        """Validate and add an immutable SavedQuery contract."""
+        from sidemantic.validation import validate_saved_query
+
+        errors, _warnings = validate_saved_query(saved_query, self.graph)
+        if errors:
+            raise ValueError(
+                f"Saved query '{saved_query.name}' validation failed:\n" + "\n".join(f"  - {e}" for e in errors)
+            )
+        self.graph.add_saved_query(saved_query)
+        self._generation += 1
+
+    def get_explore(self, name: str) -> Explore:
+        """Get a curated Explore/View by name."""
+        return self.graph.get_explore(name)
+
+    def get_saved_query(self, name: str) -> SavedQuery:
+        """Get a SavedQuery by name."""
+        return self.graph.get_saved_query(name)
+
     def query(
         self,
         metrics: list[str] | None = None,
@@ -633,6 +670,8 @@ class SemanticLayer:
         timezone: str | None = None,
         with_totals: bool = False,
         user_attributes: dict | None = None,
+        explore: str | None = None,
+        saved_query: str | None = None,
     ):
         """Execute a query against the semantic layer.
 
@@ -685,6 +724,8 @@ class SemanticLayer:
             timezone=timezone,
             with_totals=with_totals,
             user_attributes=user_attributes,
+            explore=explore,
+            saved_query=saved_query,
         )
         used_preagg = "used_preagg=true" in routing_sql
 
@@ -702,6 +743,8 @@ class SemanticLayer:
                 post_process=post_process,
                 timezone=timezone,
                 user_attributes=user_attributes,
+                explore=explore,
+                saved_query=saved_query,
             )
         else:
             sql = routing_sql
@@ -720,6 +763,8 @@ class SemanticLayer:
                 post_process=post_process,
                 timezone=timezone,
                 user_attributes=user_attributes,
+                explore=explore,
+                saved_query=saved_query,
             )
 
         return self._execute_with_preagg_fallback(
@@ -830,6 +875,168 @@ class SemanticLayer:
             limit = self.max_limit
         return limit
 
+    @staticmethod
+    def _consumption_reference(reference: str, base_model: str) -> str:
+        """Qualify a simple Explore field against its base model."""
+        if "." in reference or "(" in reference or " " in reference:
+            return reference
+        return f"{base_model}.{reference}"
+
+    def _consumption_metric_reference(self, reference: str, base_model: str) -> str:
+        """Keep graph metrics graph-scoped; qualify model-local metrics."""
+        if reference in self.graph.metrics:
+            return reference
+        return self._consumption_reference(reference, base_model)
+
+    def _resolve_consumption_contract(
+        self,
+        *,
+        explore_name: str | None,
+        saved_query_name: str | None,
+        metrics: list[str] | None,
+        dimensions: list[str] | None,
+        filters: list[str] | None,
+        segments: list[str] | None,
+        order_by: list[str] | None,
+        limit: int | None,
+        offset: int | None,
+        ungrouped: bool,
+        parameters: dict | None,
+        timezone: str | None,
+    ) -> tuple:
+        """Resolve defaults and enforce a named consumption contract."""
+        caller_supplied_order_by = order_by is not None
+        if saved_query_name:
+            supplied = {
+                "explore": explore_name,
+                "metrics": metrics,
+                "dimensions": dimensions,
+                "filters": filters,
+                "segments": segments,
+                "order_by": order_by,
+                "limit": limit,
+                "offset": offset,
+                "ungrouped": True if ungrouped else None,
+                "parameters": parameters,
+                "timezone": timezone,
+            }
+            overridden = [name for name, value in supplied.items() if value is not None]
+            if overridden:
+                raise ValueError(
+                    f"Saved query '{saved_query_name}' is immutable; remove overrides for: {', '.join(overridden)}"
+                )
+            definition = self.graph.get_saved_query(saved_query_name)
+            if definition.visibility != "public" and self.enforce_visibility:
+                raise ValueError(f"Saved query '{saved_query_name}' is not public")
+            metricflow_metadata = (definition.metadata or {}).get("metricflow", {})
+            if metricflow_metadata.get("executable") is False:
+                message = metricflow_metadata.get("compatibility_message") or "source syntax is not executable"
+                raise ValueError(f"Saved query '{saved_query_name}' cannot execute: {message}")
+            explore_name = definition.explore
+            metrics = list(definition.metrics)
+            dimensions = list(definition.dimensions)
+            filters = list(definition.filters)
+            segments = list(definition.segments)
+            order_by = list(definition.order_by)
+            limit = definition.limit
+            parameters = dict(definition.parameters) if definition.parameters is not None else None
+
+        if not explore_name:
+            return metrics, dimensions, filters, segments, order_by, limit, parameters, None
+
+        contract = self.graph.get_explore(explore_name)
+        if contract.visibility != "public" and self.enforce_visibility:
+            raise ValueError(f"Explore '{explore_name}' is not public")
+        base_model = self.graph.models.get(contract.model)
+        if self.enforce_visibility and (base_model is None or base_model.visibility != "public"):
+            raise SecurityError(f"Explore '{explore_name}' base model '{contract.model}' is not public")
+
+        if metrics is None:
+            metrics = list(contract.default_metrics)
+        if dimensions is None:
+            dimensions = list(contract.default_dimensions)
+        if (
+            not metrics
+            and not dimensions
+            and (contract.allowed_metrics is not None or contract.allowed_dimensions is not None)
+        ):
+            raise ValueError(f"Explore '{explore_name}' must select at least one metric or dimension")
+        metrics = [self._consumption_metric_reference(ref, contract.model) for ref in metrics]
+        dimensions = [self._consumption_reference(ref, contract.model) for ref in dimensions]
+        if segments is not None:
+            segments = [self._consumption_reference(ref, contract.model) for ref in segments]
+
+        if contract.allowed_metrics is not None:
+            allowed = {self._consumption_metric_reference(ref, contract.model) for ref in contract.allowed_metrics}
+            denied = [ref for ref in metrics if ref not in allowed]
+            if denied:
+                raise ValueError(f"Explore '{explore_name}' does not allow metric(s): {', '.join(denied)}")
+        if contract.allowed_dimensions is not None:
+            allowed = {self._consumption_reference(ref, contract.model) for ref in contract.allowed_dimensions}
+            denied = [ref for ref in dimensions if ref not in allowed]
+            if denied:
+                raise ValueError(f"Explore '{explore_name}' does not allow dimension(s): {', '.join(denied)}")
+
+        selected_filters = list(contract.default_filters) if filters is None else list(filters)
+        from sidemantic.core.parameter import ParameterSet
+
+        parameter_set = ParameterSet(self.graph.parameters, parameters)
+        mandatory_filters = [parameter_set.interpolate(expression) for expression in contract.filters]
+        selected_filters = [parameter_set.interpolate(expression) for expression in selected_filters]
+        graph_metrics = self.graph.metrics.keys()
+        if contract.allowed_filter_fields is not None:
+            allowed = {
+                self._consumption_metric_reference(ref, contract.model) for ref in contract.allowed_filter_fields
+            }
+            denied = sorted(
+                expression_field_references(
+                    selected_filters,
+                    contract.model,
+                    graph_metrics=graph_metrics,
+                    graph_models=self.graph.models.keys(),
+                )
+                - allowed
+            )
+            if denied:
+                raise ValueError(f"Explore '{explore_name}' does not allow filter field(s): {', '.join(denied)}")
+        filters = qualify_expression_fields(
+            [*mandatory_filters, *selected_filters],
+            contract.model,
+            graph_metrics=graph_metrics,
+        )
+        if order_by is None:
+            order_by = list(contract.default_order_by)
+        if contract.allowed_order_by is not None:
+            allowed = {self._consumption_metric_reference(ref, contract.model) for ref in contract.allowed_order_by}
+            order_references = expression_field_references(
+                order_by,
+                contract.model,
+                graph_metrics=graph_metrics,
+                graph_models=self.graph.models.keys(),
+            )
+            denied = sorted(order_references - allowed)
+            if denied:
+                raise ValueError(f"Explore '{explore_name}' does not allow ordering by: {', '.join(denied)}")
+        else:
+            order_references = expression_field_references(
+                order_by,
+                contract.model,
+                graph_metrics=graph_metrics,
+                graph_models=self.graph.models.keys(),
+            )
+        unselected_order_fields = sorted(order_references - {*metrics, *dimensions})
+        if caller_supplied_order_by and unselected_order_fields:
+            raise ValueError(
+                f"Explore '{explore_name}' ordering field(s) must be selected by the query: "
+                f"{', '.join(unselected_order_fields)}"
+            )
+        order_by = qualify_order_by_fields(order_by, contract.model, graph_metrics=graph_metrics)
+        if limit is None:
+            limit = contract.default_limit
+        if contract.max_limit is not None and limit is not None and limit > contract.max_limit:
+            raise ValueError(f"Explore '{explore_name}' limit {limit} exceeds max_limit {contract.max_limit}")
+        return metrics, dimensions, filters, segments, order_by, limit, parameters, contract.model
+
     def compile(
         self,
         metrics: list[str] | None = None,
@@ -848,6 +1055,8 @@ class SemanticLayer:
         timezone: str | None = None,
         with_totals: bool = False,
         user_attributes: dict | None = None,
+        explore: str | None = None,
+        saved_query: str | None = None,
     ) -> str:
         """Compile a query to SQL without executing.
 
@@ -887,6 +1096,29 @@ class SemanticLayer:
         """
         from sidemantic.validation import QueryValidationError, validate_query
 
+        (
+            metrics,
+            dimensions,
+            filters,
+            segments,
+            order_by,
+            limit,
+            parameters,
+            consumption_base_model,
+        ) = self._resolve_consumption_contract(
+            explore_name=explore,
+            saved_query_name=saved_query,
+            metrics=metrics,
+            dimensions=dimensions,
+            filters=filters,
+            segments=segments,
+            order_by=order_by,
+            limit=limit,
+            offset=offset,
+            ungrouped=ungrouped,
+            parameters=parameters,
+            timezone=timezone,
+        )
         metrics = metrics or []
         dimensions = dimensions or []
 
@@ -936,7 +1168,13 @@ class SemanticLayer:
         # The Rust generator implements neither query-timezone bucketing nor with_totals
         # GROUPING SETS, so use the Python path when either is requested.
         # (Pre-agg bypass for timezone queries is enforced inside SQLGenerator.generate.)
-        if self._use_rust_sql_generator and not timezone and not with_totals and not security_forces_python:
+        if (
+            self._use_rust_sql_generator
+            and not timezone
+            and not with_totals
+            and not security_forces_python
+            and consumption_base_model is None
+        ):
             inner_sql = self._compile_with_rust(
                 metrics=metrics,
                 dimensions=dimensions,
@@ -967,6 +1205,7 @@ class SemanticLayer:
                     parameters=parameters,
                     use_preaggregations=use_preaggs,
                     aliases=aliases,
+                    base_model=consumption_base_model,
                 )
                 if inner_sql.strip() != python_sql.strip():
                     if self._rust_no_fallback or self._strict_rust_sql_generator_entrypoint:
@@ -990,6 +1229,7 @@ class SemanticLayer:
                 timezone=timezone,
                 with_totals=with_totals,
                 user_attributes=user_attributes,
+                base_model=consumption_base_model,
             )
 
         return self._apply_post_process(inner_sql, post_process)
@@ -1030,6 +1270,7 @@ class SemanticLayer:
         timezone: str | None = None,
         with_totals: bool = False,
         user_attributes: dict | None = None,
+        base_model: str | None = None,
     ) -> str:
         generator = SQLGenerator(
             self.graph,
@@ -1039,6 +1280,7 @@ class SemanticLayer:
             timezone=timezone,
             allow_non_additive_unsafe=self.allow_non_additive_unsafe,
             enforce_visibility=self.enforce_visibility,
+            base_model=base_model,
         )
 
         return generator.generate(

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -110,6 +110,7 @@ class SQLGenerator:
         timezone: str | None = None,
         allow_non_additive_unsafe: bool = False,
         enforce_visibility: bool = False,
+        base_model: str | None = None,
     ):
         """Initialize SQL generator.
 
@@ -126,6 +127,9 @@ class SQLGenerator:
                 implements semi-additive handling (QUALIFY last/first snapshot per group);
                 this flag opts back into the old, naive behavior explicitly (default: False)
             enforce_visibility: Reject references to fields declared ``public: false``
+            base_model: Optional model that must anchor the generated join graph. Explore
+                contracts use this to preserve their declared row scope when callers select
+                fields only from joined models.
         """
         self.graph = graph
         self.dialect = dialect
@@ -133,6 +137,7 @@ class SQLGenerator:
         self.preagg_schema = preagg_schema
         self.allow_non_additive_unsafe = allow_non_additive_unsafe
         self.enforce_visibility = enforce_visibility
+        self.base_model = base_model
         # The timezone is interpolated into SQL string literals (AT TIME ZONE '...', etc.),
         # so it must not contain quote/escape characters. Restrict to IANA-name characters
         # to prevent SQL injection from a request- or preference-supplied value; the database
@@ -1503,6 +1508,9 @@ class SQLGenerator:
             if model_name not in seen:
                 models.append(model_name)
                 seen.add(model_name)
+
+        if self.base_model:
+            add_model(self.base_model)
 
         def collect_models_from_metric(metric_ref: str):
             """Recursively collect models needed from a metric."""

--- a/sidemantic/validation.py
+++ b/sidemantic/validation.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Literal, get_args, get_origin
 from sidemantic.sql.aggregation_detection import sql_has_aggregate
 
 if TYPE_CHECKING:
+    from sidemantic.core.consumption import Explore, SavedQuery
     from sidemantic.core.metric import Metric
     from sidemantic.core.model import Model
     from sidemantic.core.semantic_graph import SemanticGraph
@@ -33,6 +34,394 @@ class ModelValidationError(ValidationError):
     """Raised when model validation fails."""
 
     pass
+
+
+def validate_governance(value, label: str) -> tuple[list[str], list[str]]:
+    """Validate cross-field governance lifecycle metadata."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    deprecation = getattr(value, "deprecation", None)
+    status = getattr(value, "status", None)
+    if status == "deprecated" and deprecation is None:
+        errors.append(f"{label} is deprecated but has no deprecation lifecycle/message")
+    if deprecation is not None:
+        if not deprecation.message:
+            warnings.append(f"{label} deprecation has no migration message")
+        if deprecation.deprecated_at and deprecation.sunset_at and deprecation.sunset_at < deprecation.deprecated_at:
+            errors.append(f"{label} deprecation sunset_at is before deprecated_at")
+    tags = getattr(value, "tags", []) or []
+    if len(tags) != len(set(tags)):
+        errors.append(f"{label} has duplicate governance tags")
+    return errors, warnings
+
+
+def _qualified_consumption_refs(references: list[str], base_model: str) -> list[str]:
+    return [ref if "." in ref or "(" in ref or " " in ref else f"{base_model}.{ref}" for ref in references]
+
+
+def _qualified_consumption_metrics(references: list[str], base_model: str, graph: "SemanticGraph") -> list[str]:
+    return [ref if ref in graph.metrics else _qualified_consumption_refs([ref], base_model)[0] for ref in references]
+
+
+def _is_metric_or_dimension(reference: str, graph: "SemanticGraph") -> bool:
+    return not validate_query([reference], [], graph) or not validate_query([], [reference], graph)
+
+
+def _validate_consumption_expressions(
+    label: str,
+    field_kind: str,
+    expressions: list[str],
+    base_model: str,
+    graph: "SemanticGraph",
+    *,
+    query_metrics: list[str] | None = None,
+    query_dimensions: list[str] | None = None,
+) -> list[str]:
+    from sidemantic.core.consumption import expression_field_references
+
+    try:
+        references = expression_field_references(
+            expressions,
+            base_model,
+            graph_metrics=graph.metrics.keys(),
+            graph_models=graph.models.keys(),
+        )
+    except Exception as error:
+        return [f"{label} contains an invalid {field_kind} expression: {error}"]
+    errors = [
+        f"{label} {field_kind} field '{reference}' is not a metric or dimension"
+        for reference in sorted(references)
+        if not _is_metric_or_dimension(reference, graph)
+    ]
+    if errors:
+        return errors
+
+    expression_metrics: list[str] = []
+    expression_dimensions: list[str] = []
+    for reference in sorted(references):
+        if not validate_query([reference], [], graph):
+            expression_metrics.append(reference)
+        else:
+            expression_dimensions.append(reference)
+    compatibility_errors = validate_query(
+        [*(query_metrics or []), *expression_metrics],
+        [*(query_dimensions or []), *expression_dimensions],
+        graph,
+    )
+    return [
+        f"{label} {field_kind} expression is incompatible with its selected query: {error}"
+        for error in compatibility_errors
+    ]
+
+
+def _validate_order_fields_selected(
+    label: str,
+    expressions: list[str],
+    selected_metrics: list[str],
+    selected_dimensions: list[str],
+    base_model: str,
+    graph: "SemanticGraph",
+) -> list[str]:
+    from sidemantic.core.consumption import expression_field_references
+
+    try:
+        references = expression_field_references(
+            expressions,
+            base_model,
+            graph_metrics=graph.metrics.keys(),
+            graph_models=graph.models.keys(),
+        )
+    except Exception:
+        return []
+    selected = {*selected_metrics, *selected_dimensions}
+    outside = sorted(references - selected)
+    if not outside:
+        return []
+    return [f"{label} ordering field(s) must be selected by the query: {', '.join(outside)}"]
+
+
+def _validate_consumption_base_model(
+    label: str,
+    base_model: str,
+    metrics: list[str],
+    dimensions: list[str],
+    graph: "SemanticGraph",
+    filters: list[str] | None = None,
+) -> list[str]:
+    from sidemantic.sql.generator import SQLGenerator
+
+    selected_models = SQLGenerator(graph)._find_required_models(metrics, dimensions, filters or [])
+    errors: list[str] = []
+    for model_name in selected_models:
+        if model_name == base_model:
+            continue
+        try:
+            graph.find_relationship_path(base_model, model_name)
+        except (KeyError, ValueError):
+            errors.append(f"{label} has no join path from base model '{base_model}' to selected model '{model_name}'")
+    return errors
+
+
+def validate_explore(explore: "Explore", graph: "SemanticGraph") -> tuple[list[str], list[str]]:
+    """Validate a curated Explore/View contract against the physical graph."""
+    errors, warnings = validate_governance(explore, f"Explore '{explore.name}'")
+    if explore.model not in graph.models:
+        errors.append(f"Explore '{explore.name}' references model '{explore.model}' which doesn't exist")
+        return errors, warnings
+    dimensions = [*(explore.allowed_dimensions or []), *explore.default_dimensions]
+    metrics = [*(explore.allowed_metrics or []), *explore.default_metrics]
+    qualified_metrics = _qualified_consumption_metrics(metrics, explore.model, graph)
+    qualified_dimensions = _qualified_consumption_refs(dimensions, explore.model)
+    errors.extend(
+        validate_query(
+            qualified_metrics,
+            qualified_dimensions,
+            graph,
+        )
+    )
+    errors.extend(
+        _validate_consumption_base_model(
+            f"Explore '{explore.name}'",
+            explore.model,
+            qualified_metrics,
+            qualified_dimensions,
+            graph,
+        )
+    )
+    for field_kind, references in (
+        ("filter", explore.allowed_filter_fields or []),
+        ("ordering", explore.allowed_order_by or []),
+    ):
+        for reference in _qualified_consumption_metrics(references, explore.model, graph):
+            if not _is_metric_or_dimension(reference, graph):
+                errors.append(f"Explore '{explore.name}' {field_kind} field '{reference}' is not a metric or dimension")
+    errors.extend(
+        _validate_consumption_expressions(
+            f"Explore '{explore.name}'",
+            "filter",
+            [*explore.filters, *explore.default_filters],
+            explore.model,
+            graph,
+            query_metrics=qualified_metrics,
+            query_dimensions=qualified_dimensions,
+        )
+    )
+    errors.extend(
+        _validate_consumption_expressions(
+            f"Explore '{explore.name}'",
+            "ordering",
+            explore.default_order_by,
+            explore.model,
+            graph,
+            query_metrics=qualified_metrics,
+            query_dimensions=qualified_dimensions,
+        )
+    )
+    errors.extend(
+        _validate_order_fields_selected(
+            f"Explore '{explore.name}' default",
+            explore.default_order_by,
+            _qualified_consumption_metrics(explore.default_metrics, explore.model, graph),
+            _qualified_consumption_refs(explore.default_dimensions, explore.model),
+            explore.model,
+            graph,
+        )
+    )
+    if not metrics and not dimensions:
+        warnings.append(f"Explore '{explore.name}' defines no allowed or default fields")
+    if any(not value.strip() for value in [*explore.filters, *explore.default_filters, *explore.default_order_by]):
+        errors.append(f"Explore '{explore.name}' contains an empty filter or ordering expression")
+    return errors, warnings
+
+
+def validate_saved_query(saved_query: "SavedQuery", graph: "SemanticGraph") -> tuple[list[str], list[str]]:
+    """Validate a SavedQuery against its Explore and physical graph."""
+    errors, warnings = validate_governance(saved_query, f"Saved query '{saved_query.name}'")
+    metricflow_metadata = (saved_query.metadata or {}).get("metricflow", {})
+    preserved_external_syntax = metricflow_metadata.get("executable") is False
+    if preserved_external_syntax:
+        warnings.append(
+            f"Saved query '{saved_query.name}' is preserved from MetricFlow but is not executable: "
+            f"{metricflow_metadata.get('compatibility_message', 'convert source expressions to Sidemantic references')}"
+        )
+    base_model = ""
+    explore = None
+    if saved_query.explore:
+        explore = graph.explores.get(saved_query.explore)
+        if explore is None:
+            errors.append(
+                f"Saved query '{saved_query.name}' references explore '{saved_query.explore}' which doesn't exist"
+            )
+        else:
+            base_model = explore.model
+    metrics = (
+        _qualified_consumption_metrics(saved_query.metrics, base_model, graph) if base_model else saved_query.metrics
+    )
+    dimensions = (
+        _qualified_consumption_refs(saved_query.dimensions, base_model) if base_model else saved_query.dimensions
+    )
+    validated_filters = list(saved_query.filters)
+    inherited_explore_filters = list(explore.filters) if explore is not None else []
+    from sidemantic.core.parameter import ParameterSet
+
+    parameter_set = ParameterSet(graph.parameters, saved_query.parameters)
+    try:
+        validated_filters = [parameter_set.interpolate(expression) for expression in validated_filters]
+        inherited_explore_filters = [parameter_set.interpolate(expression) for expression in inherited_explore_filters]
+    except (KeyError, TypeError, ValueError) as error:
+        errors.append(f"Saved query '{saved_query.name}' has invalid parameter values: {error}")
+        validated_filters = []
+        inherited_explore_filters = []
+    if not preserved_external_syntax:
+        errors.extend(validate_query(metrics, dimensions, graph))
+        errors.extend(
+            _validate_consumption_expressions(
+                f"Saved query '{saved_query.name}'",
+                "filter",
+                validated_filters,
+                base_model,
+                graph,
+                query_metrics=metrics,
+                query_dimensions=dimensions,
+            )
+        )
+        errors.extend(
+            _validate_consumption_expressions(
+                f"Saved query '{saved_query.name}'",
+                "ordering",
+                saved_query.order_by,
+                base_model,
+                graph,
+                query_metrics=metrics,
+                query_dimensions=dimensions,
+            )
+        )
+        errors.extend(
+            _validate_order_fields_selected(
+                f"Saved query '{saved_query.name}'",
+                saved_query.order_by,
+                metrics,
+                dimensions,
+                base_model,
+                graph,
+            )
+        )
+        valid_segments: list[str] = []
+        for raw_segment in saved_query.segments:
+            segment_ref = raw_segment
+            if "." not in segment_ref and base_model:
+                segment_ref = f"{base_model}.{segment_ref}"
+            if "." not in segment_ref:
+                errors.append(
+                    f"Saved query '{saved_query.name}' segment reference must be in format 'model.segment': "
+                    f"{raw_segment}"
+                )
+                continue
+            model_name, segment_name = segment_ref.split(".", 1)
+            model = graph.models.get(model_name)
+            if model is None:
+                errors.append(
+                    f"Saved query '{saved_query.name}' segment '{raw_segment}' references model "
+                    f"'{model_name}' which doesn't exist"
+                )
+            elif model.get_segment(segment_name) is None:
+                errors.append(
+                    f"Saved query '{saved_query.name}' references segment '{segment_name}' which doesn't exist "
+                    f"on model '{model_name}'"
+                )
+            else:
+                valid_segments.append(segment_ref)
+        if explore is not None:
+            from sidemantic.sql.generator import SQLGenerator
+
+            segment_filters = SQLGenerator(graph)._resolve_segments(valid_segments)
+            errors.extend(
+                _validate_consumption_base_model(
+                    f"Saved query '{saved_query.name}'",
+                    explore.model,
+                    metrics,
+                    dimensions,
+                    graph,
+                    filters=segment_filters,
+                )
+            )
+            errors.extend(
+                _validate_consumption_expressions(
+                    f"Saved query '{saved_query.name}' inherited Explore '{explore.name}'",
+                    "filter",
+                    inherited_explore_filters,
+                    base_model,
+                    graph,
+                    query_metrics=metrics,
+                    query_dimensions=dimensions,
+                )
+            )
+            if explore.allowed_metrics is not None:
+                allowed_metrics = set(_qualified_consumption_metrics(explore.allowed_metrics, base_model, graph))
+                denied_metrics = sorted(set(metrics) - allowed_metrics)
+                if denied_metrics:
+                    errors.append(
+                        f"Saved query '{saved_query.name}' selects metric(s) not allowed by Explore "
+                        f"'{explore.name}': {', '.join(denied_metrics)}"
+                    )
+            if explore.allowed_dimensions is not None:
+                allowed_dimensions = set(_qualified_consumption_refs(explore.allowed_dimensions, base_model))
+                denied_dimensions = sorted(set(dimensions) - allowed_dimensions)
+                if denied_dimensions:
+                    errors.append(
+                        f"Saved query '{saved_query.name}' selects dimension(s) not allowed by Explore "
+                        f"'{explore.name}': {', '.join(denied_dimensions)}"
+                    )
+
+            from sidemantic.core.consumption import expression_field_references
+
+            graph_metrics = graph.metrics.keys()
+            if explore.allowed_filter_fields is not None:
+                allowed_filters = set(_qualified_consumption_metrics(explore.allowed_filter_fields, base_model, graph))
+                denied_filters = sorted(
+                    expression_field_references(
+                        validated_filters,
+                        base_model,
+                        graph_metrics=graph_metrics,
+                        graph_models=graph.models.keys(),
+                    )
+                    - allowed_filters
+                )
+                if denied_filters:
+                    errors.append(
+                        f"Saved query '{saved_query.name}' filters on field(s) not allowed by Explore "
+                        f"'{explore.name}': {', '.join(denied_filters)}"
+                    )
+            if explore.allowed_order_by is not None:
+                allowed_ordering = set(_qualified_consumption_metrics(explore.allowed_order_by, base_model, graph))
+                denied_ordering = sorted(
+                    expression_field_references(
+                        saved_query.order_by,
+                        base_model,
+                        graph_metrics=graph_metrics,
+                        graph_models=graph.models.keys(),
+                    )
+                    - allowed_ordering
+                )
+                if denied_ordering:
+                    errors.append(
+                        f"Saved query '{saved_query.name}' orders by field(s) not allowed by Explore "
+                        f"'{explore.name}': {', '.join(denied_ordering)}"
+                    )
+            if (
+                explore.max_limit is not None
+                and saved_query.limit is not None
+                and saved_query.limit > explore.max_limit
+            ):
+                errors.append(
+                    f"Saved query '{saved_query.name}' limit {saved_query.limit} exceeds Explore "
+                    f"'{explore.name}' max_limit {explore.max_limit}"
+                )
+    if not saved_query.metrics and not saved_query.dimensions:
+        errors.append(f"Saved query '{saved_query.name}' must select at least one metric or dimension")
+    if any(not value.strip() for value in [*saved_query.filters, *saved_query.order_by]):
+        errors.append(f"Saved query '{saved_query.name}' contains an empty filter or ordering expression")
+    return errors, warnings
 
 
 def _extract_literal_strings(annotation) -> set[str]:

--- a/tests/core/test_consumption_compiler.py
+++ b/tests/core/test_consumption_compiler.py
@@ -1,0 +1,414 @@
+"""Focused tests for consumption-contract compilation and validation."""
+
+import pytest
+
+from sidemantic import (
+    Dimension,
+    Explore,
+    Metric,
+    Model,
+    Parameter,
+    Relationship,
+    SavedQuery,
+    Segment,
+    SemanticLayer,
+)
+from sidemantic.core.consumption import expression_field_references, qualify_expression_fields
+from sidemantic.validation import validate_explore, validate_saved_query
+
+
+def _layer() -> SemanticLayer:
+    layer = SemanticLayer(auto_register=False)
+    layer.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            primary_key="order_id",
+            owner="analytics",
+            domain="commerce",
+            category="sales",
+            tags=["tier-1", "finance"],
+            status="active",
+            certification="certified",
+            dimensions=[
+                Dimension(name="status", type="categorical"),
+                Dimension(name="created_at", type="time", granularity="day"),
+            ],
+            metrics=[
+                Metric(name="revenue", agg="sum", sql="amount", owner="finance"),
+                Metric(name="order_count", agg="count"),
+            ],
+        )
+    )
+    layer.graph.add_explore(
+        Explore(
+            name="revenue_overview",
+            model="orders",
+            label="Revenue overview",
+            allowed_dimensions=["status", "created_at__month"],
+            allowed_metrics=["revenue", "order_count"],
+            allowed_filter_fields=["status"],
+            allowed_order_by=["revenue"],
+            default_dimensions=["status"],
+            default_metrics=["revenue"],
+            filters=["orders.status != 'deleted'"],
+            default_filters=["orders.status = 'paid'"],
+            default_order_by=["orders.revenue DESC"],
+            default_limit=25,
+            max_limit=100,
+            owner="analytics",
+            domain="commerce",
+            certification="verified",
+        )
+    )
+    layer.graph.add_saved_query(
+        SavedQuery(
+            name="paid_revenue",
+            explore="revenue_overview",
+            dimensions=["status"],
+            metrics=["revenue"],
+            filters=["orders.status = 'paid'"],
+            order_by=["orders.revenue DESC"],
+            limit=10,
+        )
+    )
+    return layer
+
+
+def test_explore_defaults_compile_and_mandatory_filters_apply():
+    sql = _layer().compile(explore="revenue_overview")
+
+    assert "SUM(orders_cte.revenue_raw)" in sql
+    assert "status <> 'deleted'" in sql
+    assert "status = 'paid'" in sql
+    assert "ORDER BY" in sql
+    assert "LIMIT 25" in sql
+
+
+def test_explore_qualifies_relative_filter_and_order_expressions():
+    layer = _layer()
+    layer.graph.add_explore(
+        Explore(
+            name="relative_contract",
+            model="orders",
+            default_metrics=["revenue"],
+            filters=["status != 'deleted'"],
+            default_filters=["status = 'paid'"],
+            default_order_by=["revenue DESC"],
+        )
+    )
+
+    sql = layer.compile(explore="relative_contract")
+
+    assert "status <> 'deleted'" in sql
+    assert "status = 'paid'" in sql
+    assert "status AS status" in sql
+    assert "revenue DESC" in sql
+
+
+def test_explore_filter_qualification_skips_subquery_columns():
+    expression = "status IN (SELECT status FROM allowed_statuses)"
+
+    assert qualify_expression_fields([expression], "orders") == [
+        "orders.status IN (SELECT status FROM allowed_statuses)"
+    ]
+    assert expression_field_references([expression], "orders") == {"orders.status"}
+
+    correlated = "EXISTS (SELECT 1 FROM allowed_statuses AS allowed WHERE allowed.status = orders.status)"
+    assert expression_field_references([correlated], "orders", graph_models={"orders"}) == {"orders.status"}
+
+
+def test_explore_queries_remain_anchored_to_the_base_model():
+    layer = _layer()
+    layer.graph.models["orders"].relationships.append(
+        Relationship(name="customers", type="many_to_one", foreign_key="customer_id")
+    )
+    layer.add_model(
+        Model(
+            name="customers",
+            table="customers",
+            primary_key="customer_id",
+            dimensions=[Dimension(name="region", type="categorical")],
+        )
+    )
+    layer.graph.add_explore(
+        Explore(
+            name="orders_by_customer",
+            model="orders",
+            allowed_dimensions=["customers.region"],
+        )
+    )
+
+    sql = layer.compile(explore="orders_by_customer", dimensions=["customers.region"])
+
+    assert "FROM orders_cte" in sql
+    assert "JOIN customers_cte" in sql
+
+
+def test_explore_enforces_allowlists_and_max_limit():
+    layer = _layer()
+
+    with pytest.raises(ValueError, match="does not allow dimension"):
+        layer.compile(explore="revenue_overview", dimensions=["orders.order_id"])
+    with pytest.raises(ValueError, match="does not allow filter field"):
+        layer.compile(explore="revenue_overview", filters=["orders.created_at > '2026-01-01'"])
+    with pytest.raises(ValueError, match="does not allow filter field"):
+        layer.compile(
+            explore="revenue_overview",
+            filters=["EXISTS (SELECT 1 WHERE orders.created_at > '2026-01-01')"],
+        )
+    with pytest.raises(ValueError, match="does not allow ordering"):
+        layer.compile(explore="revenue_overview", order_by=["orders.status"])
+    with pytest.raises(ValueError, match="exceeds max_limit"):
+        layer.compile(explore="revenue_overview", limit=101)
+
+    layer.graph.add_explore(Explore(name="choose_revenue", model="orders", allowed_metrics=["revenue"]))
+    with pytest.raises(ValueError, match="must select at least one metric or dimension"):
+        layer.compile(explore="choose_revenue")
+    assert "SUM" in layer.compile(explore="choose_revenue", metrics=["revenue"])
+
+
+def test_saved_query_is_immutable_and_compiles_through_its_explore():
+    layer = _layer()
+
+    sql = layer.compile(saved_query="paid_revenue")
+    assert "LIMIT 10" in sql
+    assert "status <> 'deleted'" in sql
+    with pytest.raises(ValueError, match="immutable"):
+        layer.compile(saved_query="paid_revenue", metrics=["orders.order_count"])
+    with pytest.raises(ValueError, match="offset"):
+        layer.compile(saved_query="paid_revenue", offset=5)
+    with pytest.raises(ValueError, match="ungrouped"):
+        layer.compile(saved_query="paid_revenue", ungrouped=True)
+    with pytest.raises(ValueError, match="timezone"):
+        layer.compile(saved_query="paid_revenue", timezone="America/Los_Angeles")
+    with pytest.raises(ValueError, match="explore"):
+        layer.compile(saved_query="paid_revenue", explore="revenue_overview")
+
+    layer.graph.add_saved_query(SavedQuery(name="all_revenue", metrics=["orders.revenue"]))
+    with pytest.raises(ValueError, match="explore"):
+        layer.compile(saved_query="all_revenue", explore="revenue_overview")
+
+
+def test_validation_accepts_metric_filters_and_preflights_saved_query_explore_constraints():
+    layer = _layer()
+    layer.graph.models["orders"].metrics.append(Metric(name="cost", agg="sum", sql="cost"))
+    explore = layer.graph.explores["revenue_overview"]
+    explore.allowed_filter_fields = ["status", "revenue"]
+    errors, _warnings = validate_explore(explore, layer.graph)
+    assert errors == []
+
+    invalid = SavedQuery(
+        name="invalid_contract",
+        explore="revenue_overview",
+        metrics=["cost"],
+        dimensions=["created_at__month"],
+        filters=["orders.created_at > '2026-01-01'"],
+        order_by=["orders.status"],
+        limit=101,
+    )
+    errors, _warnings = validate_saved_query(invalid, layer.graph)
+    assert any("metric(s) not allowed" in error for error in errors)
+    assert any("filters on field(s) not allowed" in error for error in errors)
+    assert any("orders by field(s) not allowed" in error for error in errors)
+    assert any("exceeds Explore" in error for error in errors)
+
+
+def test_validation_preflights_saved_query_segments():
+    layer = _layer()
+    layer.graph.models["orders"].segments.append(Segment(name="paid", sql="{model}.status = 'paid'"))
+
+    valid = SavedQuery(
+        name="valid_segment",
+        explore="revenue_overview",
+        metrics=["revenue"],
+        segments=["paid"],
+    )
+    errors, _warnings = validate_saved_query(valid, layer.graph)
+    assert errors == []
+    layer.graph.add_saved_query(valid)
+    assert "status = 'paid'" in layer.compile(saved_query="valid_segment")
+
+    invalid = valid.model_copy(update={"name": "invalid_segment", "segments": ["orders.missing"]})
+    errors, _warnings = validate_saved_query(invalid, layer.graph)
+    assert errors == [
+        "Saved query 'invalid_segment' references segment 'missing' which doesn't exist on model 'orders'"
+    ]
+
+
+def test_validation_preflights_consumption_filter_and_order_fields():
+    layer = _layer()
+    explore = layer.graph.explores["revenue_overview"].model_copy(
+        update={"name": "invalid_defaults", "default_order_by": ["orders.missing DESC"]}
+    )
+    errors, _warnings = validate_explore(explore, layer.graph)
+    assert "Explore 'invalid_defaults' ordering field 'orders.missing' is not a metric or dimension" in errors
+
+    saved_query = SavedQuery(
+        name="invalid_expressions",
+        metrics=["orders.revenue"],
+        filters=["orders.missing > 0"],
+        order_by=["orders.unknown DESC"],
+    )
+    errors, _warnings = validate_saved_query(saved_query, layer.graph)
+    assert "Saved query 'invalid_expressions' filter field 'orders.missing' is not a metric or dimension" in errors
+    assert "Saved query 'invalid_expressions' ordering field 'orders.unknown' is not a metric or dimension" in errors
+
+
+def test_validation_rejects_expression_models_without_a_join_path():
+    layer = _layer()
+    layer.add_model(
+        Model(
+            name="customers",
+            table="customers",
+            dimensions=[Dimension(name="region", type="categorical")],
+        )
+    )
+    explore = Explore(
+        name="disconnected_filter",
+        model="orders",
+        default_metrics=["revenue"],
+        filters=["customers.region = 'West'"],
+    )
+    errors, _warnings = validate_explore(explore, layer.graph)
+    assert any("filter expression is incompatible" in error and "No join path found" in error for error in errors)
+
+    saved_query = SavedQuery(
+        name="disconnected_saved_query",
+        explore="revenue_overview",
+        metrics=["revenue"],
+        filters=["customers.region = 'West'"],
+    )
+    errors, _warnings = validate_saved_query(saved_query, layer.graph)
+    assert any("filter expression is incompatible" in error and "No join path found" in error for error in errors)
+
+    disconnected_selection = Explore(
+        name="disconnected_selection",
+        model="orders",
+        default_dimensions=["customers.region"],
+    )
+    errors, _warnings = validate_explore(disconnected_selection, layer.graph)
+    assert (
+        "Explore 'disconnected_selection' has no join path from base model 'orders' to selected model 'customers'"
+        in errors
+    )
+
+
+def test_validation_checks_saved_query_with_mandatory_explore_filters():
+    layer = _layer()
+    layer.add_model(
+        Model(
+            name="customers",
+            table="customers",
+            metrics=[Metric(name="customer_count", agg="count")],
+        )
+    )
+    layer.graph.add_explore(
+        Explore(
+            name="mandatory_orders_filter",
+            model="orders",
+            filters=["status = 'paid'"],
+        )
+    )
+    saved_query = SavedQuery(
+        name="disconnected_from_mandatory_filter",
+        explore="mandatory_orders_filter",
+        metrics=["customers.customer_count"],
+    )
+
+    errors, _warnings = validate_saved_query(saved_query, layer.graph)
+
+    assert any(
+        "inherited Explore 'mandatory_orders_filter' filter expression is incompatible" in error
+        and "No join path found" in error
+        for error in errors
+    )
+
+    layer.graph.add_explore(Explore(name="unfiltered_orders", model="orders"))
+    disconnected_without_filter = SavedQuery(
+        name="disconnected_without_filter",
+        explore="unfiltered_orders",
+        metrics=["customers.customer_count"],
+    )
+    errors, _warnings = validate_saved_query(disconnected_without_filter, layer.graph)
+    assert (
+        "Saved query 'disconnected_without_filter' has no join path from base model 'orders' "
+        "to selected model 'customers'" in errors
+    )
+
+    layer.graph.models["customers"].segments.append(Segment(name="vip", sql="region = 'VIP'"))
+    disconnected_segment = SavedQuery(
+        name="disconnected_segment",
+        explore="unfiltered_orders",
+        metrics=["revenue"],
+        segments=["customers.vip"],
+    )
+    errors, _warnings = validate_saved_query(disconnected_segment, layer.graph)
+    assert (
+        "Saved query 'disconnected_segment' has no join path from base model 'orders' to selected model 'customers'"
+        in errors
+    )
+
+
+def test_validation_interpolates_saved_query_parameters():
+    layer = _layer()
+    with pytest.warns(DeprecationWarning):
+        layer.graph.add_parameter(Parameter(name="status", type="string"))
+    saved_query = SavedQuery(
+        name="parameterized_status",
+        explore="revenue_overview",
+        metrics=["revenue"],
+        filters=["orders.status = {{ status }}"],
+        parameters={"status": "paid"},
+    )
+
+    errors, _warnings = validate_saved_query(saved_query, layer.graph)
+
+    assert errors == []
+    layer.graph.add_saved_query(saved_query)
+    assert "status = 'paid'" in layer.compile(saved_query="parameterized_status")
+
+
+def test_validation_requires_order_fields_in_default_or_saved_selection():
+    layer = _layer()
+    explore = Explore(
+        name="unselected_default_order",
+        model="orders",
+        default_metrics=["revenue"],
+        default_order_by=["status"],
+    )
+    errors, _warnings = validate_explore(explore, layer.graph)
+    assert (
+        "Explore 'unselected_default_order' default ordering field(s) must be selected by the query: orders.status"
+        in errors
+    )
+
+    saved_query = SavedQuery(
+        name="unselected_saved_order",
+        explore="revenue_overview",
+        metrics=["revenue"],
+        order_by=["status"],
+    )
+    errors, _warnings = validate_saved_query(saved_query, layer.graph)
+    assert (
+        "Saved query 'unselected_saved_order' ordering field(s) must be selected by the query: orders.status" in errors
+    )
+
+
+def test_explore_order_override_requires_selected_field():
+    layer = _layer()
+    layer.graph.add_explore(
+        Explore(
+            name="order_override",
+            model="orders",
+            allowed_metrics=["revenue"],
+            allowed_order_by=["status"],
+            default_metrics=["revenue"],
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Explore 'order_override' ordering field\\(s\\) must be selected by the query: orders.status",
+    ):
+        layer.compile(explore="order_override", order_by=["status"])

--- a/tests/core/test_consumption_types.py
+++ b/tests/core/test_consumption_types.py
@@ -1,0 +1,123 @@
+"""Tests for consumption-contract schemas and reusable governance metadata."""
+
+import pytest
+from pydantic import ValidationError
+
+from sidemantic import Deprecation, Explore, Metric, Model, SavedQuery, View
+from sidemantic.core.consumption import (
+    expression_field_references,
+    qualify_expression_fields,
+    qualify_order_by_fields,
+)
+from sidemantic.core.governance import governance_dict
+
+
+def test_governance_defaults_and_serialization():
+    model = Model(name="orders", table="orders")
+
+    assert model.owner is None
+    assert model.tags == []
+    assert model.visibility == "public"
+    assert governance_dict(model) == {}
+
+    governed = Model(
+        name="legacy_orders",
+        table="legacy_orders",
+        owner="analytics",
+        tags=["legacy"],
+        status="deprecated",
+        deprecation=Deprecation(message="Use orders", replaced_by="orders"),
+        visibility="internal",
+    )
+    assert governance_dict(governed) == {
+        "owner": "analytics",
+        "tags": ["legacy"],
+        "status": "deprecated",
+        "deprecation": {"message": "Use orders", "replaced_by": "orders"},
+        "visibility": "internal",
+    }
+
+
+def test_model_and_metric_governance_preserve_public_compatibility():
+    assert Model(name="orders", table="orders", domain="commerce").domain == "commerce"
+
+    hidden = Metric(name="hidden_revenue", agg="sum", sql="amount", public=False)
+    internal = Metric(name="internal_revenue", agg="sum", sql="amount", visibility="internal")
+    visible = Metric(name="revenue", agg="sum", sql="amount")
+
+    assert hidden.public is False
+    assert hidden.visibility == "private"
+    assert internal.public is False
+    assert internal.visibility == "internal"
+    assert visible.public is True
+    assert visible.visibility == "public"
+
+
+def test_explore_defaults_must_respect_allowlists_and_limits():
+    valid = Explore(
+        name="revenue_overview",
+        model="orders",
+        allowed_dimensions=["status"],
+        allowed_metrics=["orders.revenue"],
+        allowed_filter_fields=["status"],
+        allowed_order_by=["revenue"],
+        default_dimensions=["orders.status"],
+        default_metrics=["revenue"],
+        default_filters=["status = 'paid'"],
+        default_order_by=["revenue DESC"],
+        default_limit=25,
+        max_limit=100,
+    )
+
+    assert View is Explore
+    assert valid.default_metrics == ["revenue"]
+
+    invalid_values = [
+        ({"allowed_dimensions": ["status"], "default_dimensions": ["created_at"]}, "default_dimensions"),
+        ({"allowed_metrics": ["revenue"], "default_metrics": ["order_count"]}, "default_metrics"),
+        (
+            {"allowed_filter_fields": ["status"], "default_filters": ["created_at > '2026-01-01'"]},
+            "default_filters",
+        ),
+        ({"allowed_order_by": ["revenue"], "default_order_by": ["status ASC"]}, "default_order_by"),
+        ({"default_limit": 101, "max_limit": 100}, "default_limit cannot exceed max_limit"),
+    ]
+    for values, message in invalid_values:
+        with pytest.raises(ValidationError, match=message):
+            Explore(name="invalid", model="orders", **values)
+
+
+def test_saved_query_rejects_invalid_limits_and_unknown_fields():
+    query = SavedQuery(
+        name="paid_revenue",
+        explore="revenue_overview",
+        metrics=["revenue"],
+        filters=["status = 'paid'"],
+        limit=10,
+    )
+    assert query.visibility == "public"
+
+    with pytest.raises(ValidationError):
+        SavedQuery(name="negative_limit", limit=-1)
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        SavedQuery(name="unknown_field", unknown=True)
+
+
+def test_expression_helpers_qualify_semantic_fields_and_skip_subqueries():
+    expression = "status IN (SELECT status FROM allowed_statuses)"
+
+    assert qualify_expression_fields([expression], "orders") == [
+        "orders.status IN (SELECT status FROM allowed_statuses)"
+    ]
+    assert expression_field_references([expression], "orders") == {"orders.status"}
+
+    correlated = "EXISTS (SELECT 1 FROM allowed_statuses AS allowed WHERE allowed.status = orders.status)"
+    assert expression_field_references([correlated], "orders", graph_models={"orders"}) == {"orders.status"}
+
+    assert qualify_expression_fields(["revenue > 0 AND status = 'paid'"], "orders", graph_metrics={"revenue"}) == [
+        "revenue > 0 AND orders.status = 'paid'"
+    ]
+    assert qualify_order_by_fields(["revenue DESC, status ASC"], "orders", graph_metrics={"revenue"}) == [
+        "revenue DESC",
+        "orders.status ASC",
+    ]


### PR DESCRIPTION
Adds reusable governance metadata and curated Explore, View, and SavedQuery schema types, including expression qualification helpers and focused validation coverage.\n\nModel and Metric now share governance fields while preserving Metric's existing public visibility compatibility. This deliberately excludes compiler, graph/runtime enforcement, discovery, CLI, adapters, docs, and generated schema changes.