### PR TITLE
Update DuckDB extension to 1.5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
 
       - name: Install DuckDB ADBC driver
         run: |
-          curl -L https://github.com/duckdb/duckdb/releases/download/v1.5.3/libduckdb-linux-amd64.zip -o /tmp/libduckdb.zip
+          curl -L https://github.com/duckdb/duckdb/releases/download/v1.5.5/libduckdb-linux-amd64.zip -o /tmp/libduckdb.zip
           unzip -q /tmp/libduckdb.zip -d /tmp/libduckdb
           echo "SIDEMANTIC_TEST_ADBC_DUCKDB_DRIVER=/tmp/libduckdb/libduckdb.so" >> "$GITHUB_ENV"
 
@@ -399,7 +399,7 @@ jobs:
 
       - name: Install DuckDB ADBC driver
         run: |
-          curl -L https://github.com/duckdb/duckdb/releases/download/v1.5.3/libduckdb-linux-amd64.zip -o /tmp/libduckdb.zip
+          curl -L https://github.com/duckdb/duckdb/releases/download/v1.5.5/libduckdb-linux-amd64.zip -o /tmp/libduckdb.zip
           unzip -q /tmp/libduckdb.zip -d /tmp/libduckdb
           echo "SIDEMANTIC_TEST_ADBC_DUCKDB_DRIVER=/tmp/libduckdb/libduckdb.so" >> "$GITHUB_ENV"
 
@@ -475,7 +475,7 @@ jobs:
 
       - name: Fetch DuckDB dependencies
         working-directory: sidemantic-duckdb
-        run: make deps DUCKDB_VERSION=v1.5.3
+        run: make deps DUCKDB_VERSION=v1.5.5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/duckdb-extension-release.yml
+++ b/.github/workflows/duckdb-extension-release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       duckdb_version:
-        description: "DuckDB tag used for extension build and tests; currently v1.5.3 only"
+        description: "DuckDB tag used for extension build and tests; currently v1.5.5 only"
         required: true
-        default: "v1.5.3"
+        default: "v1.5.5"
         type: string
       create_github_release:
         description: "Create or update a GitHub release with extension artifacts"
@@ -37,7 +37,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ inputs.duckdb_version }}"
           else
-            VERSION="v1.5.3"
+            VERSION="v1.5.5"
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/docs/duckdb-extension.md
+++ b/docs/duckdb-extension.md
@@ -26,12 +26,12 @@ The extension build needs Rust, DuckDB extension build tooling, and Ninja.
 
 ```bash
 cd sidemantic-duckdb
-make deps DUCKDB_VERSION=v1.5.3
+make deps DUCKDB_VERSION=v1.5.5
 make
 make test
 ```
 
-`DUCKDB_VERSION` is intentionally guarded to `v1.5.3` because the repository
+`DUCKDB_VERSION` is intentionally guarded to `v1.5.5` because the repository
 vendors a matching `extension-ci-tools` checkout. Update both together before
 building against a different DuckDB tag.
 
@@ -143,7 +143,7 @@ The workflow is source-package oriented. It does not publish to the DuckDB commu
 | Native format | `1` |
 | Rust runtime crate | `0.1.0` |
 | DuckDB extension source package | `0.1.0` |
-| DuckDB build target | `1.5.3` |
+| DuckDB build target | `1.5.5` |
 
 DuckDB extension artifacts are ABI-sensitive. Rebuild the extension when changing the DuckDB target version or the Rust native runtime version.
 

--- a/docs/rust-native-runtime-packaging.md
+++ b/docs/rust-native-runtime-packaging.md
@@ -93,7 +93,7 @@ The DuckDB extension is currently documented as a source-build path. Do not docu
 
 See `docs/duckdb-extension.md` for build and load commands.
 
