### PR TITLE
Harden keyless query planning

### DIFF
--- a/sidemantic/core/semantic_graph.py
+++ b/sidemantic/core/semantic_graph.py
@@ -68,6 +68,7 @@ class SemanticGraph:
     def __init__(self):
         self.models: dict[str, Model] = {}
         self.metrics: dict[str, Metric] = {}
+        self.metric_owners: dict[str, str] = {}
         self.table_calculations: dict[str, TableCalculation] = {}
         self.parameters: dict[str, Parameter] = {}
         self.import_warnings: list[dict[str, object]] = []
@@ -103,16 +104,21 @@ class SemanticGraph:
 
         self._mark_dirty()
 
-    def add_metric(self, measure: Metric) -> None:
+    def add_metric(self, measure: Metric, model_name: str | None = None) -> None:
         """Add a measure to the graph.
 
         Args:
             measure: Metric to add
+            model_name: Optional owning model for a graph-addressable model metric
         """
         if measure.name in self.metrics:
             raise ValueError(f"Measure {measure.name} already exists")
+        if model_name is not None and model_name not in self.models:
+            raise ValueError(f"Model {model_name} not found for measure {measure.name}")
 
         self.metrics[measure.name] = measure
+        if model_name is not None:
+            self.metric_owners[measure.name] = model_name
         self._mark_dirty()
 
     def add_table_calculation(self, calc: TableCalculation) -> None:

--- a/sidemantic/core/semantic_layer.py
+++ b/sidemantic/core/semantic_layer.py
@@ -1415,16 +1415,23 @@ class SemanticLayer:
             pk_columns = set(model.primary_key_columns)
             for candidate in candidates:
                 preagg = next((p for p in model.pre_aggregations if p.name == candidate.name), None)
-                if candidate.selected and (preagg is None or not pk_columns.issubset(set(preagg.dimensions or []))):
+                if candidate.selected and (
+                    not pk_columns or preagg is None or not pk_columns.issubset(set(preagg.dimensions or []))
+                ):
                     candidate.selected = False
             if not any(c.selected for c in candidates):
+                reason = (
+                    "ungrouped query, model has no declared primary key for unique rows"
+                    if not pk_columns
+                    else "ungrouped query, no rollup carries the primary key for unique rows"
+                )
                 return QueryPlan(
                     sql=sql,
                     model=model_name,
                     metrics=bare_metrics,
                     dimensions=bare_dims,
                     used_preaggregation=False,
-                    routing_reason="ungrouped query, no rollup carries the primary key for unique rows",
+                    routing_reason=reason,
                     candidates=candidates,
                 )
 

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -1530,6 +1530,9 @@ class SQLGenerator:
                 return
 
             # It's a graph-level metric, need to resolve its dependencies.
+            owning_model = self.graph.metric_owners.get(metric_ref)
+            if owning_model:
+                add_model(owning_model)
             if metric.type == "ratio":
                 if metric.numerator:
                     collect_models_from_metric(metric.numerator)
@@ -1787,7 +1790,7 @@ class SQLGenerator:
             """Recursively extract filter columns from a metric and its dependencies."""
             # Extract from the metric's own filters
             if metric.filters:
-                filter_model_name = None
+                filter_model_name = self.graph.metric_owners.get(metric.name)
                 deps = metric.get_dependencies(self.graph)
                 for dep in deps:
                     try:
