### PR TITLE
Resolve pushed filters against model sources

### DIFF
--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -594,6 +594,59 @@ class SQLGenerator:
                 result.append(f)
         return result
 
+    def _rewrite_filter_for_model_source(self, filter_sql: str, model) -> str:
+        """Resolve a pushed semantic filter against the model's raw source."""
+        model_name = model.name
+        source_alias = "t" if model.sql else None
+        resolved_filter = filter_sql.replace("{model}.", f"{model_name}.").replace("{model}", model_name)
+        try:
+            parsed = _parse_fragment(resolved_filter, self.dialect)
+        except Exception:
+            return resolved_filter
+
+        for column in list(parsed.find_all(exp.Column)):
+            table_name = column.table
+            if table_name and table_name.replace("_cte", "") != model_name:
+                continue
+
+            dimension_name = column.name
+            granularity = None
+            dimension = model.get_dimension(dimension_name)
+            if dimension is None and "__" in dimension_name:
+                candidate_name, candidate_granularity = dimension_name.rsplit("__", 1)
+                candidate = model.get_dimension(candidate_name)
+                if candidate is not None and candidate.type == "time":
+                    granularity = candidate_granularity
+                    dimension = candidate
+
+            if dimension is None:
+                column.set("table", exp.to_identifier(source_alias) if source_alias else None)
+                continue
+
+            self._ensure_sql_dimension(model_name, dimension)
+            replacement_sql = self._dimension_base_expr(dimension)
+            effective_granularity = granularity
+            if dimension.type == "time" and effective_granularity is None:
+                effective_granularity = dimension.granularity
+            if effective_granularity:
+                replacement_sql = self._date_trunc(effective_granularity, replacement_sql)
+            if source_alias:
+                replacement_sql = replacement_sql.replace("{model}", source_alias)
+            else:
+                replacement_sql = replacement_sql.replace("{model}.", "").replace("{model}", "")
+
+            try:
+                replacement = _parse_fragment(replacement_sql, self.dialect)
+            except Exception:
+                continue
+            for replacement_column in replacement.find_all(exp.Column):
+                replacement_table = replacement_column.table
+                if replacement_table and replacement_table.replace("_cte", "") == model_name:
+                    replacement_column.set("table", exp.to_identifier(source_alias) if source_alias else None)
+            column.replace(replacement)
+
+        return parsed.sql(dialect=self.dialect)
+
     def _quote_alias(self, name: str) -> str:
         """Quote an identifier for use as a SQL alias.
 
@@ -2370,22 +2423,7 @@ class SQLGenerator:
         # Build WHERE clause for pushed-down filters
         where_clause = ""
         if filters:
-            # Process filters - replace model_cte references with direct column names using SQLGlot
-            processed_filters = []
-            for f in filters:
-                try:
-                    parsed = _parse_fragment(f, self.dialect)
-                    # Remove table qualifiers (model_name_cte. or model_name.)
-                    for col in parsed.find_all(exp.Column):
-                        if col.table:
-                            clean_table = col.table.replace("_cte", "")
-                            if clean_table == model_name:
-                                col.set("table", None)
-                    processed_filter = parsed.sql(dialect=self.dialect)
-                    processed_filters.append(processed_filter)
-                except Exception:
-                    # If parsing fails, use original filter
-                    processed_filters.append(f)
+            processed_filters = [self._rewrite_filter_for_model_source(f, model) for f in filters]
 
             where_clause = f"\n  WHERE {' AND '.join(processed_filters)}"
 

--- a/tests/metrics/test_filters.py
+++ b/tests/metrics/test_filters.py
@@ -437,6 +437,63 @@ def test_filter_classification_and_rewrite_respect_nested_select_alias_scope():
     )
 
 
+def test_structured_filters_resolve_grained_and_computed_dimensions_before_where():
+    layer = SemanticLayer()
+    layer.add_model(
+        Model(
+            name="events",
+            table="events",
+            primary_key="id",
+            dimensions=[
+                Dimension(name="created_at", type="time", sql="occurred_at", granularity="day"),
+                Dimension(name="gross", type="numeric", sql="unit_price * quantity"),
+                Dimension(name="category", type="categorical"),
+            ],
+            metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+        )
+    )
+    layer.conn.execute(
+        """
+        CREATE TABLE events (
+            id INTEGER,
+            occurred_at TIMESTAMP,
+            unit_price DOUBLE,
+            quantity INTEGER,
+            category VARCHAR,
+            amount DOUBLE
+        );
+        INSERT INTO events VALUES
+            (1, '2024-01-15 12:00:00', 5, 2, 'A', 10),
+            (2, '2024-02-10 08:00:00', 12, 2, 'A', 24),
+            (3, '2024-02-12 08:00:00', 4, 2, 'B', 8);
+        """
+    )
+    filters = [
+        "events.created_at__month = DATE '2024-02-01'",
+        "events.gross >= 20",
+    ]
+
+    postgres_sql = layer.compile(
+        metrics=["events.revenue"],
+        dimensions=["events.category"],
+        filters=filters,
+        dialect="postgres",
+    )
+    where_sql = postgres_sql.split("WHERE", 1)[1]
+    assert "created_at__month" not in where_sql
+    assert "events.gross" not in where_sql
+    assert "DATE_TRUNC('MONTH', occurred_at)" in where_sql
+    assert "unit_price * quantity >= 20" in where_sql
+
+    assert df_rows(
+        layer.query(
+            metrics=["events.revenue"],
+            dimensions=["events.category"],
+            filters=filters,
+        )
+    ) == [("A", 24.0)]
+
+
 def test_metric_level_filters_use_case_when(layer):
     """Test that Metric.filters are applied via CASE WHEN inside aggregation.
 


### PR DESCRIPTION
Rewrites grained and computed semantic dimensions to their raw SQL expressions before model CTE filters run. Extracted from #283.