### PR TITLE
Preserve unprojected native state in Ossie exports

### DIFF
--- a/sidemantic/interchange/ossie/synthesis.py
+++ b/sidemantic/interchange/ossie/synthesis.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import sqlglot
+from pydantic import BaseModel
 from sqlglot import expressions as exp
 
 from sidemantic.core.metric import Metric
@@ -227,6 +228,90 @@ def _unsupported_metric_options(metric: Metric) -> list[str]:
     return unsupported
 
 
+def _unrepresented_state_diagnostics(graph: SemanticGraph) -> list[OssieDiagnostic]:
+    """Fail closed for populated fields outside the core projection's contract.
+
+    List handled fields rather than omitted ones so new native options cannot
+    silently become portable. Existing projection checks still validate the
+    supported combinations of these fields.
+    """
+    diagnostics: list[OssieDiagnostic] = []
+
+    def check(item: BaseModel, handled: set[str], location: str) -> None:
+        omitted = [
+            name
+            for name, field in type(item).model_fields.items()
+            if name not in handled and getattr(item, name) != field.get_default(call_default_factory=True)
+        ]
+        if omitted:
+            diagnostics.append(
+                _error(
+                    "ossie.synthesis.native_state_unrepresented",
+                    f"{location} has native state not represented in Ossie core: {', '.join(omitted)}.",
+                )
+            )
+
+    for model in graph.models.values():
+        # Lowering adds these source-location annotations to every core model.
+        # They describe the input document, not native state to synthesize.
+        source_annotations = (
+            {"metadata"} if not set(model.metadata or {}) - {"ossie_source_kind", "ossie_pointer"} else set()
+        )
+        check(
+            model,
+            {
+                "name",
+                "table",
+                "sql",
+                "description",
+                "primary_key",
+                "unique_keys",
+                "dimensions",
+                "metrics",
+                "relationships",
+            }
+            | source_annotations,
+            f"Model {model.name!r}",
+        )
+        for dimension in model.dimensions:
+            check(
+                dimension,
+                {"name", "type", "sql", "logical_data_type", "declared_is_time", "description", "label", "public"},
+                f"Field {model.name}.{dimension.name}",
+            )
+        for relationship in model.relationships:
+            check(
+                relationship,
+                {"name", "edge_id", "type", "foreign_key", "primary_key", "target_model", "sql", "active"},
+                f"Relationship {model.name}.{relationship.name}",
+            )
+    for metric in [*graph.metrics.values(), *(metric for model in graph.models.values() for metric in model.metrics)]:
+        check(
+            metric,
+            {
+                "name",
+                "type",
+                "agg",
+                "sql",
+                "sql_is_complete",
+                "numerator",
+                "denominator",
+                "filters",
+                "fill_nulls_with",
+                "logical_data_type",
+                "description",
+                "public",
+            },
+            f"Metric {metric.name!r}",
+        )
+    for name in ("parameters", "table_calculations", "explores", "saved_queries", "metadata", "import_warnings"):
+        if getattr(graph, name):
+            diagnostics.append(
+                _error("ossie.synthesis.native_state_unrepresented", f"Graph {name} is not represented in Ossie core.")
+            )
+    return diagnostics
+
+
 def _runtime_expression_diagnostics(graph: SemanticGraph, dialect: str) -> list[OssieDiagnostic]:
     """Keep native modifiers from masking otherwise invalid SQL declarations."""
     diagnostics: list[OssieDiagnostic] = []
@@ -241,6 +326,9 @@ def _runtime_expression_diagnostics(graph: SemanticGraph, dialect: str) -> list[
                     )
                 )
             expressions.append((f"{model.name}.{dimension.name}", dimension.sql_expr))
+            if dimension.window:
+                expressions.append((f"{model.name}.{dimension.name} window", dimension.window))
+        expressions.extend((f"{model.name}.{segment.name}", segment.sql) for segment in model.segments)
     metrics = [*graph.metrics.values(), *(metric for model in graph.models.values() for metric in model.metrics)]
     for metric in metrics:
         if metric.has_untranslated_dax:
