### PR TITLE
Preserve Ruff fixture exclusions in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,7 @@ packages = ["sidemantic"]
 line-length = 120
 target-version = "py311"
 force-exclude = true
-exclude = [
+extend-exclude = [
     "sidemantic/adapters/malloy_grammar",  # ANTLR-generated files
     "sidemantic/adapters/holistics_grammar",  # ANTLR-generated files
     "tests/ossie-fixtures/upstream/validation/validate.py",  # Exact pinned Apache validator fixture


### PR DESCRIPTION
CI and release commands pass `--exclude`, which replaces Ruff's configured `exclude` list and exposes the pinned Apache validator fixture to formatting checks. Use `extend-exclude` so the fixture exemption survives those command-line options without modifying upstream fixture bytes.
