### PR TITLE
Remove unused datetime import failing ruff on main

### DIFF
--- a/tests/core/test_security_advisor_regressions.py
+++ b/tests/core/test_security_advisor_regressions.py
@@ -6,8 +6,6 @@ Covers:
 - P1-1: enforce_visibility must also cover fields referenced only in filters/order_by.
 """
 
-import datetime
-
 import pytest
 
 from sidemantic import Dimension, Metric, Model, SemanticLayer


### PR DESCRIPTION
ruff F401 on tests/core/test_security_advisor_regressions.py (introduced in 93d3b502) fails the Python 3.11-3.13 CI jobs on main and on every PR based on it, including #311. The import is unused; the module has no other datetime reference.