@@ -617,7 +705,9 @@ def synthesize_ossie_document(
         semantic_model["metrics"] = metrics
     data = {"version": schema_version, "semantic_model": [semantic_model]}
 
+    diagnostics.extend(_unrepresented_state_diagnostics(graph))
     extension_codes = {
+        "ossie.synthesis.native_state_unrepresented",
         "ossie.synthesis.model_semantics_unsupported",
         "ossie.synthesis.field_semantics_unsupported",
         "ossie.synthesis.metric_semantics_unsupported",

--- a/tests/interchange/ossie/test_synthesis.py
+++ b/tests/interchange/ossie/test_synthesis.py
@@ -4,13 +4,17 @@ import json
 
 import pytest
 
+from sidemantic.core.consumption import Explore, SavedQuery
 from sidemantic.core.dimension import Dimension
 from sidemantic.core.metric import Metric
 from sidemantic.core.model import Model
+from sidemantic.core.parameter import Parameter
 from sidemantic.core.relationship import Relationship
 from sidemantic.core.security import SecurityPolicy
+from sidemantic.core.segment import Segment
 from sidemantic.core.semantic_graph import SemanticGraph
 from sidemantic.core.semantic_layer import SemanticLayer
+from sidemantic.core.table_calculation import TableCalculation
 from sidemantic.interchange.ossie import (
     OssieConsumerProfile,
     OssieSynthesisError,
@@ -479,3 +483,115 @@ def test_null_fill_string_literals_execute_before_and_after_portable_export(fill
     )
     imported = SemanticLayer.from_catalog(lowered.catalog, auto_register=False)
     assert imported.query(metrics=["label"]).fetchall() == [(fill,)]
+
+
+@pytest.mark.parametrize("feature", ["granularity", "segments", "window"])
+def test_native_query_semantics_require_extension_and_execute_after_roundtrip(feature):
+    graph = SemanticGraph()
+    model = Model(
+        name="orders",
+        sql="SELECT * FROM (VALUES (TIMESTAMP '2026-01-02', 10), (TIMESTAMP '2026-01-03', 20)) AS t(ts, amount)",
+        dimensions=[Dimension(name="ts", type="categorical")],
+        metrics=[Metric(name="revenue", agg="sum", sql="amount")],
+    )
+    query = {"metrics": ["orders.revenue"], "dimensions": ["orders.ts"]}
+    if feature == "granularity":
+        model.dimensions[0].type = "time"
+        model.dimensions[0].granularity = "month"
+    elif feature == "segments":
+        model.segments.append(Segment(name="large", sql="{model}.amount > 10"))
+        query["segments"] = ["orders.large"]
+    else:
+        model.dimensions[0].window = "MIN(ts) OVER ()"
+    graph.add_model(model)
+    native = SemanticLayer(auto_register=False)
+    native.graph = graph
+    expected = native.query(**query).fetchall()
+    assert len(expected) == 1
+
+    portable = synthesize_ossie_document(
+        graph, scope_name="commerce", expression_dialect="ANSI_SQL", portable_only=True
+    )
+    assert not portable.valid
+    assert portable.document is None
+    assert any(d.code == "ossie.synthesis.native_state_unrepresented" for d in portable.diagnostics)
+
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
+    assert result.valid, result.diagnostics
+    assert any(d.code == "ossie.synthesis.runtime_extension_required" for d in result.diagnostics)
+    lowered = lower_ossie_document(
+        parse_ossie_document(json.dumps(result.document.to_parsed_data()).encode()), target_dialect="duckdb"
+    )
+    assert lowered.valid, lowered.diagnostics
+    restored = lowered.catalog["commerce"].graph.models["orders"]
+    assert restored.dimensions == model.dimensions
+    assert restored.segments == model.segments
+    imported = SemanticLayer.from_catalog(lowered.catalog, auto_register=False)
+    assert imported.query(**query).fetchall() == expected
+
+
+@pytest.mark.parametrize(
+    ("owner", "field", "value"),
+    [
+        ("dimension", "supported_granularities", ["month"]),
+        ("dimension", "parent", "customer_id"),
+        ("dimension", "format", "yyyy-MM"),
+        ("model", "default_grain", "month"),
+        ("model", "auto_dimensions", True),
+        ("model", "owner", "analytics"),
+        ("model", "metadata", {"ossie_source_kind": "table", "ossie_pointer": "/datasets/0", "custom": "preserve"}),
+        ("metric", "drill_fields", ["orders.id"]),
+        ("metric", "label", "Revenue"),
+        ("relationship", "metadata", {"custom": "preserve"}),
+        ("graph", "metadata", {"custom": "preserve"}),
+        ("graph", "parameters", {"region": Parameter(name="region", type="string", default_value="US")}),
+        ("graph", "table_calculations", {"rank": TableCalculation(name="rank", type="rank")}),
+        ("graph", "explores", {"orders": Explore(name="orders", model="orders")}),
+        ("graph", "saved_queries", {"revenue": SavedQuery(name="revenue", metrics=["orders.revenue"])}),
+        ("graph", "import_warnings", [{"message": "source warning"}]),
+    ],
+)
+def test_unprojected_native_fields_are_preserved_or_refused(owner, field, value):
+    graph = _graph()
+    model = graph.models["orders"]
+    item = {
+        "graph": graph,
+        "model": model,
+        "dimension": model.dimensions[2],
+        "metric": model.metrics[0],
+        "relationship": model.relationships[0],
+    }[owner]
+    setattr(item, field, value)
+    portable = synthesize_ossie_document(
+        graph, scope_name="commerce", expression_dialect="ANSI_SQL", portable_only=True
+    )
+    assert not portable.valid
+    assert any(field in d.message for d in portable.diagnostics)
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
+    assert result.valid, result.diagnostics
+    lowered = lower_ossie_document(
+        parse_ossie_document(json.dumps(result.document.to_parsed_data()).encode()), target_dialect="duckdb"
+    )
+    assert lowered.valid, lowered.diagnostics
+    restored_graph = lowered.catalog["commerce"].graph
+    restored_model = restored_graph.models["orders"]
+    restored = {
+        "graph": restored_graph,
+        "model": restored_model,
+        "dimension": restored_model.dimensions[2],
+        "metric": restored_model.metrics[0],
+        "relationship": restored_model.relationships[0],
+    }[owner]
+    assert getattr(restored, field) == value
+
+
+@pytest.mark.parametrize("feature", ["segments", "window"])
+def test_extension_selection_does_not_hide_invalid_native_expression(feature):
+    graph = _graph()
+    if feature == "segments":
+        graph.models["orders"].segments.append(Segment(name="invalid", sql="amount > 0; SELECT 1"))
+    else:
+        graph.models["orders"].dimensions[2].window = "MIN(loaded_at) OVER (); SELECT 1"
+    result = synthesize_ossie_document(graph, scope_name="commerce", expression_dialect="ANSI_SQL")
+    assert not result.valid
+    assert any(d.code == "ossie.synthesis.expression_invalid" for d in result.diagnostics)


### PR DESCRIPTION
Ossie export could silently drop time granularity, segments, and dimension windows when no earlier projection diagnostic selected the runtime extension. Those exports changed query behavior after import and were also accepted in portable-only mode.

Detect populated native fields outside the core projection contract, preserve them through the runtime extension, and reject portable-only exports that would lose them. Keep generated source-location annotations portable and validate segment and window SQL before emitting the extension.