-Use `.github/workflows/duckdb-extension-release.yml` to build a Linux extension artifact and run the sqllogictests. The repository currently supports DuckDB `v1.5.3` only, matching the vendored `extension-ci-tools` checkout. GitHub release upload is optional and controlled by `create_github_release`.
+Use `.github/workflows/duckdb-extension-release.yml` to build a Linux extension artifact and run the sqllogictests. The repository currently supports DuckDB `v1.5.5` only, matching the vendored `extension-ci-tools` checkout. GitHub release upload is optional and controlled by `create_github_release`.
 
 Community extension publication remains a separate release step until repository signing, platform matrix, and DuckDB community registry metadata are finalized.
 

--- a/sidemantic-duckdb/Makefile
+++ b/sidemantic-duckdb/Makefile
@@ -4,7 +4,7 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # Configuration of extension
 EXT_NAME=sidemantic
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
-SUPPORTED_DUCKDB_VERSION := v1.5.3
+SUPPORTED_DUCKDB_VERSION := v1.5.5
 DUCKDB_VERSION ?= $(SUPPORTED_DUCKDB_VERSION)
 
 .PHONY: deps

--- a/sidemantic-duckdb/README.md
+++ b/sidemantic-duckdb/README.md
@@ -27,7 +27,7 @@ LOAD '/absolute/path/to/sidemantic.duckdb_extension';
 For local development:
 
 ```bash
-make deps DUCKDB_VERSION=v1.5.3
+make deps DUCKDB_VERSION=v1.5.5
 make
 make test
 ./build/release/duckdb -unsigned
@@ -382,8 +382,8 @@ SELECT sidemantic_rewrite_sql('SELECT orders.revenue FROM orders');
 cd sidemantic-duckdb
 
 # Fetch the DuckDB source version used by CI.
-# extension-ci-tools is vendored in this directory and pinned to v1.5.3.
-make deps DUCKDB_VERSION=v1.5.3
+# extension-ci-tools is vendored in this directory and pinned to v1.5.5.
+make deps DUCKDB_VERSION=v1.5.5
 
 # Build the extension. CMake builds the sibling sidemantic-rs static library automatically.
 make

--- a/sidemantic-duckdb/extension-ci-tools/.github/workflows/TestCITools.yml
+++ b/sidemantic-duckdb/extension-ci-tools/.github/workflows/TestCITools.yml
@@ -20,7 +20,7 @@ jobs:
       extension_name: quack
       override_repository: duckdb/extension-template
       override_ref: main
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.4
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3'
@@ -32,7 +32,7 @@ jobs:
       extension_name: capi_quack
       override_repository: duckdb/extension-template-c
       override_ref: main
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.4
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3;unixodbc'
@@ -50,7 +50,7 @@ jobs:
       extension_name: quack
       override_repository: duckdb/extension-template
       override_ref: main
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.4
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp;go;python3;downgraded_aws_cli;'
@@ -73,7 +73,7 @@ jobs:
       extension_name: rusty_quack
       override_repository: duckdb/extension-template-rs
       override_ref: main
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.4
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'rust;python3'
@@ -92,7 +92,7 @@ jobs:
       override_ref: main
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.4
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64'
       extra_toolchains: 'rust'
       save_cache: ${{ github.event_name != 'pull_request' }}

--- a/sidemantic-duckdb/extension-ci-tools/.github/workflows/TestCITools.yml
+++ b/sidemantic-duckdb/extension-ci-tools/.github/workflows/TestCITools.yml
@@ -20,7 +20,7 @@ jobs:
       extension_name: quack
       override_repository: duckdb/extension-template
       override_ref: main
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3'
@@ -32,7 +32,7 @@ jobs:
       extension_name: capi_quack
       override_repository: duckdb/extension-template-c
       override_ref: main
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'python3;unixodbc'
@@ -50,7 +50,7 @@ jobs:
       extension_name: quack
       override_repository: duckdb/extension-template
       override_ref: main
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'parser_tools;fortran;omp;go;python3;downgraded_aws_cli;'
@@ -73,7 +73,7 @@ jobs:
       extension_name: rusty_quack
       override_repository: duckdb/extension-template-rs
       override_ref: main
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
       extra_toolchains: 'rust;python3'
@@ -92,7 +92,7 @@ jobs:
       override_ref: main
       override_ci_tools_repository: ${{ github.repository }}
       ci_tools_version: ${{ github.sha }}
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64'
       extra_toolchains: 'rust'
       save_cache: ${{ github.event_name != 'pull_request' }}

--- a/sidemantic-duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml
+++ b/sidemantic-duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml
@@ -500,7 +500,7 @@ jobs:
 
   macos:
     name: MacOS
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     needs:
       - generate_matrix
       - linux
@@ -1119,7 +1119,7 @@ jobs:
         run: |
           DUCKDB_TAG=${{ inputs.duckdb_tag }} make set_duckdb_tag
 
-      - uses: mymindstorm/setup-emsdk@v13
+      - uses: emscripten-core/setup-emsdk@v13
         with:
           version: 3.1.71
 

--- a/sidemantic-duckdb/extension-ci-tools/README.md
+++ b/sidemantic-duckdb/extension-ci-tools/README.md
@@ -7,10 +7,13 @@ DuckDB's [Extension Template](https://github.com/duckdb/extension-template/actio
 | Extension-ci-tools Branch | DuckDB target version | Actively maintained? |
 |---------------------------|-----------------------|----------------------|
 | main                      | main                  | yes                  |
-| v1.5.2                    | v1.5.2                | yes                  |
+| v1.5.4                    | v1.5.4                | yes                  |
+| v1.5.3                    | v1.5.3                | no                   |
+| v1.5.2                    | v1.5.2                | no                   |
 | v1.5.1                    | v1.5.1                | no                   |
 | v1.5.0                    | v1.5.0                | no                   |
-| v1.4.4                    | v1.4.4                | yes                  |
+| v1.4.5                    | v1.4.5                | yes                  |
+| v1.4.4                    | v1.4.4                | no                   |
 | v1.4.3                    | v1.4.3                | no                   |
 | v1.4.2                    | v1.4.2                | no                   |
 | v1.4.1                    | v1.4.1                | no                   |

--- a/sidemantic-duckdb/extension-ci-tools/README.md
+++ b/sidemantic-duckdb/extension-ci-tools/README.md
@@ -7,7 +7,8 @@ DuckDB's [Extension Template](https://github.com/duckdb/extension-template/actio
 | Extension-ci-tools Branch | DuckDB target version | Actively maintained? |
 |---------------------------|-----------------------|----------------------|
 | main                      | main                  | yes                  |
-| v1.5.4                    | v1.5.4                | yes                  |
+| v1.5.5                    | v1.5.5                | yes                  |
+| v1.5.4                    | v1.5.4                | no                   |
 | v1.5.3                    | v1.5.3                | no                   |
 | v1.5.2                    | v1.5.2                | no                   |
 | v1.5.1                    | v1.5.1                | no                   |

--- a/sidemantic-duckdb/extension-ci-tools/config/distribution_matrix.json
+++ b/sidemantic-duckdb/extension-ci-tools/config/distribution_matrix.json
@@ -39,6 +39,7 @@
     "include": [
       {
         "duckdb_arch": "osx_amd64",
+        "runner": "macos-15",
         "osx_build_arch": "x86_64",
         "vcpkg_target_triplet": "x64-osx-release",
         "vcpkg_host_triplet": "arm64-osx-release",
@@ -47,6 +48,7 @@
       },
       {
         "duckdb_arch": "osx_arm64",
+        "runner": "macos-15",
         "osx_build_arch": "arm64",
         "vcpkg_target_triplet": "arm64-osx-release",
         "vcpkg_host_triplet": "arm64-osx-release",


### PR DESCRIPTION
Updates the DuckDB extension target, ADBC test driver, release workflow, and documentation to DuckDB 1.5.5. Refreshes the vendored extension-ci-tools files from the upstream v1.5.5 branch.