### PR TITLE
Pin Malloy grammar provenance

### DIFF
--- a/docs/compatibility/index.md
+++ b/docs/compatibility/index.md
@@ -16,7 +16,7 @@ Detailed compatibility documents describe field-level limitations where they exi
 | `hex` | — | `file_or_directory` | `.yml`, `.yaml` | Registered | Yes | 6 | Registry summary only |
 | `holistics` | `aml` | `file_or_directory` | `.aml` | Registered | Yes | 4 | Registry summary only |
 | `lookml` | `looker` | `file_or_directory` | `.lkml` | Registered | Yes | 10 | [Detailed guide](lookml.md) |
-| `malloy` | — | `file_or_directory` | `.malloy` | Registered | Yes | 10 | [Detailed guide](malloy.md) |
+| `malloy` | — | `file_or_directory` | `.malloy` | Registered | Yes | 11 | [Detailed guide](malloy.md) |
 | `metricflow` | `dbt`, `dbt-semantic-layer` | `file_or_directory` | `.yml`, `.yaml` | Registered | Yes | 6 | Registry summary only |
 | `omni` | — | `file_or_directory` | `.yml`, `.yaml` | Registered | Yes | 4 | Registry summary only |
 | `osi` | `open-semantic-interchange` | `file_or_directory` | `.yml`, `.yaml`, `.json` | Registered | Yes | 3 | [Detailed guide](osi.md) |

--- a/scripts/check_malloy_grammar_drift.py
+++ b/scripts/check_malloy_grammar_drift.py
@@ -13,6 +13,13 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GRAMMAR_DIR = REPO_ROOT / "sidemantic" / "adapters" / "malloy_grammar"
 PROVENANCE_PATH = GRAMMAR_DIR / "UPSTREAM.json"
+_NON_GENERATED_FILES = {
+    "__init__.py",
+    "MalloyLexer.g4",
+    "MalloyParser.g4",
+    "UPSTREAM.json",
+    "UPSTREAM.md",
+}
 
 
 def _sha256(content: bytes) -> str:
@@ -32,7 +39,19 @@ def _check_digest(label: str, content: bytes, expected: str) -> None:
 def check_local_bundle(provenance: dict[str, Any]) -> None:
     for name, metadata in provenance["grammar_files"].items():
         _check_digest(name, (GRAMMAR_DIR / name).read_bytes(), metadata["vendored_sha256"])
-    for name, expected in provenance["generated_files"].items():
+    generated_files = provenance["generated_files"]
+    recorded = set(generated_files)
+    actual = {path.name for path in GRAMMAR_DIR.iterdir() if path.is_file()} - _NON_GENERATED_FILES
+    if actual != recorded:
+        missing = sorted(recorded - actual)
+        unrecorded = sorted(actual - recorded)
+        details = []
+        if missing:
+            details.append(f"missing from grammar directory: {', '.join(missing)}")
+        if unrecorded:
+            details.append(f"unrecorded generated files: {', '.join(unrecorded)}")
+        raise RuntimeError(f"Malloy generated-file inventory drifted ({'; '.join(details)})")
+    for name, expected in generated_files.items():
         _check_digest(name, (GRAMMAR_DIR / name).read_bytes(), expected)
 
 