@@ -3528,6 +3531,9 @@ class SQLGenerator:
         """
         if model_context and model_context in self.graph.models:
             return model_context
+        owning_model = self.graph.metric_owners.get(metric.name)
+        if owning_model:
+            return owning_model
         if metric.sql:
             try:
                 parsed = _parse_fragment(metric.sql, self.dialect)
@@ -6205,7 +6211,8 @@ LEFT JOIN {preagg_table} AS {rollup_alias}
             # dimensions; otherwise the stored rows are aggregated and must not
             # be served ungrouped. Fall through to raw tables.
             preagg_dims = set(preagg.dimensions or [])
-            if not set(model.primary_key_columns).issubset(preagg_dims):
+            primary_key_columns = set(model.primary_key_columns)
+            if not primary_key_columns or not primary_key_columns.issubset(preagg_dims):
                 return None
 
         # Generate SQL against pre-aggregation table

--- a/tests/adapters/metricflow/test_parsing.py
+++ b/tests/adapters/metricflow/test_parsing.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 import pytest
 
+from sidemantic import Metric, Model
 from sidemantic.adapters.metricflow import MetricFlowAdapter
+from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.sql.generator import SQLGenerator
 
 # =============================================================================
@@ -1032,6 +1034,28 @@ def test_metricflow_inline_constant_count_anchored_to_model():
             assert "count" in sql.lower()
     finally:
         path.unlink(missing_ok=True)
+
+
+def test_metricflow_keyless_inline_count_planner_contract():
+    """Keyless inline row counts retain model context without a fabricated key."""
+    graph = SemanticGraph()
+    graph.add_model(Model(name="events", table="events"))
+    graph.add_metric(Metric(name="row_count", agg="count"), model_name="events")
+    graph.add_metric(
+        Metric(name="active_count", agg="count", filters=["status = 'active'"]),
+        model_name="events",
+    )
+
+    generator = SQLGenerator(graph)
+    row_count_sql = generator.generate(metrics=["row_count"])
+    assert "events" in row_count_sql.lower()
+    assert "count(*)" in row_count_sql.lower()
+    assert ".none" not in row_count_sql.lower()
+
+    active_count_sql = generator.generate(metrics=["active_count"])
+    assert "status as status" in active_count_sql.lower()
+    assert "events_cte.status = 'active'" in active_count_sql.lower()
+    assert ".none" not in active_count_sql.lower()
 
 
 def test_metricflow_inline_exprless_non_count_uses_metric_column():

--- a/tests/optimizations/test_pre_aggregations.py
+++ b/tests/optimizations/test_pre_aggregations.py
@@ -2362,6 +2362,40 @@ def test_ungrouped_rollup_without_pk_falls_to_raw(layer):
     assert plan.used_preaggregation is False
 
 
+def test_ungrouped_keyless_model_falls_to_raw(layer):
+    """An empty key set is not evidence that an aggregate rollup preserves detail rows."""
+    layer.use_preaggregations = True
+    layer.conn.execute("CREATE TABLE orders (status VARCHAR, amount DECIMAL(10, 2))")
+    layer.conn.execute("CREATE TABLE orders_preagg_by_status (status VARCHAR, revenue_raw DECIMAL(10, 2))")
+    model = Model(
+        name="orders",
+        table="orders",
+        dimensions=[Dimension(name="status", type="categorical", sql="status")],
+        metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        pre_aggregations=[PreAggregation(name="by_status", measures=["revenue"], dimensions=["status"])],
+    )
+    layer.add_model(model)
+
+    sql = layer.compile(
+        metrics=["orders.revenue"],
+        dimensions=["orders.status"],
+        ungrouped=True,
+    )
+
+    assert "orders_preagg_by_status" not in sql
+    assert "orders_cte" in sql
+    assert "used_preagg=true" not in sql
+
+    plan = layer.explain(
+        metrics=["orders.revenue"],
+        dimensions=["orders.status"],
+        ungrouped=True,
+        use_preaggregations=True,
+    )
+    assert plan.used_preaggregation is False
+    assert plan.routing_reason == "ungrouped query, model has no declared primary key for unique rows"
+
+
 def test_ungrouped_composite_pk_partial_rollup_falls_to_raw(layer):
     """A rollup carrying only part of a composite primary key cannot guarantee unique rows."""
     layer.use_preaggregations = True

--- a/tests/queries/test_basic.py
+++ b/tests/queries/test_basic.py
@@ -6,6 +6,7 @@ import sqlglot
 from sqlglot import exp
 
 from sidemantic import Dimension, Metric, Model, Relationship, Segment, SemanticLayer
+from sidemantic.validation import QueryValidationError
 from tests.utils import df_rows
 
 
@@ -799,6 +800,33 @@ def test_direct_many_to_many_without_target_key_joins_on_model_pk():
     # Local side joins on A's primary key; it never references a raw a_id column (A has none).
     assert re.search(r"a_cte\.id\b", sql)
     assert "a_cte.a_id" not in sql
+
+
+def test_keyless_direct_many_to_many_has_no_join_path_when_queried():
+    """An incomplete keyless relationship is ignored until a query actually needs that join."""
+    layer = SemanticLayer()
+    layer.add_model(
+        Model(
+            name="a",
+            table="a",
+            metrics=[Metric(name="cnt", agg="count")],
+            relationships=[Relationship(name="b", type="many_to_many", foreign_key="a_id")],
+        )
+    )
+    layer.add_model(
+        Model(
+            name="b",
+            table="b",
+            primary_key="a_id",
+            dimensions=[Dimension(name="label", type="categorical")],
+        )
+    )
+
+    sql = layer.compile(metrics=["a.cnt"])
+    assert "a_cte" in sql
+
+    with pytest.raises(QueryValidationError, match="No join path found between models"):
+        layer.compile(metrics=["a.cnt"], dimensions=["b.label"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Required planner follow-up to #291, extracted from the planner-safety portions of #274. It prevents keyless rollups from serving ungrouped detail queries, preserves graph-level metric ownership for keyless counts and filters, and keeps incomplete keyless relationships out of join planning.\n\nThis PR is stacked on recut-key-primitives and should merge only after #291.