### PR TITLE
Pin Bun for reproducible UI bundle checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,6 +509,9 @@ jobs:
 
       - name: Install bun
         uses: oven-sh/setup-bun@v2
+        with:
+          # Match the bundler that produced the committed UI distribution.
+          bun-version: '1.4.0'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,9 @@ jobs:
 
       - name: Install bun
         uses: oven-sh/setup-bun@v2
+        with:
+          # Match the bundler that produced the committed UI distribution.
+          bun-version: '1.4.0'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
The release passes Python tests but fails the UI distribution check because setup-bun installs the latest Bun. Committed bundles match 1.4.0; 1.4.2 emits different JavaScript from the same source and dependencies.

Pin Bun to 1.4.0 in the webapp CI and publish workflows so byte-for-byte bundle checks use the matching toolchain.