--- a/scripts/check_malloy_grammar_drift.py
+++ b/scripts/check_malloy_grammar_drift.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Verify the bundled Malloy grammar against its recorded provenance."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GRAMMAR_DIR = REPO_ROOT / "sidemantic" / "adapters" / "malloy_grammar"
+PROVENANCE_PATH = GRAMMAR_DIR / "UPSTREAM.json"
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _read_provenance() -> dict[str, Any]:
+    return json.loads(PROVENANCE_PATH.read_text())
+
+
+def _check_digest(label: str, content: bytes, expected: str) -> None:
+    actual = _sha256(content)
+    if actual != expected:
+        raise RuntimeError(f"{label} drifted: expected sha256 {expected}, got {actual}")
+
+
+def check_local_bundle(provenance: dict[str, Any]) -> None:
+    for name, metadata in provenance["grammar_files"].items():
+        _check_digest(name, (GRAMMAR_DIR / name).read_bytes(), metadata["vendored_sha256"])
+    for name, expected in provenance["generated_files"].items():
+        _check_digest(name, (GRAMMAR_DIR / name).read_bytes(), expected)
+
+
+def check_upstream_pin(provenance: dict[str, Any]) -> None:
+    repository = provenance["repository"].removeprefix("https://github.com/")
+    commit = provenance["commit"]
+    for name, metadata in provenance["grammar_files"].items():
+        url = f"https://raw.githubusercontent.com/{repository}/{commit}/{metadata['upstream_path']}"
+        request = urllib.request.Request(url, headers={"User-Agent": "sidemantic-grammar-drift-check"})
+        with urllib.request.urlopen(request, timeout=30) as response:
+            content = response.read()
+        _check_digest(f"upstream {name} at {commit}", content, metadata["upstream_sha256"])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--verify-upstream",
+        action="store_true",
+        help="also download the grammar from the pinned immutable upstream commit",
+    )
+    args = parser.parse_args()
+
+    provenance = _read_provenance()
+    check_local_bundle(provenance)
+    if args.verify_upstream:
+        check_upstream_pin(provenance)
+    print(f"Malloy grammar matches {provenance['version']} ({provenance['commit']}) and its recorded generated bundle.")
+
+
+if __name__ == "__main__":
+    main()

--- a/sidemantic/adapters/malloy_grammar/UPSTREAM.json
+++ b/sidemantic/adapters/malloy_grammar/UPSTREAM.json
@@ -1,0 +1,30 @@
+{
+  "repository": "https://github.com/malloydata/malloy",
+  "version": "v0.0.407",
+  "commit": "cf1f6a6449562bd9b74fc14936f47af294c3a325",
+  "antlr_version": "4.13.2",
+  "grammar_files": {
+    "MalloyLexer.g4": {
+      "upstream_path": "packages/malloy/src/lang/grammar/MalloyLexer.g4",
+      "upstream_sha256": "a6f9c71026f8c0eda68fd7f8789442a46f826804dc0b233e699592a28d5dc83d",
+      "vendored_sha256": "0b972995eb55dfa5871c1ecfc45fcad9f6fbd7b9d3a25f27a1ab21fae4848e2b",
+      "adaptation": "Python-target members and embedded lexer actions."
+    },
+    "MalloyParser.g4": {
+      "upstream_path": "packages/malloy/src/lang/grammar/MalloyParser.g4",
+      "upstream_sha256": "f0441cda85caa6578401271973e7715a9204fa3556282c3f98f5aeb83ffde1a4",
+      "vendored_sha256": "f0441cda85caa6578401271973e7715a9204fa3556282c3f98f5aeb83ffde1a4",
+      "adaptation": "none"
+    }
+  },
+  "generated_files": {
+    "MalloyLexer.py": "5bb687abdf1151d0837929850fefce1acc0a5ba257fee7d62f00e899611433de",
+    "MalloyLexer.tokens": "777d5b1a2648b16bd591b6699f4ccf4386b02742b471e28893191d920fe108f7",
+    "MalloyLexer.interp": "77cf35f32da30dca11e3af65f0908ab9891226a1dcc6ce038cbfd7d7e601f333",
+    "MalloyParser.py": "5c4443b814b138c92a9b572eeb5d9be6dc8d41cd63d759f8fd94753e2a3fe404",
+    "MalloyParser.tokens": "777d5b1a2648b16bd591b6699f4ccf4386b02742b471e28893191d920fe108f7",
+    "MalloyParser.interp": "6871528893fdb1ec7b2a3301dd52484553a7b671a2d6a63fcfc5bfcfb93e89d5",
+    "MalloyParserListener.py": "ccb4b6d99952d7ef21e490637e593a640b1d18423e0a66578daa05aeb639ac30",
+    "MalloyParserVisitor.py": "7361578509c5fc5cdf15e197302a60e724ba109779050c748bbf17ebef440218"
+  }
+}

