### PR TITLE
Secure semantic SQL transports

### DIFF
--- a/sidemantic/api_server.py
+++ b/sidemantic/api_server.py
@@ -30,7 +30,6 @@ from sidemantic.server.common import (
     table_to_json_rows,
     validate_filter_expression,
 )
-from sidemantic.sql.query_rewriter import QueryRewriter
 
 ARROW_FORMAT = "arrow"
 JSON_FORMAT = "json"
@@ -373,24 +372,6 @@ def create_app(
             )
         return parsed
 
-    def deny_free_sql_if_secured() -> None:
-        """Deny the free-form SQL endpoints when any model declares a security policy.
-
-        ``/sql`` (semantic rewrite) and ``/raw`` (direct passthrough) cannot apply
-        per-user row filters -- the rewriter/raw paths do not thread user attributes,
-        and ``/raw`` reads the underlying table directly, bypassing the model entirely.
-        Rather than silently return unscoped rows for a secured model, refuse these
-        endpoints outright when security is in play and point callers at ``/query``,
-        which enforces access gates and row filters.
-        """
-        layer = app.state.layer
-        if any(getattr(model, "security", None) is not None for model in layer.graph.models.values()):
-            raise SecurityError(
-                "The /sql and /raw endpoints cannot enforce row-level security and are "
-                "disabled because a model declares a security policy. Use the structured "
-                "/query endpoint, which applies access gates and row filters per user."
-            )
-
     @app.post("/auth/session", include_in_schema=False)
     def create_browser_session(
         request: Request,
@@ -602,11 +583,19 @@ def create_app(
         return _build_query_response(request, current_layer, table, sql=sql, format_override=format)
 
     @app.post("/sql/compile", dependencies=[Depends(require_auth)])
-    def compile_sql(payload: SQLRequest) -> dict[str, str]:
+    def compile_sql(payload: SQLRequest, request: Request) -> dict[str, str]:
         # Pure CPU: rewrites SQL from the in-memory graph, no DB access, no lock.
+        from sidemantic.core.transport_security import rewrite_transport_sql
+
         current_layer = app.state.layer
+        user_attributes = resolve_user_attributes(request)
         query = _normalize_sql_query(payload.query)
-        rewritten_sql = QueryRewriter(current_layer.graph, dialect=current_layer.dialect).rewrite(query)
+        rewritten_sql = rewrite_transport_sql(
+            current_layer,
+            query,
+            user_attributes=user_attributes,
+            transport="HTTP /sql/compile",
+        )
         return {"sql": rewritten_sql}
 
     @app.post("/sql", dependencies=[Depends(require_auth)])
@@ -617,11 +606,17 @@ def create_app(
     ):
         # Read-only query: rewrite (pure CPU) then execute on a fresh per-request
         # cursor, routed through _query_table for opt-in result caching.
+        from sidemantic.core.transport_security import rewrite_transport_sql
+
         current_layer = app.state.layer
         user_attributes = resolve_user_attributes(request)
-        deny_free_sql_if_secured()
         query = _normalize_sql_query(payload.query)
-        rewritten_sql = QueryRewriter(current_layer.graph, dialect=current_layer.dialect).rewrite(query)
+        rewritten_sql = rewrite_transport_sql(
+            current_layer,
+            query,
+            user_attributes=user_attributes,
+            transport="HTTP /sql",
+        )
         table = _query_table(app, current_layer, rewritten_sql, user_attributes=user_attributes)
         return _build_query_response(
             request,
@@ -641,9 +636,11 @@ def create_app(
         """Execute raw SQL directly on the underlying database, bypassing the semantic rewriter."""
         # Read-only query (SELECT enforced) on a fresh per-request cursor,
         # routed through _query_table for opt-in result caching.
+        from sidemantic.core.transport_security import deny_raw_sql
+
         current_layer = app.state.layer
         user_attributes = resolve_user_attributes(request)
-        deny_free_sql_if_secured()
+        deny_raw_sql(current_layer, transport="HTTP /raw")
         query = _normalize_sql_query(payload.query)
         _require_select_statement(query)
         table = _query_table(app, current_layer, query, user_attributes=user_attributes)

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -1223,6 +1224,16 @@ def mcp_serve(
     apps: bool = typer.Option(False, "--apps", help="Enable interactive UI widgets (requires mcp-ui-server)"),
     http: bool = typer.Option(False, "--http", help="Use HTTP transport instead of stdio"),
     port: int = typer.Option(4100, "--port", "-p", help="Port for HTTP server"),
+    user_attrs_file: Path = typer.Option(
+        None,
+        "--user-attrs-file",
+        help="Path to a JSON user-attributes object applied to every MCP query",
+    ),
+    enforce_visibility: bool = typer.Option(
+        False,
+        "--enforce-visibility",
+        help="Hide and reject fields declared public: false",
+    ),
 ):
     """
     Start an MCP server for the semantic layer.
@@ -1274,9 +1285,26 @@ def mcp_serve(
             effective_init_sql = resolved_connection.init_sql
 
     try:
+        user_attributes = None
+        if user_attrs_file is not None:
+            if not user_attrs_file.exists():
+                raise InvocationError(f"user-attrs file {user_attrs_file} does not exist")
+            try:
+                user_attributes = json.loads(user_attrs_file.read_text())
+            except json.JSONDecodeError as exc:
+                raise InvocationError(f"failed to parse user-attrs file {user_attrs_file}: {exc}") from exc
+            if not isinstance(user_attributes, dict):
+                raise InvocationError(f"user-attrs file {user_attrs_file} must contain a JSON object")
+
         # Initialize the semantic layer
         with progress("Initializing MCP server"):
-            initialize_layer(str(directory), connection=connection_str, init_sql=effective_init_sql)
+            initialize_layer(
+                str(directory),
+                connection=connection_str,
+                init_sql=effective_init_sql,
+                user_attributes=user_attributes,
+                enforce_visibility=enforce_visibility,
+            )
 
         # If demo mode, populate with demo data
         if demo:

--- a/sidemantic/core/security.py
+++ b/sidemantic/core/security.py
@@ -58,6 +58,99 @@ class SecurityPolicy(BaseModel):
         return hash((self.access, tuple(self.row_filters)))
 
 
+def enforce_field_visibility(
+    graph,
+    metrics: list[str] | None,
+    dimensions: list[str] | None,
+    filters: list[str] | None = None,
+    order_by: list[str] | None = None,
+    segments: list[str] | None = None,
+) -> None:
+    """Reject every reference to a non-public semantic field.
+
+    This is shared by structured compilation and SQL-rewrite transports so
+    ``public: false`` cannot be bypassed by switching protocols or by using a
+    hidden field only as a filter/order oracle.
+    """
+    from sqlglot import exp, parse_one
+
+    from sidemantic.core.semantic_layer import SecurityError
+
+    def field_is_public(model_name: str, field_name: str) -> bool:
+        model = graph.models.get(model_name)
+        if model is None:
+            return True
+        dimension = model.get_dimension(field_name)
+        if dimension is not None:
+            return dimension.public
+        metric = model.get_metric(field_name)
+        if metric is not None:
+            return metric.public
+        return True
+
+    for dimension_ref in dimensions or []:
+        ref = dimension_ref.rsplit("__", 1)[0] if "__" in dimension_ref else dimension_ref
+        if "." not in ref:
+            continue
+        model_name, field_name = ref.split(".", 1)
+        if not field_is_public(model_name, field_name):
+            raise SecurityError(f"Field '{model_name}.{field_name}' is not public")
+
+    for metric_ref in metrics or []:
+        if "." not in metric_ref:
+            metric = graph.metrics.get(metric_ref)
+            if metric is not None and not getattr(metric, "public", True):
+                raise SecurityError(f"Field '{metric_ref}' is not public")
+            continue
+        model_name, field_name = metric_ref.split(".", 1)
+        if not field_is_public(model_name, field_name):
+            raise SecurityError(f"Field '{model_name}.{field_name}' is not public")
+
+    for segment_ref in segments or []:
+        if "." not in segment_ref:
+            continue
+        model_name, segment_name = segment_ref.split(".", 1)
+        model = graph.models.get(model_name)
+        if model is None:
+            continue
+        segment = model.get_segment(segment_name) if hasattr(model, "get_segment") else None
+        if segment is not None and not getattr(segment, "public", True):
+            raise SecurityError(f"Segment '{model_name}.{segment_name}' is not public")
+
+    ref_pattern = re.compile(r"\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)\b")
+    expression_refs = [*(filters or []), *(order_by or [])]
+    candidate_models = {
+        ref.split(".", 1)[0]
+        for ref in [*(metrics or []), *(dimensions or []), *(segments or [])]
+        if "." in ref and ref.split(".", 1)[0] in graph.models
+    }
+    candidate_models.update(
+        model_name
+        for raw in expression_refs
+        for model_name, _field_name in ref_pattern.findall(raw)
+        if model_name in graph.models
+    )
+    if not candidate_models and len(graph.models) == 1:
+        candidate_models.update(graph.models)
+
+    for raw in expression_refs:
+        for model_name, field_name in ref_pattern.findall(raw):
+            field_name = field_name.rsplit("__", 1)[0] if "__" in field_name else field_name
+            if not field_is_public(model_name, field_name):
+                raise SecurityError(f"Field '{model_name}.{field_name}' is not public")
+
+        try:
+            parsed = parse_one(raw)
+        except Exception:
+            continue
+        for column in parsed.find_all(exp.Column):
+            field_name = column.name.rsplit("__", 1)[0] if "__" in column.name else column.name
+            model_names = [column.table] if column.table in graph.models else candidate_models
+            for model_name in model_names:
+                if not field_is_public(model_name, field_name):
+                    raise SecurityError(f"Field '{model_name}.{field_name}' is not public")
+
+
 def _sql_literal(value) -> str:
     """Convert a value produced by a ``{{ }}`` output to a safe SQL literal string.
 

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -924,10 +924,12 @@ class SemanticLayer:
         if security_active:
             use_preaggs = False
 
-        # The Rust SQL generator does not enforce security policies, so any query touching a
-        # model with a security policy (row filters or an access gate) must use the Python path.
-        security_forces_python = user_attributes is not None or self._query_touches_secured_model(
-            metrics, dimensions, filters, segments
+        # The Rust SQL generator does not enforce security policies or column visibility,
+        # so any active control keeps compilation on the policy-aware Python path.
+        security_forces_python = (
+            self.enforce_visibility
+            or user_attributes is not None
+            or self._query_touches_secured_model(metrics, dimensions, filters, segments)
         )
 
         inner_sql = None
@@ -1036,6 +1038,7 @@ class SemanticLayer:
             preagg_schema=self.preagg_schema,
             timezone=timezone,
             allow_non_additive_unsafe=self.allow_non_additive_unsafe,
+            enforce_visibility=self.enforce_visibility,
         )
 
         return generator.generate(
@@ -1144,48 +1147,9 @@ class SemanticLayer:
         Raises:
             SecurityError: If a referenced field's owning definition has ``public=False``.
         """
-        for dim in dimensions or []:
-            ref = dim.rsplit("__", 1)[0] if "__" in dim else dim
-            if "." not in ref:
-                continue
-            model_name, field_name = ref.split(".", 1)
-            if not self._field_is_public(model_name, field_name):
-                raise SecurityError(f"Field '{model_name}.{field_name}' is not public")
+        from sidemantic.core.security import enforce_field_visibility
 
-        for metric in metrics or []:
-            if "." not in metric:
-                # Graph-level metric reference.
-                graph_metric = self.graph.metrics.get(metric)
-                if graph_metric is not None and not getattr(graph_metric, "public", True):
-                    raise SecurityError(f"Field '{metric}' is not public")
-                continue
-            model_name, field_name = metric.split(".", 1)
-            if not self._field_is_public(model_name, field_name):
-                raise SecurityError(f"Field '{model_name}.{field_name}' is not public")
-
-        # Segments are named filters that may themselves be non-public; a segment reference is
-        # `model.segment`, not a dimension/metric, so check them explicitly.
-        for segment_ref in segments or []:
-            if "." not in segment_ref:
-                continue
-            model_name, segment_name = segment_ref.split(".", 1)
-            model = self.graph.models.get(model_name)
-            if model is None:
-                continue
-            segment = model.get_segment(segment_name) if hasattr(model, "get_segment") else None
-            if segment is not None and not getattr(segment, "public", True):
-                raise SecurityError(f"Segment '{model_name}.{segment_name}' is not public")
-
-        # filters/order_by can smuggle a hidden field. Scan them for `model.field` tokens
-        # (stripping any granularity suffix / sort direction) and reject non-public ones.
-        import re as _re
-
-        ref_pattern = _re.compile(r"\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)\b")
-        for raw in [*(filters or []), *(order_by or [])]:
-            for model_name, field_name in ref_pattern.findall(raw):
-                field_name = field_name.rsplit("__", 1)[0] if "__" in field_name else field_name
-                if not self._field_is_public(model_name, field_name):
-                    raise SecurityError(f"Field '{model_name}.{field_name}' is not public")
+        enforce_field_visibility(self.graph, metrics, dimensions, filters, order_by, segments)
 
     def _compile_with_rust(
         self,
@@ -1770,13 +1734,15 @@ class SemanticLayer:
                 "Supported: duckdb, postgres, bigquery, snowflake, clickhouse, databricks, spark, adbc"
             )
 
-    def sql(self, query: str):
+    def sql(self, query: str, *, user_attributes: dict | None = None):
         """Execute a SQL query against the semantic layer.
 
         Rewrites the SQL to use semantic layer metrics/dimensions and executes it.
 
         Args:
             query: SQL query like "SELECT revenue, status FROM orders WHERE status = 'completed'"
+            user_attributes: Per-request attributes used for model access gates and row filters.
+                A secured model is denied when this is omitted.
 
         Returns:
             DuckDB relation object (can convert to DataFrame with .df() or .to_df())
@@ -1787,37 +1753,38 @@ class SemanticLayer:
         Example:
             >>> layer.sql("SELECT orders.revenue, orders.status FROM orders WHERE orders.status = 'completed'")
         """
-        from sidemantic.sql.query_rewriter import QueryRewriter
-
-        # The SQL-first path rewrites and executes without user attributes, so it cannot
-        # apply per-user row filters or access gates. Rather than return unscoped rows for a
-        # secured model, refuse when any model declares a security policy (mirrors the HTTP
-        # /sql endpoint and MCP run_sql). The structured query()/compile() path enforces.
-        if any(getattr(model, "security", None) is not None for model in self.graph.models.values()):
-            raise SecurityError(
-                "SemanticLayer.sql() cannot enforce row-level security and is disabled because a "
-                "model declares a security policy. Use query()/compile() (structured), which "
-                "applies access gates and row filters per user."
-            )
+        from sidemantic.core.transport_security import rewrite_transport_sql
 
         cache_key = (
             getattr(self.graph, "_version", 0),
             self.dialect,
             self.use_preaggregations,
+            self.enforce_visibility,
             os.getenv("SIDEMANTIC_RS_REWRITER", "0"),
             os.getenv("SIDEMANTIC_RS_NO_FALLBACK", "0"),
             query,
         )
-        rewritten_sql = self._sql_rewrite_cache.get(cache_key)
+        rewritten_sql = self._sql_rewrite_cache.get(cache_key) if user_attributes is None else None
         if rewritten_sql is None:
-            rewriter = QueryRewriter(self.graph, dialect=self.dialect, use_preaggregations=self.use_preaggregations)
-            rewritten_sql = rewriter.rewrite(query)
-            if len(self._sql_rewrite_cache) >= self._sql_rewrite_cache_limit:
-                self._sql_rewrite_cache.pop(next(iter(self._sql_rewrite_cache)))
-            self._sql_rewrite_cache[cache_key] = rewritten_sql
+            rewritten_sql = rewrite_transport_sql(
+                self,
+                query,
+                user_attributes=user_attributes,
+                transport="SemanticLayer.sql()",
+            )
+            if user_attributes is None:
+                if len(self._sql_rewrite_cache) >= self._sql_rewrite_cache_limit:
+                    self._sql_rewrite_cache.pop(next(iter(self._sql_rewrite_cache)))
+                self._sql_rewrite_cache[cache_key] = rewritten_sql
 
         def recompile_raw():
-            return QueryRewriter(self.graph, dialect=self.dialect, use_preaggregations=False).rewrite(query)
+            return rewrite_transport_sql(
+                self,
+                query,
+                user_attributes=user_attributes,
+                transport="SemanticLayer.sql()",
+                use_preaggregations=False,
+            )
 
         return self._execute_with_preagg_fallback(
             rewritten_sql,
@@ -1840,7 +1807,12 @@ class SemanticLayer:
         """
         from sidemantic.sql.query_rewriter import QueryRewriter
 
-        rewriter = QueryRewriter(self.graph, dialect=self.dialect, use_preaggregations=self.use_preaggregations)
+        rewriter = QueryRewriter(
+            self.graph,
+            dialect=self.dialect,
+            use_preaggregations=self.use_preaggregations,
+            enforce_visibility=self.enforce_visibility,
+        )
         return rewriter.explain(query, strict=strict)
 
     def to_yaml(self, path: str | Path) -> None:

--- a/sidemantic/core/transport_security.py
+++ b/sidemantic/core/transport_security.py
@@ -1,0 +1,197 @@
+"""Shared fail-closed security gates for SQL-based transports."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def has_declared_security(layer: Any) -> bool:
+    """Return whether any model declares an access or row-level policy."""
+    return any(getattr(model, "security", None) is not None for model in layer.graph.models.values())
+
+
+def has_enforced_column_restrictions(layer: Any) -> bool:
+    """Return whether semantic column visibility is being enforced.
+
+    The enforcement flag itself is the security boundary. Even when every
+    declared semantic field is public, physical source columns that are absent
+    from the model must not become discoverable or queryable through another
+    transport.
+    """
+    return bool(getattr(layer, "enforce_visibility", False))
+
+
+def controls_are_active(layer: Any) -> bool:
+    return has_declared_security(layer) or has_enforced_column_restrictions(layer)
+
+
+def _reads_from_source(sql: str, dialect: str) -> bool:
+    """Conservatively detect source reads in SQL that the semantic rewriter passed through."""
+    import sqlglot
+    from sqlglot import exp
+
+    try:
+        parsed = sqlglot.parse_one(sql, dialect=dialect)
+    except Exception:
+        # Under active controls, an unparseable passthrough can never be proven safe.
+        return True
+    return any(True for _ in parsed.find_all(exp.Table))
+
+
+def _unrecognized_sources(sql: str, layer: Any) -> list[str]:
+    """Return source tables that are neither semantic models nor local CTEs."""
+    import sqlglot
+    from sqlglot import exp
+    from sqlglot.optimizer.scope import traverse_scope
+
+    try:
+        parsed = sqlglot.parse_one(sql, dialect=layer.dialect)
+        scopes = traverse_scope(parsed)
+    except Exception:
+        return ["<unparseable SQL>"]
+
+    semantic_sources = {name.lower() for name in layer.graph.models}
+    semantic_sources.add("metrics")
+    unrecognized: set[str] = set()
+    try:
+        for scope in scopes:
+            for _name, (_node, source) in scope.selected_sources.items():
+                # In-scope CTEs and derived tables resolve to another Scope.
+                # A Table source is a real database read in this exact scope.
+                if isinstance(source, exp.Table) and source.name.lower() not in semantic_sources:
+                    unrecognized.add(source.sql(dialect=layer.dialect))
+    except Exception:
+        return ["<unparseable SQL>"]
+    return sorted(unrecognized)
+
+
+def _has_unsafe_subquery(sql: str, dialect: str) -> bool:
+    """Return whether an expression embeds a SELECT the rewriter cannot secure."""
+    import sqlglot
+    from sqlglot import exp
+
+    try:
+        parsed = sqlglot.parse_one(sql, dialect=dialect)
+    except Exception:
+        return True
+
+    for select in parsed.find_all(exp.Select):
+        query: exp.Expression = select
+        while isinstance(query.parent, exp.SetOperation):
+            query = query.parent
+
+        parent = query.parent
+        if parent is None or isinstance(parent, exp.CTE):
+            continue
+        if isinstance(parent, exp.Subquery):
+            container = parent.parent
+            if isinstance(container, exp.SetOperation):
+                continue
+            if isinstance(container, (exp.From, exp.Join)) and container.this is parent:
+                continue
+        return True
+    return False
+
+
+def rewrite_transport_sql(
+    layer: Any,
+    query: str,
+    *,
+    user_attributes: dict | None,
+    transport: str,
+    strict: bool = True,
+    use_preaggregations: bool | None = None,
+) -> str:
+    """Rewrite SQL with row/access/column controls and reject unsafe passthrough.
+
+    When controls are active, SQL that reads a source must be recognized and
+    regenerated as semantic SQL. A query that the rewriter leaves untouched is
+    denied before execution because its policies cannot be proven to apply.
+    Projection-only queries such as ``SELECT 1`` remain safe and available.
+    """
+    from sidemantic.core.semantic_layer import SecurityError
+    from sidemantic.sql.query_rewriter import QueryRewriter
+
+    if controls_are_active(layer):
+        unrecognized = _unrecognized_sources(query, layer)
+        if unrecognized:
+            sources = ", ".join(unrecognized)
+            raise SecurityError(
+                f"{transport} refused non-semantic source(s) {sources} while security controls "
+                "are active. Query semantic model fields, or use a structured query transport "
+                "so access gates, row filters, and column restrictions are enforced."
+            )
+        if _has_unsafe_subquery(query, layer.dialect):
+            raise SecurityError(
+                f"{transport} refused a predicate subquery, projection subquery, or other expression subquery "
+                "while security controls are active because nested expression reads cannot currently prove "
+                "that access gates, row "
+                "filters, and column restrictions were enforced. Rewrite it as structured "
+                "semantic filters or a supported semantic join."
+            )
+
+    requested_preaggregations = (
+        getattr(layer, "use_preaggregations", False) if use_preaggregations is None else use_preaggregations
+    )
+    # Rollups are materialized without per-user row scope. Structured compile
+    # already disables them for active row filters; SQL transports take the
+    # conservative equivalent and bypass rollups for every secured graph.
+    if has_declared_security(layer):
+        requested_preaggregations = False
+
+    rewriter = QueryRewriter(
+        layer.graph,
+        dialect=layer.dialect,
+        use_preaggregations=requested_preaggregations,
+        enforce_visibility=getattr(layer, "enforce_visibility", False),
+        # The optional Rust planner does not accept caller attributes or run
+        # SQLGenerator's policy/visibility checks yet. Keep secured transports
+        # on the policy-aware Python planner even when it is enabled globally.
+        use_rust_rewriter=False if controls_are_active(layer) else None,
+    )
+    # Yardstick's explicit and implicit measure paths expand directly against
+    # physical model tables. They do not currently route those reads through
+    # SQLGenerator, so they cannot apply per-user access checks, row filters,
+    # or field visibility. Deny every query the rewriter would send through
+    # either path until those controls can be enforced there.
+    if controls_are_active(layer) and rewriter.would_use_yardstick_rewrite(query):
+        raise SecurityError(
+            f"{transport} refused Yardstick semantic SQL while security controls are active "
+            "because that rewrite path cannot prove access gates, row filters, and column "
+            "restrictions were enforced. Use a structured query or standard semantic SQL."
+        )
+    if controls_are_active(layer):
+        explanation = rewriter.explain(query, strict=strict, user_attributes=user_attributes)
+        if explanation.chosen_plan == "passthrough_plain_sql" and _reads_from_source(query, layer.dialect):
+            raise SecurityError(
+                f"{transport} refused SQL that could not be proven to use the semantic layer while "
+                "security controls are active. Query semantic model fields, or use a structured "
+                "query transport so access gates, row filters, and column restrictions are enforced."
+            )
+        island_rejection = explanation.rejected_rules.get("semantic_island_optimization")
+        if island_rejection and _reads_from_source(query, layer.dialect):
+            raise SecurityError(
+                f"{transport} refused a semantic subquery that could not be secured ({island_rejection}). "
+                "Rewrite the nested query using declared semantic fields, or use a structured query "
+                "transport so access gates, row filters, and column restrictions are enforced."
+            )
+        rewritten = explanation.rewritten_sql
+    else:
+        rewritten = rewriter.rewrite(query, strict=strict, user_attributes=user_attributes)
+    return rewritten
+
+
+def deny_raw_sql(layer: Any, *, transport: str) -> None:
+    """Disable a raw database bypass whenever a declared control needs enforcement."""
+    from sidemantic.core.semantic_layer import SecurityError
+
+    controls: list[str] = []
+    if has_declared_security(layer):
+        controls.append("model access/row policies")
+    if has_enforced_column_restrictions(layer):
+        controls.append("column visibility restrictions")
+    if controls:
+        raise SecurityError(
+            f"{transport} is disabled because {' and '.join(controls)} are active and raw SQL "
+            "bypasses semantic enforcement. Use structured queries or semantic SQL instead."
+        )

--- a/sidemantic/mcp_server.py
+++ b/sidemantic/mcp_server.py
@@ -27,6 +27,7 @@ def initialize_layer(
     connection: str | None = None,
     init_sql: list[str] | None = None,
     user_attributes: dict | None = None,
+    enforce_visibility: bool = False,
 ) -> SemanticLayer:
     """Initialize the semantic layer with models from directory."""
     global _layer, _user_attributes
@@ -38,7 +39,11 @@ def initialize_layer(
         else:
             connection = f"duckdb:///{Path(db_path).absolute()}"
 
-    _layer = SemanticLayer(connection=connection, init_sql=init_sql)
+    _layer = SemanticLayer(
+        connection=connection,
+        init_sql=init_sql,
+        enforce_visibility=enforce_visibility,
+    )
     load_from_directory(_layer, directory)
     _user_attributes = user_attributes
     return _layer
@@ -197,6 +202,15 @@ def _format_join_key_pairs(
 mcp = FastMCP("sidemantic")
 
 
+def _visible_dimension_name(model: Any, name: str | None, enforce_visibility: bool) -> str | None:
+    if not name or not enforce_visibility:
+        return name
+    dimension = model.get_dimension(name)
+    if dimension is not None and not getattr(dimension, "public", True):
+        return None
+    return name
+
+
 @mcp.tool(structured_output=False)
 def get_models(model_names: list[str]) -> dict[str, Any]:
     """Get detailed information about one or more models.
@@ -225,6 +239,8 @@ def get_models(model_names: list[str]) -> dict[str, Any]:
         # Get dimension details (enriched)
         dims = []
         for dim in model.dimensions:
+            if layer.enforce_visibility and not getattr(dim, "public", True):
+                continue
             dim_info: dict[str, Any] = {
                 "name": dim.name,
                 "type": dim.type,
@@ -252,6 +268,8 @@ def get_models(model_names: list[str]) -> dict[str, Any]:
         # Get metric details (enriched)
         metrics = []
         for metric in model.metrics:
+            if layer.enforce_visibility and not getattr(metric, "public", True):
+                continue
             metric_info: dict[str, Any] = {
                 "name": metric.name,
                 "sql": metric.sql,
@@ -303,6 +321,8 @@ def get_models(model_names: list[str]) -> dict[str, Any]:
         # Get segment details
         segments = []
         for seg in model.segments:
+            if layer.enforce_visibility and not getattr(seg, "public", True):
+                continue
             seg_info: dict[str, Any] = {
                 "name": seg.name,
                 "sql": seg.sql,
@@ -338,19 +358,22 @@ def get_models(model_names: list[str]) -> dict[str, Any]:
         detail: dict[str, Any] = {
             "name": model_name,
             "table": model.table,
-            "primary_key": model.primary_key,
             "dimensions": dims,
             "metrics": metrics,
             "relationships": rels,
         }
+        if primary_key := _visible_dimension_name(model, model.primary_key, layer.enforce_visibility):
+            detail["primary_key"] = primary_key
         if segments:
             detail["segments"] = segments
         if model.description:
             detail["description"] = model.description
         if model.sql:
             detail["sql"] = model.sql
-        if model.default_time_dimension:
-            detail["default_time_dimension"] = model.default_time_dimension
+        if default_time_dimension := _visible_dimension_name(
+            model, model.default_time_dimension, layer.enforce_visibility
+        ):
+            detail["default_time_dimension"] = default_time_dimension
         if model.default_grain:
             detail["default_grain"] = model.default_grain
         if model.meta:
@@ -607,20 +630,15 @@ def run_sql(query: str) -> dict[str, Any]:
         rows: Result rows as list of dicts
         row_count: Number of rows returned
     """
-    from sidemantic.sql.query_rewriter import QueryRewriter
+    from sidemantic.core.transport_security import rewrite_transport_sql
 
     layer = get_layer()
-    # This SQL-first path cannot apply per-user row filters (QueryRewriter does not
-    # accept user_attributes). Rather than return unscoped rows for a secured model,
-    # refuse this tool when any model declares a security policy -- mirroring the HTTP
-    # /sql endpoint. Use the structured run_query tool, which enforces access + filters.
-    if any(getattr(model, "security", None) is not None for model in layer.graph.models.values()):
-        raise ValueError(
-            "run_sql is disabled because a model declares a security policy; it cannot apply "
-            "row-level security. Use run_query (structured), which enforces access gates and row filters."
-        )
-    rewriter = QueryRewriter(layer.graph, dialect=layer.dialect)
-    rewritten_sql = rewriter.rewrite(query)
+    rewritten_sql = rewrite_transport_sql(
+        layer,
+        query,
+        user_attributes=get_user_attributes(),
+        transport="MCP run_sql",
+    )
 
     result = layer.adapter.execute(rewritten_sql)
     rows = result.fetchall()
@@ -659,6 +677,11 @@ def validate_query(
 
     layer = get_layer()
 
+    if layer.enforce_visibility:
+        from sidemantic.core.security import enforce_field_visibility
+
+        enforce_field_visibility(layer.graph, metrics, dimensions)
+
     errors = _validate_query(
         metrics=metrics or [],
         dimensions=dimensions or [],
@@ -693,23 +716,28 @@ def get_semantic_graph() -> dict[str, Any]:
         model_info: dict[str, Any] = {
             "name": model_name,
             "table": model.table,
-            "dimensions": [d.name for d in model.dimensions],
-            "metrics": [m.name for m in model.metrics],
+            "dimensions": [d.name for d in model.dimensions if not layer.enforce_visibility or d.public],
+            "metrics": [m.name for m in model.metrics if not layer.enforce_visibility or m.public],
             "relationships": [{"name": r.name, "type": r.type} for r in model.relationships],
         }
         if model.description:
             model_info["description"] = model.description
-        if model.segments:
-            model_info["segments"] = [s.name for s in model.segments]
-        if model.primary_key:
-            model_info["primary_key"] = model.primary_key
-        if model.default_time_dimension:
-            model_info["default_time_dimension"] = model.default_time_dimension
+        visible_segments = [s.name for s in model.segments if not layer.enforce_visibility or s.public]
+        if visible_segments:
+            model_info["segments"] = visible_segments
+        if primary_key := _visible_dimension_name(model, model.primary_key, layer.enforce_visibility):
+            model_info["primary_key"] = primary_key
+        if default_time_dimension := _visible_dimension_name(
+            model, model.default_time_dimension, layer.enforce_visibility
+        ):
+            model_info["default_time_dimension"] = default_time_dimension
         models.append(model_info)
 
     # Graph-level metrics
     graph_metrics = []
     for metric_name, metric in graph.metrics.items():
+        if layer.enforce_visibility and not getattr(metric, "public", True):
+            continue
         metric_info: dict[str, Any] = {
             "name": metric_name,
         }

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -109,6 +109,7 @@ class SQLGenerator:
         preagg_schema: str | None = None,
         timezone: str | None = None,
         allow_non_additive_unsafe: bool = False,
+        enforce_visibility: bool = False,
     ):
         """Initialize SQL generator.
 
@@ -124,12 +125,14 @@ class SQLGenerator:
                 over ALL snapshots (over-aggregated, wrong results). By default the generator
                 implements semi-additive handling (QUALIFY last/first snapshot per group);
                 this flag opts back into the old, naive behavior explicitly (default: False)
+            enforce_visibility: Reject references to fields declared ``public: false``
         """
         self.graph = graph
         self.dialect = dialect
         self.preagg_database = preagg_database
         self.preagg_schema = preagg_schema
         self.allow_non_additive_unsafe = allow_non_additive_unsafe
+        self.enforce_visibility = enforce_visibility
         # The timezone is interpolated into SQL string literals (AT TIME ZONE '...', etc.),
         # so it must not contain quote/escape characters. Restrict to IANA-name characters
         # to prevent SQL injection from a request- or preference-supplied value; the database
@@ -994,6 +997,24 @@ class SQLGenerator:
         parameters = parameters or {}
         aliases = aliases or {}
 
+        # Auto-include default_time_dimension from metrics before visibility
+        # validation and cache lookup. An implicit dimension is still part of
+        # the caller-visible result and must obey the same column restrictions.
+        if not skip_default_time_dimensions:
+            dimensions = self._apply_default_time_dimensions(metrics, dimensions)
+
+        if self.enforce_visibility:
+            from sidemantic.core.security import enforce_field_visibility
+
+            enforce_field_visibility(
+                self.graph,
+                metrics,
+                dimensions,
+                filters,
+                order_by,
+                segments,
+            )
+
         # Semi-additive (non_additive_dimension) metrics are handled below by injecting
         # a QUALIFY into the owning model's CTE (see _plan_semi_additive / _build_model_cte).
         # The plan (and any UnsupportedMetricError for unimplemented dialects or the
@@ -1030,10 +1051,6 @@ class SQLGenerator:
 
         if with_totals and ungrouped:
             raise ValueError("with_totals cannot be combined with ungrouped")
-
-        # Auto-include default_time_dimension from metrics if not already present
-        if not skip_default_time_dimensions:
-            dimensions = self._apply_default_time_dimensions(metrics, dimensions)
 
         # Resolve segments to SQL filters
         segment_filters = self._resolve_segments(segments)

--- a/sidemantic/sql/query_rewriter.py
+++ b/sidemantic/sql/query_rewriter.py
@@ -112,22 +112,34 @@ class _SemanticIslandRewrite:
 class QueryRewriter:
     """Rewrites user SQL queries to use the semantic layer."""
 
-    def __init__(self, graph: SemanticGraph, dialect: str = "duckdb", use_preaggregations: bool = False):
+    def __init__(
+        self,
+        graph: SemanticGraph,
+        dialect: str = "duckdb",
+        use_preaggregations: bool = False,
+        enforce_visibility: bool = False,
+        use_rust_rewriter: bool | None = None,
+    ):
         """Initialize query rewriter.
 
         Args:
             graph: Semantic graph with models and metrics
             dialect: SQL dialect for parsing/generation
             use_preaggregations: Enable single-model pre-aggregation routing
+            enforce_visibility: Reject semantic references to fields declared ``public: false``
+            use_rust_rewriter: Override the environment-controlled Rust rewrite path
         """
         self.graph = graph
         self.dialect = dialect
         self.use_preaggregations = use_preaggregations
-        self.generator = SQLGenerator(graph, dialect=dialect)
+        self.generator = SQLGenerator(graph, dialect=dialect, enforce_visibility=enforce_visibility)
+        self.enforce_visibility = enforce_visibility
         self._dialect_instance = self.generator._dialect_instance
         self._rewrite_cache: dict[tuple[object, ...], str] = {}
         self._rewrite_cache_limit = 256
-        self._use_rust_rewriter = os.getenv("SIDEMANTIC_RS_REWRITER", "0") == "1"
+        self._use_rust_rewriter = (
+            os.getenv("SIDEMANTIC_RS_REWRITER", "0") == "1" if use_rust_rewriter is None else use_rust_rewriter
+        )
         self._rust_no_fallback = os.getenv("SIDEMANTIC_RS_NO_FALLBACK", "0") == "1"
         self._rust_module = None
         self._rust_models_yaml: str | None = None
@@ -153,9 +165,8 @@ class QueryRewriter:
             strict: If True, raise errors for invalid SQL or non-SELECT queries.
                    If False, pass through queries that can't be rewritten.
             user_attributes: Optional per-user security attributes threaded into the underlying
-                SQL generation so access gates / deny-by-default are evaluated against the caller.
-                The SQL-first path cannot inject row filters, so callers that require row-level
-                security must deny secured models with row filters before invoking the rewriter.
+                SQL generation so access gates, deny-by-default, and row filters are evaluated
+                against the caller.
 
         Returns:
             Rewritten SQL using semantic layer
@@ -302,13 +313,19 @@ class QueryRewriter:
                 column.set("table", exp.to_identifier(aliases[column.table]))
         return rewritten
 
-    def explain(self, sql: str, strict: bool = True) -> RewriteExplanation:
+    def explain(
+        self,
+        sql: str,
+        strict: bool = True,
+        user_attributes: dict | None = None,
+    ) -> RewriteExplanation:
         """Explain how a SQL query would be rewritten by the semantic layer.
 
         The explanation follows the same routing as rewrite() but returns
         structured planner state and candidate decisions instead of only SQL.
         """
         sql = sql.strip()
+        self._rewrite_user_attributes = user_attributes
 
         if self._looks_like_yardstick_query(sql):
             try:
@@ -444,6 +461,35 @@ class QueryRewriter:
 
         if has_ctes or has_subquery_in_from or has_subquery_in_joins:
             return self._explain_ctes_or_subqueries(sql, parsed)
+
+        explicit_join_filters = []
+        if parsed.args.get("joins"):
+            explicit_join_filters = self._validate_explicit_semantic_joins(parsed)
+
+        self.inferred_table = self._extract_from_table(parsed)
+        self.table_aliases = self._source_aliases(parsed)
+        if self._needs_expression_postprocess(parsed):
+            rewritten_sql = self._rewrite_expression_query(parsed, extra_filters=explicit_join_filters)
+            return RewriteExplanation(
+                input_sql=sql,
+                rewritten_sql=rewritten_sql,
+                chosen_plan="semantic_plus_postprocess",
+                source_kind=self._source_kind_for_table(self.inferred_table),
+                candidate_plans=[
+                    CandidatePlan(
+                        name="semantic_plus_postprocess",
+                        valid=True,
+                        reason="SQL expression is evaluated over semantically generated fields",
+                    ),
+                    CandidatePlan(
+                        name="passthrough_plain_sql",
+                        valid=False,
+                        reason="query references a semantic model",
+                    ),
+                ],
+                post_process=parsed.sql(dialect=self.dialect),
+                applied_rules=["semantic_expression_postprocess"],
+            )
 
         plan = self._plan_simple_query(parsed)
         rewritten_sql = self._generate_from_plan(plan)
@@ -2980,6 +3026,18 @@ class QueryRewriter:
                     return True
 
         return False
+
+    def would_use_yardstick_rewrite(self, sql: str) -> bool:
+        """Return whether SQL would take an explicit or implicit Yardstick rewrite path."""
+        if self._looks_like_yardstick_query(sql):
+            return True
+        if not self._graph_has_yardstick_models():
+            return False
+        try:
+            parsed = sqlglot.parse_one(sql, dialect=self.dialect)
+        except Exception:
+            return False
+        return isinstance(parsed, exp.Select) and self._contains_implicit_yardstick_measure_query(parsed)
 
     def _graph_has_yardstick_models(self) -> bool:
         return any(
@@ -5719,6 +5777,18 @@ class QueryRewriter:
         def add_adhoc_metric(node: exp.AggFunc) -> str:
             nonlocal adhoc_index
             model_name = ad_hoc_metric_model(node)
+
+            # The generated temporary metric name is always public, so the
+            # generator's normal visibility check cannot see fields referenced
+            # inside its SQL. Validate those original semantic references before
+            # replacing the aggregate with a temporary metric.
+            if self.enforce_visibility:
+                from sidemantic.core.security import enforce_field_visibility
+
+                referenced_fields = [
+                    ref for column in node.find_all(exp.Column) if (ref := self._resolve_column(column)) is not None
+                ]
+                enforce_field_visibility(self.graph, referenced_fields, None)
 
             metric_name = f"__adhoc_metric_{adhoc_index}"
             adhoc_index += 1

--- a/tests/core/test_security_advisor_regressions.py
+++ b/tests/core/test_security_advisor_regressions.py
@@ -151,10 +151,28 @@ def test_visibility_blocks_hidden_field_in_filter():
         layer.compile(metrics=["orders.cnt"], filters=["orders.margin > 100"])
 
 
+def test_visibility_blocks_bare_hidden_field_in_filter():
+    layer = _visibility_layer()
+    with pytest.raises(SecurityError, match="orders.margin"):
+        layer.compile(metrics=["orders.cnt"], filters=["margin > 100"])
+
+
+def test_visibility_blocks_quoted_hidden_field_in_filter():
+    layer = _visibility_layer()
+    with pytest.raises(SecurityError, match="orders.margin"):
+        layer.compile(metrics=["orders.cnt"], filters=['"orders"."margin" > 100'])
+
+
 def test_visibility_blocks_hidden_field_in_order_by():
     layer = _visibility_layer()
     with pytest.raises(SecurityError, match="margin"):
         layer.compile(metrics=["orders.cnt"], dimensions=["orders.region"], order_by=["orders.margin"])
+
+
+def test_visibility_blocks_bare_hidden_field_in_order_by():
+    layer = _visibility_layer()
+    with pytest.raises(SecurityError, match="orders.margin"):
+        layer.compile(metrics=["orders.cnt"], dimensions=["orders.region"], order_by=["margin"])
 
 
 def test_visibility_allows_public_fields():
@@ -165,8 +183,7 @@ def test_visibility_allows_public_fields():
 
 
 def test_sql_first_path_denied_for_secured_model():
-    """P1: SemanticLayer.sql() (SQL-first, used by the CLI) cannot scope rows, so it must
-    refuse when any model declares a security policy rather than returning unfiltered rows."""
+    """SemanticLayer.sql() denies missing context and scopes rows when context is supplied."""
     layer = SemanticLayer()
     con = layer.adapter.conn
     con.execute("CREATE TABLE t (tenant INTEGER, v INTEGER)")
@@ -181,8 +198,11 @@ def test_sql_first_path_denied_for_secured_model():
             security=SecurityPolicy(row_filters=["tenant = {{ user.tenant }}"]),
         )
     )
-    with pytest.raises(SecurityError, match="sql"):
+    with pytest.raises(SecurityError, match="user_attributes"):
         layer.sql("SELECT total FROM t")
+
+    result = layer.sql("SELECT total FROM t", user_attributes={"tenant": 1})
+    assert result.fetchone() == (10,)
 
 
 def test_row_filter_boolean_control_flow_preserves_truthiness():

--- a/tests/core/test_security_enforcement.py
+++ b/tests/core/test_security_enforcement.py
@@ -216,6 +216,26 @@ def test_enforce_visibility_default_off_allows_non_public(db):
     layer.compile(metrics=["orders.margin"])
 
 
+def test_enforce_visibility_rejects_hidden_default_time_dimension(db):
+    model = Model(
+        name="orders",
+        table="orders",
+        primary_key="id",
+        default_time_dimension="created_at",
+        default_grain="day",
+        dimensions=[
+            Dimension(name="id", type="numeric"),
+            Dimension(name="created_at", sql="id", type="time", granularity="day", public=False),
+        ],
+        metrics=[Metric(name="order_count", agg="count")],
+    )
+    layer = _layer(db, enforce_visibility=True)
+    layer.add_model(model)
+
+    with pytest.raises(SecurityError, match=r"Field 'orders\.created_at' is not public"):
+        layer.compile(metrics=["orders.order_count"])
+
+
 def test_row_filtered_query_bypasses_preaggregation(db):
     """When a participating model has active row filters, pre-agg routing is disabled."""
     from sidemantic.core.pre_aggregation import PreAggregation

--- a/tests/server/test_api_security.py
+++ b/tests/server/test_api_security.py
@@ -226,8 +226,8 @@ def test_result_cache_no_cross_user_leak_end_to_end():
     assert tenants_b == {2}
 
 
-def test_sql_endpoint_denied_when_model_secured():
-    """P0-3: /sql cannot enforce row filters, so it must refuse when security is declared."""
+def test_sql_endpoint_enforces_row_filter_when_model_secured():
+    """Semantic SQL uses the same row-filtered generator as /query."""
     layer = _make_layer()
     client = TestClient(create_app(layer, auth_token="secret"))
     resp = client.post(
@@ -235,7 +235,20 @@ def test_sql_endpoint_denied_when_model_secured():
         json={"query": "SELECT order_count FROM orders"},
         headers=_headers(user_attrs={"tenant_id": 1}),
     )
-    assert resp.status_code == 403, resp.text
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["rows"] == [{"order_count": 2}]
+
+
+def test_sql_compile_endpoint_enforces_row_filter_when_model_secured():
+    layer = _make_layer()
+    client = TestClient(create_app(layer, auth_token="secret"))
+    resp = client.post(
+        "/sql/compile",
+        json={"query": "SELECT order_count FROM orders"},
+        headers=_headers(user_attrs={"tenant_id": 2}),
+    )
+    assert resp.status_code == 200, resp.text
+    assert "WHERE tenant_id = 2" in resp.json()["sql"]
 
 
 def test_raw_endpoint_denied_when_model_secured():
@@ -248,6 +261,37 @@ def test_raw_endpoint_denied_when_model_secured():
         headers=_headers(user_attrs={"tenant_id": 1}),
     )
     assert resp.status_code == 403, resp.text
+
+
+def test_sql_passthrough_denied_when_security_active():
+    layer = _make_layer()
+    layer.adapter.execute("create table audit_log (message varchar)")
+    client = TestClient(create_app(layer, auth_token="secret"))
+    resp = client.post(
+        "/sql",
+        json={"query": "SELECT message FROM audit_log"},
+        headers=_headers(user_attrs={"tenant_id": 1}),
+    )
+    assert resp.status_code == 403, resp.text
+    assert "non-semantic" in resp.json()["error"]
+
+
+def test_sql_and_raw_deny_hidden_fields_when_visibility_enforced():
+    layer = _make_layer()
+    client = TestClient(create_app(layer, auth_token="secret", enforce_visibility=True))
+    headers = _headers(user_attrs={"tenant_id": 1})
+
+    sql_resp = client.post(
+        "/sql",
+        json={"query": "SELECT secret_note, order_count FROM orders"},
+        headers=headers,
+    )
+    assert sql_resp.status_code == 403, sql_resp.text
+    assert "not public" in sql_resp.json()["error"]
+
+    raw_resp = client.post("/raw", json={"query": "SELECT status FROM orders"}, headers=headers)
+    assert raw_resp.status_code == 403, raw_resp.text
+    assert "raw sql bypasses" in raw_resp.json()["error"].lower()
 
 
 def test_sql_endpoint_allowed_without_security():

--- a/tests/server/test_transport_security_parity.py
+++ b/tests/server/test_transport_security_parity.py
@@ -1,0 +1,292 @@
+"""Security guarantees shared by HTTP, MCP, and direct semantic SQL transports."""
+
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+pytest.importorskip("pyarrow")
+
+from fastapi.testclient import TestClient
+
+from tests.optional_dep_stubs import ensure_fake_mcp
+
+_mcp_modules_before = {name for name in sys.modules if name == "mcp" or name.startswith("mcp.")}
+ensure_fake_mcp()
+
+from sidemantic import Dimension, Metric, Model, SecurityPolicy, SemanticLayer
+from sidemantic.api_server import create_app
+from sidemantic.core.semantic_layer import SecurityError
+from sidemantic.mcp_server import get_models, get_semantic_graph, initialize_layer
+from sidemantic.mcp_server import run_query as mcp_run_query
+from sidemantic.mcp_server import run_sql as mcp_run_sql
+
+for _module_name in list(sys.modules):
+    if (_module_name == "mcp" or _module_name.startswith("mcp.")) and _module_name not in _mcp_modules_before:
+        sys.modules.pop(_module_name, None)
+
+
+def _model() -> Model:
+    return Model(
+        name="orders",
+        table="orders",
+        primary_key="id",
+        dimensions=[
+            Dimension(name="tenant_id", sql="tenant_id", type="numeric"),
+            Dimension(name="secret_note", sql="secret_note", type="categorical", public=False),
+        ],
+        metrics=[Metric(name="total_amount", agg="sum", sql="amount")],
+        security=SecurityPolicy(
+            access="user.role == 'analyst'",
+            row_filters=["tenant_id = {{ user.tenant_id }}"],
+        ),
+    )
+
+
+def _layer(*, enforce_visibility: bool = False, yardstick: bool = False) -> SemanticLayer:
+    layer = SemanticLayer(enforce_visibility=enforce_visibility)
+    layer.adapter.execute("create table orders (id integer, tenant_id integer, amount double, secret_note varchar)")
+    layer.adapter.executemany(
+        "insert into orders values (?, ?, ?, ?)",
+        [(1, 1, 10.0, "a"), (2, 1, 20.0, "b"), (3, 2, 5.0, "c"), (4, 2, 7.0, "d")],
+    )
+    model = _model()
+    if yardstick:
+        model.metadata = {"yardstick": {}}
+    layer.add_model(model)
+    return layer
+
+
+def _write_model(directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    directory.joinpath("models.yml").write_text(
+        """
+models:
+  - name: orders
+    table: orders
+    primary_key: id
+    dimensions:
+      - name: tenant_id
+        sql: tenant_id
+        type: numeric
+      - name: secret_note
+        sql: secret_note
+        type: categorical
+        public: false
+    metrics:
+      - name: total_amount
+        agg: sum
+        sql: amount
+    security:
+      access: "user.role == 'analyst'"
+      row_filters:
+        - "tenant_id = {{ user.tenant_id }}"
+"""
+    )
+
+
+def _mcp_layer(
+    directory: Path,
+    attrs: dict,
+    *,
+    enforce_visibility: bool = False,
+    yardstick: bool = False,
+) -> SemanticLayer:
+    _write_model(directory)
+    layer = initialize_layer(
+        str(directory),
+        db_path=":memory:",
+        user_attributes=attrs,
+        enforce_visibility=enforce_visibility,
+    )
+    layer.adapter.execute("create table orders (id integer, tenant_id integer, amount double, secret_note varchar)")
+    layer.adapter.executemany(
+        "insert into orders values (?, ?, ?, ?)",
+        [(1, 1, 10.0, "a"), (2, 1, 20.0, "b"), (3, 2, 5.0, "c"), (4, 2, 7.0, "d")],
+    )
+    if yardstick:
+        layer.graph.models["orders"].metadata = {"yardstick": {}}
+    return layer
+
+
+def _headers(attrs: dict) -> dict[str, str]:
+    return {
+        "Authorization": "Bearer secret",
+        "X-Sidemantic-User": json.dumps(attrs),
+    }
+
+
+def test_allowed_identity_gets_identical_rows_across_http_and_mcp(tmp_path):
+    attrs = {"role": "analyst", "tenant_id": 2}
+    client = TestClient(create_app(_layer(), auth_token="secret"))
+
+    structured = client.post(
+        "/query",
+        json={"dimensions": ["orders.tenant_id"], "metrics": ["orders.total_amount"]},
+        headers=_headers(attrs),
+    )
+    semantic_sql = client.post(
+        "/sql",
+        json={"query": "SELECT tenant_id, total_amount FROM orders"},
+        headers=_headers(attrs),
+    )
+    assert structured.status_code == semantic_sql.status_code == 200
+
+    _mcp_layer(tmp_path / "mcp", attrs)
+    mcp_structured = mcp_run_query(
+        dimensions=["orders.tenant_id"],
+        metrics=["orders.total_amount"],
+    )
+    mcp_sql = mcp_run_sql("SELECT tenant_id, total_amount FROM orders")
+
+    expected = [{"tenant_id": 2, "total_amount": 12.0}]
+    assert structured.json()["rows"] == expected
+    assert semantic_sql.json()["rows"] == expected
+    assert mcp_structured["rows"] == expected
+    assert mcp_sql["rows"] == expected
+
+
+def test_raw_and_unproven_sql_fail_closed_across_http_and_mcp(tmp_path):
+    attrs = {"role": "analyst", "tenant_id": 1}
+    http_layer = _layer()
+    http_layer.adapter.execute("create table audit_log (message varchar)")
+    client = TestClient(create_app(http_layer, auth_token="secret"))
+
+    raw = client.post("/raw", json={"query": "SELECT * FROM orders"}, headers=_headers(attrs))
+    passthrough = client.post(
+        "/sql",
+        json={"query": "SELECT message FROM audit_log"},
+        headers=_headers(attrs),
+    )
+    assert raw.status_code == 403
+    assert passthrough.status_code == 403
+    assert "non-semantic" in passthrough.json()["error"]
+
+    mcp_layer = _mcp_layer(tmp_path / "mcp-raw", attrs)
+    mcp_layer.adapter.execute("create table audit_log (message varchar)")
+    with pytest.raises(SecurityError, match="non-semantic"):
+        mcp_run_sql("SELECT message FROM audit_log")
+
+
+@pytest.mark.parametrize(
+    ("query", "message"),
+    [
+        ("SELECT * FROM (SELECT amount FROM orders) AS scoped", "semantic subquery"),
+        (
+            "SELECT total_amount FROM orders WHERE EXISTS (SELECT 1 FROM orders WHERE secret_note = 'secret')",
+            "predicate subquery",
+        ),
+        ("SELECT (SELECT 1 FROM orders LIMIT 1) AS leaked, total_amount FROM orders", "projection subquery"),
+    ],
+)
+def test_unproven_nested_sql_fails_closed_across_http_and_mcp(tmp_path, query, message):
+    attrs = {"role": "analyst", "tenant_id": 1}
+    client = TestClient(create_app(_layer(enforce_visibility=True), auth_token="secret"))
+
+    response = client.post("/sql", json={"query": query}, headers=_headers(attrs))
+    assert response.status_code == 403
+    assert message in response.json()["error"]
+
+    _mcp_layer(tmp_path / message.replace(" ", "-"), attrs, enforce_visibility=True)
+    with pytest.raises(SecurityError, match=message):
+        mcp_run_sql(query)
+
+
+def test_rust_rewriter_is_disabled_for_secured_sql_transports(tmp_path, monkeypatch):
+    from sidemantic.sql.query_rewriter import QueryRewriter
+
+    attrs = {"role": "analyst", "tenant_id": 2}
+    query = "SELECT tenant_id, total_amount FROM orders"
+    monkeypatch.setenv("SIDEMANTIC_RS_REWRITER", "1")
+
+    def insecure_rust_rewrite(*_args, **_kwargs):
+        return "SELECT tenant_id, SUM(amount) AS total_amount FROM orders GROUP BY tenant_id"
+
+    monkeypatch.setattr(QueryRewriter, "_rewrite_with_rust", insecure_rust_rewrite)
+
+    client = TestClient(create_app(_layer(), auth_token="secret"))
+    response = client.post("/sql", json={"query": query}, headers=_headers(attrs))
+    assert response.status_code == 200
+    assert response.json()["rows"] == [{"tenant_id": 2, "total_amount": 12.0}]
+
+    _mcp_layer(tmp_path / "mcp-rust-disabled", attrs)
+    assert mcp_run_sql(query)["rows"] == [{"tenant_id": 2, "total_amount": 12.0}]
+
+
+def test_sql_rewrite_cache_isolated_by_visibility_state():
+    layer = SemanticLayer()
+    layer.adapter.execute("create table records (id integer, secret_note varchar)")
+    layer.adapter.execute("insert into records values (1, 'private')")
+    layer.add_model(
+        Model(
+            name="records",
+            table="records",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="id", sql="id", type="numeric"),
+                Dimension(name="secret_note", sql="secret_note", type="categorical", public=False),
+            ],
+        )
+    )
+
+    assert layer.sql("SELECT secret_note FROM records").fetchall() == [("private",)]
+
+    layer.enforce_visibility = True
+    with pytest.raises(SecurityError, match="not public"):
+        layer.sql("SELECT secret_note FROM records")
+
+
+def test_yardstick_sql_fails_closed_across_http_and_mcp(tmp_path):
+    attrs = {"role": "analyst", "tenant_id": 1}
+    queries = [
+        "SELECT AGGREGATE(total_amount) FROM orders",
+        "SELECT total_amount FROM orders",
+    ]
+    client = TestClient(create_app(_layer(yardstick=True), auth_token="secret"))
+
+    for query in queries:
+        response = client.post("/sql", json={"query": query}, headers=_headers(attrs))
+        assert response.status_code == 403
+        assert "Yardstick semantic SQL" in response.json()["error"]
+
+    _mcp_layer(tmp_path / "mcp-yardstick", attrs, yardstick=True)
+    for query in queries:
+        with pytest.raises(SecurityError, match="Yardstick semantic SQL"):
+            mcp_run_sql(query)
+
+
+def test_hidden_column_is_rejected_and_omitted_across_http_and_mcp(tmp_path):
+    attrs = {"role": "analyst", "tenant_id": 1}
+    client = TestClient(create_app(_layer(enforce_visibility=True), auth_token="secret"))
+
+    for path, payload in [
+        ("/query", {"dimensions": ["orders.secret_note"], "metrics": ["orders.total_amount"]}),
+        ("/sql", {"query": "SELECT secret_note, total_amount FROM orders"}),
+        ("/sql", {"query": "SELECT MIN(secret_note) FROM orders"}),
+    ]:
+        response = client.post(path, json=payload, headers=_headers(attrs))
+        assert response.status_code == 403
+        assert "not public" in response.json()["error"]
+
+    mcp_layer = _mcp_layer(tmp_path / "mcp-hidden", attrs, enforce_visibility=True)
+    model = mcp_layer.graph.models["orders"]
+    model.primary_key = "secret_note"
+
+    graph = get_semantic_graph()
+    assert "secret_note" not in graph["models"][0]["dimensions"]
+    assert "primary_key" not in graph["models"][0]
+    assert "primary_key" not in get_models(["orders"])["models"][0]
+
+    with pytest.raises(SecurityError, match="not public"):
+        mcp_run_query(dimensions=["orders.secret_note"], metrics=["orders.total_amount"])
+    with pytest.raises(SecurityError, match="not public"):
+        mcp_run_sql("SELECT secret_note, total_amount FROM orders")
+    with pytest.raises(SecurityError, match="not public"):
+        mcp_run_sql("SELECT MIN(secret_note) FROM orders")

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -826,11 +826,20 @@ def test_mcp_serve_calls_initialize(monkeypatch, tmp_path):
     called = {}
     events = []
 
-    def fake_initialize_layer(directory, db_path=None, connection=None, init_sql=None):
+    def fake_initialize_layer(
+        directory,
+        db_path=None,
+        connection=None,
+        init_sql=None,
+        user_attributes=None,
+        enforce_visibility=False,
+    ):
         called["directory"] = directory
         called["db_path"] = db_path
         called["connection"] = connection
         called["init_sql"] = init_sql
+        called["user_attributes"] = user_attributes
+        called["enforce_visibility"] = enforce_visibility
 
     def fake_run(*args, **kwargs):
         events.append("start")
@@ -846,6 +855,8 @@ def test_mcp_serve_calls_initialize(monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert called["directory"] == str(tmp_path)
     assert called["db_path"] is None
+    assert called["user_attributes"] is None
+    assert called["enforce_visibility"] is False
     assert called.get("run") is True
     assert events == ["warning", "start"]
 
@@ -855,6 +866,47 @@ def test_docker_entrypoint_does_not_use_eval():
     content = entrypoint_path.read_text()
 
     assert "eval " not in content
+
+
+def test_mcp_serve_applies_static_user_attributes_and_visibility(monkeypatch, tmp_path):
+    ensure_fake_mcp()
+    called = {}
+
+    def fake_initialize_layer(
+        directory,
+        db_path=None,
+        connection=None,
+        init_sql=None,
+        user_attributes=None,
+        enforce_visibility=False,
+    ):
+        called["directory"] = directory
+        called["user_attributes"] = user_attributes
+        called["enforce_visibility"] = enforce_visibility
+
+    monkeypatch.setattr("sidemantic.mcp_server.initialize_layer", fake_initialize_layer)
+    monkeypatch.setattr("sidemantic.mcp_server.mcp.run", lambda *args, **kwargs: None)
+    monkeypatch.setattr("sidemantic.cli_contract.emit_warning", lambda _message: None)
+
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    attrs_file = tmp_path / "user.json"
+    attrs_file.write_text('{"role": "analyst", "tenant_id": 7}')
+
+    result = runner.invoke(
+        app,
+        [
+            "mcp-serve",
+            str(models_dir),
+            "--user-attrs-file",
+            str(attrs_file),
+            "--enforce-visibility",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert called["user_attributes"] == {"role": "analyst", "tenant_id": 7}
+    assert called["enforce_visibility"] is True
 
 
 def test_mcp_serve_apps_implies_http_and_uses_config(monkeypatch, tmp_path):
@@ -874,11 +926,20 @@ connection:
 """
     )
 
-    def fake_initialize_layer(directory, db_path=None, connection=None, init_sql=None):
+    def fake_initialize_layer(
+        directory,
+        db_path=None,
+        connection=None,
+        init_sql=None,
+        user_attributes=None,
+        enforce_visibility=False,
+    ):
         called["directory"] = directory
         called["db_path"] = db_path
         called["connection"] = connection
         called["init_sql"] = init_sql
+        called["user_attributes"] = user_attributes
+        called["enforce_visibility"] = enforce_visibility
 
     def fake_run(*args, **kwargs):
         called["transport"] = kwargs["transport"]

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -18,7 +18,7 @@ from tests.optional_dep_stubs import ensure_fake_mcp
 ensure_fake_mcp()
 
 from sidemantic.core.semantic_layer import SecurityError
-from sidemantic.mcp_server import get_user_attributes, initialize_layer, run_query
+from sidemantic.mcp_server import get_user_attributes, initialize_layer, run_query, run_sql
 
 
 def _write_secured_models(directory: Path) -> None:
@@ -71,3 +71,24 @@ def test_static_user_attributes_scope_rows():
     result = run_query(dimensions=["orders.tenant_id"], metrics=["orders.order_count"])
     tenants = {row["tenant_id"] for row in result["rows"]}
     assert tenants == {2}
+
+
+def test_run_sql_uses_static_user_attributes_and_scopes_rows():
+    tmpdir = Path(tempfile.mkdtemp())
+    _write_secured_models(tmpdir)
+    layer = initialize_layer(str(tmpdir), db_path=":memory:", user_attributes={"tenant_id": 1})
+    _seed(layer)
+
+    result = run_sql("SELECT tenant_id, order_count FROM orders")
+    assert result["rows"] == [{"tenant_id": 1, "order_count": 2}]
+
+
+def test_run_sql_denies_unproven_passthrough_when_security_active():
+    tmpdir = Path(tempfile.mkdtemp())
+    _write_secured_models(tmpdir)
+    layer = initialize_layer(str(tmpdir), db_path=":memory:", user_attributes={"tenant_id": 1})
+    _seed(layer)
+    layer.adapter.execute("create table audit_log (message varchar)")
+
+    with pytest.raises(SecurityError, match="non-semantic"):
+        run_sql("SELECT message FROM audit_log")


### PR DESCRIPTION
Enforces model access, row policies, and field visibility across semantic SQL transports. Adds fail-closed HTTP and MCP handling plus focused transport parity coverage.