### PR TITLE
Add semantic-first MCP analysis

### DIFF
--- a/plugins/sidemantic/.claude-plugin/plugin.json
+++ b/plugins/sidemantic/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sidemantic",
-  "description": "Build, validate, and query Sidemantic semantic models, and generate analytics webapps from them. Ships the modeler and webapp-builder skills.",
+  "description": "Build, validate, and query Sidemantic semantic models, answer business questions with trusted metrics, and generate analytics webapps. Ships modeler, semantic-analyst, and webapp-builder skills.",
   "version": "1.0.0",
   "author": {
     "name": "Sidemantic"

--- a/plugins/sidemantic/.codex-plugin/plugin.json
+++ b/plugins/sidemantic/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sidemantic",
-  "description": "Build, validate, and query Sidemantic semantic models, and generate analytics webapps from them.",
+  "description": "Build, validate, and query Sidemantic semantic models, answer business questions with trusted metrics, and generate analytics webapps.",
   "version": "1.0.0",
   "author": {
     "name": "Sidemantic",
@@ -19,12 +19,13 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Sidemantic",
-    "shortDescription": "Model metrics and build analytics webapps from semantic SQL.",
-    "longDescription": "Sidemantic helps Codex build, validate, query, and migrate SQL-first semantic models, then turn those models into analytics dashboards and app surfaces.",
+    "shortDescription": "Analyze trusted metrics and build semantic analytics.",
+    "longDescription": "Sidemantic helps Codex answer business questions with trusted metrics; build, validate, query, and migrate SQL-first semantic models; and turn those models into analytics dashboards and app surfaces.",
     "developerName": "Sidemantic",
     "category": "Data & Analytics",
     "capabilities": [
       "Semantic modeling",
+      "Semantic analysis",
       "SQL generation",
       "Analytics webapps"
     ],
@@ -32,6 +33,7 @@
     "defaultPrompt": [
       "Create a Sidemantic model from my schema.",
       "Validate these metrics and dimensions.",
+      "Explain why revenue changed using our trusted metrics.",
       "Build a dashboard from my Sidemantic models."
     ],
     "brandColor": "#2563EB"

--- a/plugins/sidemantic/skills/semantic-analyst/SKILL.md
+++ b/plugins/sidemantic/skills/semantic-analyst/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: semantic-analyst
+description: Answer analytical, KPI, metric, trend, cohort, and business-performance questions through a Sidemantic semantic layer. Use when asked to analyze data, explain why a metric changed, compare segments or periods, calculate a business measure, or explore warehouse data when Sidemantic MCP tools or semantic model files are available. Discover and reuse trusted definitions, distinguish durable semantic-model gaps from one-off query logic, and prefer semantic queries over duplicated raw SQL.
+---
+
+# Semantic Analyst
+
+Use the semantic layer as accumulated business knowledge, not merely as a convenient query interface.
+
+## Workflow
+
+1. Search the semantic catalog for the user's concepts. Search by business terms and likely synonyms; do not dump the full graph unless search is unavailable or broader topology is necessary.
+2. Explain candidate metrics and inspect the relevant models. Check descriptions, dependencies, filters, aggregation or formula, grain, relationships, source file, and provenance before deciding that a metric matches the request.
+3. Translate the question into existing metrics, dimensions, segments, time grains, and one-off filters. Validate uncertain field combinations.
+4. Prefer a structured semantic query. Use semantic SQL only when the structured query cannot express a needed operation. Use raw warehouse SQL only for genuinely exploratory work outside the modeled surface, and label that result as outside the semantic layer.
+5. Check the result for the requested grain, units, time range, exclusions, null behavior, and denominator. State material assumptions.
+6. Answer the business question directly. Include the metric definition or query provenance when it affects interpretation.
+
+## Decide What Belongs in the Model
+
+Promote durable business semantics into the model; keep ephemeral analytical operations in the query.
+
+- Reuse an existing metric for requests such as revenue last week by state.
+- Apply query filters for narrow cohorts such as California users who signed up Tuesday.
+- Model definitions with durable policy, such as net revenue excluding refunds or repayment rate with an eligibility denominator.
+- Model ratios or derived measures that recur across analyses.
+- Keep unusual exploratory cohorts or temporary calculations out of the model until they become reusable.
+
+Do not create combinatorial metrics that merely bake a dimension value, date range, or one-off filter into an otherwise reusable metric.
+
+## Handle Semantic Gaps
+
+When no existing definition faithfully represents the request, do not silently invent equivalent SQL. Return a concise structured gap:
+
+```yaml
+semantic_gap:
+  requested_concept: net revenue
+  why_missing: Existing revenue does not define refund treatment.
+  reusable: true
+  recommended_action: model_metric
+  proposed_definition:
+    name: net_revenue
+    policy: gross revenue minus refunded amount
+    open_questions:
+      - Which refund statuses count?
+```
+
+Use `recommended_action: query_only` for ephemeral operations and `clarify` when business policy is ambiguous.
+
+If working as a coding agent with repository access, inspect the model's reported `source_file`, update the semantic definition through normal files and Git, run `sidemantic validate path/to/models/ --verbose`, run relevant project tests, and retry the original semantic query. Use the separate `modeler` skill for substantial authoring or migration work. If files cannot be edited, report the gap and proposed definition without claiming it was persisted.
+
+## Guardrails
+
+- Never substitute a similarly named metric without checking its definition.
+- Never hide missing business policy inside ad hoc SQL.
+- Never persist a new metric merely because a query is complex.
+- Never claim causality from descriptive results alone.
+- Preserve access controls and field visibility; do not work around unavailable semantic fields.

--- a/plugins/sidemantic/skills/semantic-analyst/agents/openai.yaml
+++ b/plugins/sidemantic/skills/semantic-analyst/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Semantic Analyst"
+  short_description: "Answer business questions with trusted metrics"
+  default_prompt: "Use $semantic-analyst to answer this business question through the Sidemantic semantic layer."

--- a/sidemantic/bootstrap.py
+++ b/sidemantic/bootstrap.py
@@ -63,20 +63,18 @@ def introspect_connection(
     """
 
     if connection.startswith("duckdb://"):
-        import duckdb
+        from sidemantic.db.duckdb import DuckDBAdapter
 
-        db_path = connection.removeprefix("duckdb:///") or ":memory:"
-        con = duckdb.connect(db_path, read_only=db_path != ":memory:" and not init_sql)
+        adapter = DuckDBAdapter.from_url(connection, init_sql=init_sql)
+        con = adapter.raw_connection
         try:
-            for statement in init_sql or []:
-                con.execute(statement)
             tables = _introspect_information_schema(con)
             if profile:
                 for table in tables:
                     _profile_table(con, table)
             return tables
         finally:
-            con.close()
+            adapter.close()
 
     from sidemantic import SemanticLayer
 

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -3017,10 +3017,10 @@ def refresh(
 
         # Connect to database
         if connection_str.startswith("duckdb://"):
-            import duckdb
+            from sidemantic.db.duckdb import DuckDBAdapter
 
-            db_path = connection_str.replace("duckdb:///", "")
-            conn = duckdb.connect(db_path)
+            duckdb_adapter = DuckDBAdapter.from_url(connection_str, init_sql=resolved_connection.init_sql)
+            conn = duckdb_adapter.raw_connection
 
             # Create schema if it doesn't exist (DuckDB only)
             if preagg_sch:

--- a/sidemantic/config.py
+++ b/sidemantic/config.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from typing import Literal
+from urllib.parse import urlencode
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -13,6 +14,10 @@ class DuckDBConnection(BaseModel):
 
     type: Literal["duckdb"] = "duckdb"
     path: str = Field(..., description="Path to DuckDB database file or :memory:")
+    config: dict[str, str | bool | int | float] | None = Field(
+        default=None,
+        description="DuckDB startup configuration passed to duckdb.connect",
+    )
     init_sql: list[str] | None = Field(
         default=None,
         description="SQL statements to run after connecting (e.g., loading extensions, attaching catalogs)",
@@ -268,7 +273,12 @@ class SidemanticConfig(BaseModel):
             db_p = Path(connection.path)
             if not db_p.is_absolute():
                 db_p = (base / db_p).resolve()
-            connection = DuckDBConnection(type="duckdb", path=str(db_p), init_sql=connection.init_sql)
+            connection = DuckDBConnection(
+                type="duckdb",
+                path=str(db_p),
+                config=connection.config,
+                init_sql=connection.init_sql,
+            )
         elif connection and isinstance(connection, FilesConnection):
             connection = FilesConnection(type="files", paths=_expand_data_paths(connection.paths, base))
         elif connection is not None and getattr(connection, "password_file", None):
@@ -324,11 +334,13 @@ def load_config(config_path: Path) -> SidemanticConfig:
     suffix = config_path.suffix.lower()
 
     if suffix in {".yaml", ".yml"}:
-        with open(config_path) as f:
-            data = _yaml_safe_load(f)
+        from sidemantic.adapters.sidemantic import substitute_env_vars
+
+        data = _yaml_safe_load(substitute_env_vars(config_path.read_text()))
     elif suffix == ".json":
-        with open(config_path) as f:
-            data = json.load(f)
+        from sidemantic.adapters.sidemantic import substitute_env_vars
+
+        data = json.loads(substitute_env_vars(config_path.read_text()))
     else:
         raise ValueError(f"Unsupported config format: {suffix}. Use .yaml, .yml, or .json")
 
@@ -420,7 +432,10 @@ def build_connection_string(config: SidemanticConfig) -> str:
         return "duckdb:///:memory:"
 
     if isinstance(config.connection, DuckDBConnection):
-        return f"duckdb:///{config.connection.path}"
+        connection = f"duckdb:///{config.connection.path}"
+        if config.connection.config:
+            connection = f"{connection}?{urlencode(config.connection.config)}"
+        return connection
     elif isinstance(config.connection, FilesConnection):
         return "duckdb:///:memory:"
     elif isinstance(config.connection, PostgreSQLConnection):

--- a/sidemantic/config.py
+++ b/sidemantic/config.py
@@ -334,20 +334,33 @@ def load_config(config_path: Path) -> SidemanticConfig:
     suffix = config_path.suffix.lower()
 
     if suffix in {".yaml", ".yml"}:
-        from sidemantic.adapters.sidemantic import substitute_env_vars
-
-        data = _yaml_safe_load(substitute_env_vars(config_path.read_text()))
+        data = _yaml_safe_load(config_path.read_text())
     elif suffix == ".json":
-        from sidemantic.adapters.sidemantic import substitute_env_vars
-
-        data = json.loads(substitute_env_vars(config_path.read_text()))
+        data = json.loads(config_path.read_text())
     else:
         raise ValueError(f"Unsupported config format: {suffix}. Use .yaml, .yml, or .json")
 
-    config = SidemanticConfig(**data)
+    config = SidemanticConfig(**_substitute_config_env_values(data))
 
     # Resolve relative paths relative to config file directory
     return config.resolve_paths(config_path.parent)
+
+
+def _substitute_config_env_values(value):
+    """Substitute environment placeholders after parsing YAML or JSON.
+
+    Substituting parsed string scalars keeps quotes, backslashes, and newlines in
+    environment values from changing the surrounding serialization syntax.
+    """
+    from sidemantic.adapters.sidemantic import substitute_env_vars
+
+    if isinstance(value, str):
+        return substitute_env_vars(value)
+    if isinstance(value, list):
+        return [_substitute_config_env_values(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _substitute_config_env_values(item) for key, item in value.items()}
+    return value
 
 
 def find_config(start_dir: Path | None = None) -> Path | None:

--- a/sidemantic/mcp_server.py
+++ b/sidemantic/mcp_server.py
@@ -1,15 +1,33 @@
 """MCP server for Sidemantic semantic layer."""
 
 import json
+import re
 from datetime import date, datetime, time
 from decimal import Decimal
 from pathlib import Path
+from time import perf_counter
 from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
 
 from sidemantic.core.semantic_layer import SemanticLayer
 from sidemantic.loaders import load_from_directory
+
+SIDEMANTIC_MCP_INSTRUCTIONS = """
+Sidemantic is the authoritative semantic layer for analytical questions. Discover
+and reuse existing metrics, dimensions, and segments before constructing equivalent
+logic. Start with search_semantic_catalog, inspect relevant definitions with
+explain_metric or get_models, and prefer run_query over run_sql when the structured
+query can express the request.
+
+Promote durable, reusable business meaning into the semantic model; keep one-off
+filters, groupings, and exploratory calculations in the query. If the requested
+business concept is not modeled, do not silently recreate it in SQL. Return a
+semantic_gap object with requested_concept, why_missing, reusable,
+recommended_action (model_metric, query_only, or clarify), and an optional
+proposed_definition. Coding clients may then update the source_file reported by
+get_models, validate the model, and retry the semantic query.
+""".strip()
 
 # Global semantic layer instance
 _layer: SemanticLayer | None = None
@@ -201,7 +219,7 @@ def _format_join_key_pairs(
 
 
 # Create MCP server
-mcp = FastMCP("sidemantic")
+mcp = FastMCP("sidemantic", instructions=SIDEMANTIC_MCP_INSTRUCTIONS)
 
 
 def _visible_dimension_name(model: Any, name: str | None, enforce_visibility: bool) -> str | None:
@@ -211,6 +229,381 @@ def _visible_dimension_name(model: Any, name: str | None, enforce_visibility: bo
     if dimension is not None and not getattr(dimension, "public", True):
         return None
     return name
+
+
+@mcp.tool(structured_output=False)
+def search_semantic_catalog(
+    query: str,
+    kinds: list[Literal["model", "dimension", "metric", "segment"]] = [],
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Search models and fields before constructing a semantic query.
+
+    Performs case-insensitive lexical search across names, qualified names, labels,
+    descriptions, tables, and SQL definitions. Results include enough metadata to
+    choose relevant models; use get_models for complete definitions before querying.
+
+    Args:
+        query: Words or a phrase to find, such as "repayment rate" or "revenue".
+        kinds: Optional result kinds to include. Empty includes all kinds.
+        limit: Maximum number of ranked results to return (1-100).
+
+    Returns:
+        Ranked catalog results with kind, name, qualified_name, model, description,
+        and source metadata when available.
+    """
+
+    def normalize(value: str) -> str:
+        return " ".join(re.findall(r"[^\W_]+", value.lower()))
+
+    def token_matches(query_token: str, candidate_token: str) -> bool:
+        """Match whole tokens and useful prefixes, never arbitrary substrings."""
+        return candidate_token == query_token or candidate_token.startswith(query_token)
+
+    def phrase_matches(query_tokens: list[str], candidate_tokens: list[str]) -> bool:
+        """Return whether query tokens match a contiguous candidate phrase."""
+        phrase_length = len(query_tokens)
+        for start in range(len(candidate_tokens) - phrase_length + 1):
+            window = candidate_tokens[start : start + phrase_length]
+            if all(
+                token_matches(query_token, candidate_token)
+                for query_token, candidate_token in zip(query_tokens, window)
+            ):
+                return True
+        return False
+
+    normalized_query = normalize(query)
+    if not normalized_query:
+        raise ValueError("query must contain at least one non-whitespace character")
+    if not 1 <= limit <= 100:
+        raise ValueError("limit must be between 1 and 100")
+
+    allowed_kinds = {"model", "dimension", "metric", "segment"}
+    requested_kinds = set(kinds) if kinds else allowed_kinds
+    invalid_kinds = requested_kinds - allowed_kinds
+    if invalid_kinds:
+        invalid = ", ".join(sorted(invalid_kinds))
+        raise ValueError(f"Unknown catalog kinds: {invalid}")
+
+    layer = get_layer()
+    tokens = normalized_query.split()
+    candidates: list[dict[str, Any]] = []
+
+    def add_candidate(
+        *,
+        kind: str,
+        name: str,
+        qualified_name: str,
+        model_name: str | None = None,
+        description: str | None = None,
+        label: str | None = None,
+        sql: str | None = None,
+        field_type: str | None = None,
+        source_file: str | None = None,
+        source_format: str | None = None,
+        table: str | None = None,
+    ) -> None:
+        if kind not in requested_kinds:
+            return
+
+        searchable_values = [qualified_name, name, model_name, description, label, sql, table]
+        normalized_values = [normalize(str(value)) for value in searchable_values if value]
+        searchable_tokens = [token for value in normalized_values for token in value.split()]
+        matched_tokens = [
+            token
+            for token in tokens
+            if any(token_matches(token, candidate_token) for candidate_token in searchable_tokens)
+        ]
+        if not matched_tokens:
+            return
+
+        normalized_name = normalize(name)
+        normalized_qualified = normalize(qualified_name)
+        score = sum(
+            sum(token_matches(token, candidate_token) for candidate_token in searchable_tokens)
+            for token in matched_tokens
+        )
+        score += len(matched_tokens) * 5
+        score += round(20 * len(matched_tokens) / len(tokens))
+        if normalized_query == normalized_qualified:
+            score += 100
+        elif normalized_query == normalized_name:
+            score += 80
+        elif normalized_name.startswith(normalized_query):
+            score += 40
+        if any(phrase_matches(tokens, value.split()) for value in normalized_values):
+            score += 20
+
+        result: dict[str, Any] = {
+            "kind": kind,
+            "name": name,
+            "qualified_name": qualified_name,
+            "score": score,
+            "matched_tokens": matched_tokens,
+        }
+        if model_name:
+            result["model"] = model_name
+        if description:
+            result["description"] = description
+        if label:
+            result["label"] = label
+        if field_type:
+            result["type"] = field_type
+        if table:
+            result["table"] = table
+        if source_file:
+            result["source_file"] = source_file
+        if source_format:
+            result["source_format"] = source_format
+        candidates.append(result)
+
+    for model_name, model in layer.graph.models.items():
+        source_file = getattr(model, "_source_file", None)
+        source_format = getattr(model, "_source_format", None)
+        add_candidate(
+            kind="model",
+            name=model_name,
+            qualified_name=model_name,
+            description=model.description,
+            table=model.table,
+            sql=model.sql,
+            source_file=source_file,
+            source_format=source_format,
+        )
+        for dimension in model.dimensions:
+            if layer.enforce_visibility and not getattr(dimension, "public", True):
+                continue
+            add_candidate(
+                kind="dimension",
+                name=dimension.name,
+                qualified_name=f"{model_name}.{dimension.name}",
+                model_name=model_name,
+                description=dimension.description,
+                label=dimension.label,
+                sql=dimension.sql,
+                field_type=dimension.type,
+                source_file=source_file,
+                source_format=source_format,
+            )
+        for metric in model.metrics:
+            if layer.enforce_visibility and not getattr(metric, "public", True):
+                continue
+            add_candidate(
+                kind="metric",
+                name=metric.name,
+                qualified_name=f"{model_name}.{metric.name}",
+                model_name=model_name,
+                description=metric.description,
+                label=metric.label,
+                sql=metric.sql,
+                field_type=metric.type or metric.agg,
+                source_file=source_file,
+                source_format=source_format,
+            )
+        for segment in model.segments:
+            if layer.enforce_visibility and not getattr(segment, "public", True):
+                continue
+            add_candidate(
+                kind="segment",
+                name=segment.name,
+                qualified_name=f"{model_name}.{segment.name}",
+                model_name=model_name,
+                description=segment.description,
+                sql=segment.sql,
+                source_file=source_file,
+                source_format=source_format,
+            )
+
+    model_metric_ids = {id(metric) for model in layer.graph.models.values() for metric in model.metrics}
+    for metric_name, metric in layer.graph.metrics.items():
+        # Conversion/retention metrics attached to a model are also registered on
+        # the graph for query resolution. Search should surface their qualified
+        # model entry once, not a second unqualified duplicate.
+        if id(metric) in model_metric_ids:
+            continue
+        if layer.enforce_visibility and not getattr(metric, "public", True):
+            continue
+        add_candidate(
+            kind="metric",
+            name=metric_name,
+            qualified_name=metric_name,
+            description=metric.description,
+            label=metric.label,
+            sql=metric.sql,
+            field_type=metric.type,
+        )
+
+    exact_candidates = [
+        candidate
+        for candidate in candidates
+        if candidate["kind"] != "model"
+        and (
+            normalize(candidate["qualified_name"]) == normalized_query
+            or normalize(candidate["name"]) == normalized_query
+        )
+    ]
+    if exact_candidates:
+        candidates = exact_candidates
+    candidates.sort(key=lambda result: (-result["score"], result["kind"], result["qualified_name"]))
+    total = len(candidates)
+    return {
+        "query": query,
+        "kinds": sorted(requested_kinds),
+        "results": candidates[:limit],
+        "result_count": min(total, limit),
+        "total_matches": total,
+        "truncated": total > limit,
+    }
+
+
+def _resolve_metric_dependency(
+    dependency: str,
+    *,
+    model_name: str | None,
+    layer: SemanticLayer,
+) -> tuple[str | None, Any] | None:
+    """Resolve a dependency using its metric's model before graph-level names."""
+    graph = layer.graph
+    if "." in dependency:
+        try:
+            return graph.resolve_metric_reference(dependency)
+        except KeyError:
+            return None
+
+    if model_name:
+        model = graph.models.get(model_name)
+        metric = model.get_metric(dependency) if model else None
+        if metric:
+            return model_name, metric
+
+    try:
+        return graph.resolve_metric_reference(dependency)
+    except KeyError:
+        return None
+
+
+def _qualified_metric_name(model_name: str | None, metric: Any, fallback: str) -> str:
+    return f"{model_name}.{metric.name}" if model_name else fallback
+
+
+def _metric_expression(metric: Any) -> str | None:
+    """Return a concise human-readable expression without compiling a query."""
+    if metric.type == "ratio" and metric.numerator and metric.denominator:
+        return f"{metric.numerator} / {metric.denominator}"
+    if metric.sql:
+        if metric.agg:
+            return metric.to_sql()
+        return metric.sql
+    if metric.agg:
+        return metric.to_sql()
+    return None
+
+
+@mcp.tool(structured_output=False)
+def explain_metric(metric_name: str) -> dict[str, Any]:
+    """Explain one metric's definition, dependencies, and source provenance.
+
+    Use after search_semantic_catalog to confirm that an existing metric matches
+    the requested business concept before querying it. Dependencies are returned
+    as canonical qualified names when resolvable, and source_models includes the
+    transitive model lineage of graph-level or derived metrics.
+
+    Args:
+        metric_name: Qualified model metric or graph-level metric name.
+
+    Returns:
+        Metric definition, direct dependencies, source models, and source metadata.
+    """
+    layer = get_layer()
+    try:
+        model_name, metric = layer.graph.resolve_metric_reference(metric_name)
+    except KeyError as exc:
+        raise ValueError(f"Metric '{metric_name}' not found") from exc
+
+    if layer.enforce_visibility and not getattr(metric, "public", True):
+        raise ValueError(f"Metric '{metric_name}' not found")
+
+    direct_dependencies = metric.get_dependencies(layer.graph, model_name)
+    canonical_dependencies: list[str] = []
+    source_models: set[str] = {model_name} if model_name else set()
+    hidden_dependency_count = 0
+
+    def collect_sources(
+        dependency_name: str,
+        dependency_model: str | None,
+        dependency_metric: Any,
+        visited: set[tuple[str | None, int]],
+    ) -> None:
+        nonlocal hidden_dependency_count
+        identity = (dependency_model, id(dependency_metric))
+        if identity in visited:
+            return
+        visited.add(identity)
+        if layer.enforce_visibility and not getattr(dependency_metric, "public", True):
+            hidden_dependency_count += 1
+            return
+        if dependency_model:
+            source_models.add(dependency_model)
+        for nested_name in dependency_metric.get_dependencies(layer.graph, dependency_model):
+            nested = _resolve_metric_dependency(nested_name, model_name=dependency_model, layer=layer)
+            if nested:
+                nested_model, nested_metric = nested
+                collect_sources(nested_name, nested_model, nested_metric, visited)
+
+    for dependency in sorted(direct_dependencies):
+        resolved = _resolve_metric_dependency(dependency, model_name=model_name, layer=layer)
+        if not resolved:
+            canonical_dependencies.append(dependency)
+            continue
+        dependency_model, dependency_metric = resolved
+        if layer.enforce_visibility and not getattr(dependency_metric, "public", True):
+            hidden_dependency_count += 1
+            continue
+        canonical_dependencies.append(_qualified_metric_name(dependency_model, dependency_metric, dependency))
+        collect_sources(dependency, dependency_model, dependency_metric, set())
+
+    result: dict[str, Any] = {
+        "metric": _qualified_metric_name(model_name, metric, metric_name),
+        "name": metric.name,
+        "depends_on": canonical_dependencies,
+        "source_models": sorted(source_models),
+    }
+    if model_name:
+        result["model"] = model_name
+    if metric.type:
+        result["type"] = metric.type
+    if metric.agg:
+        result["agg"] = metric.agg
+    if not hidden_dependency_count:
+        if expression := _metric_expression(metric):
+            result["expression"] = expression
+    if metric.description:
+        result["description"] = metric.description
+    if metric.label:
+        result["label"] = metric.label
+    if metric.filters:
+        result["filters"] = metric.filters
+    if metric.numerator and not hidden_dependency_count:
+        result["numerator"] = metric.numerator
+    if metric.denominator and not hidden_dependency_count:
+        result["denominator"] = metric.denominator
+    if metric.base_metric and not hidden_dependency_count:
+        result["base_metric"] = metric.base_metric
+    if metric.comparison_type:
+        result["comparison_type"] = metric.comparison_type
+    if metric.format:
+        result["format"] = metric.format
+    if metric.value_format_name:
+        result["value_format_name"] = metric.value_format_name
+    if hidden_dependency_count:
+        result["hidden_dependency_count"] = hidden_dependency_count
+
+    source_owner = layer.graph.models[model_name] if model_name else metric
+    if source_format := getattr(source_owner, "_source_format", None):
+        result["source_format"] = source_format
+    if source_file := getattr(source_owner, "_source_file", None):
+        result["source_file"] = source_file
+    return result
 
 
 @mcp.tool(structured_output=False)
@@ -433,6 +826,7 @@ def run_query(
 
     # Compile SQL. Pass the server-level static user attributes so model access
     # gates and row filters are enforced (None -> secured models are denied).
+    compile_started = perf_counter()
     sql = layer.compile(
         dimensions=dimensions or [],
         metrics=metrics or [],
@@ -445,8 +839,10 @@ def run_query(
         user_attributes=get_user_attributes(),
     )
 
+    compile_ms = round((perf_counter() - compile_started) * 1000, 2)
+
     if dry_run:
-        return {"sql": sql}
+        return {"sql": sql, "timing": {"compile_ms": compile_ms}}
 
     def recompile_raw():
         return layer.compile(
@@ -462,16 +858,19 @@ def run_query(
             user_attributes=get_user_attributes(),
         )
 
+    execution_started = perf_counter()
     result = layer._execute_with_preagg_fallback(
         sql,
         recompile_raw,
         use_preaggs=layer.use_preaggregations,
         strict=layer.preagg_strict,
         used_preagg="used_preagg=true" in sql,
+        execute=layer.adapter.execute,
     )
 
     # Convert to list of dicts with JSON-compatible values
     rows = result.fetchall()
+    execution_ms = round((perf_counter() - execution_started) * 1000, 2)
     columns = [desc[0] for desc in result.description]
     row_dicts = [{col: _convert_to_json_compatible(val) for col, val in zip(columns, row)} for row in rows]
 
@@ -479,6 +878,11 @@ def run_query(
         "sql": sql,
         "rows": row_dicts,
         "row_count": len(row_dicts),
+        "timing": {
+            "compile_ms": compile_ms,
+            "execution_ms": execution_ms,
+            "total_ms": round(compile_ms + execution_ms, 2),
+        },
     }
 
 
@@ -709,6 +1113,20 @@ def validate_query(
         graph=layer.graph,
     )
 
+    cohort_metrics = []
+    for metric_ref in metrics or []:
+        try:
+            _, metric = layer.graph.resolve_metric_reference(metric_ref)
+        except KeyError:
+            continue
+        if metric.type == "cohort":
+            cohort_metrics.append(metric_ref)
+    if len(cohort_metrics) > 1:
+        errors.append(
+            "Only one cohort metric can be queried at a time; split these into separate queries: "
+            + ", ".join(cohort_metrics)
+        )
+
     return {
         "valid": len(errors) == 0,
         "errors": errors,
@@ -756,7 +1174,10 @@ def get_semantic_graph() -> dict[str, Any]:
 
     # Graph-level metrics
     graph_metrics = []
+    model_metric_ids = {id(metric) for model in graph.models.values() for metric in model.metrics}
     for metric_name, metric in graph.metrics.items():
+        if id(metric) in model_metric_ids:
+            continue
         if layer.enforce_visibility and not getattr(metric, "public", True):
             continue
         metric_info: dict[str, Any] = {

--- a/sidemantic/mcp_server.py
+++ b/sidemantic/mcp_server.py
@@ -486,6 +486,14 @@ def _qualified_metric_name(model_name: str | None, metric: Any, fallback: str) -
     return f"{model_name}.{metric.name}" if model_name else fallback
 
 
+def _recover_model_metric_owner(metric: Any, layer: SemanticLayer) -> str | None:
+    """Return the model that owns a graph-registered model metric, if any."""
+    for candidate_model_name, model in layer.graph.models.items():
+        if any(candidate is metric for candidate in model.metrics):
+            return candidate_model_name
+    return None
+
+
 def _metric_expression(metric: Any) -> str | None:
     """Return a concise human-readable expression without compiling a query."""
     if metric.type == "ratio" and metric.numerator and metric.denominator:
@@ -519,6 +527,9 @@ def explain_metric(metric_name: str) -> dict[str, Any]:
         model_name, metric = layer.graph.resolve_metric_reference(metric_name)
     except KeyError as exc:
         raise ValueError(f"Metric '{metric_name}' not found") from exc
+
+    if model_name is None:
+        model_name = _recover_model_metric_owner(metric, layer)
 
     if layer.enforce_visibility and not getattr(metric, "public", True):
         raise ValueError(f"Metric '{metric_name}' not found")

--- a/sidemantic/project.py
+++ b/sidemantic/project.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from sidemantic.config import SidemanticConfig, build_connection_string, find_config, get_init_sql, load_config
 
@@ -233,9 +234,10 @@ class ProjectContext:
             database_path = None
             connection_string = build_connection_string(self.config)
             if connection_string.startswith("duckdb:///"):
-                raw_path = connection_string.removeprefix("duckdb:///")
+                raw_path = urlparse(connection_string).path.lstrip("/")
                 if raw_path != ":memory:":
-                    database_path = Path(raw_path)
+                    configured_path = self.config.connection.path
+                    database_path = Path(configured_path)
             return ResolvedConnection(
                 connection=connection_string,
                 database=database_path,

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -579,11 +579,13 @@ class SQLGenerator:
 
             self._ensure_sql_dimension(model_name, dimension)
             replacement_sql = self._dimension_base_expr(dimension)
-            effective_granularity = granularity
-            if dimension.type == "time" and effective_granularity is None:
-                effective_granularity = dimension.granularity
-            if effective_granularity:
-                replacement_sql = self._date_trunc(effective_granularity, replacement_sql)
+            # A time dimension's default granularity controls how it is projected,
+            # not the precision of predicates on the base semantic field. Keeping
+            # base filters on the raw expression preserves exact rolling windows
+            # and lets databases push timestamp predicates into the source. Only
+            # an explicit suffix such as ``created_at__day`` requests truncation.
+            if granularity:
+                replacement_sql = self._date_trunc(granularity, replacement_sql)
             if source_alias:
                 replacement_sql = replacement_sql.replace("{model}", source_alias)
             else:

--- a/tests/test_cli_project_contract.py
+++ b/tests/test_cli_project_contract.py
@@ -98,6 +98,21 @@ def test_query_uses_project_models_and_connection(monkeypatch: pytest.MonkeyPatc
     assert "2" in result.output
 
 
+def test_project_duckdb_config_does_not_become_part_of_database_filename(
+    monkeypatch: pytest.MonkeyPatch, project: Path
+):
+    (project / "sidemantic.yaml").write_text(
+        "models_dir: models\nconnection:\n  type: duckdb\n  path: data/warehouse.duckdb\n  config:\n    threads: 1\n"
+    )
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["query", "SELECT order_count FROM orders"])
+
+    assert result.exit_code == 0, result.output
+    assert "2" in result.output
+    assert not (project / "data" / "warehouse.duckdb?threads=1").exists()
+
+
 def test_migrate_query_path_is_relative_to_selected_project(
     monkeypatch: pytest.MonkeyPatch,
     project: Path,

--- a/tests/test_config_files_and_credentials.py
+++ b/tests/test_config_files_and_credentials.py
@@ -125,6 +125,29 @@ connection:
     assert get_init_sql(config) == ["load '/tmp/iceberg.duckdb_extension'"]
 
 
+@pytest.mark.parametrize("suffix", ["yaml", "json"])
+def test_load_config_preserves_serialization_characters_in_environment_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, suffix: str
+):
+    password = 'quote" backslash\\ and\nnewline'
+    monkeypatch.setenv("TEST_CONFIG_PASSWORD", password)
+    config_path = tmp_path / f"sidemantic.{suffix}"
+    if suffix == "json":
+        config_path.write_text(
+            '{"connection":{"type":"postgres","host":"h","database":"db",'
+            '"username":"u","password":"${TEST_CONFIG_PASSWORD}"}}'
+        )
+    else:
+        config_path.write_text(
+            "connection:\n  type: postgres\n  host: h\n  database: db\n  username: u\n"
+            '  password: "${TEST_CONFIG_PASSWORD}"\n'
+        )
+
+    config = load_config(config_path)
+
+    assert config.connection.password == password
+
+
 # --- password_file credentials ------------------------------------------------
 
 

--- a/tests/test_config_files_and_credentials.py
+++ b/tests/test_config_files_and_credentials.py
@@ -8,6 +8,7 @@ import pytest
 
 from sidemantic.config import (
     ClickHouseConnection,
+    DuckDBConnection,
     FilesConnection,
     PostgreSQLConnection,
     SidemanticConfig,
@@ -87,6 +88,41 @@ def test_files_connection_loads_from_yaml(tmp_path: Path):
     assert isinstance(config.connection, FilesConnection)
     assert build_connection_string(config) == "duckdb:///:memory:"
     assert len(get_init_sql(config)) == 1
+
+
+def test_duckdb_connection_config_round_trips_through_url(tmp_path: Path):
+    config = SidemanticConfig(
+        connection=DuckDBConnection(
+            path=":memory:",
+            config={"allow_unsigned_extensions": True, "threads": 4},
+        )
+    )
+
+    assert build_connection_string(config) == "duckdb:///:memory:?allow_unsigned_extensions=True&threads=4"
+
+
+def test_load_config_substitutes_environment_in_duckdb_config_and_init_sql(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setenv("TEST_DUCKDB_UNSIGNED", "true")
+    monkeypatch.setenv("TEST_ICEBERG_INIT", "load '/tmp/iceberg.duckdb_extension'")
+    config_path = tmp_path / "sidemantic.yaml"
+    config_path.write_text(
+        """
+connection:
+  type: duckdb
+  path: ":memory:"
+  config:
+    allow_unsigned_extensions: "${TEST_DUCKDB_UNSIGNED:-false}"
+  init_sql:
+    - "${TEST_ICEBERG_INIT:-install iceberg; load iceberg}"
+"""
+    )
+
+    config = load_config(config_path)
+
+    assert config.connection.config == {"allow_unsigned_extensions": "true"}
+    assert get_init_sql(config) == ["load '/tmp/iceberg.duckdb_extension'"]
 
 
 # --- password_file credentials ------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3,6 +3,7 @@
 # ruff: noqa: E402
 
 import json
+import re
 import tempfile
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -19,15 +20,18 @@ from sidemantic.core.pre_aggregation import PreAggregation
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.semantic_layer import PreaggregationStrictError
 from sidemantic.mcp_server import (
+    SIDEMANTIC_MCP_INSTRUCTIONS,
     _convert_to_json_compatible,
     _format_join_condition,
     catalog_resource,
     create_chart,
+    explain_metric,
     get_models,
     get_semantic_graph,
     initialize_layer,
     run_query,
     run_sql,
+    search_semantic_catalog,
     validate_query,
 )
 
@@ -200,6 +204,9 @@ def test_run_query_basic(demo_layer):
     assert "SUM" in result["sql"].upper()
     # Should have 2 rows (Alice and Bob)
     assert result["row_count"] == 2
+    assert result["timing"]["compile_ms"] >= 0
+    assert result["timing"]["execution_ms"] >= 0
+    assert result["timing"]["total_ms"] >= 0
     assert len(result["rows"]) == 2
 
 
@@ -214,6 +221,29 @@ def test_run_query_with_filter(demo_layer):
     assert result["sql"] is not None
     assert "WHERE" in result["sql"].upper()
     assert "Alice" in result["sql"]
+
+
+def test_run_query_base_time_filter_uses_raw_expression(demo_layer):
+    result = run_query(
+        metrics=["orders.total_revenue"],
+        where="orders.order_date >= TIMESTAMP '2024-01-02 12:34:56'",
+        dry_run=True,
+    )
+
+    where_clause = result["sql"].split("WHERE", 1)[1].split(")\nSELECT", 1)[0]
+    assert re.search(r"order_date\s*>=", where_clause)
+    assert "DATE_TRUNC" not in where_clause.upper()
+
+
+def test_run_query_explicit_time_grain_filter_truncates_expression(demo_layer):
+    result = run_query(
+        metrics=["orders.total_revenue"],
+        where="orders.order_date__day >= DATE '2024-01-02'",
+        dry_run=True,
+    )
+
+    where_clause = result["sql"].split("WHERE", 1)[1].split(")\nSELECT", 1)[0]
+    assert "DATE_TRUNC('DAY', ORDER_DATE)" in where_clause.upper()
 
 
 def test_run_query_with_order_by(demo_layer):
@@ -433,6 +463,7 @@ def test_run_query_dry_run(demo_layer):
     assert "LIMIT" in result["sql"].upper()
     # Should NOT have rows or row_count
     assert "rows" not in result
+    assert result["timing"]["compile_ms"] >= 0
     assert "row_count" not in result
 
 
@@ -523,6 +554,37 @@ def test_validate_query_invalid_metric(demo_layer):
     assert len(result["errors"]) > 0
 
 
+def test_validate_query_rejects_multiple_cohort_metrics(demo_layer):
+    orders = demo_layer.graph.models["orders"]
+    orders.metrics.extend(
+        [
+            Metric(
+                name="repeat_customers",
+                type="cohort",
+                entity="customer_name",
+                inner_metrics=[{"name": "orders", "agg": "count"}],
+                having="orders >= 2",
+                agg="count",
+            ),
+            Metric(
+                name="cross_channel_customers",
+                type="cohort",
+                entity="customer_name",
+                inner_metrics=[{"name": "orders", "agg": "count"}],
+                having="orders >= 2",
+                agg="count",
+            ),
+        ]
+    )
+
+    result = validate_query(
+        metrics=["orders.repeat_customers", "orders.cross_channel_customers"],
+    )
+
+    assert result["valid"] is False
+    assert any("Only one cohort metric" in error for error in result["errors"])
+
+
 def test_segments_via_get_models(demo_layer):
     """Test that segments are accessible via get_models (replaces list_segments)."""
     result = get_models(["orders"])
@@ -555,6 +617,171 @@ def test_get_semantic_graph(demo_layer):
     assert "segments" in model
     assert "completed_orders" in model["segments"]
     assert "primary_key" not in model
+
+
+def test_mcp_instructions_promote_semantic_first_analysis():
+    assert "authoritative semantic layer" in SIDEMANTIC_MCP_INSTRUCTIONS
+    assert "search_semantic_catalog" in SIDEMANTIC_MCP_INSTRUCTIONS
+    assert "explain_metric" in SIDEMANTIC_MCP_INSTRUCTIONS
+    assert "semantic_gap" in SIDEMANTIC_MCP_INSTRUCTIONS
+
+
+def test_search_semantic_catalog_ranks_and_filters_results(demo_layer):
+    result = search_semantic_catalog("orders.total_revenue", kinds=["metric"])
+
+    assert result["result_count"] == 1
+    assert result["results"][0]["kind"] == "metric"
+    assert result["results"][0]["qualified_name"] == "orders.total_revenue"
+
+
+def test_search_semantic_catalog_searches_descriptions_and_limits(demo_layer):
+    result = search_semantic_catalog("orders", limit=2)
+
+    assert result["result_count"] == 2
+    assert result["total_matches"] > result["result_count"]
+    assert result["truncated"] is True
+
+
+def test_search_semantic_catalog_ranks_partial_matches_for_broad_queries(demo_layer):
+    result = search_semantic_catalog("revenue status customer retention")
+
+    assert result["results"]
+    assert any(item["qualified_name"] == "orders.total_revenue" for item in result["results"])
+    revenue = next(item for item in result["results"] if item["qualified_name"] == "orders.total_revenue")
+    assert "revenue" in revenue["matched_tokens"]
+
+
+def test_search_semantic_catalog_matches_token_prefixes_not_internal_substrings(demo_layer):
+    orders = demo_layer.graph.models["orders"]
+    orders.dimensions.extend(
+        [
+            Dimension(name="longitude", sql="longitude", type="numeric"),
+            Dimension(name="github_repository", sql="github_repository", type="categorical"),
+        ]
+    )
+
+    result = search_semantic_catalog("git", kinds=["dimension"])
+
+    assert "orders.github_repository" in [item["qualified_name"] for item in result["results"]]
+    assert "orders.longitude" not in [item["qualified_name"] for item in result["results"]]
+
+
+def test_search_semantic_catalog_deduplicates_model_registered_graph_metrics(demo_layer):
+    orders = demo_layer.graph.models["orders"]
+    metric = orders.metrics[0]
+    demo_layer.graph.metrics[metric.name] = metric
+
+    result = search_semantic_catalog(metric.name, kinds=["metric"])
+
+    assert [item["qualified_name"] for item in result["results"]].count(f"orders.{metric.name}") == 1
+    assert metric.name not in [item["qualified_name"] for item in result["results"]]
+
+
+def test_search_semantic_catalog_rejects_invalid_input(demo_layer):
+    with pytest.raises(ValueError, match="non-whitespace"):
+        search_semantic_catalog("  ")
+    with pytest.raises(ValueError, match="between 1 and 100"):
+        search_semantic_catalog("revenue", limit=0)
+
+
+def test_search_semantic_catalog_respects_field_visibility(demo_layer):
+    orders = demo_layer.graph.models["orders"]
+    orders.dimensions.append(Dimension(name="secret_note", sql="secret_note", type="categorical", public=False))
+    demo_layer.enforce_visibility = True
+
+    result = search_semantic_catalog("secret note")
+
+    assert result["results"] == []
+
+
+def test_explain_metric_returns_definition_and_provenance(demo_layer):
+    result = explain_metric("orders.total_revenue")
+
+    assert result == {
+        "metric": "orders.total_revenue",
+        "name": "total_revenue",
+        "model": "orders",
+        "agg": "sum",
+        "expression": "SUM(amount)",
+        "description": "Total revenue from orders",
+        "depends_on": [],
+        "source_models": ["orders"],
+        "source_format": "Sidemantic",
+        "source_file": "orders.yml",
+    }
+
+
+def test_explain_metric_resolves_dependencies_and_transitive_sources(demo_layer):
+    orders = demo_layer.graph.models["orders"]
+    orders.metrics.extend(
+        [
+            Metric(name="refunded_revenue", agg="sum", sql="refunded_amount"),
+            Metric(
+                name="net_revenue",
+                type="derived",
+                sql="total_revenue - refunded_revenue",
+                filters=["status != 'failed'"],
+            ),
+        ]
+    )
+
+    result = explain_metric("orders.net_revenue")
+
+    assert result["expression"] == "total_revenue - refunded_revenue"
+    assert result["depends_on"] == ["orders.refunded_revenue", "orders.total_revenue"]
+    assert result["source_models"] == ["orders"]
+    assert result["filters"] == ["status != 'failed'"]
+
+
+def test_explain_metric_rejects_unknown_and_hidden_metrics(demo_layer):
+    with pytest.raises(ValueError, match="Metric 'orders.missing' not found"):
+        explain_metric("orders.missing")
+
+    orders = demo_layer.graph.models["orders"]
+    orders.metrics.append(Metric(name="secret_revenue", agg="sum", sql="amount", public=False))
+    demo_layer.enforce_visibility = True
+
+    with pytest.raises(ValueError, match="Metric 'orders.secret_revenue' not found"):
+        explain_metric("orders.secret_revenue")
+
+
+def test_explain_graph_metric_reports_cross_model_lineage(demo_layer):
+    customers = Model(
+        name="customers",
+        table="customers_table",
+        metrics=[Metric(name="customer_count", agg="count_distinct", sql="customer_id")],
+    )
+    demo_layer.add_model(customers)
+    demo_layer.add_metric(
+        Metric(
+            name="revenue_per_customer",
+            type="derived",
+            sql="orders.total_revenue / customers.customer_count",
+        )
+    )
+
+    result = explain_metric("revenue_per_customer")
+
+    assert result["metric"] == "revenue_per_customer"
+    assert result["depends_on"] == ["customers.customer_count", "orders.total_revenue"]
+    assert result["source_models"] == ["customers", "orders"]
+
+
+def test_explain_metric_does_not_leak_hidden_dependency(demo_layer):
+    orders = demo_layer.graph.models["orders"]
+    orders.metrics.extend(
+        [
+            Metric(name="internal_cost", agg="sum", sql="cost", public=False),
+            Metric(name="margin", type="derived", sql="total_revenue - internal_cost"),
+        ]
+    )
+    demo_layer.enforce_visibility = True
+
+    result = explain_metric("orders.margin")
+
+    assert result["depends_on"] == ["orders.total_revenue"]
+    assert result["hidden_dependency_count"] == 1
+    assert "internal_cost" not in json.dumps(result)
 
 
 def test_get_models_enriched(demo_layer):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -733,6 +733,21 @@ def test_explain_metric_resolves_dependencies_and_transitive_sources(demo_layer)
     assert result["filters"] == ["status != 'failed'"]
 
 
+def test_explain_metric_recovers_auto_registered_model_metric_owner(demo_layer):
+    orders = demo_layer.graph.models["orders"]
+    metric = Metric(name="revenue_yoy", type="time_comparison", base_metric="total_revenue", comparison_type="yoy")
+    orders.metrics.append(metric)
+    demo_layer.graph.metrics[metric.name] = metric
+
+    result = explain_metric("revenue_yoy")
+
+    assert result["metric"] == "orders.revenue_yoy"
+    assert result["model"] == "orders"
+    assert result["depends_on"] == ["orders.total_revenue"]
+    assert result["source_models"] == ["orders"]
+    assert result["source_file"] == "orders.yml"
+
+
 def test_explain_metric_rejects_unknown_and_hidden_metrics(demo_layer):
     with pytest.raises(ValueError, match="Metric 'orders.missing' not found"):
         explain_metric("orders.missing")


### PR DESCRIPTION
Adds semantic catalog search, metric explanation and provenance, query timing, and semantic-analysis guidance for MCP clients. Preserves raw timestamp precision for rolling-window filters and rejects unsupported multi-cohort queries. Also adds generic DuckDB startup configuration and config environment substitution so externally distributed extensions can be loaded without storing binaries in the repository.