--- a/sidemantic/adapters/malloy_grammar/UPSTREAM.md
+++ b/sidemantic/adapters/malloy_grammar/UPSTREAM.md
@@ -1,0 +1,19 @@
+# Malloy grammar provenance
+
+The bundled grammar is pinned to Malloy [`v0.0.407`](https://github.com/malloydata/malloy/releases/tag/v0.0.407), commit [`cf1f6a6449562bd9b74fc14936f47af294c3a325`](https://github.com/malloydata/malloy/commit/cf1f6a6449562bd9b74fc14936f47af294c3a325). `UPSTREAM.json` records the immutable upstream paths and checksums, the vendored checksums, and the ANTLR generator version.
+
+`MalloyParser.g4` is an exact upstream copy. `MalloyLexer.g4` preserves the same token grammar but adapts upstream TypeScript-target members and embedded lexer actions to the Python target. The generated Python lexer, parser, listener, visitor, token, and interpreter files were produced with ANTLR 4.13.2.
+
+Run the offline bundle drift check after any grammar or generated-file change:
+
+```bash
+uv run --frozen scripts/check_malloy_grammar_drift.py
+```
+
+To also verify the recorded upstream checksums against the pinned immutable commit:
+
+```bash
+uv run --frozen scripts/check_malloy_grammar_drift.py --verify-upstream
+```
+
+An intentional update must pin a specific upstream release and commit, review and preserve the Python-target lexer adaptations, regenerate every ANTLR artifact with the recorded generator version, and update `UPSTREAM.json` in the same change.

--- a/tests/adapters/malloy/test_grammar_provenance.py
+++ b/tests/adapters/malloy/test_grammar_provenance.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHECK_PATH = REPO_ROOT / "scripts" / "check_malloy_grammar_drift.py"
+
+
+def _drift_check_module():
+    spec = importlib.util.spec_from_file_location("malloy_grammar_drift_check", CHECK_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bundled_grammar_matches_recorded_upstream_pin() -> None:
+    drift_check = _drift_check_module()
+    provenance = drift_check._read_provenance()
+
+    assert provenance["version"] == "v0.0.407"
+    assert provenance["commit"] == "cf1f6a6449562bd9b74fc14936f47af294c3a325"
+    assert provenance["antlr_version"] == "4.13.2"
+    drift_check.check_local_bundle(provenance)

--- a/tests/adapters/malloy/test_grammar_provenance.py
+++ b/tests/adapters/malloy/test_grammar_provenance.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CHECK_PATH = REPO_ROOT / "scripts" / "check_malloy_grammar_drift.py"
 
@@ -23,3 +25,12 @@ def test_bundled_grammar_matches_recorded_upstream_pin() -> None:
     assert provenance["commit"] == "cf1f6a6449562bd9b74fc14936f47af294c3a325"
     assert provenance["antlr_version"] == "4.13.2"
     drift_check.check_local_bundle(provenance)
+
+
+def test_generated_artifact_inventory_must_be_complete() -> None:
+    drift_check = _drift_check_module()
+    provenance = drift_check._read_provenance()
+    provenance["generated_files"].pop("MalloyParser.py")
+
+    with pytest.raises(RuntimeError, match="unrecorded generated files: MalloyParser.py"):
+        drift_check.check_local_bundle(provenance)


### PR DESCRIPTION
Pins the bundled ANTLR grammar to Malloy v0.0.407 and its immutable upstream commit. Records the intentional Python-target lexer adaptation and adds offline bundle plus optional upstream drift verification.