### PR TITLE
Preserve native semantics in Ossie round trips

### DIFF
--- a/docs/compatibility/ossie.md
+++ b/docs/compatibility/ossie.md
@@ -198,7 +198,7 @@ emits canonical output and reports an `ossie.serialization.exact_source_mismatch
 warning. This guarantee does not apply to an Ossie -> runtime graph -> Ossie
 conversion.
 
-## Fail-closed graph synthesis
+## Graph synthesis and runtime preservation
 
 Exporting a runtime graph creates a new logical document. It requires both:
 
@@ -212,24 +212,40 @@ and validates the completed document against the pinned schema. It validates
 that expression text in the named dialect but does not infer its origin,
 transpile it, or relabel it as another dialect.
 
-Synthesis refuses the complete output when it encounters meaning it would have
-to invent or misrepresent, including a missing or ambiguous dataset source,
-untranslated non-SQL expressions, invalid scalar SQL, unsupported datatypes or
-relationship cardinality, missing or duplicate edge identity, unusable key
-arrays, non-unique relationship targets, and conflicting metric definitions.
-Synthesis also refuses metric filters, null filling, non-additive/time/window
-modifiers, unresolved inheritance, security restrictions, private fields,
-custom join SQL, inactive relationships, and relationship role aliases. These
-runtime settings cannot be silently reduced to an unfiltered aggregate or a
-key-only join. Model-owned
-columnless aggregates such as `COUNT(*)` are refused because Ossie has no metric
-owner field to preserve their dataset binding.
+Simple aggregate filters are emitted as conditional SQL and null filling as
+`COALESCE`. Model-owned columnless aggregates such as `COUNT(*)` and `SUM(1)`
+reference a constant dataset field so they retain their row source.
+
+For native behaviors that Ossie core cannot express, synthesis preserves the
+graph in a versioned `SIDEMANTIC` custom extension. This includes non-additive,
+time and window metrics, inheritance, security restrictions, private fields,
+custom or inactive joins, and relationship role aliases. Python Sidemantic restores
+these definitions on import; security templates are evaluated for each query's
+user context. The extension records its SQL dialect and a fingerprint of the
+core projection. Unsupported versions, malformed payloads, incompatible dialects,
+and edits that make the projection stale are rejected.
+
+Extension-dependent documents contain only an empty placeholder dataset in
+their core projection. Real sources and metrics live in the extension, so
+consumers that ignore it cannot execute unrestricted or simplified definitions.
+Export emits a warning that Sidemantic extension support is required. Use
+`sidemantic convert ... --ossie-portable-only` (or `portable_only=True` in the
+export API) to require portable core output instead. Invalid SQL, unresolved
+inheritance references, and other invalid declarations still fail export.
+
+The experimental Rust implementation does not restore this extension; it sees
+the empty core placeholder.
 
 Model-owned SQL is parsed and its column nodes are qualified in the owning
 dataset's context. Function names, literals, quoted identifiers, existing column
 qualifiers, and derived metric references retain their meaning.
 
 Graph synthesis cannot create ontology documents or recover source-only fields.
+
+Directory loading recognizes explicit `*.ossie.json` files anywhere in the
+source tree. Arbitrarily named JSON documents still follow the dbt `OSI/`
+directory convention; generated `target/` and `dbt_packages/` artifacts are
+excluded. Malformed explicitly named files report an error.
 
 ## CLI examples
 

--- a/sidemantic/adapters/ossie.py
+++ b/sidemantic/adapters/ossie.py
@@ -213,6 +213,7 @@ class OssieAdapter(BaseAdapter):
         expression_dialect: str | None = None,
         schema_version: str | None = None,
         serialization: OssieSerialization | str | None = None,
+        portable_only: bool = False,
     ) -> None:
         """Synthesize and write one schema-valid logical Ossie document.
 
@@ -235,6 +236,12 @@ class OssieAdapter(BaseAdapter):
             schema_version=schema_version or self._schema_version,
             serialization=output_serialization,
             consumer_profile=self._parse_options.consumer_profile,
+            portable_only=portable_only,
         )
         document = require_synthesized_document(synthesis)
+        if synthesis.diagnostics:
+            import warnings
+
+            for diagnostic in synthesis.diagnostics:
+                warnings.warn(diagnostic.message, UserWarning, stacklevel=2)
         self.export_document(document, destination, serialization=output_serialization)

--- a/sidemantic/cli.py
+++ b/sidemantic/cli.py
@@ -1493,6 +1493,11 @@ def convert(
         "--ossie-permissive",
         help="Preserve invalid Ossie source while lowering only independently safe constructs",
     ),
+    ossie_portable_only: bool = typer.Option(
+        False,
+        "--ossie-portable-only",
+        help="Require portable Ossie core output instead of preserving native behavior in a Sidemantic extension",
+    ),
     force: bool = typer.Option(False, "--force", help="Allow writing to an existing destination"),
 ):
     """Convert semantic definitions through the shared format registry."""
@@ -1564,6 +1569,7 @@ def convert(
                 target_export_options = {
                     "scope_name": ossie_scope,
                     "expression_dialect": ossie_expression_dialect,
+                    "portable_only": ossie_portable_only,
                 }
                 if ossie_consumer_profile is not None:
                     target_adapter_options = {"consumer_profile": ossie_consumer_profile}

--- a/sidemantic/interchange/ossie/lowering.py
+++ b/sidemantic/interchange/ossie/lowering.py
@@ -29,6 +29,7 @@ from sidemantic.interchange.ossie.expression_validation import scalar_sql_expres
 from sidemantic.interchange.ossie.identifier import identifier_within_limit, normalize_identifier
 from sidemantic.interchange.ossie.parser import OssieParseResult
 from sidemantic.interchange.ossie.profiles import OssieImportPolicy
+from sidemantic.interchange.ossie.runtime_extension import decode_runtime_extension, resolve_runtime_graph
 from sidemantic.interchange.ossie.semantic_validation import (
     SemanticValidationResult,
     validate_ossie_semantics,
@@ -259,10 +260,11 @@ def _lower_scope(
     target_dialect: str,
     diagnostics: list[OssieDiagnostic],
     document_diagnostics: tuple[OssieDiagnostic, ...],
+    runtime_override: SemanticGraph | None = None,
 ) -> CompiledSemanticScope:
-    graph = SemanticGraph()
+    graph = runtime_override if runtime_override is not None else SemanticGraph()
     source_dialect = result.options.source_dialect if result.options else None
-    dataset_values = _array(semantic_model.get("datasets"))
+    dataset_values = _array(semantic_model.get("datasets")) if runtime_override is None else ()
     lowered_models: dict[str, Model] = {}
 
     # Model/Metric construction has a legacy auto-registration hook. Lowering
@@ -396,7 +398,7 @@ def _lower_scope(
             graph.add_model(model)
             lowered_models[normalize_identifier(dataset_name)] = model
 
-        relationships = _array(semantic_model.get("relationships"))
+        relationships = _array(semantic_model.get("relationships")) if runtime_override is None else ()
         for relationship_index, relationship, edge_id in _unique_named_items(relationships):
             pointer = f"/semantic_model/{scope_index}/relationships/{relationship_index}"
             from_name = _name(relationship.get("from"))
@@ -459,7 +461,7 @@ def _lower_scope(
                 )
             )
 
-        metrics = _array(semantic_model.get("metrics"))
+        metrics = _array(semantic_model.get("metrics")) if runtime_override is None else ()
         for metric_index, metric, metric_name in _unique_named_items(metrics):
             pointer = f"/semantic_model/{scope_index}/metrics/{metric_index}"
             selected = _expression_for_target(metric.get("expression"), target_dialect)
@@ -626,6 +628,35 @@ def lower_ossie_document(
         if not identifier_within_limit(name):
             continue
         scope_id = name if name_counts[normalize_identifier(name)] == 1 else f"{name}@{index}"
+        try:
+            runtime_override = decode_runtime_extension(semantic_model, target_dialect=selected_target)
+            if runtime_override is not None:
+                runtime_override = resolve_runtime_graph(runtime_override)
+        except (ValueError, TypeError) as exc:
+            diagnostics.append(
+                _diagnostic(
+                    parse_result,
+                    code="ossie.lowering.runtime_extension_invalid",
+                    message=f"Sidemantic runtime extension cannot be restored safely: {exc}",
+                    pointer=f"/semantic_model/{index}/custom_extensions",
+                    scope=scope_id,
+                )
+            )
+            # Even permissive imports must never fall back to a potentially
+            # unrestricted core projection after rejecting native policies.
+            continue
+        if runtime_override is not None:
+            diagnostics.append(
+                OssieDiagnostic(
+                    severity=OssieDiagnosticSeverity.WARNING,
+                    code="ossie.lowering.runtime_extension_restored",
+                    message="Restored native Sidemantic runtime semantics; other consumers require Sidemantic extension support.",
+                    json_pointer=f"/semantic_model/{index}/custom_extensions",
+                    scope=scope_id,
+                    source=_source_location(parse_result),
+                    profile=parse_result.profile,
+                )
+            )
         scopes.append(
             _lower_scope(
                 parse_result,
@@ -636,6 +667,7 @@ def lower_ossie_document(
                 target_dialect=selected_target,
                 diagnostics=diagnostics,
                 document_diagnostics=tuple(all_pre_lowering),
+                runtime_override=runtime_override,
             )
         )
 

--- a/sidemantic/interchange/ossie/runtime_extension.py
+++ b/sidemantic/interchange/ossie/runtime_extension.py
@@ -1,0 +1,248 @@
+"""Versioned native runtime preservation for consumers supporting Sidemantic.
+
+The core fingerprint detects edits to a projection; it is not a signature or a
+trust boundary. Native SQL and security templates retain the same trust model
+as an authored Sidemantic model and are never evaluated while importing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from copy import deepcopy
+
+from pydantic import BaseModel, ConfigDict, TypeAdapter
+
+from sidemantic.core.consumption import Explore, SavedQuery
+from sidemantic.core.inheritance import (
+    resolve_metric_inheritance,
+    resolve_model_inheritance,
+    resolve_model_metric_inheritance,
+)
+from sidemantic.core.metric import Metric
+from sidemantic.core.model import Model
+from sidemantic.core.parameter import Parameter
+from sidemantic.core.registry import reset_current_layer, set_current_layer
+from sidemantic.core.semantic_graph import SemanticGraph
+from sidemantic.core.table_calculation import TableCalculation
+from sidemantic.validation import validate_model
+
+RUNTIME_VENDOR = "SIDEMANTIC"
+_FORMAT = "sidemantic.runtime"
+_VERSION = 1
+_COLLECTIONS = {
+    "models": Model,
+    "metrics": Metric,
+    "parameters": Parameter,
+    "table_calculations": TableCalculation,
+    "explores": Explore,
+    "saved_queries": SavedQuery,
+}
+
+
+class _RuntimePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    format: str
+    version: int
+    expression_dialect: str
+    core_sha256: str
+    graph: dict[str, object]
+
+
+def _json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+
+
+def _core_hash(semantic_model: Mapping[str, object]) -> str:
+    core = {key: value for key, value in semantic_model.items() if key != "custom_extensions"}
+    return hashlib.sha256(_json(core).encode()).hexdigest()
+
+
+def _graph_data(graph: SemanticGraph) -> dict[str, object]:
+    data = {key: {name: _native_data(item) for name, item in getattr(graph, key).items()} for key in _COLLECTIONS}
+    data.update(metric_owners=dict(graph.metric_owners), metadata=graph.metadata, import_warnings=graph.import_warnings)
+    return data
+
+
+def _native_data(item: BaseModel) -> dict[str, object]:
+    """Preserve authored defaults and in-place collection edits for inheritance."""
+    full = item.model_dump(mode="json")
+    result = {}
+    for name, field in type(item).model_fields.items():
+        value = getattr(item, name)
+        if name not in item.model_fields_set and value == field.get_default(call_default_factory=True):
+            continue
+        if isinstance(value, BaseModel):
+            result[name] = _native_data(value)
+        elif isinstance(value, list):
+            result[name] = [
+                _native_data(child) if isinstance(child, BaseModel) else serialized
+                for child, serialized in zip(value, full[name], strict=True)
+            ]
+        else:
+            # Some native execution fields (edge IDs and logical/time roles)
+            # are excluded from ordinary model export, but belong here.
+            result[name] = full[name] if name in full else TypeAdapter(field.annotation).dump_python(value, mode="json")
+    return result
+
+
+def resolve_runtime_graph(graph: SemanticGraph) -> SemanticGraph:
+    """Resolve inheritance on isolated copies using the native runtime rules."""
+    resolved = deepcopy(graph)
+    token = set_current_layer(None)
+    try:
+        resolved.models = resolve_model_inheritance(resolved.models)
+        resolved.metrics = resolve_metric_inheritance(resolved.metrics)
+        # Native inheritance uses ordinary model_dump, which intentionally
+        # omits interchange-only fields. Restore those from the declaration
+        # that owns each merged member, without changing inheritance rules.
+        for model in resolved.models.values():
+            lineage = _lineage(graph.models[model.name], graph.models)
+            for collection in ("dimensions", "metrics", "relationships"):
+                members = {item.name: item for ancestor in lineage for item in getattr(ancestor, collection)}
+                for item in getattr(model, collection):
+                    _restore_excluded_fields(item, [members[item.name]])
+        for metric in resolved.metrics.values():
+            _restore_excluded_fields(metric, _lineage(graph.metrics[metric.name], graph.metrics))
+        for model in resolved.models.values():
+            declared_metrics = {metric.name: metric for metric in model.metrics}
+            resolve_model_metric_inheritance(model)
+            for metric in model.metrics:
+                _restore_excluded_fields(metric, _lineage(declared_metrics[metric.name], declared_metrics))
+            if bool(model.table) == bool(model.sql):
+                raise ValueError(f"Runtime model {model.name!r} requires exactly one table or SQL source")
+            if model.has_untranslated_dax or any(
+                item.has_untranslated_dax for item in [*model.dimensions, *model.metrics]
+            ):
+                raise ValueError(f"Runtime model {model.name!r} contains untranslated DAX")
+            errors = validate_model(model)
+            if errors:
+                raise ValueError("; ".join(errors))
+            for relationship in model.relationships:
+                if relationship.related_model not in resolved.models:
+                    raise ValueError(f"Runtime relationship references unknown model {relationship.related_model!r}")
+                if relationship.through is not None and relationship.through not in resolved.models:
+                    raise ValueError(f"Runtime relationship references unknown junction {relationship.through!r}")
+        if any(metric.has_untranslated_dax for metric in resolved.metrics.values()):
+            raise ValueError("Runtime graph contains untranslated DAX metrics")
+        resolved.build_adjacency()
+    finally:
+        reset_current_layer(token)
+    return resolved
+
+
+def _lineage(item: BaseModel, declarations: Mapping[str, BaseModel]) -> list[BaseModel]:
+    ancestors = [item]
+    while getattr(item, "extends", None):
+        item = declarations[item.extends]
+        ancestors.append(item)
+    return list(reversed(ancestors))
+
+
+def _restore_excluded_fields(item: BaseModel, ancestors: list[BaseModel]) -> None:
+    for name, field in type(item).model_fields.items():
+        if not field.exclude:
+            continue
+        for ancestor in ancestors:
+            if name in ancestor.model_fields_set:
+                setattr(item, name, deepcopy(getattr(ancestor, name)))
+
+
+def encode_runtime_extension(
+    graph: SemanticGraph,
+    semantic_model: Mapping[str, object],
+    *,
+    expression_dialect: str,
+) -> dict[str, str]:
+    """Capture declarative graph state without connection or request/user state."""
+    payload = {
+        "format": _FORMAT,
+        "version": _VERSION,
+        "expression_dialect": expression_dialect.upper(),
+        "core_sha256": _core_hash(semantic_model),
+        "graph": _graph_data(graph),
+    }
+    extension = {"vendor_name": RUNTIME_VENDOR, "data": _json(payload)}
+    # Exercise exactly the same validation before publishing native state.
+    decode_runtime_extension(
+        {**semantic_model, "custom_extensions": [extension]},
+        target_dialect=expression_dialect,
+    )
+    return extension
+
+
+def _object_without_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"Duplicate runtime extension JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def decode_runtime_extension(semantic_model: Mapping[str, object], *, target_dialect: str) -> SemanticGraph | None:
+    """Restore native state, refusing malformed, unsupported, or stale payloads."""
+    extensions = semantic_model.get("custom_extensions", [])
+    if not isinstance(extensions, (list, tuple)):
+        raise ValueError("custom_extensions must be an array")
+    recognized = [
+        item for item in extensions if isinstance(item, Mapping) and item.get("vendor_name") == RUNTIME_VENDOR
+    ]
+    if not recognized:
+        return None
+    if len(recognized) != 1:
+        raise ValueError("Exactly one Sidemantic runtime extension is allowed per scope")
+    extension = recognized[0]
+    if set(extension) != {"vendor_name", "data"} or not isinstance(extension.get("data"), str):
+        raise ValueError("Malformed Sidemantic runtime extension envelope")
+    payload = _RuntimePayload.model_validate(
+        json.loads(extension["data"], object_pairs_hook=_object_without_duplicates)
+    )
+    if payload.format != _FORMAT or payload.version != _VERSION:
+        raise ValueError("Unsupported Sidemantic runtime extension format or version")
+    dialect = payload.expression_dialect
+    if dialect not in {"ANSI_SQL", "BIGQUERY", "DATABRICKS", "SNOWFLAKE"}:
+        raise ValueError(f"Unsupported runtime expression dialect {dialect!r}")
+    if dialect != "ANSI_SQL" and dialect.lower() != target_dialect.lower():
+        raise ValueError(f"Runtime extension requires target dialect {dialect!r}, received {target_dialect!r}")
+    if payload.core_sha256 != _core_hash(semantic_model):
+        raise ValueError("Sidemantic runtime extension is stale: the Ossie core projection was edited")
+    data = payload.graph
+    if set(data) != {*_COLLECTIONS, "metric_owners", "metadata", "import_warnings"}:
+        raise ValueError("Runtime graph has missing or unknown state collections")
+    graph = SemanticGraph()
+    token = set_current_layer(None)
+    try:
+        for collection, item_type in _COLLECTIONS.items():
+            values = data[collection]
+            if not isinstance(values, dict):
+                raise ValueError(f"Runtime {collection} must be a named object")
+            restored = {}
+            for name, value in values.items():
+                item = item_type.model_validate(deepcopy(value))
+                if item.name != name:
+                    raise ValueError(f"Runtime {collection} key {name!r} does not match its declared name")
+                # Native models historically ignore unknown fields. Requiring the
+                # canonical form prevents silently dropping future policy.
+                if _json(_native_data(item)) != _json(value):
+                    raise ValueError(f"Runtime {collection} entry {name!r} contains noncanonical or unknown fields")
+                restored[name] = item
+            setattr(graph, collection, restored)
+    finally:
+        reset_current_layer(token)
+    owners = data["metric_owners"]
+    if not isinstance(owners, dict) or any(
+        name not in graph.metrics or not isinstance(owner, str) or owner not in graph.models
+        for name, owner in owners.items()
+    ):
+        raise ValueError("Runtime metric owners reference unknown metrics or models")
+    if not isinstance(data["metadata"], dict) or not isinstance(data["import_warnings"], list):
+        raise ValueError("Runtime metadata and import warnings have invalid types")
+    graph.metric_owners = owners
+    graph.metadata = data["metadata"]
+    graph.import_warnings = data["import_warnings"]
+    resolve_runtime_graph(graph)
+    graph.build_adjacency()
+    return graph

--- a/sidemantic/interchange/ossie/synthesis.py
+++ b/sidemantic/interchange/ossie/synthesis.py
@@ -32,6 +32,7 @@ from sidemantic.interchange.ossie.profiles import (
     OssieSerialization,
     resolve_ossie_profile,
 )
+from sidemantic.interchange.ossie.runtime_extension import encode_runtime_extension
 from sidemantic.interchange.ossie.semantic_validation import validate_ossie_semantics
 from sidemantic.interchange.ossie.validation import validate_ossie_schema
 
@@ -104,6 +105,9 @@ def _metric_expression(metric: Metric) -> str | None:
         return f"{metric.numerator} / NULLIF({metric.denominator}, 0)"
     if metric.agg:
         inner = metric.sql or "*"
+        if metric.filters:
+            condition = " AND ".join(f"({item})" for item in metric.filters)
+            inner = f"CASE WHEN {condition} THEN {'1' if inner == '*' else inner} ELSE NULL END"
         if metric.agg == "count_distinct":
             return f"COUNT(DISTINCT {inner})"
         aggregate = {"variance_pop": "VAR_POP"}.get(metric.agg, metric.agg.upper())
@@ -111,8 +115,31 @@ def _metric_expression(metric: Metric) -> str | None:
     return metric.sql
 
 
+def _generated_field(
+    graph: SemanticGraph, fields: dict[str, dict[str, str]], owner: str, expression: str, preferred: str
+) -> str:
+    generated = fields.setdefault(owner, {})
+    for name, existing in generated.items():
+        if existing == expression:
+            return name
+    names = {normalize_identifier(d.name) for d in graph.models[owner].dimensions}
+    names.update(normalize_identifier(m.name) for m in graph.models[owner].metrics)
+    names.update(normalize_identifier(name) for name in generated)
+    name = preferred
+    while normalize_identifier(name) in names:
+        name += "_"
+    generated[name] = expression
+    return name
+
+
 def _qualify_metric_expression(
-    expression: str, metric: Metric, owner: str | None, graph: SemanticGraph, dialect: str
+    expression: str,
+    metric: Metric,
+    owner: str | None,
+    graph: SemanticGraph,
+    dialect: str,
+    generated_fields: dict[str, dict[str, str]],
+    model_local: bool,
 ) -> str | None:
     """Move model-local column expressions into Ossie's scope-wide namespace."""
     parsed = sqlglot.parse_one(expression, read=_SQLGLOT_DIALECTS[dialect])
@@ -120,9 +147,18 @@ def _qualify_metric_expression(
     # the same name as a metric. Derived formulas instead consume metric refs.
     raw_columns = metric.sql_is_complete or bool(metric.agg) or any(parsed.find_all(exp.AggFunc))
     if owner and raw_columns and not any(parsed.find_all(exp.Column)):
-        # COUNT(*) and SUM(1) still depend on the owner's rows. Ossie has no
-        # metric owner field; emitting these would lose the dataset binding.
-        return None
+        # An explicit constant dataset field retains the row source even when
+        # the aggregate contains only literals (including COUNT(*)).
+        name = _generated_field(graph, generated_fields, owner, "1", "__sidemantic_row")
+        for aggregate in parsed.find_all(exp.AggFunc):
+            inner = aggregate.this
+            if inner is None or isinstance(inner, exp.Distinct):
+                return None
+            anchor = exp.column(name, table=owner)
+            aggregate.set(
+                "this",
+                anchor if isinstance(inner, exp.Star) else exp.Case().when(anchor.eq(1), inner),
+            )
     metric_names = set(graph.metrics)
     metric_names.update(item.name for model in graph.models.values() for item in model.metrics)
     for column in parsed.find_all(exp.Column):
@@ -134,6 +170,22 @@ def _qualify_metric_expression(
             continue
         if owner and not column.table:
             column.set("table", exp.to_identifier(owner))
+        if model_local and raw_columns and column.table == owner:
+            dimension = graph.models[owner].get_dimension(column.name)
+            if dimension is not None and dimension.sql_expr != column.name:
+                # Model measures consume physical columns. A scope metric that
+                # uses the same field name would instead apply its dimension's
+                # expression, changing both measure inputs and filter operands.
+                raw = column.copy()
+                raw.set("table", None)
+                field_name = _generated_field(
+                    graph,
+                    generated_fields,
+                    owner,
+                    raw.sql(dialect=_SQLGLOT_DIALECTS[dialect]),
+                    "__sidemantic_raw",
+                )
+                column.set("this", exp.to_identifier(field_name))
     return parsed.sql(dialect=_SQLGLOT_DIALECTS[dialect])
 
 
@@ -141,8 +193,6 @@ def _unsupported_metric_options(metric: Metric) -> list[str]:
     # These require query context or additional runtime rewrites. Emitting just
     # sql would silently discard filters, null handling, or time semantics.
     options = (
-        "filters",
-        "fill_nulls_with",
         "non_additive_dimension",
         "non_additive_window_groupings",
         "offset_window",
@@ -170,18 +220,65 @@ def _unsupported_metric_options(metric: Metric) -> list[str]:
         "extends",
     )
     unsupported = [name for name in options if getattr(metric, name) is not None and getattr(metric, name) != []]
+    if metric.filters and (not metric.agg or metric.sql_is_complete):
+        unsupported.append("filters")
     if not metric.public:
         unsupported.append("public=False")
     return unsupported
 
 
+def _runtime_expression_diagnostics(graph: SemanticGraph, dialect: str) -> list[OssieDiagnostic]:
+    """Keep native modifiers from masking otherwise invalid SQL declarations."""
+    diagnostics: list[OssieDiagnostic] = []
+    expressions: list[tuple[str, str]] = []
+    for model in graph.models.values():
+        for dimension in model.dimensions:
+            if dimension.has_untranslated_dax:
+                diagnostics.append(
+                    _error(
+                        "ossie.synthesis.expression_language_unsupported",
+                        f"Field {model.name}.{dimension.name} contains untranslated DAX.",
+                    )
+                )
+            expressions.append((f"{model.name}.{dimension.name}", dimension.sql_expr))
+    metrics = [*graph.metrics.values(), *(metric for model in graph.models.values() for metric in model.metrics)]
+    for metric in metrics:
+        if metric.has_untranslated_dax:
+            diagnostics.append(
+                _error(
+                    "ossie.synthesis.expression_language_unsupported",
+                    f"Metric {metric.name!r} contains untranslated DAX.",
+                )
+            )
+        if metric.sql:
+            expressions.append((metric.name, metric.sql))
+        expressions.extend((metric.name, item) for item in metric.filters or ())
+    for name, expression in expressions:
+        # Parameter templates need native request context. The extension keeps
+        # them verbatim; it never renders them using the exporting user's data.
+        if "{{" in expression or "{%" in expression:
+            continue
+        error = _scalar_expression_error(expression.replace("{model}", "runtime_model"), dialect)
+        if error is not None:
+            diagnostics.append(
+                _error("ossie.synthesis.expression_invalid", f"Expression for {name!r} is invalid: {error}")
+            )
+    return diagnostics
+
+
 def _dataset(model: Model, dialect: str, index: int, diagnostics: list[OssieDiagnostic]) -> dict[str, object] | None:
     pointer = f"/semantic_model/0/datasets/{index}"
-    if model.extends or (model.security and (model.security.access is not True or model.security.row_filters)):
+    if (
+        model.extends
+        or model.invariant_filters
+        or model.default_time_dimension
+        or model.schema_exposure
+        or (model.security and (model.security.access is not True or model.security.row_filters))
+    ):
         diagnostics.append(
             _error(
                 "ossie.synthesis.model_semantics_unsupported",
-                f"Model {model.name!r} has inheritance or security settings that Ossie synthesis cannot preserve.",
+                f"Model {model.name!r} requires Sidemantic inheritance, row scope, time defaults, or security semantics.",
                 pointer,
             )
         )
@@ -386,14 +483,15 @@ def _metrics(
     models: dict[str, Model],
     dialect: str,
     diagnostics: list[OssieDiagnostic],
+    generated_fields: dict[str, dict[str, str]],
 ) -> list[dict[str, object]]:
-    candidates: list[tuple[Metric, str | None]] = [
-        (metric, graph.metric_owners.get(name)) for name, metric in graph.metrics.items()
+    candidates: list[tuple[Metric, str | None, bool]] = [
+        (metric, graph.metric_owners.get(name), False) for name, metric in graph.metrics.items()
     ]
-    candidates.extend((metric, model.name) for model in models.values() for metric in model.metrics)
+    candidates.extend((metric, model.name, True) for model in models.values() for metric in model.metrics)
     result: list[dict[str, object]] = []
     seen: dict[str, str] = {}
-    for metric, owner in candidates:
+    for metric, owner, model_local in candidates:
         unsupported = _unsupported_metric_options(metric)
         if unsupported or metric.has_untranslated_dax:
             diagnostics.append(
@@ -414,6 +512,11 @@ def _metrics(
                 )
             )
             continue
+        if owner:
+            expression = expression.replace("{model}", owner)
+        if metric.fill_nulls_with is not None:
+            value = exp.convert(metric.fill_nulls_with).sql(dialect=_SQLGLOT_DIALECTS[dialect])
+            expression = f"COALESCE({expression}, {value})"
         expression_error = _scalar_expression_error(expression, dialect)
         if expression_error is not None:
             diagnostics.append(
@@ -423,7 +526,9 @@ def _metrics(
                 )
             )
             continue
-        expression = _qualify_metric_expression(expression, metric, owner, graph, dialect)
+        expression = _qualify_metric_expression(
+            expression, metric, owner, graph, dialect, generated_fields, model_local
+        )
         if expression is None:
             diagnostics.append(
                 _error(
@@ -468,6 +573,7 @@ def synthesize_ossie_document(
     schema_version: str = "0.2.0.dev0",
     serialization: OssieSerialization | str = OssieSerialization.YAML,
     consumer_profile: OssieConsumerProfile | str = OssieConsumerProfile.OSSIE_CORE,
+    portable_only: bool = False,
 ) -> OssieSynthesisResult:
     """Synthesize one logical document without guessing scope or dialect."""
 
@@ -498,12 +604,61 @@ def synthesize_ossie_document(
     ]
     semantic_model: dict[str, object] = {"name": scope_name, "datasets": datasets}
     relationships = _relationships(models, diagnostics)
-    metrics = _metrics(graph, models, dialect, diagnostics)
+    generated_fields: dict[str, dict[str, str]] = {}
+    metrics = _metrics(graph, models, dialect, diagnostics, generated_fields)
+    for dataset in datasets:
+        for field_name, expression in generated_fields.get(dataset["name"], {}).items():
+            dataset.setdefault("fields", []).append(
+                {"name": field_name, "expression": _expression(expression, dialect)}
+            )
     if relationships:
         semantic_model["relationships"] = relationships
     if metrics:
         semantic_model["metrics"] = metrics
     data = {"version": schema_version, "semantic_model": [semantic_model]}
+
+    extension_codes = {
+        "ossie.synthesis.model_semantics_unsupported",
+        "ossie.synthesis.field_semantics_unsupported",
+        "ossie.synthesis.metric_semantics_unsupported",
+        "ossie.synthesis.metric_unrepresentable",
+        "ossie.synthesis.metric_owner_unrepresentable",
+        "ossie.synthesis.metric_name_collision",
+        "ossie.synthesis.relationship_semantics_unsupported",
+        "ossie.synthesis.relationship_cardinality_unsupported",
+        "ossie.synthesis.relationship_identity_missing",
+    }
+    if diagnostics and not portable_only and all(item.code in extension_codes for item in diagnostics):
+        expression_diagnostics = _runtime_expression_diagnostics(graph, dialect)
+        if expression_diagnostics:
+            return OssieSynthesisResult(document=None, diagnostics=tuple(expression_diagnostics))
+        # Core-only consumers must not see an unrestricted source or a metric
+        # with silently simplified behavior. The authoritative graph lives in
+        # the vendor extension; the required core dataset is an empty sentinel.
+        semantic_model = {
+            "name": scope_name,
+            "description": "Requires the Sidemantic runtime extension; core datasets contain no business data.",
+            "datasets": [
+                {
+                    "name": "sidemantic_runtime_required",
+                    "source": "SELECT NULL AS runtime_extension_required WHERE 1 = 0",
+                }
+            ],
+        }
+        try:
+            extension = encode_runtime_extension(graph, semantic_model, expression_dialect=dialect)
+        except (TypeError, ValueError) as exc:
+            diagnostics.append(_error("ossie.synthesis.runtime_extension_invalid", str(exc)))
+        else:
+            semantic_model["custom_extensions"] = [extension]
+            data = {"version": schema_version, "vendors": ["SIDEMANTIC"], "semantic_model": [semantic_model]}
+            diagnostics = [
+                _warning(
+                    "ossie.synthesis.runtime_extension_required",
+                    "This document requires Sidemantic runtime extension v1 to execute. "
+                    "Other consumers see only an empty dataset; use portable_only=True to require Ossie core output.",
+                )
+            ]
 
     validation = validate_ossie_schema(data, profile=profile, consumer_profile=profile.consumer_profile)
     diagnostics.extend(validation.diagnostics)

--- a/sidemantic/loaders.py
+++ b/sidemantic/loaders.py
@@ -411,7 +411,16 @@ def load_from_directory(
                 adapter = SidemanticAdapter()
         elif suffix == ".json":
             content = file_path.read_text()
-            if '"ldm"' in content and '"datasets"' in content:
+            if file_path.name.lower().endswith(".ossie.json"):
+                # An explicit format suffix opts into Ossie discovery anywhere
+                # in the source tree, including malformed files without markers.
+                if _is_generated_artifact(file_path, directory):
+                    continue
+                adapter = OssieAdapter(
+                    target_dialect=layer.dialect or "duckdb",
+                    scope_id=ossie_scope_id,
+                )
+            elif '"ldm"' in content and '"datasets"' in content:
                 adapter = GoodDataAdapter()
             elif '"projectModel"' in content:
                 adapter = GoodDataAdapter()

--- a/sidemantic/sql/generator.py
+++ b/sidemantic/sql/generator.py
@@ -2433,25 +2433,25 @@ class SQLGenerator:
                         )
                 else:
                     base_sql = replace_model_placeholder(measure.sql_expr)
+                    # The raw source may be a subquery aliased as t, rather
+                    # than the semantic model name used in measure SQL.
+                    base_sql = self._strip_model_prefixes([base_sql], model.name)[0]
 
                 # Apply measure filters if present (wrap in CASE WHEN)
                 if measure.filters:
                     # Filters are SQL conditions like "{model}.field = 'value'"
                     # Replace {model} placeholder and combine into CASE WHEN
                     filter_conditions = []
-                    for filter_str in measure.filters:
+                    for filter_str in self._strip_model_prefixes(measure.filters, model.name):
                         # Replace {model} with nothing since we're in the CTE selecting from raw table
                         filter_sql = filter_str.replace("{model}.", "").replace("{model}", "")
                         filter_conditions.append(filter_sql)
 
                     if filter_conditions:
                         filter_sql = " AND ".join(filter_conditions)
-                        # For count measures, return 1 if condition met, else NULL
-                        # COUNT counts non-NULL values, so we need NULL to exclude non-matching rows
-                        if measure.agg == "count":
-                            measure_sql = f"CASE WHEN {filter_sql} THEN 1 ELSE NULL END"
-                        else:
-                            measure_sql = f"CASE WHEN {filter_sql} THEN {base_sql} ELSE NULL END"
+                        # base_sql is 1 for COUNT(*), but COUNT(expr) must retain
+                        # its expression so matching NULL values are not counted.
+                        measure_sql = f"CASE WHEN {filter_sql} THEN {base_sql} ELSE NULL END"
                     else:
                         measure_sql = base_sql
                 else:
@@ -3974,6 +3974,7 @@ class SQLGenerator:
                                 agg_type=measure.agg,
                                 dialect=self.dialect,
                             )
+                            agg_expr = self._wrap_with_fill_nulls(agg_expr, measure)
                         else:
                             # Use helper that applies metric-level filters via CASE WHEN
                             # This ensures each metric's filter only affects that metric
@@ -4239,11 +4240,8 @@ class SQLGenerator:
             Wrapped SQL expression
         """
         if metric.fill_nulls_with is not None:
-            # Quote string values
-            if isinstance(metric.fill_nulls_with, str):
-                fill_value = f"'{metric.fill_nulls_with}'"
-            else:
-                fill_value = str(metric.fill_nulls_with)
+            # Render typed literals so quotes in string defaults are escaped.
+            fill_value = exp.convert(metric.fill_nulls_with).sql(dialect=self.dialect)
             return f"COALESCE({sql_expr}, {fill_value})"
         return sql_expr
 
@@ -4407,13 +4405,15 @@ class SQLGenerator:
 
         # Simple aggregation - filters are already applied in CTE's raw column
         if agg_func == "COUNT_DISTINCT":
-            return f"COUNT(DISTINCT {raw_col})"
-        if agg_func == "COUNT":
+            aggregate = f"COUNT(DISTINCT {raw_col})"
+        elif agg_func == "COUNT":
             # Always use COUNT(raw_col) to avoid fan-out overcounting in multi-model joins.
-            # The CTE projects a non-NULL raw column for matching rows, so COUNT(raw_col)
-            # is equivalent to COUNT(*) for single-model queries but correct for joins.
-            return f"COUNT({raw_col})"
-        return f"{agg_func}({raw_col})"
+            # Row counts project 1 for matching rows; expression counts retain
+            # their NULL values. Both exclude rows removed by measure filters.
+            aggregate = f"COUNT({raw_col})"
+        else:
+            aggregate = f"{agg_func}({raw_col})"
+        return self._wrap_with_fill_nulls(aggregate, measure)
 
     def _ensure_sql_dimension(self, model_name: str, dimension) -> None:
         if getattr(dimension, "has_untranslated_dax", False):

--- a/tests/adapters/osi/test_ossie_adapter.py
+++ b/tests/adapters/osi/test_ossie_adapter.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from sidemantic import SemanticLayer
 from sidemantic.adapters.osi import OSIAdapter
 from sidemantic.adapters.ossie import OssieAdapter, OssieImportError
 from sidemantic.core.dimension import Dimension
@@ -220,11 +221,13 @@ def test_graph_export_refuses_unidentified_relationships(tmp_path: Path) -> None
     )
 
     with pytest.raises(OssieSynthesisError):
-        OssieAdapter(export_scope_name="commerce", expression_dialect="ANSI_SQL").export(graph, tmp_path / "model.yaml")
+        OssieAdapter(export_scope_name="commerce", expression_dialect="ANSI_SQL").export(
+            graph, tmp_path / "model.yaml", portable_only=True
+        )
 
 
 @pytest.mark.parametrize("adapter_class", [OssieAdapter, OSIAdapter])
-def test_filtered_metric_export_refusal_preserves_existing_output(tmp_path: Path, adapter_class) -> None:
+def test_filtered_metric_export_roundtrip_executes(tmp_path: Path, adapter_class) -> None:
     graph = SemanticGraph()
     graph.add_model(
         Model(
@@ -234,10 +237,41 @@ def test_filtered_metric_export_refusal_preserves_existing_output(tmp_path: Path
         )
     )
     output = tmp_path / "model.yaml"
+    adapter_class(export_scope_name="commerce", expression_dialect="ANSI_SQL").export(graph, output, portable_only=True)
+    assert not yaml.safe_load(output.read_text())["semantic_model"][0].get("custom_extensions")
+    layer = SemanticLayer()
+    layer.graph = adapter_class().parse(output)
+    layer.adapter.conn.execute("create table orders(amount integer, status varchar)")
+    layer.adapter.conn.execute("insert into orders values (100, 'paid'), (20, 'paid'), (500, 'pending')")
+    assert layer.query(metrics=["paid_revenue"]).fetchall() == [(120,)]
+
+
+@pytest.mark.parametrize("adapter_class", [OssieAdapter, OSIAdapter])
+def test_native_metric_portable_export_refusal_preserves_existing_output(tmp_path: Path, adapter_class) -> None:
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            dimensions=[Dimension(name="day", type="time", granularity="day")],
+            metrics=[Metric(name="balance", agg="sum", sql="amount", non_additive_dimension="day")],
+        )
+    )
+    output = tmp_path / "model.yaml"
     output.write_text("existing document\n")
 
     with pytest.raises(OssieSynthesisError) as error:
-        adapter_class(export_scope_name="commerce", expression_dialect="ANSI_SQL").export(graph, output)
+        adapter_class(export_scope_name="commerce", expression_dialect="ANSI_SQL").export(
+            graph, output, portable_only=True
+        )
 
     assert any(d.code == "ossie.synthesis.metric_semantics_unsupported" for d in error.value.diagnostics)
     assert output.read_text() == "existing document\n"
+
+    with pytest.warns(UserWarning, match="requires Sidemantic runtime extension"):
+        adapter_class(export_scope_name="commerce", expression_dialect="ANSI_SQL").export(graph, output)
+    layer = SemanticLayer()
+    layer.graph = adapter_class().parse(output)
+    layer.adapter.conn.execute("create table orders(day date, amount integer)")
+    layer.adapter.conn.execute("insert into orders values ('2026-01-01',100), ('2026-01-31',120)")
+    assert layer.query(metrics=["orders.balance"], dimensions=["orders.day__month"]).fetchall()[0][1] == 120

--- a/tests/core/test_directory_loaders.py
+++ b/tests/core/test_directory_loaders.py
@@ -500,6 +500,47 @@ def test_load_from_directory_detects_released_osi_json(tmp_path):
     assert "order_count" in layer.graph.metrics
 
 
+@pytest.mark.parametrize("relative_path", ["orders.ossie.json", "models/orders.ossie.json"])
+def test_load_from_directory_detects_explicit_ossie_json_outside_osi_tree(tmp_path, relative_path):
+    source = tmp_path / relative_path
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        '{"version": "0.2.0.dev0", "semantic_model": [{"name": "analytics", '
+        '"datasets": [{"name": "orders", "source": "analytics.orders"}]}]}'
+    )
+
+    layer = SemanticLayer()
+    load_from_directory(layer, tmp_path)
+
+    assert list(layer.graph.models) == ["orders"]
+    assert layer.graph.models["orders"].table == "analytics.orders"
+    assert layer.graph.models["orders"]._source_format == "Ossie"
+
+
+@pytest.mark.parametrize("content", ['{"version":', "{}"])
+def test_load_from_directory_surfaces_invalid_explicit_ossie_json(tmp_path, content):
+    (tmp_path / "invalid.ossie.json").write_text(content)
+
+    with pytest.raises(ValueError, match=r"invalid\.ossie\.json"):
+        load_from_directory(SemanticLayer(), tmp_path)
+
+    layer = SemanticLayer()
+    load_from_directory(layer, tmp_path, strict=False)
+    assert not layer.graph.models
+
+
+@pytest.mark.parametrize("generated_dir", ["target", "dbt_packages", "OSI/target"])
+def test_load_from_directory_skips_generated_explicit_ossie_json(tmp_path, generated_dir):
+    generated = tmp_path / generated_dir
+    generated.mkdir(parents=True)
+    (generated / "invalid.ossie.json").write_text('{"version":')
+
+    layer = SemanticLayer()
+    load_from_directory(layer, tmp_path)
+
+    assert not layer.graph.models
+
+
 def test_auto_loader_rejects_multi_scope_ossie_instead_of_flattening_namespaces(tmp_path):
     source = tmp_path / "multiple.yaml"
     source.write_text(

--- a/tests/interchange/ossie/test_runtime_extension.py
+++ b/tests/interchange/ossie/test_runtime_extension.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sidemantic import Dimension, Metric, Model, SecurityPolicy, SemanticLayer
+from sidemantic.core.registry import reset_current_layer, set_current_layer
+from sidemantic.core.relationship import Relationship
+from sidemantic.core.semantic_graph import SemanticGraph
+from sidemantic.core.semantic_layer import SecurityError
+from sidemantic.interchange.ossie import (
+    OssieImportPolicy,
+    OssieParseOptions,
+    lower_ossie_document,
+    parse_ossie_document,
+)
+from sidemantic.interchange.ossie.runtime_extension import decode_runtime_extension, encode_runtime_extension
+
+
+def _document(graph, *, dialect="ANSI_SQL"):
+    scope = {
+        "name": "native",
+        "datasets": [{"name": "runtime_required", "source": "SELECT NULL AS required WHERE 1 = 0"}],
+    }
+    scope["custom_extensions"] = [encode_runtime_extension(graph, scope, expression_dialect=dialect)]
+    return {"version": "0.2.0.dev0", "vendors": ["SIDEMANTIC"], "semantic_model": [scope]}
+
+
+def _lower(document, *, policy=OssieImportPolicy.STRICT, target="duckdb"):
+    return lower_ossie_document(
+        parse_ossie_document(
+            json.dumps(document).encode(),
+            options=OssieParseOptions(import_policy=policy, validate_schema=True),
+        ),
+        target_dialect=target,
+    )
+
+
+def test_runtime_extension_restores_per_request_security_and_private_fields():
+    original = SemanticLayer()
+    original.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            dimensions=[
+                Dimension(name="tenant", type="numeric"),
+                Dimension(name="secret", type="categorical", public=False),
+            ],
+            metrics=[Metric(name="total", agg="sum", sql="amount")],
+            security=SecurityPolicy(access="user.enabled", row_filters=["tenant = {{ user.tenant }}"]),
+        )
+    )
+    document = _document(original.graph)
+    assert document["semantic_model"][0]["datasets"][0]["source"] == "SELECT NULL AS required WHERE 1 = 0"
+    lowered = _lower(document)
+    assert lowered.valid
+    graph = lowered.catalog["native"].graph
+    assert graph.models["orders"].model_dump() == original.graph.models["orders"].model_dump()
+    layer = SemanticLayer(enforce_visibility=True)
+    layer.graph = graph
+    layer.adapter.conn.execute("create table orders(tenant integer, amount integer, secret varchar)")
+    layer.adapter.conn.execute("insert into orders values (1,10,'one'), (2,50,'two')")
+    for tenant, expected in [(1, 10), (2, 50)]:
+        assert layer.query(
+            metrics=["orders.total"], user_attributes={"enabled": True, "tenant": tenant}
+        ).fetchall() == [(expected,)]
+    with pytest.raises(SecurityError):
+        layer.compile(metrics=["orders.total"], user_attributes={"enabled": False, "tenant": 1})
+    with pytest.raises(SecurityError):
+        layer.compile(dimensions=["orders.secret"], user_attributes={"enabled": True, "tenant": 1})
+    with pytest.raises(SecurityError):
+        layer.compile(metrics=["orders.total"])
+
+
+def test_preserves_runtime_metrics_roles_and_inheritance():
+    graph = SemanticGraph()
+    graph.add_model(Model(name="base_orders", table="orders"))
+    graph.add_model(Model(name="customers", table="customers", primary_key="id"))
+    graph.add_model(
+        Model(
+            name="orders",
+            table="orders",
+            extends="base_orders",
+            default_time_dimension="day",
+            dimensions=[Dimension(name="day", type="time", granularity="day")],
+            relationships=[
+                Relationship(name="buyer", target_model="customers", type="many_to_one", foreign_key="buyer_id")
+            ],
+            metrics=[
+                Metric(name="balance", agg="sum", sql="amount", non_additive_dimension="day"),
+                Metric(name="running", type="cumulative", sql="amount", agg="sum", window="7 days"),
+                Metric(name="previous", type="time_comparison", base_metric="balance", comparison_type="mom"),
+            ],
+        )
+    )
+    graph.add_metric(Metric(name="owned", agg="sum", sql="amount"), model_name="orders")
+    restored = _lower(_document(graph)).catalog["native"].graph
+    from sidemantic.core.inheritance import resolve_model_inheritance
+
+    assert restored.models["orders"].model_dump(mode="json") == resolve_model_inheritance(graph.models)[
+        "orders"
+    ].model_dump(mode="json")
+    assert restored.metric_owners == {"owned": "orders"}
+    assert restored.metrics.keys() == graph.metrics.keys()
+    assert restored.get_model("buyer").name == "customers"
+
+
+def test_nonadditive_metric_roundtrip_executes_last_snapshot():
+    layer = SemanticLayer()
+    layer.add_model(
+        Model(
+            name="balance",
+            table="balance",
+            dimensions=[Dimension(name="day", type="time", granularity="day")],
+            metrics=[Metric(name="total", agg="sum", sql="amount", non_additive_dimension="day")],
+        )
+    )
+    layer.graph = _lower(_document(layer.graph)).catalog["native"].graph
+    layer.adapter.conn.execute("create table balance(day date, amount integer)")
+    layer.adapter.conn.execute("insert into balance values ('2026-01-01',100), ('2026-01-31',120)")
+    assert layer.query(metrics=["balance.total"], dimensions=["balance.day__month"]).fetchall()[0][1] == 120
+
+
+@pytest.mark.parametrize("policy", [OssieImportPolicy.STRICT, OssieImportPolicy.PERMISSIVE])
+@pytest.mark.parametrize("corruption", ["json", "version", "core", "field", "owner", "duplicate", "unknown_state"])
+def test_invalid_runtime_extension_never_falls_back_to_core(policy, corruption):
+    graph = SemanticGraph()
+    graph.add_model(Model(name="orders", table="orders", security=SecurityPolicy(access=False)))
+    document = _document(graph)
+    scope = document["semantic_model"][0]
+    extension = scope["custom_extensions"][0]
+    payload = json.loads(extension["data"])
+    if corruption == "json":
+        extension["data"] = "{"
+    elif corruption == "core":
+        scope["datasets"][0]["source"] = "orders"
+    elif corruption == "duplicate":
+        scope["custom_extensions"].append(dict(extension))
+    else:
+        if corruption == "version":
+            payload["version"] = 2
+        elif corruption == "field":
+            payload["graph"]["models"]["orders"]["security"]["future_policy"] = "deny"
+        elif corruption == "owner":
+            payload["graph"]["metric_owners"] = {"missing": "orders"}
+        elif corruption == "unknown_state":
+            payload["graph"]["future_policy"] = "deny"
+        extension["data"] = json.dumps(payload)
+    lowered = _lower(document, policy=policy)
+    assert not lowered.executable
+    assert any(item.code == "ossie.lowering.runtime_extension_invalid" for item in lowered.diagnostics)
+
+
+def test_runtime_extension_enforces_source_dialect():
+    document = _document(SemanticGraph(), dialect="BIGQUERY")
+    assert _lower(document, target="bigquery").valid
+    assert not _lower(document, target="duckdb").executable
+
+
+def test_foreign_extensions_are_preserved_but_not_executed():
+    assert (
+        decode_runtime_extension(
+            {"custom_extensions": [{"vendor_name": "OTHER", "data": "arbitrary"}]}, target_dialect="duckdb"
+        )
+        is None
+    )
+
+
+def test_runtime_model_construction_does_not_register_in_ambient_layer():
+    graph = SemanticGraph()
+    graph.add_model(Model(name="orders", table="orders", metrics=[Metric(name="total", agg="count")]))
+    document = _document(graph)
+    ambient = SemanticLayer()
+    token = set_current_layer(ambient)
+    try:
+        assert _lower(document).valid
+    finally:
+        reset_current_layer(token)
+    assert ambient.graph.models == {}
+    assert ambient.graph.metrics == {}
+
+
+def test_inherited_source_and_metric_defaults_execute_after_roundtrip():
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="base",
+            table="orders",
+            metrics=[Metric(name="total", agg="sum", sql="amount", filters=["amount > 0"])],
+        )
+    )
+    child = Model(name="child", extends="base")
+    child.metrics.append(Metric(name="large", extends="total", filters=["amount > 20"]))
+    graph.add_model(child)
+    document = _document(graph)
+    decoded = decode_runtime_extension(document["semantic_model"][0], target_dialect="duckdb")
+    assert "table" not in decoded.models["child"].model_fields_set
+    assert decoded.models["child"].metrics[0].extends == "total"
+    layer = SemanticLayer()
+    layer.graph = _lower(document).catalog["native"].graph
+    layer.adapter.conn.execute("create table orders(amount integer)")
+    layer.adapter.conn.execute("insert into orders values (-5), (10), (50)")
+    assert layer.query(metrics=["child.total", "child.large"]).fetchall() == [(60, 50)]
+
+
+@pytest.mark.parametrize("parent", ["missing", "child"])
+def test_invalid_inheritance_is_refused_before_export(parent):
+    graph = SemanticGraph()
+    graph.add_model(Model(name="child", extends=parent))
+    with pytest.raises(ValueError, match="not found|Circular inheritance"):
+        _document(graph)
+
+
+def test_inherited_runtime_fields_survive_native_flattening():
+    graph = SemanticGraph()
+    graph.add_model(Model(name="customers", table="customers", primary_key="id"))
+    graph.add_model(
+        Model(
+            name="base",
+            table="orders",
+            dimensions=[
+                Dimension(name="day", type="time", granularity="day", logical_data_type="Date", declared_is_time=True)
+            ],
+            relationships=[
+                Relationship(name="customers", type="many_to_one", foreign_key="customer_id", edge_id="customer_edge")
+            ],
+            metrics=[Metric(name="total", agg="sum", sql="amount", logical_data_type="Decimal")],
+        )
+    )
+    graph.add_model(Model(name="child", extends="base"))
+    restored = _lower(_document(graph)).catalog["native"].graph.models["child"]
+    assert restored.relationships[0].edge_id == "customer_edge"
+    assert restored.dimensions[0].logical_data_type == "Date"
+    assert restored.dimensions[0].declared_is_time is True
+    assert restored.metrics[0].logical_data_type == "Decimal"
+
+
+def test_relationship_role_instances_execute_distinct_joins_after_roundtrip():
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="customers",
+            table="customers",
+            primary_key="id",
+            dimensions=[Dimension(name="name", type="categorical")],
+        )
+    )
+    orders = Model(
+        name="orders",
+        table="orders",
+        dimensions=[Dimension(name="id", type="numeric")],
+        metrics=[Metric(name="total", agg="sum", sql="amount")],
+    )
+    for role in ["buyer", "recipient"]:
+        orders.relationships.append(
+            Relationship(
+                name=role,
+                target_model="customers",
+                edge_id=f"order_{role}",
+                type="many_to_one",
+                foreign_key=f"{role}_id",
+            )
+        )
+    graph.add_model(orders)
+    layer = SemanticLayer()
+    layer.graph = _lower(_document(graph)).catalog["native"].graph
+    assert [edge.edge_id for edge in layer.graph.models["orders"].relationships] == ["order_buyer", "order_recipient"]
+    layer.adapter.conn.execute("create table customers(id integer, name varchar)")
+    layer.adapter.conn.execute("insert into customers values (1,'Buyer'), (2,'Recipient')")
+    layer.adapter.conn.execute(
+        "create table orders(id integer, buyer_id integer, recipient_id integer, amount integer)"
+    )
+    layer.adapter.conn.execute("insert into orders values (9,1,2,100)")
+    assert layer.query(
+        metrics=["orders.total"], dimensions=["orders.id", "buyer.name", "recipient.name"]
+    ).fetchall() == [(9, "Buyer", "Recipient", 100)]
+
+
+def test_cumulative_metric_executes_after_roundtrip():
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="daily",
+            table="daily",
+            dimensions=[Dimension(name="day", type="time", granularity="day")],
+            metrics=[
+                Metric(name="total", agg="sum", sql="amount"),
+                Metric(name="running", type="cumulative", sql="daily.total"),
+            ],
+        )
+    )
+    layer = SemanticLayer()
+    layer.graph = _lower(_document(graph)).catalog["native"].graph
+    layer.adapter.conn.execute("create table daily(day date, amount integer)")
+    layer.adapter.conn.execute("insert into daily values ('2026-01-01',10), ('2026-01-02',20)")
+    rows = layer.query(metrics=["daily.running"], dimensions=["daily.day"], order_by=["daily.day"]).fetchall()
+    assert [row[-1] for row in rows] == [10, 30]

--- a/tests/interchange/ossie/test_synthesis.py
+++ b/tests/interchange/ossie/test_synthesis.py
@@ -118,7 +118,7 @@ def test_synthesis_refuses_to_invent_relationship_identity_or_keys() -> None:
         Relationship(name="customers", type="many_to_one", foreign_key="customer_id", primary_key=None)
     ]
 
-    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL", portable_only=True)
 
     assert not result.valid
     assert result.document is None
@@ -192,8 +192,6 @@ def test_synthesis_closes_over_relationship_endpoint_semantics() -> None:
 @pytest.mark.parametrize(
     "options",
     [
-        {"filters": ["status = 'paid'"]},
-        {"fill_nulls_with": 0},
         {"non_additive_dimension": "loaded_at"},
         {"non_additive_window_groupings": ["customer_id"]},
         {"offset_window": "1 month"},
@@ -206,7 +204,7 @@ def test_synthesis_refuses_result_affecting_metric_options(options: dict) -> Non
     graph = _graph()
     graph.models["orders"].metrics = [Metric(name="revenue", agg="sum", sql="amount", **options)]
 
-    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL", portable_only=True)
 
     assert result.document is None
     assert any(d.code == "ossie.synthesis.metric_semantics_unsupported" for d in result.diagnostics)
@@ -219,7 +217,7 @@ def test_synthesis_refuses_relationship_behavior_not_expressed_by_keys(options: 
     for name, value in options.items():
         setattr(relationship, name, value)
 
-    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL", portable_only=True)
 
     assert result.document is None
     assert any(d.code == "ossie.synthesis.relationship_semantics_unsupported" for d in result.diagnostics)
@@ -231,7 +229,7 @@ def test_synthesis_refuses_to_erase_relationship_role_instances() -> None:
     relationship.name = "billing_customer"
     relationship.target_model = "customers"
 
-    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL", portable_only=True)
 
     assert result.document is None
     assert any(
@@ -274,6 +272,13 @@ def test_synthesis_accepts_reordered_unique_key_without_reordering_join_pairs(ke
         ({"sql": "SUM(amount) + SUM(quantity)"}, 21),
         ({"agg": "sum", "sql": 'coalesce("amount", 0) * orders.quantity'}, 40),
         ({"type": "derived", "agg": "sum", "sql": "amount * quantity"}, 40),
+        ({"agg": "sum", "sql": "amount", "filters": ["quantity = 2"]}, 10),
+        ({"agg": "sum", "sql": "amount", "filters": ["quantity < 0"], "fill_nulls_with": 0}, 0),
+        ({"agg": "count"}, 3),
+        ({"agg": "sum", "sql": "1"}, 3),
+        ({"agg": "count", "filters": ["quantity >= 0"]}, 3),
+        ({"agg": "count", "sql": "amount", "filters": ["quantity >= 0"]}, 2),
+        ({"agg": "count_distinct", "sql": "amount", "filters": ["quantity = 2"]}, 1),
     ],
 )
 def test_synthesis_qualifies_expression_columns_and_preserves_numeric_results(options: dict, expected: float) -> None:
@@ -281,11 +286,14 @@ def test_synthesis_qualifies_expression_columns_and_preserves_numeric_results(op
     graph.add_model(
         Model(
             name="orders",
-            sql="SELECT * FROM (VALUES (10, 2), (5, 4), (NULL, 0)) AS t(amount, quantity)",
+            sql="SELECT * FROM (VALUES (10, 2), (5, 4), (NULL, 0)) AS orders(amount, quantity)",
             dimensions=[Dimension(name="amount", type="numeric"), Dimension(name="quantity", type="numeric")],
             metrics=[Metric(name="value", **options)],
         )
     )
+    native = SemanticLayer(auto_register=False)
+    native.graph = graph
+    assert float(native.query(metrics=["orders.value"]).fetchone()[0]) == pytest.approx(expected)
     result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
     assert result.valid, result.diagnostics
     parsed = parse_ossie_document(json.dumps(result.document.to_parsed_data()).encode(), source_identifier="test.json")
@@ -319,14 +327,15 @@ def test_synthesis_preserves_model_metric_references_in_derived_formulas(express
 
 
 @pytest.mark.parametrize("options", [{"agg": "count"}, {"agg": "sum", "sql": "1"}])
-def test_synthesis_refuses_to_lose_model_binding_for_columnless_aggregates(options: dict) -> None:
+def test_synthesis_retains_model_binding_for_columnless_aggregates(options: dict) -> None:
     graph = _graph()
     graph.models["orders"].metrics = [Metric(name="row_count", **options)]
 
     result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
 
-    assert result.document is None
-    assert any(d.code == "ossie.synthesis.metric_owner_unrepresentable" for d in result.diagnostics)
+    assert result.valid, result.diagnostics
+    scope = result.document.to_parsed_data()["semantic_model"][0]
+    assert "orders.__sidemantic_row" in scope["metrics"][0]["expression"]["dialects"][0]["expression"]
 
 
 @pytest.mark.parametrize(
@@ -342,7 +351,7 @@ def test_synthesis_refuses_to_discard_model_security_or_inheritance(options: dic
     for name, value in options.items():
         setattr(graph.models["orders"], name, value)
 
-    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL", portable_only=True)
 
     assert result.document is None
     assert any(d.code == "ossie.synthesis.model_semantics_unsupported" for d in result.diagnostics)
@@ -362,7 +371,111 @@ def test_synthesis_refuses_to_expose_private_dimensions() -> None:
     graph = _graph()
     graph.models["orders"].dimensions[-1].public = False
 
-    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL", portable_only=True)
 
     assert result.document is None
     assert any(d.code == "ossie.synthesis.field_semantics_unsupported" for d in result.diagnostics)
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"non_additive_dimension": "loaded_at"},
+        {"offset_window": "1 month"},
+        {"window_expression": "SUM(amount)", "window_frame": "ROWS UNBOUNDED PRECEDING"},
+        {"public": False},
+    ],
+)
+def test_synthesis_restores_native_metric_semantics_through_extension(options):
+    graph = _graph()
+    graph.models["orders"].metrics = [Metric(name="value", agg="sum", sql="amount", **options)]
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
+    assert result.valid, result.diagnostics
+    assert any(d.code == "ossie.synthesis.runtime_extension_required" for d in result.diagnostics)
+    document = result.document.to_parsed_data()
+    assert all("analytics.orders" not in d["source"] for d in document["semantic_model"][0]["datasets"])
+    lowered = lower_ossie_document(parse_ossie_document(json.dumps(document).encode()), target_dialect="duckdb")
+    assert lowered.valid, lowered.diagnostics
+    assert lowered.catalog["commerce"].graph.models["orders"].metrics[0] == graph.models["orders"].metrics[0]
+
+
+def test_native_extension_does_not_hide_invalid_sql():
+    graph = _graph()
+    graph.models["orders"].metrics = [Metric(name="value", agg="sum", sql="amount; SELECT 1", public=False)]
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
+    assert not result.valid
+    assert any(d.code == "ossie.synthesis.expression_invalid" for d in result.diagnostics)
+
+
+def test_columnless_aggregate_uses_own_rows_and_avoids_declared_field_collision():
+    graph = SemanticGraph()
+    graph.add_model(Model(name="unrelated", sql="SELECT 1 AS id"))
+    graph.add_model(
+        Model(
+            name="orders",
+            sql="SELECT * FROM (VALUES (NULL), (NULL), (NULL)) AS t(id)",
+            dimensions=[Dimension(name="__sidemantic_row", type="numeric", sql="id")],
+            metrics=[Metric(name="rows", agg="count")],
+        )
+    )
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL", portable_only=True)
+    assert result.valid, result.diagnostics
+    lowered = lower_ossie_document(
+        parse_ossie_document(json.dumps(result.document.to_parsed_data()).encode()), target_dialect="duckdb"
+    )
+    layer = SemanticLayer.from_catalog(lowered.catalog, auto_register=False)
+    assert layer.query(metrics=["rows"]).fetchall() == [(3,)]
+
+
+@pytest.mark.parametrize("model_local", [True, False])
+@pytest.mark.parametrize("filtered", [True, False])
+def test_roundtrip_distinguishes_physical_measure_columns_from_semantic_fields(model_local, filtered):
+    graph = SemanticGraph()
+    model = Model(
+        name="orders",
+        sql="SELECT * FROM (VALUES (10), (5), (NULL)) AS t(amount)",
+        dimensions=[Dimension(name="amount", type="numeric", sql="amount * 2")],
+    )
+    graph.add_model(model)
+    metric = Metric(
+        name="value",
+        agg="sum",
+        sql="amount" if model_local else "orders.amount",
+        filters=["amount > 7" if model_local else "orders.amount > 7"] if filtered else None,
+    )
+    if model_local:
+        model.metrics.append(metric)
+    else:
+        graph.add_metric(metric)
+    native = SemanticLayer(auto_register=False)
+    native.graph = graph
+    expected = native.query(metrics=["orders.value" if model_local else "value"]).fetchall()
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL", portable_only=True)
+    assert result.valid, result.diagnostics
+    lowered = lower_ossie_document(
+        parse_ossie_document(json.dumps(result.document.to_parsed_data()).encode()), target_dialect="duckdb"
+    )
+    imported = SemanticLayer.from_catalog(lowered.catalog, auto_register=False)
+    assert imported.query(metrics=["value"]).fetchall() == expected
+
+
+@pytest.mark.parametrize("fill", ["", "can't"])
+def test_null_fill_string_literals_execute_before_and_after_portable_export(fill):
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            sql="SELECT CAST(NULL AS VARCHAR) AS label",
+            metrics=[Metric(name="label", agg="max", sql="label", fill_nulls_with=fill)],
+        )
+    )
+    native = SemanticLayer(auto_register=False)
+    native.graph = graph
+    assert native.query(metrics=["orders.label"]).fetchall() == [(fill,)]
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL", portable_only=True)
+    assert result.valid, result.diagnostics
+    lowered = lower_ossie_document(
+        parse_ossie_document(json.dumps(result.document.to_parsed_data()).encode()), target_dialect="duckdb"
+    )
+    imported = SemanticLayer.from_catalog(lowered.catalog, auto_register=False)
+    assert imported.query(metrics=["label"]).fetchall() == [(fill,)]

--- a/tests/metrics/test_advanced.py
+++ b/tests/metrics/test_advanced.py
@@ -1,6 +1,7 @@
 """Test advanced metric features: grain-to-date, fill_nulls_with, offsets, conversion."""
 
 import duckdb
+import pytest
 
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.metric import Metric
@@ -137,6 +138,37 @@ def test_fill_nulls_with_zero():
 
     assert completed[1] == 100
     assert pending[1] == 0  # Filled with 0 instead of NULL!
+
+
+@pytest.mark.parametrize(
+    ("source", "filters", "expected_ratio"),
+    [
+        ("SELECT CAST(NULL AS INTEGER) AS amount", None, 0.1),
+        ("SELECT 10 AS amount", ["amount < 0"], 0.1),
+        ("SELECT 10 AS amount WHERE false", None, 0),
+    ],
+)
+def test_model_measure_null_fill_applies_to_direct_and_dependent_metrics(source, filters, expected_ratio):
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            sql=source,
+            metrics=[
+                Metric(name="total", agg="sum", sql="amount", filters=filters, fill_nulls_with=10),
+                Metric(name="twice", type="derived", sql="total * 2"),
+                Metric(name="rows", agg="count"),
+                Metric(name="rate", type="ratio", numerator="rows", denominator="total"),
+            ],
+        )
+    )
+    sql = SQLGenerator(graph).generate(metrics=["orders.total", "orders.twice", "orders.rate"])
+
+    with duckdb.connect(":memory:") as conn:
+        total, twice, rate = conn.execute(sql).fetchone()
+
+    assert (total, twice) == (10, 20)
+    assert rate == pytest.approx(expected_ratio)
 
 
 def test_fill_nulls_with_string():

--- a/tests/metrics/test_symmetric_aggs.py
+++ b/tests/metrics/test_symmetric_aggs.py
@@ -758,3 +758,30 @@ def test_filtered_count_under_fanout():
     assert row[1] != row[2]
 
     conn.close()
+
+
+def test_model_measure_null_fill_under_fanout():
+    graph = SemanticGraph()
+    graph.add_model(
+        Model(
+            name="orders",
+            sql="SELECT 1 AS order_id, CAST(NULL AS INTEGER) AS amount",
+            primary_key="order_id",
+            metrics=[Metric(name="average", agg="avg", sql="amount", fill_nulls_with=10)],
+            relationships=[
+                Relationship(name="items", type="one_to_many", foreign_key="order_id", primary_key="order_id")
+            ],
+        )
+    )
+    graph.add_model(
+        Model(
+            name="items",
+            sql="SELECT * FROM (VALUES (1, 1, 'X'), (2, 1, 'X')) AS t(item_id, order_id, region)",
+            primary_key="item_id",
+            dimensions=[Dimension(name="region", type="categorical")],
+        )
+    )
+    sql = SQLGenerator(graph).generate(metrics=["orders.average"], dimensions=["items.region"])
+
+    with duckdb.connect(":memory:") as conn:
+        assert conn.execute(sql).fetchall() == [("X", 10)]

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -10,6 +10,9 @@ import pytest
 from typer.testing import CliRunner
 
 import sidemantic.cli as cli_module
+from sidemantic import SemanticLayer
+from sidemantic.adapters.ossie import OssieAdapter
+from sidemantic.adapters.sidemantic import SidemanticAdapter
 from sidemantic.cli import app
 from tests.optional_dep_stubs import ensure_fake_riffq
 
@@ -531,7 +534,7 @@ models:
 
 
 @pytest.mark.parametrize("target_format", ["ossie", "osi"])
-def test_convert_refuses_filtered_metrics_without_writing_lossy_output(tmp_path: Path, target_format: str):
+def test_convert_filtered_metrics_roundtrip_executes(tmp_path: Path, target_format: str):
     source = tmp_path / "source.yml"
     output = tmp_path / "output.yml"
     source.write_text("""models:
@@ -559,12 +562,69 @@ def test_convert_refuses_filtered_metrics_without_writing_lossy_output(tmp_path:
             "commerce",
             "--ossie-expression-dialect",
             "ANSI_SQL",
+            "--ossie-portable-only",
         ],
     )
 
-    assert result.exit_code == 1, result.output
-    assert "filters" in result.stderr
-    assert not output.exists()
+    assert result.exit_code == 0, result.output
+    layer = SemanticLayer()
+    layer.graph = OssieAdapter().parse(output)
+    layer.adapter.conn.execute("create table orders(amount integer, status varchar)")
+    layer.adapter.conn.execute("insert into orders values (100, 'paid'), (20, 'paid'), (500, 'pending')")
+    assert layer.query(metrics=["paid_revenue"]).fetchall() == [(120,)]
+
+
+@pytest.mark.parametrize("target_format", ["ossie", "osi"])
+def test_convert_native_metric_extension_roundtrip_and_portable_refusal(tmp_path: Path, target_format: str):
+    source = tmp_path / "source.yml"
+    output = tmp_path / "output.ossie.json"
+    restored = tmp_path / "restored.yml"
+    source.write_text("""models:
+  - name: orders
+    table: orders
+    dimensions:
+      - {name: day, type: time, granularity: day}
+    metrics:
+      - name: balance
+        agg: sum
+        sql: amount
+        non_additive_dimension: day
+""")
+    arguments = [
+        "convert",
+        str(source),
+        "--from",
+        "sidemantic",
+        "--to",
+        target_format,
+        "--output",
+        str(output),
+        "--ossie-scope",
+        "commerce",
+        "--ossie-expression-dialect",
+        "ANSI_SQL",
+        "--force",
+    ]
+    output.write_text("existing document\n")
+    refused = runner.invoke(app, [*arguments, "--ossie-portable-only"])
+    assert refused.exit_code == 1, refused.output
+    assert "non_additive_dimension" in refused.stderr
+    assert output.read_text() == "existing document\n"
+
+    with pytest.warns(UserWarning, match="requires Sidemantic runtime extension"):
+        converted = runner.invoke(app, arguments)
+    assert converted.exit_code == 0, converted.output
+    assert json.loads(output.read_text())["semantic_model"][0]["custom_extensions"]
+    reimported = runner.invoke(
+        app,
+        ["convert", str(output), "--from", target_format, "--to", "sidemantic", "--output", str(restored)],
+    )
+    assert reimported.exit_code == 0, reimported.output
+    layer = SemanticLayer()
+    layer.graph = SidemanticAdapter().parse(restored)
+    layer.adapter.conn.execute("create table orders(day date, amount integer)")
+    layer.adapter.conn.execute("insert into orders values ('2026-01-01',100), ('2026-01-31',120)")
+    assert layer.query(metrics=["orders.balance"], dimensions=["orders.day__month"]).fetchall()[0][1] == 120
 
 
 def test_validate_accepts_current_ossie_dialects_and_vendors(tmp_path: Path):

--- a/tests/test_sql_generation_security.py
+++ b/tests/test_sql_generation_security.py
@@ -279,6 +279,22 @@ def test_count_metrics_with_filters(layer):
     assert "* AS completed_orders_raw" not in sql
 
 
+def test_filtered_count_expression_preserves_nulls(layer):
+    layer.add_model(
+        Model(
+            name="orders",
+            sql="SELECT * FROM (VALUES (10, true), (NULL, true), (10, true), (20, false)) AS t(amount, active)",
+            metrics=[
+                Metric(name="rows", agg="count", filters=["active"]),
+                Metric(name="values", agg="count", sql="amount", filters=["active"]),
+                Metric(name="distinct_values", agg="count_distinct", sql="amount", filters=["active"]),
+            ],
+        )
+    )
+
+    assert layer.query(metrics=["orders.rows", "orders.values", "orders.distinct_values"]).fetchall() == [(3, 2, 1)]
+
+
 def test_table_calculation_with_division():
     """Test safe evaluator handles division correctly."""
     calc = TableCalculation(name="margin_pct", type="formula", expression="(${revenue} - ${cost}) / ${revenue} * 100")


### PR DESCRIPTION
Ossie export now preserves filtered and columnless aggregates in portable SQL, including physical measure inputs that differ from transformed dimensions. Native inheritance, role aliases, time/window behavior, and security settings round-trip through a versioned Sidemantic extension. Its core projection contains no business data, and a portable-only option remains available.

Also discovers explicit `*.ossie.json` files outside `OSI/` and fixes native filtered-count and null-fill behavior uncovered by before/after execution checks.
