### PR TITLE
Sync WASM demo UI assets

### DIFF
--- a/examples/sidemantic_wasm_demo/src/components/sidemantic/sidemantic-ui-static.js
+++ b/examples/sidemantic_wasm_demo/src/components/sidemantic/sidemantic-ui-static.js
@@ -8232,12 +8232,12 @@ function useQueryResult(backend, query) {
       return;
     }
     const current = ++token.current;
-    setState((prev) => ({ result: prev.result, loading: true }));
+    setState((prev) => ({ result: prev.result, resultKey: prev.resultKey, loading: true }));
     const timer = setTimeout(() => {
       beginQuery();
       backend.runQuery(query).then((result) => {
         if (current === token.current)
-          setState({ result, loading: false });
+          setState({ result, resultKey: key ?? undefined, loading: false });
       }).catch((err) => {
         if (current === token.current) {
           setState({ loading: false, error: err instanceof Error ? err.message : String(err) });
@@ -8246,7 +8246,7 @@ function useQueryResult(backend, query) {
     }, DEBOUNCE_MS);
     return () => clearTimeout(timer);
   }, [key, backend]);
-  return state;
+  return { ...state, queryKey: key ?? undefined };
 }
 
 // webapp/src/components/FilterEditor.tsx


### PR DESCRIPTION
Synchronizes the WASM demo’s vendored static UI with the canonical distribution updated by #320. This restores tests/test_ui_distribution.py::test_wasm_uses_exact_static_distribution.